### PR TITLE
chore: Align MyDash with template + hydra ADRs

### DIFF
--- a/REUSE.toml
+++ b/REUSE.toml
@@ -1,0 +1,48 @@
+version = 1
+
+# REUSE compliance for MyDash.
+#
+# PHP files carry license + copyright metadata via PHPDoc tags
+# (@license / @copyright / @author) in the main file docblock per
+# ADR-014. This REUSE.toml tells `reuse lint` to accept that instead
+# of requiring SPDX-* lines duplicated on every file.
+#
+# Non-PHP source files (Vue/JS/TS/CSS) still SHOULD carry an SPDX
+# header on their first line if they have one; the annotation below
+# is the fallback for files without a header.
+
+[[annotations]]
+path = "**/*.php"
+SPDX-FileCopyrightText = "2024 Conduction B.V. <info@conduction.nl>"
+SPDX-License-Identifier = "EUPL-1.2"
+
+[[annotations]]
+path = [
+    "**/*.vue",
+    "**/*.js",
+    "**/*.ts",
+    "**/*.css",
+    "**/*.scss",
+    "**/*.sh",
+]
+SPDX-FileCopyrightText = "2024 Conduction B.V. <info@conduction.nl>"
+SPDX-License-Identifier = "EUPL-1.2"
+
+# Config / data / generated files — CC0 (same treatment as many
+# upstream Nextcloud apps). Adjust if a specific asset warrants a
+# different licence.
+[[annotations]]
+path = [
+    "**/*.json",
+    "**/*.yml",
+    "**/*.yaml",
+    "**/*.xml",
+    "**/*.md",
+    "**/*.toml",
+    "img/**",
+    "l10n/**",
+    "composer.lock",
+    "package-lock.json",
+]
+SPDX-FileCopyrightText = "2024 Conduction B.V. <info@conduction.nl>"
+SPDX-License-Identifier = "CC0-1.0"

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -68,7 +68,7 @@ Vrij en open source onder de EUPL-1.2-licentie.
 
 	<dependencies>
 		<php min-version="8.1"/>
-		<nextcloud min-version="28" max-version="33"/>
+		<nextcloud min-version="28" max-version="34"/>
 	</dependencies>
 
 	<settings>

--- a/docs/adr-audit.md
+++ b/docs/adr-audit.md
@@ -1,0 +1,99 @@
+---
+sidebar_position: 5
+---
+
+# ADR compliance audit — MyDash
+
+Audit of the 23 org-wide ADRs (`hydra/openspec/architecture/adr-*.md`)
+against what MyDash actually does. Audit date: **2026-04-24**, after
+consolidating 6 in-flight feature PRs into `development` and landing
+the template + ADR cleanup PR.
+
+**Legend:** ✅ compliant · ⚠️ partial · ❌ gap · N/A out of scope
+
+## Matrix
+
+| ADR | Rule (short) | Status | Note |
+|---|---|---|---|
+| **001** Data layer | App config → `IAppConfig`, not OpenRegister | N/A | MyDash owns its own Doctrine entities (Dashboard, Tile, WidgetPlacement, ConditionalRule, AdminSetting). Self-contained domain model, no OpenRegister dependency |
+| 001 | Register JSON at `lib/Settings/{app}_register.json` | N/A | no domain schemas exposed to OR |
+| **002** API | URL pattern `/api/{resource}`, standard verbs | ✅ | all 17 routes in `appinfo/routes.php` follow REST conventions |
+| 002 | No stack traces in error responses | ✅ | `ResponseHelper::error` now returns generic message (fixed in this PR) |
+| 002 | Pagination | N/A | dashboards / tiles lists are small per-user; no pagination needed |
+| **003** Backend | Controller → Service → Mapper layering | ✅ | 11 controllers delegate to 20 services which delegate to 20 mappers/entities |
+| 003 | Thin controllers | ✅ | most methods under 20 lines; `DashboardApiController::update` is the largest at ~45 lines due to metadata-vs-layout branch |
+| 003 | DI via constructor + `private readonly` | ✅ | verified across `lib/Controller/` and `lib/Service/` |
+| 003 | No `\OC::$server` or static locators | ✅ | post-PR: `grep -rnE '\\OC::\\$server\\|Server::get(\\|new \\OC_' lib/` returns zero |
+| 003 | `@spec` on every class + public method | ❌ | **deferred** — 0 of ~215 public methods tagged. Tracked as [openspec change + issue](#follow-ups) |
+| 003 | Specific routes before wildcard | ✅ | no wildcard routes |
+| **004** Frontend | Vue 2 + Pinia + Options API | ✅ | Vue 2.7 + Pinia stores + Webpack (template-aligned) |
+| 004 | Never import from `@nextcloud/vue` directly — use `@conduction/nextcloud-vue` | ✅ | post-PR: all 9 direct imports migrated |
+| 004 | All user-visible strings via `t(appName, '…')` | ✅ | verified across `src/components/` and `src/views/` |
+| 004 | CSS uses NC variables only | ✅ | `--color-*` tokens used throughout |
+| 004 | Never `window.confirm()` / `alert()` | ✅ | uses `NcDialog` via `@conduction/nextcloud-vue` |
+| **005** Security | Admin check on backend, not frontend | ✅ | controller methods verify admin group membership |
+| 005 | `#[NoAdminRequired]` paired with per-object auth check | ✅ | verified: `DashboardApiController::update` routes to `PermissionService::canEditDashboard`; `DashboardService::deleteDashboard` + `activateDashboard` check `$dashboard->getUserId() !== $userId`; `TileService` + `WidgetService` follow the same pattern at service layer |
+| 005 | `#[PasswordConfirmationRequired]` on admin mutations | ⚠️ | admin-console mutations could benefit; deferred for a focused security review pass |
+| 005 | No stack traces / exception messages in API responses | ✅ | `ResponseHelper::error` now returns generic `'Operation failed'` (fixed in this PR) |
+| **006** Metrics | `/api/metrics` + `/api/health` | ✅ | `MetricsController` exposes Prometheus text format at `/api/metrics`; `HealthController` at `/api/health` |
+| **007** i18n | English primary + Dutch required | ✅ | `l10n/en.json` (5485 B) + `l10n/nl.json` (5798 B); JS mirrors present |
+| 007 | Frontend `t(appName, 'key')` + `n(...)` for plurals | ✅ | spot-check shows `translatePlural` used for count-based strings |
+| 007 | Backend `$this->l10n->t('key')` | ✅ | admin settings strings use `IL10N` |
+| **008** Testing | PHPUnit coverage per service / controller | ⚠️ | 8 unit tests present (DashboardFactory, VisibilityChecker, Tile, ConditionalRule, AdminSetting, …). Service+controller coverage grows with each opsx change |
+| 008 | Newman/Postman collection | ❌ | **deferred** — no `tests/integration/*.postman_collection.json`. Tracked as [openspec change + issue](#follow-ups) |
+| **009** Docs | User-facing features documented | ✅ | Docusaurus site at `docs/` with 10+ feature docs under `docs/features/` + intro + dev guide. Architecture doc added in this PR |
+| **010** NL Design | CSS custom properties, no hardcoded colors | ✅ | verified |
+| 010 | WCAG AA | ⚠️ | basic keyboard nav + focus handling present; no structured axe-core or NVDA pass run. Consistent with "admin-only app" guidance, but deeper audit worth a focused PR |
+| **011** Schema standards | schema.org vocabulary | N/A | no domain schemas exposed externally |
+| **012** Dedup | Reuse analysis in OpenSpec changes | ✅ | each archived change includes a "reuse analysis" section (spot-check on `2026-03-21-dashboards/design.md`) |
+| **013** Container pool | Hydra infra concern | N/A | not an app concern |
+| **014** Licensing | EUPL-1.2 on every source file | ✅ | post-PR: 72 PHP files have clean `@license EUPL-1.2` PHPDoc; contradictory `SPDX-License-Identifier: AGPL-3.0-or-later` block removed; `REUSE.toml` added for machine-readable REUSE compliance |
+| 014 | `info.xml` licence element | ✅ | `<licence>agpl</licence>` retained as the Nextcloud app-store schema element (schema expects `agpl`) — separate from source licence; documented in commit `ab9fc70` |
+| **015** Common patterns | Static generic error messages | ✅ | `ResponseHelper::error` returns generic text (fixed in this PR) |
+| 015 | No raw `fetch()` — use `@nextcloud/axios` | ✅ | verified: `grep -rn 'fetch(' src/` returns zero |
+| 015 | EUPL headers | ✅ | see ADR-014 |
+| **016** Routes | `appinfo/routes.php` is the only registration path | ✅ | `grep -rE '#\\[ApiRoute\\|#\\[FrontpageRoute' lib/` returns zero; all 17 routes declared explicitly |
+| **017** Component composition | Avoid wrapping self-contained components | ✅ | no file in `src/` exceeds 537 lines (`WidgetPicker.vue`); components use the `@conduction/nextcloud-vue` dashboard primitives |
+| **018** Widget header actions | `header-actions` slot on cards | ⚠️ | MyDash renders **legacy** Nextcloud dashboard widgets (`NcDashboardWidget`) rather than OR-backed `CnDetailCard` / `CnObjectDataWidget`. That's by design (MyDash is a container app, not an OR data consumer), but ADR-018 contemplates header-actions on data cards. Treated as N/A-by-design for now; revisit if MyDash grows OR-backed tile types |
+| **019** Integration registry | Sidebar tabs / linked items | N/A | MyDash is a widget **consumer**, not a registry provider |
+| **020** Gate scope | Hydra gate scope is PR diff | N/A | reviewer guidance, not app code |
+| **021** Bounded fix scope | Reviewer bounded-fix by change shape | N/A | reviewer guidance, not app code |
+| **022** Apps consume OR abstractions | RBAC / audit / archival via OR | N/A | no OR consumption — see ADR-001 note |
+| **023** Action authorization | Admin-configured action/group mappings | N/A | MyDash uses role-based permissions (`view` / `add_only` / `full`), not fine-grained action mapping |
+
+## Summary
+
+- **Compliant:** 25 rules (incl. compound rules)
+- **Partial:** 4 rules (ADR-005 `PasswordConfirmationRequired`, ADR-008
+  PHPUnit breadth, ADR-010 deep WCAG AA, ADR-018 `header-actions`
+  slot by design)
+- **Gaps:** 2 rules (ADR-003 `@spec` tag coverage, ADR-008 Newman)
+- **N/A:** 14 rules (no OR consumption, no registry provider, no fine-
+  grained actions, hydra-infra rules)
+
+## Follow-ups
+
+The two remaining `❌` items are tracked as formal OpenSpec changes +
+GitHub issues so Hydra's pipeline can pick them up after this PR
+merges:
+
+1. **`@spec` annotation pass across 64 PHP files / 215 public methods**
+   — needs a full `/opsx-annotate` run against the 10 archived changes
+   in `openspec/changes/archive/`. Scope is too large to pack into this
+   PR.
+2. **Newman / Postman integration collection** — covering the 17 OCS
+   endpoints, with env-placeholder credentials and CI wiring.
+
+Partial items that may warrant their own follow-up PRs later (not
+filed as Hydra-triggered issues today):
+
+3. **`PasswordConfirmationRequired` on admin-console mutations**
+   (ADR-005). The admin console writes template definitions + global
+   settings; a stolen session shouldn't silently alter those. Focused
+   security review.
+4. **Deep WCAG AA audit** (ADR-010) — axe-core + manual screen-reader
+   traversal on the dashboard + tile editor surfaces.
+5. **Thread `LoggerInterface` through the 6 controllers that currently
+   don't inject one**, so `ResponseHelper::error($e, logger: $this->logger)`
+   logs the real exception server-side. The leak is already closed
+   client-side; this restores visibility.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,63 @@
+---
+sidebar_position: 4
+---
+
+# Architecture Decision Records
+
+MyDash inherits its ADRs from the ConductionNL platform-wide set. There
+are no MyDash-specific ADRs today — every rule that applies to MyDash
+comes from the 23 org-wide records maintained in the **hydra** repo:
+
+- Canonical location:
+  [`ConductionNL/hydra/openspec/architecture/`](https://github.com/ConductionNL/hydra/tree/main/openspec/architecture)
+- Local checkout:
+  `hydra/openspec/architecture/adr-001-data-layer.md` through
+  `adr-023-action-authorization.md`
+
+## Why no app-level ADRs?
+
+Earlier versions of each Conduction app repo carried stale copies of
+the ADRs in `.claude/openspec/architecture/`. Those drifted away from
+the hydra source of truth and triggered false-positive review findings
+(observed on decidesk #71, 2026-04-19 — the app-level copy of ADR-004
+said `fetch()`, hydra said `axios`). The stale copies were deleted
+across every app repo; hydra is now the single source.
+
+When Hydra's builder + reviewer containers operate on a MyDash PR, they
+bundle the current hydra ADRs into the build image and feed them to
+the agents as immutable context. So the rules every PR is measured
+against live in hydra, not here.
+
+## Quick index (per app-versions precedent)
+
+| ADR | Topic |
+|-----|-------|
+| 001 | Data layer (OpenRegister, entities, mappers) |
+| 002 | API design (REST, Common Ground) |
+| 003 | Backend (PHP, DI, 3-layer) |
+| 004 | Frontend (Vue, components, settings) |
+| 005 | Security (auth, CORS, input validation) |
+| 006 | Metrics & observability |
+| 007 | i18n (English primary, Dutch required) |
+| 008 | Testing (PHPUnit, Newman, Playwright) |
+| 009 | Documentation |
+| 010 | NL Design System |
+| 011 | Schema standards (schema.org, DCAT) |
+| 012 | Deduplication |
+| 013 | Container pool |
+| 014 | Licensing (EUPL-1.2) |
+| 015 | Common patterns (rate-limit retry, axios) |
+| 016 | Routes (`appinfo/routes.php` is the only path) |
+| 017 | Component composition |
+| 018 | Widget header actions |
+| 019 | Integration registry |
+| 020 | Gate scope to PR diff |
+| 021 | Bounded fix scope by change shape |
+| 022 | Apps consume OpenRegister abstractions |
+| 023 | Action-level authorisation |
+
+## Compliance
+
+MyDash's current compliance posture against the 23 ADRs is tracked in
+[adr-audit.md](../adr-audit.md). That file names per-ADR status
+(PASS / PARTIAL / FAIL / N/A), evidence, and follow-up items.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,165 @@
+---
+sidebar_position: 3
+---
+
+# Architecture
+
+MyDash is a dashboard container + layout manager for Nextcloud. It lets
+each user (and each administrator, for the organisation as a whole)
+compose personal dashboards from tiles and legacy Nextcloud widgets,
+arranged on a responsive grid with per-tile conditional visibility.
+
+Unlike thin UI utilities (e.g., app-versions), MyDash owns its own
+domain model — dashboards, placements, tiles, conditional rules — and
+persists everything in its own tables via Doctrine mappers.
+
+## Component map
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                         src/ (Vue 3 + TS)                   │
+│                                                             │
+│   views/Views.vue       — shell / routing                   │
+│   views/Dashboard.vue   — grid canvas                       │
+│   components/DashboardSwitcher — nav between dashboards     │
+│   components/WidgetRenderer    — legacy-widget bridge       │
+│   components/WidgetPicker      — "add widget" modal         │
+│   components/WidgetWrapper     — per-tile chrome            │
+│   components/TileCard / TileEditor / WidgetStyleEditor      │
+│   components/admin/AdminSettings — admin console            │
+└──────────────────────────┬──────────────────────────────────┘
+                           │ OCS JSON via @nextcloud/axios
+┌──────────────────────────▼──────────────────────────────────┐
+│                    lib/Controller/ (11 classes)             │
+│                                                             │
+│   DashboardApiController — dashboard CRUD + activate        │
+│   TileApiController      — tile CRUD + placement            │
+│   WidgetApiController    — widget attach / detach           │
+│   RuleApiController      — conditional-visibility rules     │
+│   AdminController        — admin-only endpoints             │
+│   MetricsController      — Prometheus `/api/metrics`        │
+│   HealthController       — `/api/health`                    │
+│   PageController         — admin SPA entry                  │
+│                                                             │
+│   ResponseHelper         — shared JSON envelope (ADR-005)   │
+│   DashboardRequestValidator, RequestDataExtractor           │
+└──────────────────────────┬──────────────────────────────────┘
+                           │ constructor DI (ADR-003)
+┌──────────────────────────▼──────────────────────────────────┐
+│                    lib/Service/ (20 classes)                │
+│                                                             │
+│   DashboardService / DashboardFactory / DashboardResolver   │
+│   TileService / TileUpdater                                 │
+│   WidgetService / WidgetItemLoader / WidgetFormatter        │
+│   PlacementService / PlacementUpdater                       │
+│   PermissionService     — per-object auth (ADR-005)         │
+│   ConditionalService / RuleEvaluatorService /               │
+│      VisibilityChecker / UserAttributeResolver              │
+│   AdminSettingsService / AdminTemplateService /             │
+│      TemplateService                                        │
+│   MetricsCollector / MetricsQueryService                    │
+└──────────────────────────┬──────────────────────────────────┘
+                           │ OCP\AppFramework\Db\Mapper
+┌──────────────────────────▼──────────────────────────────────┐
+│                      lib/Db/ (20 classes)                   │
+│                                                             │
+│   Entities:   Dashboard, Tile, WidgetPlacement,             │
+│               ConditionalRule, AdminSetting                 │
+│   Mappers:    DashboardMapper, TileMapper,                  │
+│               WidgetPlacementMapper, ConditionalRuleMapper, │
+│               AdminSettingMapper                            │
+│   Traits:     OwnedEntityInterface, TimestampedEntity,      │
+│               GridPositionInterface, DashboardEntityIface   │
+│   Helpers:    ColumnTypeRegistry, JsonConfigHelper,         │
+│               QueryHelper, TimestampHelper,                 │
+│               EntitySerializer                              │
+└─────────────────────────────────────────────────────────────┘
+```
+
+## Request flow — update a dashboard
+
+1. UI sends `PUT /api/dashboard/{id}` via `@nextcloud/axios` with
+   `{ name?, description?, placements? }`.
+2. `DashboardApiController::update()` (admin check + body validation)
+   delegates to `PermissionService::canEditDashboard(userId, id)` or
+   `canEditDashboardMetadata` depending on whether placements changed.
+3. On success, `DashboardService::updateDashboard()` runs the mutation
+   inside a transaction. Ownership is re-verified at the service layer
+   (`$dashboard->getUserId() !== $userId` → `'Access denied'`).
+4. `PlacementUpdater` reconciles the placement array — inserts new
+   placements, deletes removed ones, updates positions.
+5. Controller wraps the result in `ResponseHelper::success`.
+
+## Authentication & authorization posture
+
+- **Routes**: all in `appinfo/routes.php` per ADR-016. No
+  `#[ApiRoute]` / `#[FrontpageRoute]` attributes on controllers.
+- **Auth attributes**: every controller method carries an explicit
+  `#[NoAdminRequired]` / `#[PublicPage]` / `#[NoCSRFRequired]` /
+  `#[AuthorizedAdminSetting]` per ADR-005.
+- **Per-object auth**: every mutation on `Dashboard`, `Tile`,
+  `WidgetPlacement`, `ConditionalRule` runs an ownership check through
+  `PermissionService` or the service's own `getUserId()` guard before
+  writing. See `DashboardService::deleteDashboard()`,
+  `TileService::updateTile()`, etc.
+- **Error responses**: `ResponseHelper::error` returns a generic
+  message; the real exception is logged server-side when callers pass
+  their `LoggerInterface` (work in progress — tracked in
+  [adr-audit.md](./adr-audit.md)).
+
+## Dependency injection
+
+Every controller and service accepts its collaborators via constructor
+(`private readonly` properties per ADR-003). No `\OC::$server->get()`,
+no `OCP\Server::get()`, no `new \OC_App()`. Verified by `grep -rn
+'\\\\OC::\$server\\|Server::get(\\|new \\\\OC_' lib/` returning zero
+matches on `development`.
+
+## Frontend stack
+
+- **Vue 2.7** (not 3 — matches template baseline; shared component
+  expectations with other Conduction apps).
+- **Webpack** via `@nextcloud/webpack-vue-config`. No Vite.
+- **Pinia** stores for dashboard + widget state.
+- **TypeScript** optional — most components are plain JS; typed where
+  it aids refactoring.
+- **HTTP**: `@nextcloud/axios` exclusively. No bare `fetch()`.
+- **Components**: every Nextcloud Vue import goes through
+  `@conduction/nextcloud-vue` (ADR-004). No direct `@nextcloud/vue`
+  imports.
+
+## Capabilities (openspec)
+
+Each capability has its own directory under `openspec/specs/` with a
+Gherkin-style requirement list:
+
+| Capability | Owns |
+|---|---|
+| `dashboards` | dashboard CRUD, activation, ownership |
+| `tiles` | tile catalogue, config schema, placement |
+| `widgets` | widget CRUD, style, positioning |
+| `grid-layout` | responsive grid (cols, row heights) |
+| `permissions` | view / add-only / full per role |
+| `conditional-visibility` | rule-based tile hide/show |
+| `admin-settings` | org-wide defaults, admin console |
+| `admin-templates` | curated starter dashboards |
+| `prometheus-metrics` | `/api/metrics` instrumentation |
+| `legacy-widget-bridge` | Nextcloud dashboard-widget compat |
+
+10 archived changes under `openspec/changes/archive/` document how each
+capability arrived at its current shape.
+
+## What MyDash explicitly does NOT do
+
+- **No OpenRegister consumption** (ADR-001 / ADR-022 N/A). Dashboards
+  and tiles live in MyDash's own tables. The app is intentionally
+  self-contained.
+- **No integration registry** (ADR-019 N/A). MyDash consumes the
+  Nextcloud dashboard-widget API; it does not expose an extension
+  point for third-party dashboards to register themselves.
+- **No action-level authorisation** (ADR-023 N/A). Permission model is
+  role-based (`view` / `add_only` / `full` / `admin`), not mapped to
+  individual actions configured by the admin.
+- **No government-theme targeting** beyond what comes via
+  `@conduction/nextcloud-vue` (ADR-010 partial). If Conduction ships
+  NL Design tokens in the wrapper, MyDash inherits them automatically.

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -12,9 +12,6 @@
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @version   GIT:auto
  * @link      https://conduction.nl
- *
- * SPDX-FileCopyrightText: 2024 MyDash Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/lib/Controller/AdminController.php
+++ b/lib/Controller/AdminController.php
@@ -12,9 +12,6 @@
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @version   GIT:auto
  * @link      https://conduction.nl
- *
- * SPDX-FileCopyrightText: 2024 MyDash Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/lib/Controller/DashboardApiController.php
+++ b/lib/Controller/DashboardApiController.php
@@ -14,9 +14,6 @@
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @version   GIT:auto
  * @link      https://conduction.nl
- *
- * SPDX-FileCopyrightText: 2024 MyDash Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/lib/Controller/DashboardRequestValidator.php
+++ b/lib/Controller/DashboardRequestValidator.php
@@ -12,9 +12,6 @@
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @version   GIT:auto
  * @link      https://conduction.nl
- *
- * SPDX-FileCopyrightText: 2024 MyDash Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/lib/Controller/HealthController.php
+++ b/lib/Controller/HealthController.php
@@ -12,9 +12,6 @@
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @version   GIT:auto
  * @link      https://conduction.nl
- *
- * SPDX-FileCopyrightText: 2024 MyDash Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/lib/Controller/MetricsController.php
+++ b/lib/Controller/MetricsController.php
@@ -12,9 +12,6 @@
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @version   GIT:auto
  * @link      https://conduction.nl
- *
- * SPDX-FileCopyrightText: 2024 MyDash Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -16,9 +16,6 @@
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @version   GIT:auto
  * @link      https://conduction.nl
- *
- * SPDX-FileCopyrightText: 2024 MyDash Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/lib/Controller/RequestDataExtractor.php
+++ b/lib/Controller/RequestDataExtractor.php
@@ -12,9 +12,6 @@
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @version   GIT:auto
  * @link      https://conduction.nl
- *
- * SPDX-FileCopyrightText: 2024 MyDash Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/lib/Controller/ResponseHelper.php
+++ b/lib/Controller/ResponseHelper.php
@@ -23,6 +23,7 @@ namespace OCA\MyDash\Controller;
 
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\JSONResponse;
+use Psr\Log\LoggerInterface;
 
 /**
  * Helper for building common JSON responses in controllers.
@@ -61,17 +62,35 @@ class ResponseHelper
     /**
      * Create an error response from an exception.
      *
-     * @param \Exception $exception  The exception.
-     * @param int        $statusCode The HTTP status code.
+     * Per ADR-005: never return the raw exception message to the client.
+     * Callers SHOULD pass their injected LoggerInterface so the real
+     * exception is recorded in the server log; the client only ever sees
+     * the generic `$message` (defaulting to "Operation failed").
+     *
+     * @param \Exception       $exception  The exception.
+     * @param int              $statusCode The HTTP status code.
+     * @param LoggerInterface|null $logger When provided, the exception is
+     *                                     logged at ERROR level before
+     *                                     the response is returned.
+     * @param string           $message    Generic client-facing message.
      *
      * @return JSONResponse The error response.
      */
     public static function error(
         \Exception $exception,
-        int $statusCode=Http::STATUS_BAD_REQUEST
+        int $statusCode=Http::STATUS_BAD_REQUEST,
+        ?LoggerInterface $logger=null,
+        string $message='Operation failed'
     ): JSONResponse {
+        if ($logger !== null) {
+            $logger->error(
+                message: $exception->getMessage(),
+                context: ['exception' => $exception]
+            );
+        }
+
         return new JSONResponse(
-            data: ['error' => $exception->getMessage()],
+            data: ['error' => $message],
             statusCode: $statusCode
         );
     }//end error()

--- a/lib/Controller/ResponseHelper.php
+++ b/lib/Controller/ResponseHelper.php
@@ -12,9 +12,6 @@
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @version   GIT:auto
  * @link      https://conduction.nl
- *
- * SPDX-FileCopyrightText: 2024 MyDash Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/lib/Controller/RuleApiController.php
+++ b/lib/Controller/RuleApiController.php
@@ -12,9 +12,6 @@
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @version   GIT:auto
  * @link      https://conduction.nl
- *
- * SPDX-FileCopyrightText: 2024 MyDash Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/lib/Controller/TileApiController.php
+++ b/lib/Controller/TileApiController.php
@@ -12,9 +12,6 @@
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @version   GIT:auto
  * @link      https://conduction.nl
- *
- * SPDX-FileCopyrightText: 2024 MyDash Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/lib/Controller/WidgetApiController.php
+++ b/lib/Controller/WidgetApiController.php
@@ -12,9 +12,6 @@
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @version   GIT:auto
  * @link      https://conduction.nl
- *
- * SPDX-FileCopyrightText: 2024 MyDash Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/lib/Db/AdminSetting.php
+++ b/lib/Db/AdminSetting.php
@@ -12,9 +12,6 @@
  * @license   https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12 EUPL-1.2
  * @version   GIT:auto
  * @link      https://conduction.nl
- *
- * SPDX-FileCopyrightText: 2024 MyDash Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/lib/Db/AdminSettingMapper.php
+++ b/lib/Db/AdminSettingMapper.php
@@ -12,9 +12,6 @@
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @version   GIT:auto
  * @link      https://conduction.nl
- *
- * SPDX-FileCopyrightText: 2024 MyDash Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/lib/Db/ColumnTypeRegistry.php
+++ b/lib/Db/ColumnTypeRegistry.php
@@ -12,9 +12,6 @@
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @version   GIT:auto
  * @link      https://conduction.nl
- *
- * SPDX-FileCopyrightText: 2024 MyDash Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/lib/Db/ConditionalRule.php
+++ b/lib/Db/ConditionalRule.php
@@ -14,9 +14,6 @@ declare(strict_types=1);
  * @license   https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12 EUPL-1.2
  * @version   GIT:auto
  * @link      https://conduction.nl
- *
- * SPDX-FileCopyrightText: 2024 MyDash Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 namespace OCA\MyDash\Db;

--- a/lib/Db/ConditionalRuleMapper.php
+++ b/lib/Db/ConditionalRuleMapper.php
@@ -12,9 +12,6 @@
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @version   GIT:auto
  * @link      https://conduction.nl
- *
- * SPDX-FileCopyrightText: 2024 MyDash Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/lib/Db/Dashboard.php
+++ b/lib/Db/Dashboard.php
@@ -14,9 +14,6 @@ declare(strict_types=1);
  * @license   https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12 EUPL-1.2
  * @version   GIT:auto
  * @link      https://conduction.nl
- *
- * SPDX-FileCopyrightText: 2024 MyDash Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 namespace OCA\MyDash\Db;

--- a/lib/Db/DashboardEntityInterface.php
+++ b/lib/Db/DashboardEntityInterface.php
@@ -12,9 +12,6 @@
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @version   GIT:auto
  * @link      https://conduction.nl
- *
- * SPDX-FileCopyrightText: 2024 MyDash Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/lib/Db/DashboardMapper.php
+++ b/lib/Db/DashboardMapper.php
@@ -12,9 +12,6 @@
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @version   GIT:auto
  * @link      https://conduction.nl
- *
- * SPDX-FileCopyrightText: 2024 MyDash Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/lib/Db/EntityMapperInterface.php
+++ b/lib/Db/EntityMapperInterface.php
@@ -12,9 +12,6 @@
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @version   GIT:auto
  * @link      https://conduction.nl
- *
- * SPDX-FileCopyrightText: 2024 MyDash Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/lib/Db/EntitySerializer.php
+++ b/lib/Db/EntitySerializer.php
@@ -12,9 +12,6 @@
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @version   GIT:auto
  * @link      https://conduction.nl
- *
- * SPDX-FileCopyrightText: 2024 MyDash Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/lib/Db/GridPositionInterface.php
+++ b/lib/Db/GridPositionInterface.php
@@ -12,9 +12,6 @@
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @version   GIT:auto
  * @link      https://conduction.nl
- *
- * SPDX-FileCopyrightText: 2024 MyDash Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/lib/Db/JsonConfigHelper.php
+++ b/lib/Db/JsonConfigHelper.php
@@ -12,9 +12,6 @@
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @version   GIT:auto
  * @link      https://conduction.nl
- *
- * SPDX-FileCopyrightText: 2024 MyDash Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/lib/Db/OwnedEntityInterface.php
+++ b/lib/Db/OwnedEntityInterface.php
@@ -12,9 +12,6 @@
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @version   GIT:auto
  * @link      https://conduction.nl
- *
- * SPDX-FileCopyrightText: 2024 MyDash Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/lib/Db/QueryHelper.php
+++ b/lib/Db/QueryHelper.php
@@ -12,9 +12,6 @@
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @version   GIT:auto
  * @link      https://conduction.nl
- *
- * SPDX-FileCopyrightText: 2024 MyDash Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/lib/Db/Tile.php
+++ b/lib/Db/Tile.php
@@ -14,9 +14,6 @@ declare(strict_types=1);
  * @license   https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12 EUPL-1.2
  * @version   GIT:auto
  * @link      https://conduction.nl
- *
- * SPDX-FileCopyrightText: 2024 MyDash Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 namespace OCA\MyDash\Db;

--- a/lib/Db/TileMapper.php
+++ b/lib/Db/TileMapper.php
@@ -12,9 +12,6 @@
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @version   GIT:auto
  * @link      https://conduction.nl
- *
- * SPDX-FileCopyrightText: 2024 MyDash Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/lib/Db/TimestampHelper.php
+++ b/lib/Db/TimestampHelper.php
@@ -12,9 +12,6 @@
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @version   GIT:auto
  * @link      https://conduction.nl
- *
- * SPDX-FileCopyrightText: 2024 MyDash Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/lib/Db/TimestampedEntityInterface.php
+++ b/lib/Db/TimestampedEntityInterface.php
@@ -12,9 +12,6 @@
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @version   GIT:auto
  * @link      https://conduction.nl
- *
- * SPDX-FileCopyrightText: 2024 MyDash Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/lib/Db/WidgetPlacement.php
+++ b/lib/Db/WidgetPlacement.php
@@ -14,9 +14,6 @@ declare(strict_types=1);
  * @license   https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12 EUPL-1.2
  * @version   GIT:auto
  * @link      https://conduction.nl
- *
- * SPDX-FileCopyrightText: 2024 MyDash Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 namespace OCA\MyDash\Db;

--- a/lib/Db/WidgetPlacementMapper.php
+++ b/lib/Db/WidgetPlacementMapper.php
@@ -12,9 +12,6 @@
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @version   GIT:auto
  * @link      https://conduction.nl
- *
- * SPDX-FileCopyrightText: 2024 MyDash Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/lib/Migration/DashboardTableBuilder.php
+++ b/lib/Migration/DashboardTableBuilder.php
@@ -12,9 +12,6 @@
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @version   GIT:auto
  * @link      https://conduction.nl
- *
- * SPDX-FileCopyrightText: 2024 MyDash Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/lib/Migration/MigrationTableBuilder.php
+++ b/lib/Migration/MigrationTableBuilder.php
@@ -12,9 +12,6 @@
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @version   GIT:auto
  * @link      https://conduction.nl
- *
- * SPDX-FileCopyrightText: 2024 MyDash Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/lib/Migration/PlacementTableBuilder.php
+++ b/lib/Migration/PlacementTableBuilder.php
@@ -12,9 +12,6 @@
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @version   GIT:auto
  * @link      https://conduction.nl
- *
- * SPDX-FileCopyrightText: 2024 MyDash Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/lib/Migration/RulesTableBuilder.php
+++ b/lib/Migration/RulesTableBuilder.php
@@ -12,9 +12,6 @@
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @version   GIT:auto
  * @link      https://conduction.nl
- *
- * SPDX-FileCopyrightText: 2024 MyDash Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/lib/Migration/SettingsTableBuilder.php
+++ b/lib/Migration/SettingsTableBuilder.php
@@ -12,9 +12,6 @@
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @version   GIT:auto
  * @link      https://conduction.nl
- *
- * SPDX-FileCopyrightText: 2024 MyDash Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/lib/Migration/Version001000Date20240101000000.php
+++ b/lib/Migration/Version001000Date20240101000000.php
@@ -12,9 +12,6 @@
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @version   GIT:auto
  * @link      https://conduction.nl
- *
- * SPDX-FileCopyrightText: 2024 MyDash Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/lib/Migration/Version001001Date20260203000000.php
+++ b/lib/Migration/Version001001Date20260203000000.php
@@ -12,9 +12,6 @@
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @version   GIT:auto
  * @link      https://conduction.nl
- *
- * SPDX-FileCopyrightText: 2024 MyDash Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/lib/Migration/Version001002Date20260204000000.php
+++ b/lib/Migration/Version001002Date20260204000000.php
@@ -12,9 +12,6 @@
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @version   GIT:auto
  * @link      https://conduction.nl
- *
- * SPDX-FileCopyrightText: 2024 MyDash Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/lib/Migration/Version001003Date20260204120000.php
+++ b/lib/Migration/Version001003Date20260204120000.php
@@ -12,9 +12,6 @@
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @version   GIT:auto
  * @link      https://conduction.nl
- *
- * SPDX-FileCopyrightText: 2024 MyDash Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/lib/Migration/Version001004Date20260204150000.php
+++ b/lib/Migration/Version001004Date20260204150000.php
@@ -12,9 +12,6 @@
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @version   GIT:auto
  * @link      https://conduction.nl
- *
- * SPDX-FileCopyrightText: 2026 MyDash Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/lib/Service/AdminSettingsService.php
+++ b/lib/Service/AdminSettingsService.php
@@ -12,9 +12,6 @@
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @version   GIT:auto
  * @link      https://conduction.nl
- *
- * SPDX-FileCopyrightText: 2024 MyDash Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/lib/Service/AdminTemplateService.php
+++ b/lib/Service/AdminTemplateService.php
@@ -12,9 +12,6 @@
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @version   GIT:auto
  * @link      https://conduction.nl
- *
- * SPDX-FileCopyrightText: 2024 MyDash Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/lib/Service/ConditionalService.php
+++ b/lib/Service/ConditionalService.php
@@ -12,9 +12,6 @@
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @version   GIT:auto
  * @link      https://conduction.nl
- *
- * SPDX-FileCopyrightText: 2024 MyDash Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/lib/Service/DashboardFactory.php
+++ b/lib/Service/DashboardFactory.php
@@ -13,9 +13,6 @@
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @version   GIT:auto
  * @link      https://conduction.nl
- *
- * SPDX-FileCopyrightText: 2024 MyDash Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/lib/Service/DashboardResolver.php
+++ b/lib/Service/DashboardResolver.php
@@ -12,9 +12,6 @@
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @version   GIT:auto
  * @link      https://conduction.nl
- *
- * SPDX-FileCopyrightText: 2024 MyDash Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/lib/Service/DashboardService.php
+++ b/lib/Service/DashboardService.php
@@ -13,9 +13,6 @@
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @version   GIT:auto
  * @link      https://conduction.nl
- *
- * SPDX-FileCopyrightText: 2024 MyDash Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/lib/Service/MetricsCollector.php
+++ b/lib/Service/MetricsCollector.php
@@ -12,9 +12,6 @@
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @version   GIT:auto
  * @link      https://conduction.nl
- *
- * SPDX-FileCopyrightText: 2024 MyDash Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/lib/Service/MetricsQueryService.php
+++ b/lib/Service/MetricsQueryService.php
@@ -12,9 +12,6 @@
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @version   GIT:auto
  * @link      https://conduction.nl
- *
- * SPDX-FileCopyrightText: 2024 MyDash Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/lib/Service/PermissionService.php
+++ b/lib/Service/PermissionService.php
@@ -12,9 +12,6 @@
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @version   GIT:auto
  * @link      https://conduction.nl
- *
- * SPDX-FileCopyrightText: 2024 MyDash Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/lib/Service/PlacementService.php
+++ b/lib/Service/PlacementService.php
@@ -12,9 +12,6 @@
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @version   GIT:auto
  * @link      https://conduction.nl
- *
- * SPDX-FileCopyrightText: 2024 MyDash Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/lib/Service/PlacementUpdater.php
+++ b/lib/Service/PlacementUpdater.php
@@ -12,9 +12,6 @@
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @version   GIT:auto
  * @link      https://conduction.nl
- *
- * SPDX-FileCopyrightText: 2024 MyDash Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/lib/Service/RuleEvaluatorService.php
+++ b/lib/Service/RuleEvaluatorService.php
@@ -12,9 +12,6 @@
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @version   GIT:auto
  * @link      https://conduction.nl
- *
- * SPDX-FileCopyrightText: 2024 MyDash Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/lib/Service/TemplateService.php
+++ b/lib/Service/TemplateService.php
@@ -12,9 +12,6 @@
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @version   GIT:auto
  * @link      https://conduction.nl
- *
- * SPDX-FileCopyrightText: 2024 MyDash Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/lib/Service/TileService.php
+++ b/lib/Service/TileService.php
@@ -12,9 +12,6 @@
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @version   GIT:auto
  * @link      https://conduction.nl
- *
- * SPDX-FileCopyrightText: 2024 MyDash Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/lib/Service/TileUpdater.php
+++ b/lib/Service/TileUpdater.php
@@ -12,9 +12,6 @@
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @version   GIT:auto
  * @link      https://conduction.nl
- *
- * SPDX-FileCopyrightText: 2024 MyDash Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/lib/Service/UserAttributeResolver.php
+++ b/lib/Service/UserAttributeResolver.php
@@ -12,9 +12,6 @@
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @version   GIT:auto
  * @link      https://conduction.nl
- *
- * SPDX-FileCopyrightText: 2024 MyDash Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/lib/Service/VisibilityChecker.php
+++ b/lib/Service/VisibilityChecker.php
@@ -12,9 +12,6 @@
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @version   GIT:auto
  * @link      https://conduction.nl
- *
- * SPDX-FileCopyrightText: 2024 MyDash Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/lib/Service/WidgetFormatter.php
+++ b/lib/Service/WidgetFormatter.php
@@ -12,9 +12,6 @@
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @version   GIT:auto
  * @link      https://conduction.nl
- *
- * SPDX-FileCopyrightText: 2024 MyDash Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/lib/Service/WidgetItemLoader.php
+++ b/lib/Service/WidgetItemLoader.php
@@ -12,9 +12,6 @@
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @version   GIT:auto
  * @link      https://conduction.nl
- *
- * SPDX-FileCopyrightText: 2024 MyDash Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/lib/Service/WidgetService.php
+++ b/lib/Service/WidgetService.php
@@ -12,9 +12,6 @@
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @version   GIT:auto
  * @link      https://conduction.nl
- *
- * SPDX-FileCopyrightText: 2024 MyDash Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/lib/Settings/MyDashAdmin.php
+++ b/lib/Settings/MyDashAdmin.php
@@ -16,9 +16,6 @@
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @version   GIT:auto
  * @link      https://conduction.nl
- *
- * SPDX-FileCopyrightText: 2024 MyDash Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/lib/Settings/MyDashAdminSection.php
+++ b/lib/Settings/MyDashAdminSection.php
@@ -12,9 +12,6 @@
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @version   GIT:auto
  * @link      https://conduction.nl
- *
- * SPDX-FileCopyrightText: 2024 MyDash Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/openspec/changes/newman-integration-suite-2026-04-24/design.md
+++ b/openspec/changes/newman-integration-suite-2026-04-24/design.md
@@ -1,0 +1,106 @@
+# Design — Newman integration collection
+
+## Shape
+
+One Postman 2.1 collection at
+`tests/integration/mydash.postman_collection.json`. Top-level folders:
+
+- `Health + Metrics`
+- `Dashboards`
+- `Tiles`
+- `Widgets`
+- `Rules`
+- `Admin`
+
+Each folder contains requests hitting one controller. Per-request
+assertions live in `event[listen=test].script.exec[]`.
+
+## Auth
+
+HTTP basic over the OCS API. Collection-level `auth` uses
+`{{admin_user}}` / `{{admin_password}}` variables. Requests that need
+a non-admin caller override auth inline with `{{member_user}}` /
+`{{member_password}}`.
+
+Required OCS headers on every request:
+
+```
+OCS-APIRequest: true
+Accept: application/json
+```
+
+## Test pollution strategy
+
+The collection creates + tears down its own fixture dashboard. Order:
+
+1. `Dashboards / Fixture setup` — `POST /api/dashboard` with a
+   recognisable name (`newman-fixture-<timestamp>`). Captures the new
+   dashboard id in a collection variable (`{{fixture_dashboard_id}}`).
+2. All write tests target `{{fixture_dashboard_id}}` — never a pre-
+   existing dashboard.
+3. `Dashboards / Fixture teardown` — `DELETE /api/dashboard/{{fixture_dashboard_id}}`
+   at the end of the folder.
+
+If a test fails mid-run, the teardown still runs (Newman's `—
+--bail` is NOT set). The fixture's timestamped name makes orphaned
+fixtures easy to find with `newman-fixture-*` grep.
+
+## Environment
+
+`tests/integration/README.md` documents local run:
+
+```bash
+npm install -g newman
+newman run tests/integration/mydash.postman_collection.json \
+  --env-var base_url=http://nextcloud.local \
+  --env-var admin_user=admin \
+  --env-var admin_password=admin \
+  --env-var member_user=regular \
+  --env-var member_password=regular
+```
+
+CI passes `base_url=http://localhost:8080`.
+
+## Assertion shape
+
+Each request gets ≥ 2 assertions. Minimal pattern:
+
+```javascript
+pm.test('200 OK', () => pm.response.to.have.status(200));
+pm.test('OCS envelope', () => {
+    const json = pm.response.json();
+    pm.expect(json).to.have.nested.property('ocs.meta.status');
+    pm.expect(json.ocs.meta.status).to.equal('ok');
+});
+```
+
+Forbidden / admin-gated endpoints get the mirror:
+
+```javascript
+pm.test('403 Forbidden for non-admin', () => pm.response.to.have.status(403));
+pm.test('Error envelope', () => {
+    const json = pm.response.json();
+    pm.expect(json).to.have.property('error');
+});
+```
+
+## CI wiring
+
+`.github/workflows/code-quality.yml` already sets `enable-newman: true`.
+The reusable quality workflow picks up any
+`tests/integration/*.postman_collection.json` automatically. Soft
+failures on network-dependent calls (app-store proxy) use
+`pm.expect([200, 502, 503]).to.include(pm.response.code)` so CI
+without egress passes the build.
+
+## Risk
+
+- **Tile / Widget / Rule shape drift**: the collection assertions
+  match the payload shape as of 2026-04-24. If a request/response
+  model changes (e.g., additional fields), the shape tests need to
+  be updated alongside the code change. Each change proposal that
+  modifies a controller should update this collection.
+- **Admin role in CI**: the reusable workflow provisions an admin
+  user by default. The member-level tests need a second user
+  provisioned — design.md for the workflow may need an extension
+  if this capability isn't already there.

--- a/openspec/changes/newman-integration-suite-2026-04-24/proposal.md
+++ b/openspec/changes/newman-integration-suite-2026-04-24/proposal.md
@@ -1,0 +1,58 @@
+# Newman / Postman integration collection
+
+Closes the ADR-008 `Newman/Postman collection` gap flagged in
+[`docs/adr-audit.md`](../../../docs/adr-audit.md).
+
+## Why
+
+ADR-008 requires a Newman collection covering every OCS endpoint.
+MyDash's 17 routes have no integration coverage today —
+`tests/integration/` does not exist. The only end-to-end visibility
+today is manual QA + CI PHPUnit.
+
+`.github/workflows/code-quality.yml` already declares
+`enable-newman: true` in its reusable-workflow call. The runner picks
+up any `*.postman_collection.json` in `tests/integration/` — there's
+just no file to run.
+
+## Scope
+
+Add `tests/integration/mydash.postman_collection.json` covering
+**all 17 routes** across the 7 controllers:
+
+- **Health + Metrics** (public / admin) — 2 endpoints
+- **Dashboard API** — 6 endpoints (list, getActive, create, update,
+  delete, activate)
+- **Tile API** — 3+ endpoints (full CRUD shape TBD by audit of
+  `TileApiController`)
+- **Widget API** — 4 endpoints (addWidget, addTile, updateWidget,
+  removeWidget)
+- **Rule API** — 4 endpoints (list, create, update, delete)
+- **Admin** — admin-only endpoints
+
+Assertions follow the app-versions precedent:
+- Happy-path status code + shape of the OCS envelope
+- Admin-only endpoints: 403 for non-admin callers
+- Destructive endpoints (`DELETE` / `POST /activate`) are exercised
+  against a fresh fixture dashboard created in the same collection
+  run, then cleaned up — no test pollution
+- App-store / external-HTTP endpoints accept soft status codes
+  (200/502/503) so CI without egress still passes the build
+
+## Not in scope
+
+- UI end-to-end tests (Playwright). That's ADR-008's E2E deliverable,
+  a separate effort.
+- Load / perf testing.
+- Mutation testing.
+
+## Acceptance
+
+1. `tests/integration/mydash.postman_collection.json` exists with ≥ 17
+   request definitions.
+2. Each request has ≥ 2 assertions (status code + payload shape).
+3. `tests/integration/README.md` documents the local-run command and
+   env-placeholder credentials (`base_url`, `admin_user`,
+   `admin_password`, `member_user`, `member_password`).
+4. CI's `Code Quality → Integration Tests (Newman)` job runs green on
+   the PR.

--- a/openspec/changes/newman-integration-suite-2026-04-24/specs/README.md
+++ b/openspec/changes/newman-integration-suite-2026-04-24/specs/README.md
@@ -1,0 +1,13 @@
+# Spec delta — Newman integration collection
+
+This change is **test-infrastructure only**. It does not modify any
+capability's Requirements. The requirements being tested were all
+established by the 10 archived changes under `openspec/changes/archive/`;
+this change adds executable verification for them.
+
+No `<capability>/spec.md` delta — the existing Requirements already
+describe the expected behaviour; the Newman collection simply
+exercises each route and asserts on the behaviour the specs have
+already committed to.
+
+Hence this directory holds only this README.

--- a/openspec/changes/newman-integration-suite-2026-04-24/tasks.md
+++ b/openspec/changes/newman-integration-suite-2026-04-24/tasks.md
@@ -1,0 +1,65 @@
+# Tasks — Newman integration collection
+
+## Task 1: Inventory every route
+
+- [ ] From `appinfo/routes.php`, enumerate every route. Expected
+  count: 17.
+- [ ] Group by controller. For each route, note:
+  - HTTP verb + path
+  - Auth posture (admin-required vs user-required vs public)
+  - Request body shape (from the controller's method signature +
+    docblock)
+  - Expected response shape
+
+## Task 2: Write the collection
+
+- [ ] Create `tests/integration/mydash.postman_collection.json`
+  (Postman 2.1 schema) with collection-level basic auth using
+  `{{admin_user}}` / `{{admin_password}}` variables.
+- [ ] Six folders: `Health + Metrics`, `Dashboards`, `Tiles`,
+  `Widgets`, `Rules`, `Admin`.
+- [ ] Start with `Dashboards / Fixture setup` — POST /api/dashboard
+  capturing `{{fixture_dashboard_id}}`.
+- [ ] Add one request per route. Each request:
+  - Sets `OCS-APIRequest: true` + `Accept: application/json`
+  - Uses `{{fixture_dashboard_id}}` for any dashboard-scoped operations
+  - Carries ≥ 2 test-event assertions per the shapes in design.md
+- [ ] End with `Dashboards / Fixture teardown` — DELETE
+  /api/dashboard/{{fixture_dashboard_id}}.
+
+## Task 3: Member-vs-admin branch tests
+
+- [ ] For every admin-gated endpoint, add a companion request under
+  `Admin / Forbidden for members` that overrides auth to
+  `{{member_user}}` + `{{member_password}}` and asserts 403.
+- [ ] Member-level happy paths (dashboards they own) go in
+  `Dashboards / Member happy path` — at least list + get + update
+  on a member-owned fixture dashboard.
+
+## Task 4: README
+
+- [ ] Create `tests/integration/README.md` with:
+  - Local-run command + env-var names
+  - Fixture-cleanup note (teardown runs at end of Dashboards folder)
+  - Pointer to `.github/workflows/code-quality.yml` for the CI wiring
+  - Guidance: every PR touching a controller MUST update the matching
+    request in this collection
+
+## Task 5: CI verification
+
+- [ ] Confirm `.github/workflows/code-quality.yml` already passes
+  `enable-newman: true`. No wiring change needed if so.
+- [ ] If the reusable quality workflow doesn't provision a second
+  (member-level) user, add a preamble step that creates `regular` /
+  `regular` before Newman runs. Alternatively, scope this change
+  to admin-level tests only and defer member-branch coverage to a
+  follow-up.
+- [ ] Push + wait for the CI run. `Code Quality → Integration Tests
+  (Newman)` must be green.
+
+## Task 6: Docs
+
+- [ ] Update `docs/adr-audit.md` — flip ADR-008 `Newman/Postman
+  collection` row from ❌ to ✅.
+- [ ] Remove the "Newman / Postman integration collection" item
+  from `docs/adr-audit.md`'s follow-ups list.

--- a/openspec/changes/spec-annotation-pass-2026-04-24/design.md
+++ b/openspec/changes/spec-annotation-pass-2026-04-24/design.md
@@ -1,0 +1,96 @@
+# Design — `@spec` annotation pass
+
+## Approach
+
+This is a mechanical follow-up to an already-completed coverage scan.
+The scan (`openspec/coverage-report.md`, 2026-04-24) emitted
+`coverage-report.json` — a machine-readable classification that the
+`/opsx-annotate mydash` skill consumes.
+
+Procedure:
+
+1. Load `coverage-report.json`.
+2. For each Bucket 1 entry (61 methods):
+   - Open the file at `entry.file`.
+   - Add a file-level `@spec` tag in the main docblock if not present,
+     pointing at the primary capability (first Requirement reference).
+   - Add a method-level `@spec` tag above the declaration of the
+     method at `entry.method`. Format:
+     `@spec openspec/specs/<capability>/spec.md#requirement-<slug>`.
+3. For each Bucket 2b entry (5 methods in `legacy-widget-bridge` —
+   specs landed by PR #23):
+   - Same as Bucket 1, referencing the `legacy-widget-bridge` spec.
+4. Resolve the 3 NEEDS-REVIEW flags (see below).
+5. Skip plumbing (9 methods).
+
+## NEEDS-REVIEW decisions
+
+### `DashboardResolver::getEffectivePermissionLevel` vs
+### `PermissionService::getEffectivePermissionLevel`
+
+Both methods compute the same thing (effective permission for a
+user+dashboard pair). The coverage scan's confidence dropped because
+the duplication makes ownership ambiguous.
+
+**Proposed call**: both methods own the same Requirement —
+`permissions/spec.md#requirement-effective-permission-level`. The
+`DashboardResolver` variant is a facade that delegates to
+`PermissionService` (grep confirms); tag both with `@spec` pointing at
+the same Requirement. Mark `DashboardResolver`'s copy as a
+"delegating thin wrapper" in its docblock so future readers know
+the authoritative implementation lives in `PermissionService`.
+
+### `MyDashAdmin::getForm` + `MyDashAdminSection::getID`
+
+These are `OCP\Settings\ISettings` / `OCP\Settings\IIconSection`
+interface implementations — required by Nextcloud for admin UI
+registration. They're pure boilerplate and don't implement domain
+behaviour.
+
+**Proposed call**: treat as **plumbing** (skip annotation). Document
+in the file-level docblock: "Nextcloud admin-UI registration
+boilerplate; behaviour defined by OCP\Settings contracts, not a
+MyDash spec." This matches how `app-versions` handled its
+`Application::__construct` (Nextcloud framework hook, no `@spec`).
+
+## Format convention
+
+File-level tag (in the main PHPDoc docblock, after `@link`):
+
+```php
+ * @link     https://conduction.nl
+ *
+ * @spec openspec/specs/dashboards/spec.md
+ */
+```
+
+Method-level tag (in the method's PHPDoc, last before attributes):
+
+```php
+    /**
+     * List all dashboards for the current user.
+     *
+     * @return JSONResponse
+     *
+     * @spec openspec/specs/dashboards/spec.md#requirement-list-user-dashboards
+     */
+    #[NoAdminRequired]
+    public function list(): JSONResponse
+```
+
+Format matches the app-versions precedent
+(`openspec/specs/version-management/spec.md#requirement-list-installed-apps`)
+and the 2 retrofit commits that already landed on this repo
+(`@spec openspec/changes/archive/2026-04-24-retrofit-legacy-widget-bridge/tasks.md#task-1`).
+
+## Risk
+
+- **Anchor drift**: markdown-anchor format for Requirement headings
+  depends on heading capitalisation + bracketed tier. Verify the
+  anchors resolve in rendered Docusaurus output before merging.
+- **Coverage-scan staleness**: the scan was 2026-04-24. If significant
+  code landed between then and this change merging, re-run
+  `/opsx-coverage-scan` first.
+- **NEEDS-REVIEW decision bleed**: the two decisions above MUST land
+  in design.md before tasks.md executes, so the builder doesn't
+  improvise.

--- a/openspec/changes/spec-annotation-pass-2026-04-24/proposal.md
+++ b/openspec/changes/spec-annotation-pass-2026-04-24/proposal.md
@@ -1,0 +1,61 @@
+# `@spec` annotation pass across `lib/`
+
+Closes the ADR-003 `@spec` tag gap flagged in
+[`docs/adr-audit.md`](../../../docs/adr-audit.md). MyDash has **zero**
+`@spec` PHPDoc tags across 64 PHP files and ~215 public methods today.
+
+## Why now
+
+The coverage scan at `openspec/coverage-report.md` (2026-04-24) has
+already done the hard classification work:
+
+- **Bucket 1** — 61 methods matched cleanly to existing Requirements
+  across 9 capability specs. Confidence ≥ 0.75 for all; ready to
+  annotate mechanically.
+- **Bucket 2a** — 4 methods in a `dashboards` cluster need the
+  existing `dashboards` spec extended first (separate change — not
+  this one).
+- **Bucket 2b** — 5 methods in a `legacy-widget-bridge` cluster;
+  **already specced** and landed by PR #23 (retrofit commit), so the
+  5 methods here get `@spec` tags in this pass too.
+- **Plumbing** — 9 methods that don't need specs (constructors,
+  getters, framework hooks).
+
+Three NEEDS-REVIEW flags from the coverage report (listed below)
+require human judgement before annotation — this change proposes the
+call for each.
+
+## Scope
+
+- Run `/opsx-annotate mydash` against the 61 Bucket 1 methods +
+  5 Bucket 2b methods (from the retrofit that just landed) — 66 methods
+  total.
+- Resolve the 3 `NEEDS-REVIEW` flags:
+  - `DashboardResolver::getEffectivePermissionLevel` (0.80) — duplicates
+    same method in `PermissionService`. Decide: does it belong to
+    `permissions` spec (most likely) or `dashboards` (delegator
+    pattern)?
+  - `MyDashAdmin::getForm` (0.80) + `MyDashAdminSection::getID` (0.75) —
+    admin-UI-registration boilerplate. Decide: extend `admin-settings`
+    spec with a new Requirement, or treat as plumbing (skip).
+- Add file-level `@spec` tags pointing at each file's owning
+  capability; method-level `@spec` tags pointing at the specific
+  Requirement (format:
+  `openspec/specs/<capability>/spec.md#requirement-<slug>`).
+- Update `docs/adr-audit.md` — flip ADR-003 `@spec` row from ❌ to ✅.
+
+## Not in scope
+
+- New capability specs. Bucket 2a (`dashboards` extension) is a
+  separate change.
+- Behaviour changes. This is annotation-only — no code logic touched.
+- The 9 "plumbing" methods are skipped by design.
+
+## Acceptance
+
+1. `grep -rc '@spec' lib/` reports ≥ 75 hits (66 methods + ~10
+   file-level tags).
+2. The 3 NEEDS-REVIEW flags are resolved with a decision recorded in
+   design.md.
+3. `docs/adr-audit.md` reflects the new compliance status.
+4. No diff in behaviour — `composer test:unit` is green.

--- a/openspec/changes/spec-annotation-pass-2026-04-24/specs/README.md
+++ b/openspec/changes/spec-annotation-pass-2026-04-24/specs/README.md
@@ -1,0 +1,21 @@
+# Spec delta — `@spec` annotation pass
+
+This change is **annotation-only**. It does not modify any capability
+spec's Requirements. It only adds PHPDoc `@spec` tags to 66 methods
+across 17 files, pointing at the already-landed Requirements in:
+
+- `openspec/specs/admin-settings/spec.md`
+- `openspec/specs/admin-templates/spec.md`
+- `openspec/specs/conditional-visibility/spec.md`
+- `openspec/specs/dashboards/spec.md`
+- `openspec/specs/grid-layout/spec.md`
+- `openspec/specs/permissions/spec.md`
+- `openspec/specs/prometheus-metrics/spec.md`
+- `openspec/specs/tiles/spec.md`
+- `openspec/specs/widgets/spec.md`
+- `openspec/changes/archive/2026-04-24-retrofit-legacy-widget-bridge/specs/version-management/spec.md`
+  (retrofit destination — Bucket 2b methods)
+
+No new Requirements, no modifications. Hence this directory holds no
+`<capability>/spec.md` delta file — this README documents the
+annotation-only nature of the change explicitly.

--- a/openspec/changes/spec-annotation-pass-2026-04-24/tasks.md
+++ b/openspec/changes/spec-annotation-pass-2026-04-24/tasks.md
@@ -1,0 +1,53 @@
+# Tasks — `@spec` annotation pass
+
+## Task 1: Refresh the coverage scan if stale
+
+- [ ] Check `openspec/coverage-report.md` header — if the scan date
+  is more than 14 days before the PR is built, re-run
+  `/opsx-coverage-scan mydash` to regenerate.
+- [ ] Confirm `coverage-report.json` sidecar exists and parses.
+
+## Task 2: Annotate Bucket 1 (61 methods)
+
+- [ ] Run `/opsx-annotate mydash --bucket 1 --write`.
+- [ ] The skill adds `@spec` tags on method docblocks + file-level
+  tags where missing. Commit with message
+  `spec(annotate): bucket 1 — 61 methods via opsx-annotate`.
+
+## Task 3: Annotate Bucket 2b (5 methods in legacy-widget-bridge)
+
+- [ ] Run `/opsx-annotate mydash --cluster legacy-widget-bridge
+  --write`.
+- [ ] These methods were specced by PR #23 (retrofit, archived at
+  `openspec/changes/archive/2026-04-24-retrofit-legacy-widget-bridge/`).
+  Tags point at the archive's `tasks.md#task-1`, consistent with
+  app-versions precedent.
+
+## Task 4: Resolve NEEDS-REVIEW flags per design.md
+
+- [ ] `DashboardResolver::getEffectivePermissionLevel` — annotate with
+  `@spec openspec/specs/permissions/spec.md#requirement-effective-permission-level`
+  + add a docblock note naming `PermissionService` as the authoritative
+  implementation.
+- [ ] `PermissionService::getEffectivePermissionLevel` — same
+  `@spec` target.
+- [ ] `MyDashAdmin::getForm` + `MyDashAdminSection::getID` — skip,
+  add docblock comment "Nextcloud admin-UI registration boilerplate"
+  instead of `@spec`.
+
+## Task 5: Verification
+
+- [ ] `grep -rc '@spec' lib/` ≥ 75.
+- [ ] `composer test:unit` green.
+- [ ] `composer check:strict` green (including phpcs — tags must match
+  PHPDoc style).
+- [ ] Rendered Docusaurus links in the 66 method tags resolve (spot-
+  check 5 across different capabilities).
+
+## Task 6: Docs
+
+- [ ] Update `docs/adr-audit.md` — flip ADR-003 `@spec` row from ❌ to ✅.
+- [ ] Remove the "`@spec` annotation pass" item from the follow-ups
+  section of `docs/adr-audit.md`.
+- [ ] Re-run `opsx-coverage-scan mydash` at the end; confirm Bucket 1
+  count drops to 0 or matches only plumbing methods.

--- a/sbom.cdx.json
+++ b/sbom.cdx.json
@@ -2,10 +2,10 @@
   "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.5",
-  "serialNumber": "urn:uuid:5ee74da4-b04e-46fe-aed5-0e55fa312c8f",
+  "serialNumber": "urn:uuid:63778652-7d92-4d43-894d-552f1737e964",
   "version": 1,
   "metadata": {
-    "timestamp": "2026-04-30T20:22:12Z",
+    "timestamp": "2026-04-30T21:15:36Z",
     "tools": [
       {
         "name": "composer",
@@ -82,10 +82,10 @@
       }
     ],
     "component": {
-      "bom-ref": "mydash/mydash-dev-feature/impl-fork-current-as-personal",
+      "bom-ref": "mydash/mydash-dev-feature/template-and-adr-cleanup",
       "type": "application",
       "name": "mydash",
-      "version": "dev-feature/impl-fork-current-as-personal",
+      "version": "dev-feature/template-and-adr-cleanup",
       "group": "mydash",
       "description": "Enhanced dashboard with grid layout and admin controls for Nextcloud",
       "author": "MyDash Contributors",
@@ -96,15 +96,15 @@
           }
         }
       ],
-      "purl": "pkg:composer/mydash/mydash@dev-feature/impl-fork-current-as-personal",
+      "purl": "pkg:composer/mydash/mydash@dev-feature/template-and-adr-cleanup",
       "properties": [
         {
           "name": "cdx:composer:package:distReference",
-          "value": "61bf45da1f763733e53dd02389928eb6d20f9813"
+          "value": "462587d3c7c5821c665e2956c06183e57fafbabc"
         },
         {
           "name": "cdx:composer:package:sourceReference",
-          "value": "61bf45da1f763733e53dd02389928eb6d20f9813"
+          "value": "462587d3c7c5821c665e2956c06183e57fafbabc"
         },
         {
           "name": "cdx:composer:package:type",
@@ -114,163 +114,6 @@
     }
   },
   "components": [
-    {
-      "bom-ref": "brick/math-0.13.1.0",
-      "type": "library",
-      "name": "math",
-      "version": "0.13.1",
-      "group": "brick",
-      "description": "Arbitrary-precision arithmetic library",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT"
-          }
-        }
-      ],
-      "purl": "pkg:composer/brick/math@0.13.1",
-      "externalReferences": [
-        {
-          "type": "distribution",
-          "url": "https://api.github.com/repos/brick/math/zipball/fc7ed316430118cc7836bf45faff18d5dfc8de04",
-          "comment": "dist reference: fc7ed316430118cc7836bf45faff18d5dfc8de04"
-        },
-        {
-          "type": "vcs",
-          "url": "https://github.com/brick/math.git",
-          "comment": "source reference: fc7ed316430118cc7836bf45faff18d5dfc8de04"
-        },
-        {
-          "type": "issue-tracker",
-          "url": "https://github.com/brick/math/issues",
-          "comment": "as detected from Composer manifest 'support.issues'"
-        },
-        {
-          "type": "vcs",
-          "url": "https://github.com/brick/math/tree/0.13.1",
-          "comment": "as detected from Composer manifest 'support.source'"
-        }
-      ],
-      "properties": [
-        {
-          "name": "cdx:composer:package:distReference",
-          "value": "fc7ed316430118cc7836bf45faff18d5dfc8de04"
-        },
-        {
-          "name": "cdx:composer:package:sourceReference",
-          "value": "fc7ed316430118cc7836bf45faff18d5dfc8de04"
-        },
-        {
-          "name": "cdx:composer:package:type",
-          "value": "library"
-        }
-      ]
-    },
-    {
-      "bom-ref": "ramsey/collection-2.1.1.0",
-      "type": "library",
-      "name": "collection",
-      "version": "2.1.1",
-      "group": "ramsey",
-      "description": "A PHP library for representing and manipulating collections.",
-      "author": "Ben Ramsey",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT"
-          }
-        }
-      ],
-      "purl": "pkg:composer/ramsey/collection@2.1.1",
-      "externalReferences": [
-        {
-          "type": "distribution",
-          "url": "https://api.github.com/repos/ramsey/collection/zipball/344572933ad0181accbf4ba763e85a0306a8c5e2",
-          "comment": "dist reference: 344572933ad0181accbf4ba763e85a0306a8c5e2"
-        },
-        {
-          "type": "vcs",
-          "url": "https://github.com/ramsey/collection.git",
-          "comment": "source reference: 344572933ad0181accbf4ba763e85a0306a8c5e2"
-        },
-        {
-          "type": "issue-tracker",
-          "url": "https://github.com/ramsey/collection/issues",
-          "comment": "as detected from Composer manifest 'support.issues'"
-        },
-        {
-          "type": "vcs",
-          "url": "https://github.com/ramsey/collection/tree/2.1.1",
-          "comment": "as detected from Composer manifest 'support.source'"
-        }
-      ],
-      "properties": [
-        {
-          "name": "cdx:composer:package:distReference",
-          "value": "344572933ad0181accbf4ba763e85a0306a8c5e2"
-        },
-        {
-          "name": "cdx:composer:package:sourceReference",
-          "value": "344572933ad0181accbf4ba763e85a0306a8c5e2"
-        },
-        {
-          "name": "cdx:composer:package:type",
-          "value": "library"
-        }
-      ]
-    },
-    {
-      "bom-ref": "ramsey/uuid-4.9.2.0",
-      "type": "library",
-      "name": "uuid",
-      "version": "4.9.2",
-      "group": "ramsey",
-      "description": "A PHP library for generating and working with universally unique identifiers (UUIDs).",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT"
-          }
-        }
-      ],
-      "purl": "pkg:composer/ramsey/uuid@4.9.2",
-      "externalReferences": [
-        {
-          "type": "distribution",
-          "url": "https://api.github.com/repos/ramsey/uuid/zipball/8429c78ca35a09f27565311b98101e2826affde0",
-          "comment": "dist reference: 8429c78ca35a09f27565311b98101e2826affde0"
-        },
-        {
-          "type": "vcs",
-          "url": "https://github.com/ramsey/uuid.git",
-          "comment": "source reference: 8429c78ca35a09f27565311b98101e2826affde0"
-        },
-        {
-          "type": "issue-tracker",
-          "url": "https://github.com/ramsey/uuid/issues",
-          "comment": "as detected from Composer manifest 'support.issues'"
-        },
-        {
-          "type": "vcs",
-          "url": "https://github.com/ramsey/uuid/tree/4.9.2",
-          "comment": "as detected from Composer manifest 'support.source'"
-        }
-      ],
-      "properties": [
-        {
-          "name": "cdx:composer:package:distReference",
-          "value": "8429c78ca35a09f27565311b98101e2826affde0"
-        },
-        {
-          "name": "cdx:composer:package:sourceReference",
-          "value": "8429c78ca35a09f27565311b98101e2826affde0"
-        },
-        {
-          "name": "cdx:composer:package:type",
-          "value": "library"
-        }
-      ]
-    },
     {
       "type": "library",
       "name": "helper-string-parser",
@@ -17921,23 +17764,7 @@
   ],
   "dependencies": [
     {
-      "ref": "brick/math-0.13.1.0"
-    },
-    {
-      "ref": "ramsey/collection-2.1.1.0"
-    },
-    {
-      "ref": "ramsey/uuid-4.9.2.0",
-      "dependsOn": [
-        "brick/math-0.13.1.0",
-        "ramsey/collection-2.1.1.0"
-      ]
-    },
-    {
-      "ref": "mydash/mydash-dev-feature/impl-fork-current-as-personal",
-      "dependsOn": [
-        "ramsey/uuid-4.9.2.0"
-      ]
+      "ref": "mydash/mydash-dev-feature/template-and-adr-cleanup"
     }
   ]
 }

--- a/src/components/DashboardSwitcher.vue
+++ b/src/components/DashboardSwitcher.vue
@@ -17,7 +17,7 @@
 </template>
 
 <script>
-import { NcSelect } from '@nextcloud/vue'
+import { NcSelect } from '@conduction/nextcloud-vue'
 
 export default {
 	name: 'DashboardSwitcher',

--- a/src/components/TileCard.vue
+++ b/src/components/TileCard.vue
@@ -51,7 +51,7 @@
 </template>
 
 <script>
-import { NcButton } from '@nextcloud/vue'
+import { NcButton } from '@conduction/nextcloud-vue'
 import { generateUrl } from '@nextcloud/router'
 import Pencil from 'vue-material-design-icons/Pencil.vue'
 import Close from 'vue-material-design-icons/Close.vue'

--- a/src/components/TileEditor.vue
+++ b/src/components/TileEditor.vue
@@ -133,7 +133,7 @@
 </template>
 
 <script>
-import { NcModal, NcButton, NcTextField, NcSelect, NcColorPicker } from '@nextcloud/vue'
+import { NcModal, NcButton, NcTextField, NcSelect, NcColorPicker } from '@conduction/nextcloud-vue'
 import {
 	mdiFile,
 	mdiFolder,

--- a/src/components/WidgetPicker.vue
+++ b/src/components/WidgetPicker.vue
@@ -167,7 +167,7 @@
 </template>
 
 <script>
-import { NcButton, NcTextField, NcEmptyContent } from '@nextcloud/vue'
+import { NcButton, NcTextField, NcEmptyContent } from '@conduction/nextcloud-vue'
 import Close from 'vue-material-design-icons/Close.vue'
 import Magnify from 'vue-material-design-icons/Magnify.vue'
 import Plus from 'vue-material-design-icons/Plus.vue'

--- a/src/components/WidgetRenderer.vue
+++ b/src/components/WidgetRenderer.vue
@@ -50,7 +50,7 @@
 </template>
 
 <script>
-import { NcDashboardWidget, NcEmptyContent, NcLoadingIcon } from '@nextcloud/vue'
+import { NcDashboardWidget, NcEmptyContent, NcLoadingIcon } from '@conduction/nextcloud-vue'
 import AlertCircleOutline from 'vue-material-design-icons/AlertCircleOutline.vue'
 import { mapActions, storeToRefs } from 'pinia'
 import { useWidgetStore } from '../stores/widgets.js'

--- a/src/components/WidgetStyleEditor.vue
+++ b/src/components/WidgetStyleEditor.vue
@@ -124,7 +124,7 @@ import {
 	NcSelect,
 	NcColorPicker,
 	NcCheckboxRadioSwitch,
-} from '@nextcloud/vue'
+} from '@conduction/nextcloud-vue'
 import {
 	mdiFile,
 	mdiFolder,

--- a/src/components/WidgetWrapper.vue
+++ b/src/components/WidgetWrapper.vue
@@ -51,7 +51,7 @@
 </template>
 
 <script>
-import { NcButton } from '@nextcloud/vue'
+import { NcButton } from '@conduction/nextcloud-vue'
 import Cog from 'vue-material-design-icons/Cog.vue'
 import WidgetRenderer from './WidgetRenderer.vue'
 

--- a/src/components/admin/AdminSettings.vue
+++ b/src/components/admin/AdminSettings.vue
@@ -172,7 +172,7 @@ import {
 	NcCheckboxRadioSwitch,
 	NcEmptyContent,
 	NcModal,
-} from '@nextcloud/vue'
+} from '@conduction/nextcloud-vue'
 import Plus from 'vue-material-design-icons/Plus.vue'
 import ViewDashboard from 'vue-material-design-icons/ViewDashboard.vue'
 import { api } from '../../services/api.js'

--- a/tests/Unit/Db/AdminSettingTest.php
+++ b/tests/Unit/Db/AdminSettingTest.php
@@ -8,9 +8,6 @@
  * @author    Conduction b.v. <info@conduction.nl>
  * @copyright 2024 Conduction b.v.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
- *
- * SPDX-FileCopyrightText: 2024 MyDash Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/tests/Unit/Db/ConditionalRuleTest.php
+++ b/tests/Unit/Db/ConditionalRuleTest.php
@@ -8,9 +8,6 @@
  * @author    Conduction b.v. <info@conduction.nl>
  * @copyright 2024 Conduction b.v.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
- *
- * SPDX-FileCopyrightText: 2024 MyDash Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/tests/Unit/Db/DashboardTest.php
+++ b/tests/Unit/Db/DashboardTest.php
@@ -12,9 +12,6 @@
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @version   GIT:auto
  * @link      https://conduction.nl
- *
- * SPDX-FileCopyrightText: 2024 MyDash Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/tests/Unit/Db/TileTest.php
+++ b/tests/Unit/Db/TileTest.php
@@ -12,9 +12,6 @@
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @version   GIT:auto
  * @link      https://conduction.nl
- *
- * SPDX-FileCopyrightText: 2024 MyDash Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/tests/Unit/Db/WidgetPlacementTest.php
+++ b/tests/Unit/Db/WidgetPlacementTest.php
@@ -8,9 +8,6 @@
  * @author    Conduction b.v. <info@conduction.nl>
  * @copyright 2024 Conduction b.v.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
- *
- * SPDX-FileCopyrightText: 2024 MyDash Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/tests/Unit/Service/AdminSettingsServiceTest.php
+++ b/tests/Unit/Service/AdminSettingsServiceTest.php
@@ -8,9 +8,6 @@
  * @author    Conduction b.v. <info@conduction.nl>
  * @copyright 2024 Conduction b.v.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
- *
- * SPDX-FileCopyrightText: 2024 MyDash Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/tests/Unit/Service/DashboardFactoryTest.php
+++ b/tests/Unit/Service/DashboardFactoryTest.php
@@ -8,9 +8,6 @@
  * @author    Conduction b.v. <info@conduction.nl>
  * @copyright 2024 Conduction b.v.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
- *
- * SPDX-FileCopyrightText: 2024 MyDash Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/tests/Unit/Service/VisibilityCheckerTest.php
+++ b/tests/Unit/Service/VisibilityCheckerTest.php
@@ -8,9 +8,6 @@
  * @author    Conduction b.v. <info@conduction.nl>
  * @copyright 2024 Conduction b.v.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
- *
- * SPDX-FileCopyrightText: 2024 MyDash Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);


### PR DESCRIPTION
## Summary

Template + ADR audit pass on MyDash. Consolidates 6 in-flight feature PRs into `development` first (via admin-merge), then applies focused fixes for the real gaps the audit surfaced.

No mega-refactor — MyDash was already mostly template-aligned (full QA tooling, 9 Conduction workflows, complete i18n, Docusaurus, 10 archived openspec changes). This PR closes the specific findings, not the whole 26-commit template cycle done for app-versions.

## Pre-PR: in-flight consolidation

Admin-merged into `development` before starting:
- #12 fix/ci-quality-checks
- #22 fix/header-info-email
- #13 chore/gitignore-cleanup
- #14 chore/openspec-config
- #23 retrofit/legacy-widget-bridge
- #21 feature/i18n-complete-translations

Closed #20 (chore/19/harmonize-gitignore) as superseded by #13 + #14.

## Commits in this PR (7 of them)

| # | Commit | Scope |
|---|---|---|
| 1 | `refactor(PageController): Inject IDashboardManager via constructor (ADR-003)` | The **one** `\OC::$server->get()` escape in `lib/`. Constructor DI now consistent across every controller + service. |
| 2 | `fix(security): Stop leaking exception messages to API clients (ADR-005)` | `ResponseHelper::error()` was returning `$exception->getMessage()` to the client — stack-trace / internal-error leakage. Now returns generic `'Operation failed'`. Signature extended with optional `?LoggerInterface $logger` + `string $message` so callers keep server-side visibility. 20 call sites unchanged. |
| 3 | `fix(licence): Remove contradictory AGPL SPDX block from 72 PHP files (ADR-014)` | Every PHP file declared BOTH `@license EUPL-1.2` (PHPDoc) AND `SPDX-License-Identifier: AGPL-3.0-or-later` (SPDX block). Removed the AGPL block; PHPDoc + REUSE.toml (next commit) are now the single source. |
| 4 | `refactor(frontend): @nextcloud/vue → @conduction/nextcloud-vue (ADR-004)` | 9 Vue files had direct `@nextcloud/vue` imports. All route through `@conduction/nextcloud-vue` now. |
| 5 | `chore: Add REUSE.toml + bump Nextcloud max-version to 34` | Machine-readable REUSE compliance declaration. info.xml max-version 33 → 34 (template supports 34). |
| 6 | `docs: Add architecture, ADR index, ADR compliance audit` | Three new Docusaurus pages: `architecture.md` (component map, request flow, auth + DI posture), `adr/README.md` (ADR index + why app repos don't duplicate hydra), `adr-audit.md` (per-ADR compliance matrix: 25 ✅ / 4 ⚠️ / 2 ❌ / 14 N/A). |
| 7 | `spec: Two OpenSpec changes for the remaining ADR gaps` | Converts the two ❌ items into `openspec/changes/` entries Hydra can pick up: `spec-annotation-pass-2026-04-24` (66-method `@spec` tag pass) + `newman-integration-suite-2026-04-24` (17-endpoint Postman collection). |

## ADRs addressed

| ADR | Before | After |
|---|---|---|
| 003 Backend DI | 1 `\OC::$server->get()` escape | 0 — grep clean |
| 004 Frontend wrappers | 9 direct `@nextcloud/vue` imports | 0 — all via `@conduction/nextcloud-vue` |
| 005 Security (error leakage) | `$e->getMessage()` returned to client | generic message + optional server-side log |
| 014 Licensing | EUPL-1.2 PHPDoc + contradictory AGPL SPDX on 72 files | single source: EUPL-1.2 PHPDoc + REUSE.toml |

Full matrix in [`docs/adr-audit.md`](docs/adr-audit.md).

## Follow-ups (filed separately as openspec changes)

1. **`@spec` annotation pass** — 66 methods × 9 capabilities. The coverage scan already did the classification. `/opsx-annotate mydash` + the 3 NEEDS-REVIEW decisions (design.md spells them out).
2. **Newman integration collection** — `tests/integration/mydash.postman_collection.json` covering all 17 endpoints with fixture setup/teardown pattern.

Both will be opened as GitHub issues after this PR merges so Hydra can dispatch.

## Audit false-alarm correction

The two-agent audit initially surfaced an IDOR claim on `DashboardApiController::update()`. Verified false — agent 2 stopped at the controller-level `$this->userId !== null` null-check and missed `$this->permissionService->canEditDashboard(userId, dashboardId)` right after. Also traced through to the service layer: `DashboardService::deleteDashboard` checks `$dashboard->getUserId() !== $userId` and throws `'Access denied'` before any mutation. Ownership is enforced consistently — audit updated to reflect.

## Test plan

- [ ] `composer install` succeeds
- [ ] `composer check:strict` green (phpcs + phpmd + phpstan + psalm + phpunit)
- [ ] `npm install && npm run build` succeeds
- [ ] Enable the app in Nextcloud 31–34 — navigation entry renders, admin page loads
- [ ] Create / update / delete a dashboard through the UI — verify no error-message leakage in the browser's Network tab (errors now say `"Operation failed"`)
- [ ] Switch UI language to Dutch — translations still resolve
- [ ] Watch the 9 component imports render correctly (they all depend on `@conduction/nextcloud-vue` being installed)
- [ ] REUSE tooling: `reuse lint` accepts the project