### PR TITLE
fix(headers): @author email typo dev@conductio.nl -> info@conduction.nl

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -10,7 +10,7 @@
  * @category Test
  * @package  OCA\MyDash\Tests
  *
- * @author    Conduction Development Team <dev@conductio.nl>
+ * @author    Conduction Development Team <info@conduction.nl>
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *


### PR DESCRIPTION
See ConductionNL/nextcloud-app-template#19 for the root-cause fix in the template. Sweeps 1 docblock occurrence in this repo. No code semantics touched.