### PR TITLE
chore: add missing generated artifact entries to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,9 @@ Thumbs.db
 /coverage/
 /phpqa/
 
+.phpunit.cache/
+phpmetrics/
+
 # Environment
 .env
 .env.local


### PR DESCRIPTION
Adds `.phpunit.cache/` and `phpmetrics/` to `.gitignore` to prevent generated test and quality tool artifacts from being tracked. These cause unnecessary dirty-submodule noise in the parent repo.

Already present: `/coverage/`