### PR TITLE
Add 25 OpenSpec proposals for multi-tenant dashboard platform

### DIFF
--- a/openspec/changes/active-dashboard-resolution/proposal.md
+++ b/openspec/changes/active-dashboard-resolution/proposal.md
@@ -1,0 +1,57 @@
+# Active-dashboard resolution chain
+
+## Why
+
+Define the deterministic precedence MyDash uses to pick *which* dashboard to render for a user when they open the workspace, given the multi-scope model (`user` / `group_shared` / `default`-group). The existing REQ-DASH-009 ("Dashboard Resolution Chain") covers a one-scope personal-only model. The multi-scope model (introduced by `multi-scope-dashboards` and `default-dashboard-flag`) needs a longer chain that prefers the user's saved preference but falls back through group → default → first. Without a canonical resolver each frontend code path could diverge and pick a different "active" dashboard, producing flicker and confusing users.
+
+## What Changes
+
+- Introduce a per-user pref key `active_dashboard_uuid` that holds the UUID of the dashboard the user last opened (or explicitly pinned).
+- Add `DashboardService::resolveActiveDashboard(string $userId, ?string $primaryGroupId): ?array` that walks a 7-step precedence chain and returns `{dashboard, source}` (or `null` for the empty-state case).
+- The 7-step chain is: (1) saved pref UUID if visible to user, (2) `isDefault=1` group-shared in primary group, (3) `isDefault=1` default-group dashboard, (4) first group-shared in primary group, (5) first group-shared in default group, (6) first personal dashboard, (7) `null`.
+- If the saved pref points to a dashboard the user can no longer see (deleted / removed from group), silently clear the pref on read (write-on-read with WARNING log) and continue down the chain. No error surfaced to the user.
+- The resolver returns `source: 'user' | 'group' | 'default'` so the frontend knows which API endpoint to PUT to on save.
+- Add `POST /api/dashboards/active` write endpoint accepting `{uuid: string}` so the frontend can persist the user's choice on switch. Empty string clears the pref. No existence check on write — the resolver's stale-preference path handles invalid UUIDs.
+- `WorkspaceController` calls the resolver and pushes `activeDashboardId` + `dashboardSource` into initial state on first render.
+- Frontend `useDashboardsStore.resolveActive()` mirrors the precedence so client-side `switchDashboard()` picks consistently after store mutations.
+
+## Capabilities
+
+### New Capabilities
+
+(none — the feature folds into the existing `dashboards` capability)
+
+### Modified Capabilities
+
+- `dashboards`: adds REQ-DASH-018 (active-dashboard resolution chain — multi-scope) and REQ-DASH-019 (persist active-dashboard preference). Existing REQ-DASH-001..017 are untouched. REQ-DASH-009 (the one-scope chain) remains in force for callers that ask for a personal-only resolution; the new REQ-DASH-018 is the workspace-level resolver.
+
+## Impact
+
+**Affected code:**
+
+- `lib/Service/DashboardService.php` — add `resolveActiveDashboard(string $userId, ?string $primaryGroupId): ?array`, `setActivePreference(string $userId, string $uuid): void`, and the `ACTIVE_DASHBOARD_UUID_PREF_KEY` constant
+- `lib/Controller/DashboardController.php` — add `setActiveDashboard()` mapped to `POST /api/dashboards/active`
+- `lib/Controller/WorkspaceController.php` — call the resolver and push `activeDashboardId` + `dashboardSource` into initial-state JSON on first render
+- `appinfo/routes.php` — register `POST /api/dashboards/active`
+- `src/stores/dashboards.js` — frontend mirror of the precedence; `resolveActive()` getter; `switchDashboard(uuid)` action POSTs to the new endpoint
+
+**Affected APIs:**
+
+- 1 new route (`POST /api/dashboards/active`)
+- No existing routes changed — `GET /api/dashboards/visible` (REQ-DASH-013) is unchanged and is the source of truth for "what dashboards can the user see"
+
+**Dependencies:**
+
+- `OCP\IConfig::setUserValue` / `getUserValue` — already injected elsewhere, used to persist the per-user preference
+- No new composer or npm dependencies
+
+**Migration:**
+
+- Zero schema impact: the preference lives in `oc_preferences` via `IConfig`. No new table or column.
+- No data backfill required: missing preference is treated as "no saved choice" and the chain falls through to step 2.
+
+## Notes
+
+- Resolver MUST be pure (no side effects on read) except the silent pref-cleanup when the saved id is invalid. That cleanup is observable in REQ-DASH-018 scenario "stale preference is silently cleared".
+- We deliberately chose a single `oc_preferences` key over the alternative of repurposing the per-user `isActive` boolean flag because group-shared dashboards have no per-user row to flip — the pref key works uniformly across all three scopes.
+- Stale prefs are cleaned per-request, not via cron — the load on `IConfig::deleteUserValue` is bounded by login frequency. If this becomes a hotspot we can revisit with a background job in a follow-up change.

--- a/openspec/changes/active-dashboard-resolution/specs/dashboards/spec.md
+++ b/openspec/changes/active-dashboard-resolution/specs/dashboards/spec.md
@@ -1,0 +1,86 @@
+---
+capability: dashboards
+delta: true
+status: draft
+---
+
+# Dashboards — Delta from change `active-dashboard-resolution`
+
+## ADDED Requirements
+
+### Requirement: REQ-DASH-018 Active-dashboard resolution chain (multi-scope)
+
+When the workspace page renders for a user, the system MUST resolve which dashboard is "active" by walking the following precedence and stopping at the first match:
+
+1. The dashboard whose UUID equals the user's `active_dashboard_uuid` preference, IF that dashboard is currently visible to the user (per REQ-DASH-013).
+2. The `group_shared` dashboard with `isDefault = 1` in the user's primary group (per `group-routing` change, REQ-TMPL-012).
+3. The `group_shared` dashboard with `isDefault = 1` in the synthetic `'default'` group.
+4. The first `group_shared` dashboard (by `sortOrder` ascending, then `createdAt`) in the user's primary group.
+5. The first `group_shared` dashboard in the `'default'` group.
+6. The user's first personal `user`-type dashboard (by `sortOrder`, then `createdAt`).
+7. `null` — the workspace page MUST then render an empty-state with a "Create your first dashboard" affordance.
+
+The resolver MUST attach a `source` field to the returned dashboard descriptor with one of `'user'`, `'group'`, `'default'`.
+
+#### Scenario: Honoured user preference
+
+- GIVEN user "alice" has `active_dashboard_uuid` set to `<X.uuid>`
+- AND `X` is a personal dashboard owned by alice
+- WHEN she opens the workspace page
+- THEN the resolved active dashboard MUST be `X` with `source = 'user'`
+
+#### Scenario: Stale preference is silently cleared
+
+- GIVEN user "alice" has `active_dashboard_uuid` set to `<Y.uuid>`
+- AND `Y` has been deleted (or is no longer visible to alice)
+- WHEN she opens the workspace page
+- THEN the resolver MUST clear her `active_dashboard_uuid` preference (set to empty string or unset)
+- AND MUST proceed down the precedence chain
+- AND the response MUST NOT raise an error to the user
+
+#### Scenario: Group default wins over default-group default
+
+- GIVEN user "bob" belongs to group "engineering"
+- AND group "engineering" has a default dashboard `E`
+- AND the `'default'` group also has a default dashboard `D`
+- AND bob has no `active_dashboard_uuid` preference
+- WHEN he opens the workspace page
+- THEN the resolved dashboard MUST be `E` with `source = 'group'`
+
+#### Scenario: Falls through to default group when primary group has no dashboards
+
+- GIVEN user "carol" belongs to group "support" which has zero group-shared dashboards
+- AND the `'default'` group has one default dashboard `D`
+- WHEN she opens the workspace page
+- THEN the resolved dashboard MUST be `D` with `source = 'default'`
+
+#### Scenario: Empty state when no dashboards exist anywhere
+
+- GIVEN a brand-new MyDash install with no dashboards of any type
+- WHEN any user opens the workspace page
+- THEN the resolver MUST return `null`
+- AND the response MUST include `activeDashboardId: ''` in initial state
+- AND the page MUST render the empty-state UI
+
+### Requirement: REQ-DASH-019 Persist active-dashboard preference
+
+The system MUST expose `POST /api/dashboards/active` accepting `{uuid: string}`. On success it MUST persist the value to the user's `active_dashboard_uuid` preference.
+
+#### Scenario: Save preference
+
+- GIVEN user "alice" is logged in
+- WHEN she sends `POST /api/dashboards/active` with body `{"uuid": "abc-123"}`
+- THEN her `active_dashboard_uuid` preference MUST become `"abc-123"`
+- AND the response MUST be HTTP 200 `{status: 'success'}`
+
+#### Scenario: Empty uuid clears the preference
+
+- GIVEN alice has a saved preference
+- WHEN she sends `POST /api/dashboards/active` with body `{"uuid": ""}`
+- THEN her `active_dashboard_uuid` preference MUST be cleared (next page load falls through the chain from step 2)
+
+#### Scenario: No existence check on write
+
+- GIVEN alice sends `POST /api/dashboards/active` with body `{"uuid": "does-not-exist"}`
+- THEN the system MUST accept the write (HTTP 200)
+- NOTE: The resolver's stale-preference path (REQ-DASH-018 scenario "stale preference") will silently clear it on next render. We deliberately do not validate on write to keep the endpoint cheap.

--- a/openspec/changes/active-dashboard-resolution/tasks.md
+++ b/openspec/changes/active-dashboard-resolution/tasks.md
@@ -1,0 +1,52 @@
+# Tasks — active-dashboard-resolution
+
+## 1. Backend resolver
+
+- [ ] 1.1 Add user pref key constant `DashboardService::ACTIVE_DASHBOARD_UUID_PREF_KEY = 'active_dashboard_uuid'`
+- [ ] 1.2 Add `DashboardService::resolveActiveDashboard(string $userId, ?string $primaryGroupId): ?array` returning `['dashboard' => Dashboard, 'source' => 'user'|'group'|'default']` or `null`
+- [ ] 1.3 Implement the 7-step precedence chain exactly as REQ-DASH-018 lists (saved pref → group default → default-group default → first-in-group → first-in-default-group → first personal → null)
+- [ ] 1.4 Implement stale-preference auto-clear: when the saved UUID is not in `findVisibleToUser` results, call `IConfig::deleteUserValue` (write-on-read) and emit a `LoggerInterface::warning` line
+- [ ] 1.5 Resolver MUST be otherwise pure (no other side effects on read)
+
+## 2. Backend write endpoint
+
+- [ ] 2.1 Add `DashboardService::setActivePreference(string $userId, string $uuid): void` that writes to `IConfig::setUserValue` (or deletes when uuid is empty string)
+- [ ] 2.2 Add `DashboardController::setActiveDashboard()` mapped to `POST /api/dashboards/active` with `#[NoAdminRequired]` — accepts `{uuid: string}`, returns HTTP 200 `{status: 'success'}`
+- [ ] 2.3 Register the route in `appinfo/routes.php`
+- [ ] 2.4 No existence check on write (per REQ-DASH-019 scenario "no existence check on write")
+
+## 3. Workspace integration
+
+- [ ] 3.1 Update `WorkspaceController` to call `resolveActiveDashboard($currentUserId, $primaryGroupId)` on first render
+- [ ] 3.2 Push `activeDashboardId` (or `''` when null) and `dashboardSource` into initial-state JSON via `IInitialState`
+- [ ] 3.3 When resolver returns null, ensure the page renders the empty-state UI (per REQ-DASH-018 scenario "empty state")
+
+## 4. Frontend
+
+- [ ] 4.1 Mirror the 7-step precedence in `useDashboardsStore.resolveActive()` for client-side `switchDashboard()` flows after store mutations
+- [ ] 4.2 Add `switchDashboard(uuid)` action that updates store state and POSTs to `/api/dashboards/active` (fire-and-forget; surface failure as a toast but do not block UI)
+- [ ] 4.3 Empty-state component shown when `resolveActive()` returns null — includes a "Create your first dashboard" affordance
+
+## 5. PHPUnit tests
+
+- [ ] 5.1 Table-driven test covering all 7 steps with permutations (saved pref / no pref; group default present / absent; default-group default present / absent; first-in-group present / absent; first personal present / absent; nothing-at-all)
+- [ ] 5.2 Stale preference cleared exactly once per request (not on every visibility check)
+- [ ] 5.3 Cross-group preference invalidated correctly — alice pref points to a dashboard whose group she no longer belongs to
+- [ ] 5.4 `setActivePreference` accepts non-existent UUIDs without erroring (REQ-DASH-019 scenario "no existence check on write")
+- [ ] 5.5 Empty-string uuid clears the preference (REQ-DASH-019 scenario "empty uuid clears the preference")
+
+## 6. Playwright tests
+
+- [ ] 6.1 Empty state shows on a fresh user with no dashboards (any type, any group)
+- [ ] 6.2 Switching dashboard fires `POST /api/dashboards/active` with the new UUID and the next page load picks up the saved choice
+- [ ] 6.3 Stale preference (dashboard deleted between sessions) silently falls through to step 2 of the chain — no error toast
+
+## 7. Quality gates
+
+- [ ] 7.1 `composer check:strict` (PHPCS, PHPMD, Psalm, PHPStan) passes — fix any pre-existing issues encountered along the way
+- [ ] 7.2 ESLint + Stylelint clean on touched Vue/JS files
+- [ ] 7.3 Update generated OpenAPI spec / Postman collection so external API consumers see the new endpoint
+- [ ] 7.4 `i18n` keys for new error messages and the empty-state copy in both `nl` and `en` per the i18n requirement
+- [ ] 7.5 SPDX headers on every new PHP file (inside the docblock per the SPDX-in-docblock convention) — gate-spdx must pass
+- [ ] 7.6 Run all 10 `hydra-gates` locally before opening PR
+- [ ] 7.7 Stale prefs are cleaned per request, not via cron — document the rationale in `design.md` if added (see proposal Notes)

--- a/openspec/changes/allow-personal-dashboards-flag/proposal.md
+++ b/openspec/changes/allow-personal-dashboards-flag/proposal.md
@@ -1,0 +1,29 @@
+# Allow-personal-dashboards flag — runtime gating
+
+The existing REQ-ASET-003 declares the `allow_user_dashboards` setting but does not specify how it gates the personal-dashboard endpoints at runtime. This change adds the gating semantics: when the flag is OFF, every personal-dashboard creation/fork endpoint MUST return 403 with a specific error code so the UI can render a coherent state, and existing personal dashboards MUST remain readable.
+
+## Affected code units
+
+- `lib/Controller/DashboardController.php` — every `POST /api/dashboards`, `POST /api/dashboards/{uuid}/fork`, and `POST /api/dashboards/active` (when target is personal) must check the flag
+- `lib/Service/DashboardService.php` — `getAllowUserDashboards(): bool` becomes a precondition checker
+- `src/views/WorkspaceApp.vue` — hide "+ New Dashboard" button when flag is off
+- `src/views/AdminApp.vue` — toggle wired to `POST /api/admin/settings`
+- Modifies REQ-ASET-003 (which already declares the setting)
+
+## Why a delta to `admin-settings`
+
+The setting itself is already declared. This change formalises:
+1. The exact runtime behaviour when toggled (what 403 means)
+2. The "do not auto-delete" semantics (existing personal dashboards survive, just become read-only-forking-disabled)
+3. The error envelope so the frontend can localise the message
+
+## Approach
+
+- Modify REQ-ASET-003 to declare side effects on personal-dashboard endpoints.
+- Personal dashboards already created remain visible and editable; only **creation/fork** is blocked while the flag is off.
+- Surfaced in initial state as `allowUserDashboards: bool` so the frontend can render appropriate empty states / hide buttons.
+
+## Notes
+
+- Default value is `'0'` (off) — admins must opt in.
+- Toggling off does NOT delete existing personal dashboards. It only blocks new ones. Document this clearly in the admin UI.

--- a/openspec/changes/allow-personal-dashboards-flag/specs/admin-settings/spec.md
+++ b/openspec/changes/allow-personal-dashboards-flag/specs/admin-settings/spec.md
@@ -1,0 +1,84 @@
+---
+capability: admin-settings
+delta: true
+status: draft
+---
+
+# Admin Settings — Delta from change `allow-personal-dashboards-flag`
+
+## MODIFIED Requirements
+
+### Requirement: REQ-ASET-003 Allow User Dashboards Setting (extended runtime gating)
+
+The setting `allow_user_dashboards` (boolean stored as `'0'` / `'1'`, default `'0'`) MUST gate every endpoint that **creates** a personal (`type='user'`) dashboard. Read endpoints, update endpoints, and existing personal dashboards MUST remain accessible regardless of the flag's value. Toggling the flag MUST NOT mutate any dashboard records.
+
+The endpoints listed below MUST evaluate the flag at request time and, when it equals `'0'`, MUST return HTTP 403 with response body `{status: 'error', error: 'personal_dashboards_disabled', message: <translated string>}`:
+
+- `POST /api/dashboards` (when payload omits `type` or sets `type='user'`)
+- `POST /api/dashboards/{uuid}/fork` (always — fork target is always `type='user'`)
+
+Endpoints that MUST NOT check the flag (so existing personal dashboards remain functional):
+
+- `GET /api/dashboards/visible`
+- `GET /api/dashboards/{uuid}`
+- `PUT /api/dashboards/{uuid}` (existing personal dashboard updates)
+- `DELETE /api/dashboards/{uuid}` (users can still clean up their old personal dashboards)
+- `POST /api/dashboards/active`
+- All `group_shared` and `admin_template` endpoints
+
+#### Scenario: Flag off blocks personal dashboard creation
+
+- **GIVEN** admin setting `allow_user_dashboards = '0'`
+- **WHEN** user "alice" sends `POST /api/dashboards` with body `{"name": "My Test"}`
+- **THEN** the system MUST return HTTP 403 with `{status: 'error', error: 'personal_dashboards_disabled', message: 'Personal dashboards are not enabled by your administrator'}`
+
+#### Scenario: Flag off blocks fork
+
+- **GIVEN** admin setting `allow_user_dashboards = '0'`
+- **AND** alice can read group-shared dashboard `S`
+- **WHEN** she sends `POST /api/dashboards/{S.uuid}/fork`
+- **THEN** the system MUST return HTTP 403 with the same `personal_dashboards_disabled` error envelope
+
+#### Scenario: Flag off does not break existing personal dashboards
+
+- **GIVEN** alice has 2 existing personal dashboards `P1`, `P2`
+- **AND** admin toggles `allow_user_dashboards` from `'1'` to `'0'`
+- **WHEN** alice opens the workspace page
+- **THEN** `P1` and `P2` MUST still appear in `GET /api/dashboards/visible`
+- **AND** alice MUST be able to `PUT` and `DELETE` them
+- **AND** alice MUST be able to set either as her active dashboard
+- **AND** only `POST /api/dashboards` and fork endpoints MUST return 403
+
+#### Scenario: Toggling does not destructively mutate data
+
+- **GIVEN** alice has 1 personal dashboard `P1` (active)
+- **AND** admin toggles `allow_user_dashboards` to `'0'` and back to `'1'`
+- **THEN** `P1` MUST still exist with all original fields and placements
+- **AND** `P1.isActive` MUST still be `1` (unchanged)
+- **AND** no rows in `oc_mydash_dashboards` or `oc_mydash_widget_placements` MUST have been touched
+
+#### Scenario: Default value when setting is missing
+
+- **GIVEN** a fresh MyDash install with no row for `allow_user_dashboards` in `oc_mydash_admin_settings`
+- **WHEN** any code reads the setting
+- **THEN** it MUST evaluate to `false` (creation blocked)
+
+## ADDED Requirements
+
+### Requirement: REQ-ASET-015 Initial-state mirror of the flag
+
+The setting's current value MUST be pushed as initial state `allowUserDashboards: bool` on every workspace and admin page render so the frontend can hide the "+ New Dashboard" affordance and the fork button without an extra round-trip.
+
+#### Scenario: Initial state matches setting
+
+- **GIVEN** admin setting `allow_user_dashboards = '1'`
+- **WHEN** any user loads the workspace page
+- **THEN** the page initial state MUST include `allowUserDashboards: true`
+
+#### Scenario: Frontend honours the flag
+
+- **GIVEN** initial state has `allowUserDashboards: false`
+- **WHEN** the workspace renders
+- **THEN** the "+ New Dashboard" button in the sidebar MUST NOT be visible
+- **AND** any "Fork as personal" affordance MUST NOT be visible
+- **AND** attempting to invoke the underlying actions via direct API call MUST still hit the 403 (defense in depth)

--- a/openspec/changes/allow-personal-dashboards-flag/tasks.md
+++ b/openspec/changes/allow-personal-dashboards-flag/tasks.md
@@ -1,0 +1,31 @@
+# Tasks — allow-personal-dashboards-flag
+
+## 1. Backend
+
+- [ ] 1.1 Add `DashboardService::assertPersonalDashboardsAllowed(): void` (throws `PersonalDashboardsDisabledException`)
+- [ ] 1.2 Define `PersonalDashboardsDisabledException` mapping to HTTP 403 with `error: 'personal_dashboards_disabled'`
+- [ ] 1.3 Call assert in `DashboardController::create` (when type=user) and `::fork`
+- [ ] 1.4 Ensure read/update/delete endpoints do NOT call the assert
+- [ ] 1.5 Update `WorkspaceController::index` to push `allowUserDashboards` initial state
+- [ ] 1.6 Update admin endpoints to surface flag in their initial state too
+
+## 2. Frontend
+
+- [ ] 2.1 Hide "+ New Dashboard" sidebar button when `!allowUserDashboards`
+- [ ] 2.2 Hide "Fork to personal" button when `!allowUserDashboards`
+- [ ] 2.3 Surface 403 with `error === 'personal_dashboards_disabled'` as a localised toast
+- [ ] 2.4 Document the toggle's "data is preserved" behaviour in the admin UI helper text
+
+## 3. Tests
+
+- [ ] 3.1 PHPUnit: 403 envelope shape exactly matches REQ-ASET-003 scenario
+- [ ] 3.2 PHPUnit: existing personal dashboards remain readable/editable when flag off
+- [ ] 3.3 PHPUnit: toggling does not mutate data (assert row counts before/after)
+- [ ] 3.4 Playwright: button visibility matches flag state
+- [ ] 3.5 Playwright: direct API call (bypassing UI) still returns 403
+
+## 4. Quality
+
+- [ ] 4.1 `composer check:strict` passes
+- [ ] 4.2 OpenAPI updated with the 403 response variant
+- [ ] 4.3 Translation file entries for `'Personal dashboards are not enabled by your administrator'`

--- a/openspec/changes/custom-icon-upload-pattern/proposal.md
+++ b/openspec/changes/custom-icon-upload-pattern/proposal.md
@@ -1,0 +1,55 @@
+# Custom-icon upload pattern
+
+## Why
+
+MyDash currently lets administrators and users pick a dashboard or tile icon only from a fixed registry of built-in MDI components (per `dashboard-icons`). Real organisations want to brand dashboards with their own logos, departmental icons, or scenario-specific imagery — none of which fit the curated registry. We could split the storage into two columns (`iconName` + `iconUrl`) and a discriminator field, but that triples the surface area of every read path, breaks existing `icon`-aware code, and forces a data migration. Instead we extend the existing `icon` field to accept either a built-in name OR a resource URL, with a single runtime discriminator and a single dual-mode render component. This change formalises the field-format convention, the picker UX, and the renderer contract — the actual upload endpoint is owned by the parallel `resource-uploads` capability.
+
+## What Changes
+
+- Add a pure `isCustomIconUrl(name)` discriminator to `src/constants/dashboardIcons.js` that returns `true` when the value starts with `/` or `http`.
+- Update `getIconComponent(name)` to return `null` for URL inputs, signalling to callers that they must render an `<img>` instead of a `<component>`.
+- Introduce a shared `IconRenderer` Vue component that branches internally so consumers stop duplicating the if/else.
+- Introduce an `IconPicker` Vue component that surfaces a registry `<select>` and a file-upload input side-by-side, both writing to the same `v-model` and previewing via `IconRenderer`.
+- Refactor `DashboardSwitcher`, the admin dashboard CRUD UI, the link-button widget icon, and the tile editor to use `IconRenderer` and `IconPicker` instead of inline branching.
+- Document the single-column convention in the `Dashboard` and `WidgetPlacement` entity docblocks. No database schema change.
+
+## Capabilities
+
+### New Capabilities
+
+(none — this change extends the existing `dashboard-icons` capability)
+
+### Modified Capabilities
+
+- `dashboard-icons`: adds REQ-ICON-005 (URL/name discriminator), REQ-ICON-006 (`getIconComponent` returns null for URLs), REQ-ICON-007 (`IconRenderer` dual-mode), REQ-ICON-008 (`IconPicker` dual-input UX), REQ-ICON-009 (single-column field convention). Existing REQ-ICON-001..004 are untouched.
+
+## Impact
+
+**Affected code:**
+
+- `src/constants/dashboardIcons.js` — add `isCustomIconUrl`, update `getIconComponent` URL handling
+- `src/components/Dashboard/IconRenderer.vue` — new shared dual-mode renderer
+- `src/components/Dashboard/IconPicker.vue` — new combined select-plus-upload picker with live preview
+- `src/components/DashboardSwitcher.vue`, admin dashboard CRUD UI, link-button widget icon component, tile editor — refactored to use `IconRenderer` / `IconPicker`
+- `lib/Db/Dashboard.php`, `lib/Db/WidgetPlacement.php` — update `icon` / `tileIcon` field docblocks to document the dual-format convention
+
+**Affected APIs:**
+
+- No new backend routes (this change relies on the upload endpoint owned by `resource-uploads`)
+- No change to existing `/api/dashboards` or widget endpoints — the `icon` field already exists and is opaque to the backend
+
+**Dependencies:**
+
+- Depends on the parallel `resource-uploads` change for the upload endpoint and resource URL format (`/apps/mydash/resource/{id}`)
+- No new composer or npm dependencies
+
+**Migration:**
+
+- Zero-impact: no schema change. Existing rows with built-in icon names continue to render unchanged. New rows may store either a name or a URL in the same column.
+- No data backfill required.
+
+## Notes
+
+- The `'/'` and `'http'` prefix heuristic is fragile against future built-in registry entries that happen to start with `/`. The registry today contains none; future additions MUST be validated against the discriminator.
+- File upload size and MIME validation are owned by `resource-uploads` — `IconPicker` only forwards the file and reads the returned URL.
+- Switching a dashboard from a custom URL back to a built-in name does NOT delete the previously uploaded resource. Resource lifecycle (orphan cleanup) is owned by `resource-uploads`.

--- a/openspec/changes/custom-icon-upload-pattern/specs/dashboard-icons/spec.md
+++ b/openspec/changes/custom-icon-upload-pattern/specs/dashboard-icons/spec.md
@@ -1,0 +1,125 @@
+---
+capability: dashboard-icons
+delta: true
+status: draft
+---
+
+# Dashboard Icons — Delta from change `custom-icon-upload-pattern`
+
+## ADDED Requirements
+
+### Requirement: URL/name discriminator (REQ-ICON-005)
+
+The system MUST expose a pure function `isCustomIconUrl(name: string|null): boolean` that returns `true` when `name` is a non-null string AND begins with either `'/'` or `'http'`. All other inputs (built-in registry names, null, undefined, empty string) MUST return `false`. The function MUST NOT call any side-effecting code (no fetch, no DOM access, no globals).
+
+#### Scenario: URL inputs return true
+
+- WHEN `isCustomIconUrl('/apps/mydash/resource/abc123.png')` is called
+- THEN it MUST return `true`
+- AND `isCustomIconUrl('https://example.com/icon.svg')` MUST return `true`
+- AND `isCustomIconUrl('http://example.com/icon.png')` MUST return `true`
+
+#### Scenario: Registry names return false
+
+- WHEN `isCustomIconUrl('Star')` is called
+- THEN it MUST return `false`
+- AND `isCustomIconUrl('ViewDashboard')` MUST return `false`
+
+#### Scenario: Null and empty inputs return false
+
+- WHEN `isCustomIconUrl(null)` is called
+- THEN it MUST return `false`
+- AND `isCustomIconUrl('')` MUST return `false`
+- AND `isCustomIconUrl(undefined)` MUST return `false`
+
+### Requirement: getIconComponent returns null for URLs (REQ-ICON-006)
+
+`getIconComponent(name)` MUST return `null` when `isCustomIconUrl(name)` is true. Callers MUST then render the URL via `<img>` (not via `<component :is>`). This is the contract that lets the picker, switcher, and admin list use a single render component.
+
+#### Scenario: URL input yields a null component
+
+- GIVEN the discriminator considers `/apps/mydash/resource/x.png` a custom URL
+- WHEN `getIconComponent('/apps/mydash/resource/x.png')` is called
+- THEN it MUST return `null`
+- AND callers MUST interpret `null` as "render via `<img>`", NOT as "use the default icon"
+
+#### Scenario: Unknown built-in name still returns the default component
+
+- GIVEN `isCustomIconUrl('NotARegistryEntry')` is `false`
+- WHEN `getIconComponent('NotARegistryEntry')` is called
+- THEN it MUST return the `DEFAULT_ICON` component (per REQ-ICON-001)
+- AND MUST NOT return `null`
+
+### Requirement: IconRenderer dual-mode rendering (REQ-ICON-007)
+
+The shared `IconRenderer` component MUST accept a single `name` prop (string or null) and render either an `<img>` or a `<component :is>` based on `isCustomIconUrl(name)`. Consumers MUST use `IconRenderer` rather than branching on the icon shape themselves.
+
+#### Scenario: Render a built-in icon
+
+- GIVEN `IconRenderer` is rendered with prop `name="Star"`
+- THEN the DOM MUST contain a `<svg>` element (the Star MDI component)
+- AND MUST NOT contain an `<img>` element
+
+#### Scenario: Render a custom URL icon
+
+- GIVEN `IconRenderer` is rendered with prop `name="/apps/mydash/resource/abc.png"`
+- THEN the DOM MUST contain `<img src="/apps/mydash/resource/abc.png">`
+- AND MUST NOT contain a `<component>` rendering of an MDI icon
+
+#### Scenario: Render with null name falls back to default
+
+- GIVEN `IconRenderer` is rendered with prop `name={null}`
+- THEN it MUST render the `DEFAULT_ICON` component
+- AND MUST NOT throw
+- AND MUST NOT render an empty placeholder
+
+#### Scenario: Alt text for custom URL icons
+
+- GIVEN `IconRenderer` is rendered with `name="/apps/mydash/resource/abc.png"` and an `alt` prop of `"Marketing"`
+- THEN the rendered `<img>` MUST have `alt="Marketing"`
+- AND when no `alt` prop is supplied the rendered `<img>` MUST fall back to a non-empty default (e.g. the dashboard or widget name)
+
+### Requirement: IconPicker dual-input UX (REQ-ICON-008)
+
+The `IconPicker` component MUST present BOTH affordances visible simultaneously: a `<select>` of registry option names (per REQ-ICON-003) AND an "Upload icon" `<input type="file" accept="image/*">` button. Selecting either MUST update the same `v-model` value: a registry option assigns the option string, an upload POSTs to the resource-uploads endpoint and assigns the returned URL string. A 24×24 preview thumbnail of the current value MUST be rendered via `IconRenderer`.
+
+#### Scenario: Switching from built-in to custom
+
+- GIVEN `IconPicker` v-model is currently `"Star"`
+- WHEN the user uploads a file successfully and the upload returns URL `/apps/mydash/resource/abc.png`
+- THEN the v-model value MUST become `/apps/mydash/resource/abc.png`
+- AND the preview MUST switch from `<svg>` (Star) to `<img>` (the uploaded image)
+
+#### Scenario: Switching from custom back to built-in
+
+- GIVEN v-model value is `/apps/mydash/resource/abc.png`
+- WHEN the user picks `"Home"` from the `<select>`
+- THEN the v-model value MUST become `"Home"`
+- AND the preview MUST switch from `<img>` to `<svg>` (Home)
+- NOTE: switching away does NOT delete the previously uploaded resource (resource lifecycle is owned by `resource-uploads` capability)
+
+#### Scenario: Upload error preserves previous value
+
+- GIVEN `IconPicker` v-model is currently `"Star"`
+- WHEN the user attempts an upload that fails (HTTP error or non-image MIME rejected by the upload endpoint)
+- THEN the v-model value MUST remain `"Star"`
+- AND the picker MUST surface a visible error state to the user
+- AND the preview MUST continue to show the Star icon
+
+### Requirement: Field convention is single-column (REQ-ICON-009)
+
+Database columns that store an icon (currently `oc_mydash_dashboards.icon` and `oc_mydash_widget_placements.tileIcon`) MUST hold either a registry name OR a URL string OR NULL — never a typed-discriminator object like `{kind: 'name'|'url', value: ...}`. Discrimination is purely runtime via `isCustomIconUrl`. No schema migration is required when a value flips between built-in and custom forms.
+
+#### Scenario: Mixed values across rows render without migration
+
+- GIVEN three dashboards exist with `icon` values `'Star'`, `'/apps/mydash/resource/x.png'`, and `null`
+- WHEN any consumer reads them and passes each `icon` to `IconRenderer`
+- THEN no migration or transformation is required
+- AND all three dashboards MUST render correctly (svg, img, default svg respectively)
+
+#### Scenario: Switching a dashboard's icon between forms is a plain UPDATE
+
+- GIVEN dashboard `D1` has `icon = 'Star'`
+- WHEN the admin uploads a custom icon for `D1` and the picker resolves to URL `/apps/mydash/resource/y.png`
+- THEN persisting the change MUST be a single `UPDATE oc_mydash_dashboards SET icon = '/apps/mydash/resource/y.png' WHERE id = ?`
+- AND no auxiliary table or column MUST be touched

--- a/openspec/changes/custom-icon-upload-pattern/tasks.md
+++ b/openspec/changes/custom-icon-upload-pattern/tasks.md
@@ -1,0 +1,48 @@
+# Tasks — custom-icon-upload-pattern
+
+## 1. Discriminator module
+
+- [ ] 1.1 Add `isCustomIconUrl(name)` export to `src/constants/dashboardIcons.js` returning `true` only for non-null strings beginning with `'/'` or `'http'`
+- [ ] 1.2 Update `getIconComponent(name)` to return `null` when `isCustomIconUrl(name)` is true (must NOT fall back to `DEFAULT_ICON` for URLs)
+- [ ] 1.3 Add Vitest covering the truth table: URL prefixes (`/apps/...`, `http://`, `https://`), registry names (`Star`, `ViewDashboard`), and falsy inputs (`null`, `undefined`, `''`)
+- [ ] 1.4 Add Vitest asserting `getIconComponent` returns `null` for a URL input AND returns `DEFAULT_ICON` for an unknown registry name (REQ-ICON-001 still holds)
+
+## 2. IconRenderer component
+
+- [ ] 2.1 Create `src/components/Dashboard/IconRenderer.vue` accepting `name`, `alt`, and `size` props
+- [ ] 2.2 Branch internally: `<img :src="name" :alt="alt">` when `isCustomIconUrl(name)`, else `<component :is="getIconComponent(name)" :size="size">`
+- [ ] 2.3 Default `alt` to a non-empty string (consumer-supplied label, falling back to dashboard/widget name)
+- [ ] 2.4 Vitest: rendering branches by input type (built-in name → svg, URL → img, null → default svg)
+- [ ] 2.5 Vitest: `alt` prop is propagated to the rendered `<img>` for URL inputs
+
+## 3. IconPicker component
+
+- [ ] 3.1 Create `src/components/Dashboard/IconPicker.vue` with both a `<select>` of registry names AND a file-upload input visible at the same time
+- [ ] 3.2 On select change: emit/update `v-model` with the chosen option string
+- [ ] 3.3 On file select: POST the file to the `resource-uploads` endpoint, then update `v-model` with the returned URL string
+- [ ] 3.4 Render a 24×24 live preview of the current value via `IconRenderer`
+- [ ] 3.5 Surface loading and error states for the upload (spinner during POST, visible error when the request fails or the response is non-2xx)
+- [ ] 3.6 On upload error: leave the previous `v-model` value unchanged (do not clobber)
+
+## 4. Refactor existing call sites
+
+- [ ] 4.1 Replace ad-hoc icon-or-image branches in `DashboardSwitcher` with `<IconRenderer>`
+- [ ] 4.2 Replace branches in the admin dashboard list / CRUD UI with `<IconRenderer>` and use `<IconPicker>` in the create/edit forms
+- [ ] 4.3 Replace branches in the link-button widget icon and the tile editor with `<IconRenderer>` and `<IconPicker>`
+- [ ] 4.4 Grep test: no remaining `v-if="iconUrl"` / inline `isCustomIconUrl` branches outside `IconRenderer.vue` and `IconPicker.vue`
+
+## 5. Documentation
+
+- [ ] 5.1 Update the `icon` field docblock on `lib/Db/Dashboard.php` to state that the column may hold either a registry name, a `/apps/mydash/resource/...` URL, or NULL
+- [ ] 5.2 Update the `tileIcon` field docblock on `lib/Db/WidgetPlacement.php` with the same convention
+
+## 6. End-to-end tests
+
+- [ ] 6.1 Playwright: open dashboard editor, switch from a built-in icon to an uploaded one, verify the preview swaps from `<svg>` to `<img>` and the value persists after save
+- [ ] 6.2 Playwright: switch back from an uploaded icon to a built-in one, verify the preview swaps back and the value persists
+- [ ] 6.3 Playwright: render a workspace where multiple dashboards mix built-in and uploaded icons, confirm all render correctly with no console errors
+
+## 7. Quality
+
+- [ ] 7.1 ESLint clean on all changed `.vue` and `.js` files
+- [ ] 7.2 `composer check:strict` clean for the touched PHP entity docblock changes (PHPCS, PHPMD, Psalm, PHPStan)

--- a/openspec/changes/dashboard-icons/proposal.md
+++ b/openspec/changes/dashboard-icons/proposal.md
@@ -1,0 +1,26 @@
+# Dashboard icons — registry capability
+
+Introduce a new `dashboard-icons` capability that owns the catalogue of icons available for dashboards (in the switcher sidebar, admin list, etc.). Provides a stable named registry plus a discriminator function that lets the same icon field hold either a registry name OR an uploaded URL.
+
+## Affected code units
+
+- `src/constants/dashboardIcons.js` — new module exporting `DASHBOARD_ICONS`, `DEFAULT_ICON`, `getIconComponent(name)`, `isCustomIconUrl(name)`
+- `src/components/Dashboard/IconRenderer.vue` — small component that renders `<component :is>` for built-in icons or `<img>` for URLs
+- `lib/Db/Dashboard.php` — annotate `icon` field convention (NULL or registry name or URL)
+- No DB schema change (the column already exists on `oc_mydash_dashboards`)
+
+## Why a new capability
+
+The icon system is a small, self-contained surface that is consumed by the sidebar, admin UI, and (separately) the link-button widget icon picker. Pulling it out as its own capability gives a single place to grow the icon set, swap rendering libraries, or add icon search later — without bloating the `dashboards` capability.
+
+## Approach
+
+- 15 named icons drawn from `vue-material-design-icons` to start (a deliberate small palette: `ViewDashboard`, `Home`, `ChartBar`, `Cog`, `AccountGroup`, `Calendar`, `FileDocument`, `Bell`, `Star`, `Heart`, `BookOpenVariant`, `Lightbulb`, `RocketLaunch`, `Earth`, `Briefcase`).
+- `DEFAULT_ICON = 'ViewDashboard'`.
+- Frontend-only; no backend involvement (icon names are persisted as opaque strings on the `dashboards.icon` column).
+- Custom uploaded icons (the `custom-icon-upload-pattern` change) extend this with URL semantics.
+
+## Notes
+
+- We deliberately keep the palette small for a curated UX. Future change can introduce a full MDI search picker if needed.
+- Icon component imports are tree-shake-friendly (only referenced ones land in the bundle).

--- a/openspec/changes/dashboard-icons/specs/dashboard-icons/spec.md
+++ b/openspec/changes/dashboard-icons/specs/dashboard-icons/spec.md
@@ -1,0 +1,119 @@
+---
+capability: dashboard-icons
+delta: true
+status: draft
+---
+
+# Dashboard Icons — Delta from change `dashboard-icons`
+
+## Context
+
+MyDash dashboards (and dashboard list items in the switcher sidebar and admin UI) display an icon next to their name. This capability owns the icon vocabulary: a small curated registry of named built-in icons that live in the frontend bundle, plus the lookup/render functions that consumers use. A separate change (`custom-icon-upload-pattern`) extends this capability so the same `icon` field can also hold an uploaded resource URL.
+
+The icon system has no backend persistence of its own — it operates on the existing `oc_mydash_dashboards.icon` column (and any other column that follows the same convention, e.g. `oc_mydash_widget_placements.tileIcon`).
+
+The `icon` field convention:
+- **NULL or empty string** → render `DEFAULT_ICON`
+- **A registered icon name** (e.g. `'ViewDashboard'`, `'Home'`) → look up in `DASHBOARD_ICONS`
+- **A URL** (starts with `/` or `http`) → see `custom-icon-upload-pattern` (out of scope for this base capability)
+
+Frontend exports:
+
+| Export | Type | Purpose |
+|---|---|---|
+| `DASHBOARD_ICONS` | `Record<string, VueComponent>` | Map from icon name → component import |
+| `DEFAULT_ICON` | `string` | The fallback name (currently `'ViewDashboard'`) |
+| `getIconComponent(name: string \| null)` | `VueComponent` | Look up; falls back to `DEFAULT_ICON` for null/empty/unknown |
+| `isCustomIconUrl(name: string \| null)` | `boolean` | True when name starts with `/` or `http` (consumed by `custom-icon-upload-pattern`) |
+
+## ADDED Requirements
+
+### Requirement: REQ-ICON-001 Curated registry of built-in icons
+
+The system MUST maintain a curated registry of at least 15 built-in dashboard icons drawn from `vue-material-design-icons`. The registry MUST include at minimum these names: `ViewDashboard`, `Home`, `ChartBar`, `Cog`, `AccountGroup`, `Calendar`, `FileDocument`, `Bell`, `Star`, `Heart`, `BookOpenVariant`, `Lightbulb`, `RocketLaunch`, `Earth`, `Briefcase`. Any consumer that renders an icon by name MUST resolve it through this registry — there MUST NOT be parallel ad-hoc registries elsewhere.
+
+#### Scenario: Resolve a built-in name
+
+- GIVEN the registry contains `'Star'`
+- WHEN `getIconComponent('Star')` is called
+- THEN it MUST return the `vue-material-design-icons/Star.vue` component reference
+
+#### Scenario: Resolve an unknown name falls back to default
+
+- GIVEN the registry does not contain `'NonExistent'`
+- WHEN `getIconComponent('NonExistent')` is called
+- THEN it MUST return the component for `DEFAULT_ICON` (currently `ViewDashboard`)
+
+#### Scenario: Default icon is `'ViewDashboard'`
+
+- GIVEN the constants module is loaded
+- WHEN `DEFAULT_ICON` is read
+- THEN its value MUST equal the string `'ViewDashboard'`
+- AND `DASHBOARD_ICONS[DEFAULT_ICON]` MUST be defined
+
+#### Scenario: Registry contains all 15 named icons
+
+- GIVEN the registry module is loaded
+- WHEN `Object.keys(DASHBOARD_ICONS)` is inspected
+- THEN it MUST contain every name listed in this requirement
+- AND its length MUST be at least 15
+
+### Requirement: REQ-ICON-002 Null and empty handling
+
+`getIconComponent` MUST tolerate `null`, `undefined`, and empty string inputs — all of these MUST resolve to the `DEFAULT_ICON` component. The function MUST NOT throw and MUST NOT return `null` for these inputs.
+
+#### Scenario: Null input
+
+- GIVEN any caller invokes the helper with no name available
+- WHEN `getIconComponent(null)` is called
+- THEN it MUST return the `DEFAULT_ICON` component
+- AND it MUST NOT throw
+
+#### Scenario: Undefined input
+
+- GIVEN a dashboard record where `icon` is `undefined`
+- WHEN `getIconComponent(undefined)` is called
+- THEN it MUST return the `DEFAULT_ICON` component
+- AND it MUST NOT throw
+
+#### Scenario: Empty string input
+
+- GIVEN a dashboard record where `icon` is the empty string
+- WHEN `getIconComponent('')` is called
+- THEN it MUST return the `DEFAULT_ICON` component
+- AND it MUST NOT throw
+
+### Requirement: REQ-ICON-003 Single picker source for admin UI
+
+When the admin UI renders an icon picker (e.g. when creating or editing a dashboard), the available options MUST be enumerated from `Object.keys(DASHBOARD_ICONS)` directly. Hardcoding option lists in the picker template is forbidden so the picker stays in lock-step with the registry whenever icons are added or removed.
+
+#### Scenario: Picker reflects registry size
+
+- GIVEN the registry has 15 entries
+- WHEN the icon picker `<select>` renders
+- THEN it MUST emit exactly 15 `<option>` elements (one per registry key)
+- AND each option's `value` MUST match a registry key string
+
+#### Scenario: Picker stays in sync when registry grows
+
+- GIVEN the registry is extended to 17 entries in a future change
+- WHEN the icon picker `<select>` renders without code changes
+- THEN it MUST emit exactly 17 `<option>` elements
+
+### Requirement: REQ-ICON-004 Tree-shakeable imports
+
+Each icon component import in the registry module MUST be a separate `import` statement so production bundles only include the icons actually referenced by the registry. Bulk wildcard imports (`import * as icons from 'vue-material-design-icons'`) MUST NOT be used in this module.
+
+#### Scenario: Bundle includes only referenced icons
+
+- GIVEN a production webpack build with no other consumers of `vue-material-design-icons`
+- WHEN the bundled `js/main.js` is inspected
+- THEN it MUST include at most the 15 icons listed in REQ-ICON-001
+- AND it MUST NOT include the full library
+
+#### Scenario: No wildcard imports in registry module
+
+- GIVEN the source file `src/constants/dashboardIcons.js`
+- WHEN its import statements are inspected
+- THEN none MUST use `import *` syntax against `vue-material-design-icons`
+- AND each registered icon MUST have its own dedicated `import …Icon from 'vue-material-design-icons/<Name>.vue'` line

--- a/openspec/changes/dashboard-icons/tasks.md
+++ b/openspec/changes/dashboard-icons/tasks.md
@@ -1,0 +1,42 @@
+# Tasks — dashboard-icons
+
+## 1. Frontend registry module
+
+- [ ] 1.1 Create `src/constants/dashboardIcons.js` exporting `DASHBOARD_ICONS`, `DEFAULT_ICON`, `getIconComponent`, `isCustomIconUrl`
+- [ ] 1.2 Add 15 separate `import …Icon from 'vue-material-design-icons/<Name>.vue'` statements (no wildcard / barrel imports — see REQ-ICON-004)
+- [ ] 1.3 Implement `getIconComponent(name)` so it returns the registry component, falling back to `DASHBOARD_ICONS[DEFAULT_ICON]` on null / undefined / empty / unknown (REQ-ICON-001, REQ-ICON-002)
+- [ ] 1.4 Implement `isCustomIconUrl(name)` returning true when name is a non-empty string starting with `/` or `http` (consumed by `custom-icon-upload-pattern`)
+- [ ] 1.5 Set `DEFAULT_ICON = 'ViewDashboard'` and assert `DASHBOARD_ICONS[DEFAULT_ICON]` exists at module load
+
+## 2. Reusable renderer component
+
+- [ ] 2.1 Create `src/components/Dashboard/IconRenderer.vue` accepting prop `name: string|null` and `size: number = 20`
+- [ ] 2.2 Branch in template: when `isCustomIconUrl(name)` render `<img :src="name" :width="size" :height="size" alt="">`
+- [ ] 2.3 Otherwise render `<component :is="getIconComponent(name)" :size="size" />`
+- [ ] 2.4 Add component-level docblock noting the URL branch is foundation for `custom-icon-upload-pattern`
+
+## 3. Refactor existing consumers
+
+- [ ] 3.1 Replace hardcoded MDI icon imports inside `DashboardSwitcher` with `<IconRenderer :name="dash.icon" />`
+- [ ] 3.2 Replace hardcoded MDI imports in the admin dashboard list with `<IconRenderer :name="dash.icon" />`
+- [ ] 3.3 Replace hardcoded MDI imports in the tile editor with `<IconRenderer :name="tile.icon" />`
+- [ ] 3.4 Add an icon picker `<select>` driven by `Object.keys(DASHBOARD_ICONS)` in dashboard create/edit form (REQ-ICON-003)
+- [ ] 3.5 Grep audit: no `vue-material-design-icons/<Name>.vue` import remains outside `dashboardIcons.js` for dashboard contexts
+
+## 4. Backend annotation (no schema change)
+
+- [ ] 4.1 Add a docblock on `lib/Db/Dashboard.php`'s `icon` field describing the convention (NULL or registry name or URL)
+- [ ] 4.2 Confirm no migration is needed (column already exists on `oc_mydash_dashboards`)
+
+## 5. Tests
+
+- [ ] 5.1 Vitest: `getIconComponent` resolution table — built-in name, default, null, undefined, empty string, unknown name
+- [ ] 5.2 Vitest: `DASHBOARD_ICONS` length is at least 15 and contains every name from REQ-ICON-001
+- [ ] 5.3 Vitest: `isCustomIconUrl` returns true for `/foo.svg` and `https://x/y.png`, false for `'Star'`, `''`, `null`
+- [ ] 5.4 Visual snapshot (Storybook or equivalent): all 15 icons rendered at size 20 and 32
+
+## 6. Quality gates
+
+- [ ] 6.1 ESLint clean on `src/constants/dashboardIcons.js` and `src/components/Dashboard/IconRenderer.vue`
+- [ ] 6.2 Bundle-size check: production `main.js` delta ≤ 8 KB gzipped (the 15 icon SVGs)
+- [ ] 6.3 PHPCS clean on `lib/Db/Dashboard.php` if the docblock change touches it

--- a/openspec/changes/dashboard-sharing-followups/design.md
+++ b/openspec/changes/dashboard-sharing-followups/design.md
@@ -1,0 +1,125 @@
+# Design — dashboard-sharing-followups
+
+## Context
+
+The baseline `dashboard-sharing` capability is shipped: per-user/per-group share rows, three permission levels (`view_only`, `add_only`, `full`), owner-only management. This change layers operational concerns on top: discovery (notifications), efficient management (bulk replace), and lifecycle (cascade on user delete with retention). The biggest design question is the cascade — owner deletion is destructive by default, and the user requirement is that **a dashboard with at least one admin-level recipient must survive the owner being deleted**. Everything else is mostly mechanical.
+
+## Decision: Pull notifications via Nextcloud's `INotifier`, not push or polling
+
+Nextcloud already ships an `INotifier` ecosystem with three rendering surfaces (bell dropdown, activity stream, daily email digest) and an `INotificationManager` for publishing. By implementing `INotifier::prepare()` for two subjects (`dashboard_shared`, `dashboard_ownership_transferred`) we get all three surfaces for free, plus translation, plus deep-linking, plus deduplication of unread state.
+
+**Alternatives considered:**
+
+- **WebSocket / SSE push** — Nextcloud doesn't ship a usable bidirectional channel for app code. Requires Talk's HPB or a separate broker. Rejected: too much infrastructure for a low-frequency event.
+- **Polling endpoint + frontend badge** — would require client-side state and a new endpoint. The bell already polls and renders unread counts; we'd be reinventing it.
+- **Email-only via `IMailer`** — would skip the in-app surface entirely. Bad UX for active users.
+
+**Trade-off:** the bell renders on the next poll cycle (default 30s), so notifications are not real-time. Acceptable for share events.
+
+## Decision: Notify on add and on level upgrade only — never on remove or downgrade
+
+Sharing tends to be additive ("Alice shared X with you"). Revocations and demotions are quiet operations: the recipient simply loses access. Notifying on revoke creates two failure modes:
+
+- spam (e.g. a sharer iterating the share list multiple times to fix a typo)
+- an awkward "Alice removed your access to X" message that adds no actionable information — the dashboard simply disappears from their list
+
+Demotions (full → add_only) follow the same logic: the recipient still has access; the change is silent.
+
+A *level upgrade* (view_only → full) is treated as a re-share for notification purposes, since it can functionally enable new behaviour (add widgets, edit layout) for the recipient.
+
+## Decision: Group shares fan out at publish time, not at subscribe time
+
+Two options for group share notifications:
+
+- **(a) Fan-out at publish**: when the share is created, resolve the group's member list once and emit one notification per member.
+- **(b) Subscribe at read**: keep one notification row, and at read time check group membership.
+
+We pick (a) because Nextcloud's `INotificationManager` is publish-only; there's no "match all members of group X" subscription primitive. (a) also produces cleaner per-user state (read/unread tracked per recipient out of the box).
+
+The trade-off is that a member who joins the group **after** the share is created will not get the notification. They will still see the dashboard in their list because group resolution at read time *is* live for the visibility query — only the notification is missed. This is acceptable; the alternative has worse failure modes.
+
+## Decision: Bulk replace is `PUT`, not `POST` or `PATCH`
+
+`PUT /api/dashboard/{id}/shares` with `{shares: [...]}` payload makes the intent unambiguous: "this is the entire desired share list". Any share not in the payload disappears.
+
+- **Why not `POST`**: POST is used today for "add one share". Reusing the verb with a different semantic would break clients.
+- **Why not `PATCH`**: PATCH implies partial mutation, which would require a vocabulary like `{add: [...], remove: [...]}`. Possible, but the simple "replace" semantic matches how the UI naturally behaves (user edits the list, hits save).
+
+The trade-off is that it requires the client to send the full list — but the list is small (typically <20 shares per dashboard) so the bytes cost is trivial.
+
+## Decision: Admin pool excludes `add_only` recipients
+
+The retention algorithm only considers `permission_level = 'full'` shares as candidates for ownership transfer. `add_only` recipients can edit content but the user requirement explicitly says "admin (users can edit and delete the dashboard)" — that maps to `full` only.
+
+If a dashboard has only `view_only` and `add_only` shares and the owner is deleted, **the dashboard is deleted**. This may be surprising; we surface it via the `mydash_dashboards_orphaned_at_owner_deletion_total` Prometheus counter so admins can detect cases where they want to bump shares to `full` proactively.
+
+We considered a "preserve if at least one human can still see it" rule (i.e. retention threshold = `view_only`). Rejected: it would silently leave dashboards owned by `null`/system, which adds a third ownership state we don't want to model.
+
+## Decision: New-owner selection is deterministic, not interactive
+
+When the owner is deleted, the listener picks a new owner without prompting. The rule:
+
+1. Among `user`-type `full` shares, smallest `created_at` wins.
+2. If none, expand the alphabetically-first `group`-type `full` share, pick the alphabetically-first remaining member.
+3. If still none (concurrency edge case), fall through to delete.
+
+**Why deterministic:** the deletion event is synchronous — we cannot wait for human input. We could enqueue a "needs new owner" job and email all admins, but that introduces ambiguous state (a dashboard with `user_id = NULL` for an unbounded period). The simple rule is predictable and replayable.
+
+**Why created_at ASC:** approximates "earliest-trusted recipient", a heuristic for "person Alice deliberately picked first when she set up the dashboard". Alphabetic is the tiebreaker for groups because there's no per-group ordering.
+
+The new owner gets a `dashboard_ownership_transferred` notification ("X is now yours — ownership transferred after the previous owner was removed") so they're not surprised by the dashboard appearing as theirs.
+
+## Decision: Synchronous cascade in the event listener
+
+`UserDeletedEvent` is fired synchronously inside the user-removal flow. We do all work — share cleanup, dashboard retention/deletion, ownership transfer, notification publishing — synchronously inside the listener, in DB transactions per dashboard.
+
+**Alternative considered:** publish a `mydash.user_deleted` queue message and process asynchronously. Rejected: introduces a queue dependency, complicates testing, and creates a window where dashboards owned by a deleted user are still visible/usable. Simpler to do it inline and pay the deletion-time latency cost.
+
+**Risk:** a deletion of a heavily-sharing user (e.g. an admin who owned 100 dashboards) could take seconds. Mitigation: the listener is bounded by the number of owned dashboards, which in practice is small (median <10). If it becomes a problem we can move to a queued model later — the listener's current contract is "complete or fail loudly", not "complete fast".
+
+## Decision: No automatic re-share when a recipient user is recreated
+
+If user `bob` is deleted and later recreated with the same uid, **shares are not restored**. The old share rows were deleted permanently in step A of the listener.
+
+This is the right call because (a) a recreated uid is not necessarily the same human, (b) the original sharer should re-grant intentionally, and (c) backup/restore is the proper recovery channel for accidental deletions.
+
+## Decision: Group deletion is out of scope
+
+`OCP\Group\Events\GroupDeletedEvent` exists, and we could mirror the user-deletion logic for groups. We are not doing it in this change because:
+
+- Group deletion is rare and usually administrative
+- A deleted group leaves shares with an unreachable `share_with` — they're inert (no recipients), not actively harmful
+- The optional Migration 001006 (orphan cleanup) covers this case if an admin opts in
+
+A future change can add a `GroupDeletedListener` if usage shows it's a real problem.
+
+## Decision: No bulk frontend UI for revoke-all-for-recipient
+
+The `DELETE /api/sharees/{shareType}/{shareWith}` endpoint is added but not surfaced in the UI in this change. Rationale: the operation has no clear UI affordance ("here's a recipient — what dashboards do they see from me?" requires building an inverse view that doesn't exist). Exposing it via API only lets admin tooling and `occ` scripts use it without committing to a UI shape we haven't designed.
+
+## Edge cases
+
+### Owner deletes themselves while still owning shared dashboards
+
+`occ user:delete <self>` is allowed for the system administrator. Shares are evaluated against the deleted user's *current* group membership at the moment of deletion. If the deleted user shared with themselves indirectly (shouldn't be possible — `addShare` rejects self-shares), the listener handles it as if no admin were available.
+
+### A user has both a direct share AND is in a shared group on the same dashboard
+
+The retention algorithm considers them once: direct user shares are evaluated first. If they're also in a `full`-level group share, they only end up in the candidate pool once.
+
+### Concurrent owner deletion + new share
+
+Two concurrent transactions:
+
+1. T1: admin deletes user `alice` (owner of dashboard 5)
+2. T2: alice's frontend issues `POST /api/dashboard/5/shares` (added bob as `full`)
+
+If T2 commits before T1's listener reads the share table, the listener sees bob and transfers ownership to him. If T2 commits after, T1 deletes the dashboard and bob's share row is cascaded away. Either outcome is consistent — there's no torn state.
+
+### A `full`-level group share whose group has zero current members
+
+The pool resolves to empty. The dashboard is deleted. This is correct behaviour: an empty group means no human is privileged on this dashboard.
+
+### Notification spam mitigation
+
+A user adding 50 recipients via the bulk endpoint produces 50 notifications, one per recipient. Each recipient gets one notification (fan-out is per-target, not per-share-event). Recipients can mute the `mydash` notifier in their personal settings via the existing Nextcloud notification preferences UI — no special handling needed.

--- a/openspec/changes/dashboard-sharing-followups/proposal.md
+++ b/openspec/changes/dashboard-sharing-followups/proposal.md
@@ -1,0 +1,76 @@
+# Dashboard sharing follow-ups: notifications, bulk management, cascade
+
+## Why
+
+The baseline `dashboard-sharing` capability (REQ-SHARE-001..007) ships per-user/per-group dashboard sharing with view, add, and full access levels. In real use, three operational gaps stand out:
+
+1. **No discovery signal.** A recipient only learns they have access to a new shared dashboard if they happen to reopen the dashboard menu and notice the new entry. There is no inbox, no badge, no email — for high-value collaboration scenarios (e.g. an admin shares a compliance dashboard with the legal team) the sharing event must produce a visible signal so the recipient acts on it.
+2. **Share management is one-row-at-a-time.** Adding ten users to a dashboard means ten POST round-trips with no atomicity guarantee, and there is no API surface for "replace all shares" or "remove a recipient from every dashboard". This is a problem both for power users (a department lead onboarding a class of users) and for cleanup scenarios.
+3. **User deletion leaves dangling state and can destroy collaboration unintentionally.** When a Nextcloud user is removed (`occ user:delete`, federated-user revocation, retention policy), today their owned dashboards are deleted; any shares they granted become orphaned share rows; any shares granted **to** them remain in the table forever. Worse, deleting an owner can wipe out a dashboard that the rest of the organisation still actively uses, because the share rows never promoted any recipient to ownership.
+
+This change adds a Nextcloud-native pull notification on share creation, a bulk share-management API, and a deletion cascade that **preserves dashboards still owned by an admin-level recipient** by transferring ownership rather than deleting.
+
+## What Changes
+
+### Pull notifications when shared
+- On every successful `addShare` (insert OR update where `permission_level` increased), publish a Nextcloud notification via `OCP\Notification\IManager` to the recipient(s):
+  - `app: 'mydash'`, `subject: 'dashboard_shared'`, `objectType: 'dashboard'`, `objectId: <dashboardId>`
+  - For group shares, fan out one notification per current group member (resolved at publish time via `IGroupManager`).
+  - The notification payload carries `{sharerUserId, dashboardName, permissionLevel}` so the notifier can render "Alice shared **Marketing Overview** with you (full access)" with a deep link to `/apps/mydash/?dashboard={uuid}`.
+- Implement `INotifier` so the notification renders in the bell, the activity stream, and the email digest using existing Nextcloud channels — no new transport.
+- Provide a single "Dismiss" action that marks the notification read; no in-notification accept/reject (Pattern A: shared dashboards appear automatically in the recipient's list).
+- When a share is **removed** OR **downgraded**, no notification is published (avoid notification spam for routine permission changes).
+
+### Bulk share management
+- Add `PUT /api/dashboard/{id}/shares` accepting `{shares: Share[]}` — replaces the entire share list for the dashboard atomically. Existing shares not in the payload are deleted; new entries are inserted; matching entries are upserted. One DB transaction, one notification batch (one notification per newly-added or upgraded recipient, not for unchanged or removed ones).
+- Add `DELETE /api/sharees/{shareType}/{shareWith}` — owner-restricted to the *caller's* dashboards: removes every share where this caller is the owner AND the share targets the named recipient. Used to "stop sharing anything with Bob".
+- Frontend `DashboardConfigModal` gains "Save shares" / "Cancel" buttons that buffer changes locally and submit a single `PUT` on save, instead of the current per-row immediate write.
+
+### Cascade on user deletion (with admin-retention guard)
+- Listen to Nextcloud's `OCP\User\Events\UserDeletedEvent`. When user `X` is deleted:
+  1. **Remove all shares granted *to* X** (`share_type = 'user' AND share_with = X`). Group shares are unaffected — group membership is managed by Nextcloud's user removal hook elsewhere.
+  2. **For every dashboard owned by X**, evaluate the *admin pool*:
+     - The admin pool of dashboard `D` consists of every share row on `D` whose `permission_level = 'full'`, expanded as: each `user`-type share contributes one user; each `group`-type share contributes the current member list (resolved via `IGroupManager`) at deletion time.
+     - **If the admin pool is non-empty**, the dashboard MUST be retained: ownership is transferred to one admin from the pool (selection rule: prefer explicit `user`-type shares, ordered by `created_at ASC`; fall back to the alphabetically-first member of the alphabetically-first group-share). The matching share row for the new owner is deleted (they own it now). All other shares are retained as-is. The new owner receives a `dashboard_ownership_transferred` notification.
+     - **If the admin pool is empty**, the dashboard and all its placements/shares are deleted (existing behaviour).
+- This logic runs synchronously in the event listener inside a single DB transaction.
+- Group deletion is **not** handled by this change (no `GroupDeletedEvent` listener) — group shares pointing at a deleted group simply become unreachable shares; a follow-up periodic cleanup job is out of scope here.
+
+## Capabilities
+
+### New Capabilities
+
+(none — all changes fold into the existing `dashboard-sharing` capability)
+
+### Modified Capabilities
+
+- `dashboard-sharing`: adds REQ-SHARE-008 (notify on share), REQ-SHARE-009 (bulk replace), REQ-SHARE-010 (revoke-all-for-recipient), REQ-SHARE-011 (notification rendering), REQ-SHARE-012 (cascade on user delete with admin retention), REQ-SHARE-013 (ownership-transfer notification). Existing REQ-SHARE-001..007 are untouched.
+
+## Impact
+
+**Affected code:**
+
+- `lib/Notification/Notifier.php` — new `INotifier` implementation parsing `mydash`/`dashboard_shared` and `mydash`/`dashboard_ownership_transferred` subjects; deep-link target via `IURLGenerator`
+- `lib/AppInfo/Application.php` — register `Notifier` via `IRegistrationContext::registerNotifierService()`; register `UserDeletedListener` for `UserDeletedEvent`
+- `lib/Listener/UserDeletedListener.php` — new event listener implementing the retention algorithm above; depends on `DashboardMapper`, `DashboardShareMapper`, `WidgetPlacementMapper`, `IGroupManager`, `IManager` (for ownership-transfer notifications)
+- `lib/Service/DashboardShareService.php` — split internal `addShare` into `_persist + _notify` so the bulk path can do one transaction + one notification batch; add `replaceShares(int $dashboardId, array $shares, string $userId): array`, `revokeAllForRecipient(string $shareType, string $shareWith, string $callerId): int`, `transferOwnership(int $dashboardId, string $newUserId): void`
+- `lib/Controller/DashboardShareApiController.php` — add `replace(int $id, array $shares)` and `revokeForRecipient(string $shareType, string $shareWith)` actions
+- `appinfo/routes.php` — register `PUT /api/dashboard/{id}/shares` and `DELETE /api/sharees/{shareType}/{shareWith}`
+- `src/services/api.js` — add `replaceShares(id, shares)` and `revokeAllForRecipient(shareType, shareWith)`
+- `src/components/DashboardConfigModal.vue` — buffer share edits in local state until save; "Save" calls `replaceShares` once
+
+**Affected APIs:**
+
+- 2 new routes (PUT bulk replace, DELETE revoke-all)
+- 0 existing routes change semantics; the per-row `POST /api/dashboard/{id}/shares` and `DELETE /api/dashboard/share/{shareId}` continue to exist and continue to publish notifications, so legacy clients keep working
+
+**Dependencies:**
+
+- `OCP\Notification\IManager` and `INotifier` — already available in Nextcloud core, no new composer dep
+- `OCP\User\Events\UserDeletedEvent` — already available
+- No new npm dependencies
+
+**Migration:**
+
+- No schema changes. The existing `oc_mydash_dashboard_shares` table is sufficient.
+- One-time data hygiene: a one-shot repair step (`Migration/Version001006Date20260430130000.php`) MAY scan for shares whose `share_with` userId no longer exists in `oc_users` and remove them. This is OPTIONAL and gated behind an admin opt-in to avoid surprise data deletion on environments with federated/external users.

--- a/openspec/changes/dashboard-sharing-followups/specs/dashboard-sharing/spec.md
+++ b/openspec/changes/dashboard-sharing-followups/specs/dashboard-sharing/spec.md
@@ -1,0 +1,228 @@
+---
+capability: dashboard-sharing
+delta: true
+status: draft
+---
+
+# Dashboard Sharing — Delta from change `2026-04-30-dashboard-sharing-followups`
+
+## ADDED Requirements
+
+### Requirement: REQ-SHARE-008 Notify recipient on share add and on level upgrade
+
+When a share is created OR its `permission_level` is **upgraded** (`view_only → add_only|full`, or `add_only → full`), the system MUST publish a Nextcloud notification to each affected recipient via `OCP\Notification\IManager`. The notification MUST use:
+
+- `app: 'mydash'`, `subject: 'dashboard_shared'`
+- `objectType: 'dashboard'`, `objectId: <dashboardId as string>`
+- `subjectParameters: [sharerUserId, dashboardName, permissionLevel]`
+
+For `share_type='group'` shares, the system MUST fan out one notification per current group member at publish time, excluding the sharer.
+
+The system MUST NOT publish notifications when:
+- a share is **removed** (revocation is silent)
+- a share's level is **downgraded** (`full → add_only|view_only`, or `add_only → view_only`)
+- a re-share writes the same `(dashboardId, shareType, shareWith, permissionLevel)` tuple (no-op upsert)
+
+#### Scenario: User share publishes one notification
+
+- GIVEN alice owns dashboard `5` ("Q3 Plan"), and bob has no existing share on it
+- WHEN alice sends `POST /api/dashboard/5/shares` with `{shareType: "user", shareWith: "bob", permissionLevel: "view_only"}`
+- THEN exactly one `INotification` MUST be published with `user='bob'`, `app='mydash'`, `subject='dashboard_shared'`, parameters `["alice", "Q3 Plan", "view_only"]`, `objectType='dashboard'`, `objectId='5'`
+
+#### Scenario: Group share fans out per current member
+
+- GIVEN dashboard `5` has no shares
+- AND group `marketing` has members `bob`, `carol`, `dave`
+- WHEN alice (not a member of `marketing`) sends `POST /api/dashboard/5/shares` with `{shareType: "group", shareWith: "marketing", permissionLevel: "full"}`
+- THEN exactly 3 notifications MUST be published — one each to bob, carol, dave
+- AND alice MUST NOT receive a notification even if she is a member of `marketing`
+
+#### Scenario: Level upgrade publishes a notification
+
+- GIVEN dashboard `5` is shared with bob at `view_only`
+- WHEN alice updates the share to `permissionLevel: "full"` via `POST /api/dashboard/5/shares` with the same `(shareType, shareWith)`
+- THEN one `INotification` MUST be published to bob with `subjectParameters[2] = "full"`
+
+#### Scenario: Level downgrade is silent
+
+- GIVEN dashboard `5` is shared with bob at `full`
+- WHEN alice updates the share to `permissionLevel: "view_only"`
+- THEN no `INotification` MUST be published
+
+#### Scenario: No-op upsert is silent
+
+- GIVEN dashboard `5` is shared with bob at `view_only`
+- WHEN alice re-sends `POST /api/dashboard/5/shares` with `{shareType: "user", shareWith: "bob", permissionLevel: "view_only"}`
+- THEN the share row MUST remain unchanged (same `created_at`)
+- AND no `INotification` MUST be published
+
+#### Scenario: Revocation is silent
+
+- GIVEN dashboard `5` is shared with bob at `view_only` (share id 17)
+- WHEN alice sends `DELETE /api/dashboard/share/17`
+- THEN the share row MUST be deleted
+- AND no `INotification` MUST be published
+
+### Requirement: REQ-SHARE-009 Bulk replace shares
+
+The system MUST support `PUT /api/dashboard/{id}/shares` accepting a JSON body `{"shares": Share[]}` that replaces the entire share list for the dashboard atomically. Only the dashboard owner MUST be allowed to call this endpoint. The operation MUST run in a single DB transaction.
+
+After the transaction commits, the system MUST publish notifications per REQ-SHARE-008 only for entries that are newly added or upgraded; entries that are unchanged, removed, or downgraded MUST NOT trigger a notification.
+
+#### Scenario: Replace adds, upgrades, and removes in one call
+
+- GIVEN dashboard `5` (owned by alice) has shares: `(user, bob, view_only)`, `(user, carol, view_only)`, `(group, sales, view_only)`
+- WHEN alice sends `PUT /api/dashboard/5/shares` with body `{"shares": [{"shareType": "user", "shareWith": "bob", "permissionLevel": "full"}, {"shareType": "user", "shareWith": "dave", "permissionLevel": "view_only"}]}`
+- THEN after commit, the share rows for dashboard `5` MUST be exactly: `(user, bob, full)` and `(user, dave, view_only)`
+- AND notifications MUST be published to bob (level upgrade) and dave (new share)
+- AND no notification MUST be published to carol (removed) or sales members (removed)
+
+#### Scenario: Idempotent re-PUT publishes nothing
+
+- GIVEN dashboard `5` has shares `(user, bob, full)` and `(user, dave, view_only)`
+- WHEN alice sends `PUT /api/dashboard/5/shares` with the exact same payload
+- THEN no rows MUST change
+- AND no notifications MUST be published
+
+#### Scenario: Non-owner is denied
+
+- GIVEN dashboard `5` is owned by alice and shared with bob at `full`
+- WHEN bob sends `PUT /api/dashboard/5/shares` with any payload
+- THEN the system MUST return HTTP 403
+- AND no rows MUST be modified
+
+### Requirement: REQ-SHARE-010 Revoke all shares granted to a recipient
+
+The system MUST support `DELETE /api/sharees/{shareType}/{shareWith}` for an authenticated user. The operation MUST delete every share row where:
+
+- `share_type = $shareType AND share_with = $shareWith`, AND
+- the share's `dashboard_id` references a dashboard whose `user_id` equals the calling user's id
+
+It MUST NOT touch shares on dashboards owned by other users, even if the calling user has a `full`-level share on them.
+
+The response MUST include the count of removed share rows. No notifications MUST be published.
+
+#### Scenario: Owner revokes a recipient across all their dashboards
+
+- GIVEN alice owns dashboards `5` and `7`
+- AND both are shared with bob at various levels
+- AND alice is also a member of group `marketing`, and dashboard `9` (owned by carol) is shared with `marketing` at `full`
+- WHEN alice sends `DELETE /api/sharees/user/bob`
+- THEN the share rows on dashboards `5` and `7` referencing bob MUST be deleted
+- AND any share row on dashboard `9` MUST remain unchanged (alice is not the owner of `9`)
+- AND the response MUST report the number of rows actually deleted (2 in this scenario)
+
+### Requirement: REQ-SHARE-011 Notifier renders share and ownership-transfer subjects
+
+The app MUST register an `OCP\Notification\INotifier` implementation with `id = 'mydash'` that handles two subjects: `dashboard_shared` and `dashboard_ownership_transferred`. For any other subject the notifier MUST throw `\OCP\Notification\UnknownNotificationException` so that other notifiers may handle it.
+
+For `dashboard_shared`, the rendered notification MUST include:
+- A rich subject "{sharerDisplayName} shared **{dashboardName}** with you"
+- A parsed message naming the permission level (e.g. "Full access", "Add-only access", "View-only access")
+- A primary link to `/apps/mydash/?dashboard={dashboardUuid}`
+
+For `dashboard_ownership_transferred`, the rendered notification MUST include:
+- A rich subject "**{dashboardName}** is now yours"
+- A parsed message stating ownership was transferred because the previous owner was removed
+- A primary link to the same deep link
+
+Localisation MUST be performed via `IFactory::get('mydash')` so the existing Dutch and English translation files are used.
+
+#### Scenario: Notifier renders share notification in English
+
+- GIVEN an `INotification` with `app='mydash'`, `subject='dashboard_shared'`, `subjectParameters=['alice','Q3 Plan','full']`, `objectType='dashboard'`, `objectId='5'`
+- WHEN the notifier prepares it for `languageCode='en'`
+- THEN the rich subject MUST be `"alice shared **Q3 Plan** with you"`
+- AND the parsed message MUST be `"Full access"`
+- AND the link MUST resolve via `IURLGenerator::linkToRouteAbsolute('mydash.page.index') . '?dashboard=' . <uuid of dashboard 5>`
+
+#### Scenario: Unknown subject throws
+
+- GIVEN an `INotification` with `app='mydash'`, `subject='something_else'`
+- WHEN the notifier prepares it
+- THEN `\OCP\Notification\UnknownNotificationException` MUST be thrown
+
+### Requirement: REQ-SHARE-012 Cascade and admin retention on user deletion
+
+The app MUST listen to `OCP\User\Events\UserDeletedEvent`. On every event for user `X`, in a single DB transaction per affected dashboard, the system MUST:
+
+1. **Recipient cleanup**: delete every share row where `share_type='user' AND share_with=X`. Group shares are unaffected.
+
+2. **Owned-dashboard handling**: for every dashboard whose `user_id = X`:
+   - **Compute the admin pool**: every user reachable via a share row on that dashboard with `permission_level = 'full'`. `user`-type shares contribute their target uid; `group`-type shares contribute the group's current member list (resolved live via `IGroupManager`). Already-deleted users (resolved through `IUserManager::get(uid)`) MUST be excluded.
+   - **If the admin pool is non-empty**: the dashboard MUST be retained. Pick the new owner via REQ-SHARE-013, transfer ownership, and delete only the share row that previously granted that new owner access. All other shares MUST be retained.
+   - **If the admin pool is empty**: the dashboard, its widget placements, and all its share rows MUST be deleted (existing cascade behaviour from REQ-SHARE-007).
+
+#### Scenario: Owner deletion preserves dashboard with a full-level user share
+
+- GIVEN alice owns dashboard `5`
+- AND dashboard `5` is shared with bob at `full` and with carol at `view_only`
+- WHEN the system processes `UserDeletedEvent` for alice
+- THEN dashboard `5` MUST still exist
+- AND `dashboards.user_id` for dashboard `5` MUST equal `bob`
+- AND the share row that granted bob access MUST be deleted
+- AND the share row granting carol view-only access MUST remain
+
+#### Scenario: Owner deletion preserves dashboard via group full-level share
+
+- GIVEN alice owns dashboard `5`
+- AND dashboard `5` is shared with group `leads` (members `dave`, `eve`) at `full`
+- AND no other shares exist
+- WHEN the system processes `UserDeletedEvent` for alice
+- THEN dashboard `5` MUST still exist
+- AND `user_id` for dashboard `5` MUST equal `dave` (alphabetically-first member of the group, see REQ-SHARE-013)
+- AND the group share row MUST remain (group shares are not consumed by ownership transfer)
+
+#### Scenario: Owner deletion deletes dashboard when no admin pool
+
+- GIVEN alice owns dashboard `5`
+- AND dashboard `5` is shared with bob at `view_only` only
+- WHEN the system processes `UserDeletedEvent` for alice
+- THEN dashboard `5` MUST be deleted
+- AND its widget placements MUST be deleted
+- AND its share row to bob MUST be deleted
+
+#### Scenario: Recipient deletion cleans up that user's shares
+
+- GIVEN dashboards `5`, `7`, and `9` each have a share `(user, bob, view_only)`
+- AND bob owns no dashboards himself
+- WHEN the system processes `UserDeletedEvent` for bob
+- THEN all three of those share rows MUST be deleted
+- AND no other state MUST change
+
+#### Scenario: Group share where every member is gone falls through to delete
+
+- GIVEN alice owns dashboard `5`
+- AND dashboard `5` is shared with group `ghosts` at `full`
+- AND every member of `ghosts` is a deleted user (none resolve via `IUserManager::get`)
+- WHEN the system processes `UserDeletedEvent` for alice
+- THEN dashboard `5` MUST be deleted (admin pool is empty after filtering)
+
+### Requirement: REQ-SHARE-013 Deterministic new-owner selection
+
+When REQ-SHARE-012 calls for picking a new owner from the admin pool, the system MUST apply this ordering rule:
+
+1. Among `share_type='user'` shares with `permission_level='full'`, pick the one with the smallest `created_at`.
+2. If none, expand the alphabetically-first `share_type='group'` share with `permission_level='full'`. From that group's still-existing members (per `IUserManager::get`), pick the alphabetically-first uid.
+3. If both branches yield no candidate, fall back to the deletion path (REQ-SHARE-012, empty-pool branch).
+
+The selected new owner MUST receive a notification with `subject='dashboard_ownership_transferred'`, `subjectParameters=[dashboardName]`, `objectType='dashboard'`, `objectId=<dashboardId>`.
+
+#### Scenario: User share earliest created wins
+
+- GIVEN dashboard `5` has full-level user shares: `(bob, created_at='2026-01-15')`, `(carol, created_at='2026-02-01')`, `(dave, created_at='2025-12-10')`
+- WHEN ownership transfer is required
+- THEN dave MUST be selected (earliest `created_at`)
+
+#### Scenario: Falls back to alphabetic group member when no user shares
+
+- GIVEN dashboard `5` has only group full-level shares: `(zeta-team, full)`, `(alpha-team, full)`
+- AND `alpha-team` members are `victor`, `bob`, `alex`; `zeta-team` is `mark`, `lily`
+- WHEN ownership transfer is required
+- THEN alex MUST be selected (alphabetically-first member of alphabetically-first group)
+
+#### Scenario: Ownership-transfer notification is published to the new owner only
+
+- GIVEN dashboard `5` ("Q3 Plan") undergoes ownership transfer to bob
+- WHEN the listener completes
+- THEN exactly one `INotification` MUST be published with `user='bob'`, `subject='dashboard_ownership_transferred'`, `subjectParameters=['Q3 Plan']`, `objectType='dashboard'`, `objectId='5'`

--- a/openspec/changes/dashboard-sharing-followups/tasks.md
+++ b/openspec/changes/dashboard-sharing-followups/tasks.md
@@ -1,0 +1,91 @@
+# Tasks — dashboard-sharing-followups
+
+## 1. Notifier service
+
+- [ ] 1.1 Create `lib/Notification/Notifier.php` implementing `OCP\Notification\INotifier`
+  - `getID()` returns `'mydash'`
+  - `getName()` returns `'MyDash'` (translatable)
+  - `prepare(INotification, $languageCode)` handles two subjects: `dashboard_shared`, `dashboard_ownership_transferred`
+  - For unknown subjects throw `\OCP\Notification\UnknownNotificationException`
+  - Use `IURLGenerator::linkToRouteAbsolute('mydash.page.index')` plus a `?dashboard={uuid}` query for the deep link
+- [ ] 1.2 Use `IFactory::get('mydash')` for translations of the rendered strings:
+  - `dashboard_shared`: rich subject "Alice shared **Marketing Overview** with you" + parsed message "{permissionLevel} access"
+  - `dashboard_ownership_transferred`: rich subject "**Marketing Overview** is now yours" + parsed message "Ownership transferred after the previous owner was removed"
+- [ ] 1.3 Register the notifier in `lib/AppInfo/Application.php::register()` via `$context->registerNotifierService(Notifier::class)`
+- [ ] 1.4 Add unit test covering both subjects, English + at least one other locale (Dutch since project ships nl/en)
+
+## 2. Notification publishing
+
+- [ ] 2.1 Inject `OCP\Notification\IManager` into `DashboardShareService`
+- [ ] 2.2 Extract a private `_persistShare(int $dashboardId, string $shareType, string $shareWith, string $level): array{share: DashboardShare, isNew: bool, isUpgrade: bool}` from the current `addShare`
+- [ ] 2.3 Add a private `_notifyShared(DashboardShare $share, string $sharerUserId, string $dashboardName)` that:
+  - For `share_type='user'`: creates one `INotification` for that single recipient
+  - For `share_type='group'`: resolves group members at publish time via `IGroupManager::getDisplayNames()` (or members iterator) and creates one notification per current member, excluding the sharer
+  - Sets `setSubject('dashboard_shared', [sharerUserId, dashboardName, permissionLevel])` and `setObject('dashboard', (string) $dashboardId)`
+- [ ] 2.4 The current `addShare()` becomes: `_persistShare(...)` THEN `_notifyShared(...)` only when `isNew === true || isUpgrade === true` (not on downgrades, not on no-op writes)
+- [ ] 2.5 The `removeShare()` path does NOT publish anything (revocations are silent — user can re-discover absence by reopening the menu)
+- [ ] 2.6 Add unit test: mock `IManager`, assert exactly one notification per fan-out target, assert no notification on level downgrade
+
+## 3. Bulk replace endpoint
+
+- [ ] 3.1 Add `DashboardShareService::replaceShares(int $dashboardId, array $shares, string $userId): array` that:
+  - Asserts caller is owner
+  - Validates each entry's `shareType`, `shareWith`, `permissionLevel`
+  - Loads existing shares once
+  - In a single transaction: deletes shares not in payload, upserts the rest
+  - Returns the new full list
+  - Calls `_notifyShared` only for entries where `isNew === true || isUpgrade === true`
+- [ ] 3.2 Add `DashboardShareApiController::replace(int $id, ?array $shares)` action — same `#[NoAdminRequired]` attribute, same userId guard pattern as the existing `create`
+- [ ] 3.3 Register route `PUT /api/dashboard/{id}/shares` in `appinfo/routes.php`
+- [ ] 3.4 Add `api.replaceShares(dashboardId, shares)` to `src/services/api.js`
+- [ ] 3.5 Update `DashboardConfigModal.vue`: replace the per-row immediate `addShare`/`removeShare` calls with a `pendingShares` data array. Save button posts via `replaceShares` and reloads. Cancel reverts to the server snapshot.
+- [ ] 3.6 Add backend integration test covering: add+remove+upgrade in one PUT; idempotent re-PUT with same payload publishes 0 notifications
+
+## 4. Revoke-all-for-recipient
+
+- [ ] 4.1 Add `DashboardShareService::revokeAllForRecipient(string $shareType, string $shareWith, string $callerId): int` that:
+  - Joins `oc_mydash_dashboard_shares` to `oc_mydash_dashboards` on `dashboardId = id` filtered to `dashboards.user_id = callerId`
+  - Deletes all matching rows in one statement, returns the affected row count
+- [ ] 4.2 Add `DashboardShareApiController::revokeForRecipient(string $shareType, string $shareWith)`
+- [ ] 4.3 Register route `DELETE /api/sharees/{shareType}/{shareWith}` in `appinfo/routes.php`
+- [ ] 4.4 Add `api.revokeAllForRecipient(shareType, shareWith)` to `src/services/api.js`
+- [ ] 4.5 No UI surface in this change — exposed for admin tools / scripted cleanup. Frontend wiring deferred.
+
+## 5. UserDeletedEvent listener with admin retention
+
+- [ ] 5.1 Create `lib/Listener/UserDeletedListener.php` implementing `IEventListener<UserDeletedEvent>`
+- [ ] 5.2 Register in `lib/AppInfo/Application.php::register()` via `$context->registerEventListener(UserDeletedEvent::class, UserDeletedListener::class)`
+- [ ] 5.3 In `handle()`:
+  - Resolve `$userId = $event->getUser()->getUID()`
+  - **Step A**: delete every share where `share_type='user' AND share_with=$userId` (recipient cleanup)
+  - **Step B**: for every dashboard owned by `$userId`:
+    - Compute admin pool: load every share with `permission_level='full'`; for `user`-type entries the userId is added directly; for `group`-type entries, expand via `IGroupManager::get($groupId)->searchUsers('', 1000)` capped at 1000 per group
+    - Filter the admin pool to existing users (skip already-deleted accounts)
+    - **If pool is empty**: delete the dashboard, its placements, and its shares (existing `deleteDashboard` logic via `DashboardService`)
+    - **If pool is non-empty**: pick the new owner using the rule below, transfer ownership, delete only the new owner's matching share row, publish a `dashboard_ownership_transferred` notification to them
+  - All Step B work runs in a single DB transaction per dashboard
+- [ ] 5.4 New-owner selection rule (codified):
+  1. Among `user`-type shares with `permission_level='full'`, take the one with the smallest `created_at`
+  2. If none, expand the alphabetically-first `group`-type share's member list and pick the alphabetically-first uid still active
+  3. If both fail (pool became empty between resolve and pick), fall through to delete
+- [ ] 5.5 Add `DashboardShareService::transferOwnership(int $dashboardId, string $newUserId): void`:
+  - Updates the dashboard's `user_id` and stamps `updated_at`
+  - Deletes the share row that previously gave `newUserId` access
+  - All other shares are kept as-is
+- [ ] 5.6 Add unit tests: pool with one user share; pool with only group share; pool empty; group share where every member is also deleted (cycle); concurrent owner-deletion edge case
+
+## 6. Optional one-shot data hygiene migration
+
+- [ ] 6.1 Create `lib/Migration/Version001006Date20260430130000.php` (`SimpleMigrationStep`)
+- [ ] 6.2 In `postSchemaChange`, gated by an admin setting `mydash.cleanup_orphan_shares = true`:
+  - Find share rows where `share_type='user'` and the `share_with` uid no longer resolves via `IUserManager::get()`
+  - Find share rows where `share_type='group'` and the `share_with` group no longer resolves via `IGroupManager::get()`
+  - Delete those rows; emit a count to the migration output
+- [ ] 6.3 Default the setting to `false` so no surprise deletions on federated environments
+
+## 7. Documentation + telemetry
+
+- [ ] 7.1 Update `docs/sharing.md` (create if missing) with the share lifecycle diagram, including the new ownership-transfer path
+- [ ] 7.2 Add a `mydash_dashboards_orphaned_at_owner_deletion_total` Prometheus counter incremented inside `UserDeletedListener` for each dashboard where the admin pool was empty (we deleted)
+- [ ] 7.3 Add a `mydash_dashboard_ownership_transferred_total` counter for the success branch
+- [ ] 7.4 Update `openspec/specs/dashboard-sharing/spec.md` with the new REQ-SHARE-008..013 once the change is archived (this is the post-merge merge step done by `/opsx-archive`)

--- a/openspec/changes/dashboard-switcher-sidebar/proposal.md
+++ b/openspec/changes/dashboard-switcher-sidebar/proposal.md
@@ -1,0 +1,54 @@
+# Dashboard switcher sidebar
+
+## Why
+
+The runtime shell (`WorkspaceApp.vue`) currently has no first-class navigation surface for switching between the dashboards a user can see. With `multi-scope-dashboards` introducing three sources (personal, primary group, default group) plus a `source` discriminator, users need a single place to browse them all and pick one. Inline switching from the topbar would not scale beyond a handful of dashboards and could not host the personal-dashboard create/delete affordances that `allow_user_dashboards` gates. A dedicated slide-in sidebar gives every visible dashboard a row, groups them by origin, and isolates the animation + emit contract from the runtime shell so each can evolve independently (e.g. a future "shared with me" section).
+
+## What Changes
+
+- Add a new `dashboard-switcher` capability owning a slide-in left navigation panel.
+- Render up to three sections in fixed order (primary group / default group / personal), with empty sections collapsed entirely (no orphan headings).
+- Each row uses the shared `IconRenderer` from the `dashboard-icons` capability — no inline icon-URL branching in the sidebar template.
+- Click on any row emits `update:open(false)` then `switch(id, source)`; the `source` discriminator is load-bearing because the parent uses it to pick the correct API endpoint (group vs default vs personal).
+- Personal rows expose a hover-revealed delete button (CSS `display: none → inline-flex`) that emits `delete-dashboard(id)` with `@click.stop` so it never triggers a switch.
+- A `+ New Dashboard` row appears at the end of the personal section when (and only when) `allowUserDashboards === true`; clicking it emits `update:open(false)` then `create-dashboard()`.
+- Slide-in animation is CSS-only via `transform: translateX(-100%) ↔ translateX(0)` over 0.25s ease; the `.open` class is toggled from the `isOpen` prop.
+- A companion `SidebarBackdrop.vue` is added so the runtime shell can wire click-to-close without polluting the sidebar's own DOM.
+
+## Capabilities
+
+### New Capabilities
+
+- `dashboard-switcher` — owns REQ-SWITCH-001..007 covering three-section layout, switch/click semantics, active-item highlight, personal-row delete affordance, create-dashboard affordance, slide-in animation, and shared icon rendering.
+
+### Modified Capabilities
+
+(none — `dashboards` and `dashboard-icons` are consumed but not modified)
+
+## Impact
+
+**Affected code:**
+
+- `src/components/Workspace/DashboardSwitcherSidebar.vue` — the new sidebar component
+- `src/components/Workspace/SidebarBackdrop.vue` — click-to-close backdrop consumed by `runtime-shell`
+- `src/views/WorkspaceApp.vue` — wire `v-model:open`, handle `@switch`, `@create-dashboard`, `@delete-dashboard`
+- Translation catalogue entries: `'Dashboards'`, `'Default'`, `'My Dashboards'`, `'+ New Dashboard'`, `'Delete dashboard'`, `'Close'`
+
+**Affected APIs:**
+
+- None directly. The sidebar emits `switch(id, source)` and the parent (`runtime-shell`) routes to the correct endpoint already defined in `multi-scope-dashboards` (REQ-DASH-013/REQ-DASH-014).
+
+**Dependencies:**
+
+- Consumes `IconRenderer` from the `dashboard-icons` capability (built-in icons + URL discriminator)
+- No new npm dependencies
+
+**Migration:**
+
+- Pure additive frontend change. No schema or API migration required.
+
+## Notes
+
+- The `source` discriminator on each emit is load-bearing — it tells the runtime shell which fetch endpoint to use (group vs user vs default group).
+- All section labels are translated via `t()`.
+- A future "(read-only)" affix on group/default dashboards is out of scope; tracked separately if needed.

--- a/openspec/changes/dashboard-switcher-sidebar/specs/dashboard-switcher/spec.md
+++ b/openspec/changes/dashboard-switcher-sidebar/specs/dashboard-switcher/spec.md
@@ -1,0 +1,161 @@
+---
+capability: dashboard-switcher
+delta: true
+status: draft
+---
+
+# Dashboard Switcher — Delta from change `dashboard-switcher-sidebar`
+
+## Purpose
+
+The dashboard switcher is a left-edge slide-in sidebar that lets a user see every dashboard visible to them and switch between them with a single click. Dashboards are grouped into three labelled sections by source (primary group, default group, personal). The sidebar also surfaces personal-dashboard creation and deletion when allowed.
+
+## Data Model
+
+The component is stateless beyond its `v-model:open` flag. Its inputs:
+
+| Prop | Type | Required | Notes |
+|---|---|---|---|
+| `isOpen` | `Boolean` | yes | controlled by parent via `v-model:open` |
+| `groupName` | `String` | no | display name of the user's primary group; falls back to `'Dashboards'` |
+| `groupDashboards` | `Array<{id, name, icon, source: 'group'\|'default'}>` | yes | combined matched + folded default group |
+| `userDashboards` | `Array<{id, name, icon}>` | yes | personal dashboards |
+| `activeDashboardId` | `String` | no | id of currently active dashboard for highlighting |
+| `allowUserDashboards` | `Boolean` | no | when true, "+ New Dashboard" affordance is shown |
+
+Emits: `switch(id: string, source: 'group'\|'default'\|'user')`, `create-dashboard()`, `delete-dashboard(id: string)`, `update:open(boolean)`.
+
+## ADDED Requirements
+
+### Requirement: REQ-SWITCH-001 Three-section navigation
+
+The sidebar MUST render up to three sections in this fixed order, separated by a horizontal divider when both adjacent sections are non-empty:
+
+1. **Primary group dashboards** — items from `groupDashboards` where `source !== 'default'`. Section label: `groupName || t('Dashboards')`.
+2. **Default group dashboards** — items from `groupDashboards` where `source === 'default'`. Section label: `t('Default')`.
+3. **My Dashboards** — items from `userDashboards`. Rendered when `userDashboards.length > 0` OR `allowUserDashboards === true`. Section label: `t('My Dashboards')`.
+
+Empty sections MUST NOT render their label or container at all (no empty heading).
+
+#### Scenario: All three sections present
+
+- GIVEN `groupDashboards` contains 2 matched + 1 default-source items, and `userDashboards` contains 2 items
+- WHEN the sidebar renders
+- THEN it MUST render 3 section headings in order: `groupName`, `'Default'`, `'My Dashboards'`
+- AND there MUST be exactly 2 dividers (between sections 1↔2 and 2↔3)
+
+#### Scenario: Only personal dashboards section visible
+
+- GIVEN `groupDashboards = []` and `userDashboards` has 1 item
+- WHEN the sidebar renders
+- THEN only the `'My Dashboards'` section MUST be visible
+- AND no dividers MUST render
+
+#### Scenario: Personal section visible when allowed even with empty list
+
+- GIVEN `userDashboards = []` and `allowUserDashboards: true`
+- WHEN the sidebar renders
+- THEN the `'My Dashboards'` section heading MUST render
+- AND the `+ New Dashboard` button MUST be the only entry in the section
+
+### Requirement: REQ-SWITCH-002 Switch click semantics
+
+Clicking any dashboard item MUST emit `switch(id, source)` where `source` is derived from the item's section:
+
+- Primary-group items → `source: 'group'`
+- Default-group items → `source: 'default'` (regardless of the dashboard's record-level source)
+- Personal items → `source: 'user'`
+
+Before emitting `switch`, the sidebar MUST emit `update:open(false)` so the parent can close the sidebar in the same tick.
+
+#### Scenario: Click a personal dashboard
+
+- GIVEN the user clicks an item in the `My Dashboards` section with `id = 'p1'`
+- THEN the sidebar MUST emit `update:open(false)`
+- AND THEN MUST emit `switch('p1', 'user')`
+
+#### Scenario: Click a default-group dashboard
+
+- GIVEN the user clicks an item in the `Default` section with `id = 'd1'`
+- THEN the sidebar MUST emit `switch('d1', 'default')`
+- AND MUST NOT emit `switch('d1', 'group')` even though the underlying dashboard is technically a `group_shared` type
+
+### Requirement: REQ-SWITCH-003 Active item highlight
+
+The dashboard whose `id === activeDashboardId` MUST receive a visual `.active` class with `--color-primary-element-light` background and `--color-primary` icon tint. At most one item may be active at a time.
+
+#### Scenario: Active highlight follows prop
+
+- GIVEN `activeDashboardId = 'd1'`
+- WHEN the sidebar renders
+- THEN the item with id `'d1'` MUST have CSS class `active`
+- AND no other item MUST have that class
+
+#### Scenario: Active highlight updates on prop change
+
+- GIVEN `activeDashboardId` changes from `'d1'` to `'p1'`
+- WHEN the next render cycle runs
+- THEN `'d1'` MUST lose the `active` class
+- AND `'p1'` MUST gain it
+
+### Requirement: REQ-SWITCH-004 Personal dashboard delete affordance
+
+Items in the `My Dashboards` section (excluding the `+ New Dashboard` row) MUST display a small close-icon delete button on hover (CSS-only `display: none → inline-flex`). Clicking it MUST emit `delete-dashboard(id)` and MUST NOT trigger the row's `switch` event (use `@click.stop`).
+
+#### Scenario: Hover reveals delete button
+
+- GIVEN a personal dashboard item with `id = 'p1'`
+- WHEN the user hovers over the row
+- THEN the delete button MUST become visible (CSS hover state)
+
+#### Scenario: Delete click does not trigger switch
+
+- GIVEN the delete button is visible
+- WHEN the user clicks it
+- THEN the sidebar MUST emit `delete-dashboard('p1')`
+- AND MUST NOT emit `switch(...)`
+- AND MUST NOT emit `update:open(false)` (closing decision is up to the parent)
+
+### Requirement: REQ-SWITCH-005 Create-dashboard affordance
+
+When `allowUserDashboards: true`, the `My Dashboards` section MUST end with a row labelled `t('+ New Dashboard')` (with a Plus icon) styled as a primary-coloured action. Clicking it MUST emit `update:open(false)` THEN `create-dashboard()`.
+
+#### Scenario: Create button hidden when feature disabled
+
+- GIVEN `allowUserDashboards: false`
+- WHEN the sidebar renders
+- THEN the `+ New Dashboard` row MUST NOT be present in the DOM
+
+#### Scenario: Create button click
+
+- GIVEN the user clicks `+ New Dashboard`
+- THEN the sidebar MUST emit `update:open(false)`
+- AND THEN MUST emit `create-dashboard` (no payload)
+
+### Requirement: REQ-SWITCH-006 Slide-in animation
+
+The sidebar MUST be fixed-position (`top: 50px` to clear the Nextcloud header), `width: 280px`, `z-index: 1500`. Open/close MUST be animated via `transform: translateX(-100%)` ↔ `translateX(0)` over `0.25s ease`. The `.open` CSS class MUST be added when `isOpen === true`.
+
+#### Scenario: Closed state is off-screen
+
+- GIVEN `isOpen: false`
+- WHEN the sidebar renders
+- THEN its computed `transform` MUST equal `translateX(-100%)`
+- AND it MUST be invisible to the user (off-screen)
+
+#### Scenario: Open state slides in
+
+- GIVEN `isOpen` transitions from `false` to `true`
+- THEN the sidebar's `transform` MUST animate to `translateX(0)` over 250 ms
+- AND `transition-timing-function` MUST be `ease`
+
+### Requirement: REQ-SWITCH-007 Icon rendering via shared renderer
+
+Each dashboard item's icon MUST be rendered via the shared `IconRenderer` component (from `dashboard-icons` capability). The sidebar MUST NOT branch on `isCustomIconUrl` itself.
+
+#### Scenario: Mixed built-in and custom icons
+
+- GIVEN three dashboards with `icon` values `'Star'`, `'/apps/mydash/resource/x.png'`, `null`
+- WHEN the sidebar renders
+- THEN all three MUST render correctly via `IconRenderer`
+- AND no inline `v-if="iconUrl"` branches MUST exist in the sidebar template

--- a/openspec/changes/dashboard-switcher-sidebar/tasks.md
+++ b/openspec/changes/dashboard-switcher-sidebar/tasks.md
@@ -1,0 +1,40 @@
+# Tasks — dashboard-switcher-sidebar
+
+## 1. Component
+
+- [ ] 1.1 Create `src/components/Workspace/DashboardSwitcherSidebar.vue` with props (`isOpen`, `groupName`, `groupDashboards`, `userDashboards`, `activeDashboardId`, `allowUserDashboards`) and emits (`switch`, `create-dashboard`, `delete-dashboard`, `update:open`) per REQ-SWITCH-001..007
+- [ ] 1.2 Add internal computed `matchedGroupDashboards = groupDashboards.filter(d => d.source !== 'default')` and `defaultGroupDashboards = groupDashboards.filter(d => d.source === 'default')` (REQ-SWITCH-001)
+- [ ] 1.3 Use `<IconRenderer>` for every icon (no inline `v-if="iconUrl"` branches in this template) (REQ-SWITCH-007)
+- [ ] 1.4 CSS root: `position: fixed; top: 50px; width: 280px; z-index: 1500; transform: translateX(-100%); transition: transform .25s ease` (REQ-SWITCH-006)
+- [ ] 1.5 `&.open` selector toggles `transform: translateX(0)` when `isOpen === true` (REQ-SWITCH-006)
+- [ ] 1.6 Personal-row delete button: `display: none` by default, `inline-flex` on row hover; click handler uses `@click.stop` and emits `delete-dashboard(id)` only (REQ-SWITCH-004)
+- [ ] 1.7 Active-item highlight: row with `id === activeDashboardId` gets `.active` class with `--color-primary-element-light` background and `--color-primary` icon tint (REQ-SWITCH-003)
+- [ ] 1.8 Click on dashboard row emits `update:open(false)` THEN `switch(id, source)` where `source` is derived from the row's section (REQ-SWITCH-002)
+- [ ] 1.9 `+ New Dashboard` row only rendered when `allowUserDashboards === true`; click emits `update:open(false)` THEN `create-dashboard()` (REQ-SWITCH-005)
+- [ ] 1.10 Add companion `src/components/Workspace/SidebarBackdrop.vue` (click-to-close backdrop) for the runtime shell to wire alongside the sidebar
+
+## 2. Integration
+
+- [ ] 2.1 Wire `<DashboardSwitcherSidebar>` from `src/views/WorkspaceApp.vue` (runtime-shell) with `v-model:open="sidebarOpen"`
+- [ ] 2.2 Parent maps `@switch` payload `(id, source)` to the correct API endpoint per REQ-DASH-013 (`source === 'user' → personal endpoint`, `'group' → group endpoint`, `'default' → default-group endpoint`)
+- [ ] 2.3 Parent handles `@create-dashboard` per REQ-DASH-020 (or current personal-create endpoint) and `@delete-dashboard` per REQ-DASH-005
+- [ ] 2.4 Parent renders `<SidebarBackdrop>` when `sidebarOpen === true`; clicking the backdrop sets `sidebarOpen = false`
+
+## 3. Tests
+
+- [ ] 3.1 Vitest: section visibility table — three sections × empty/non-empty matrix (REQ-SWITCH-001)
+- [ ] 3.2 Vitest: emit order on switch — `update:open(false)` MUST be emitted before `switch(id, source)` (REQ-SWITCH-002)
+- [ ] 3.3 Vitest: `source` discriminator on switch matches the section the row was rendered in (REQ-SWITCH-002)
+- [ ] 3.4 Vitest: `delete-dashboard` does not also emit `switch` or `update:open` (REQ-SWITCH-004)
+- [ ] 3.5 Vitest: `+ New Dashboard` row absent from the DOM when `allowUserDashboards: false` (REQ-SWITCH-005)
+- [ ] 3.6 Vitest: `.active` class is on exactly the row whose id matches `activeDashboardId`, and updates reactively when the prop changes (REQ-SWITCH-003)
+- [ ] 3.7 Playwright: hover reveals delete button on personal items only; group/default items have no delete affordance (REQ-SWITCH-004)
+- [ ] 3.8 Playwright: clicking the backdrop or the topbar hamburger closes the sidebar; clicking the sidebar itself does not
+- [ ] 3.9 Playwright: open/close animation completes in ~250 ms with `transform: translateX` driving the slide (REQ-SWITCH-006)
+
+## 4. Quality
+
+- [ ] 4.1 ESLint + Stylelint clean
+- [ ] 4.2 Translation entries present in catalogue: `'Dashboards'`, `'Default'`, `'My Dashboards'`, `'+ New Dashboard'`, `'Delete dashboard'`, `'Close'`
+- [ ] 4.3 WCAG: keyboard focus trap inside open sidebar, Esc key closes the sidebar (emits `update:open(false)`)
+- [ ] 4.4 WCAG: every actionable row exposes an accessible name; delete button has `aria-label="Delete dashboard"`

--- a/openspec/changes/default-dashboard-flag/proposal.md
+++ b/openspec/changes/default-dashboard-flag/proposal.md
@@ -1,0 +1,59 @@
+# Default-dashboard flag per group
+
+## Why
+
+The `multi-scope-dashboards` change introduced `group_shared` dashboards but left an open question: when a user belongs to a group with multiple shared dashboards (or has no `active_dashboard` preference yet, or that preference points to a deleted dashboard), which dashboard should they land on first? Today an admin has no way to tell the system "this is the canonical entry-point dashboard for the marketing group". This change formalises a single default per group by reusing the existing `isDefault SMALLINT` column (already in use for `admin_template` records per REQ-TMPL-008) and adds the API needed to flip it. Personal `user`-type dashboards are deliberately excluded — they already have `isActive` (REQ-DASH-006) for the same purpose.
+
+## What Changes
+
+- Reuse the existing `isDefault SMALLINT` column on `oc_mydash_dashboards`; do not add a new column or a `defaultDashboardId` field on a parent table.
+- Add `DashboardService::setGroupDefault(string $groupId, string $uuid): void` that runs in a single DB transaction (UPDATE all other dashboards in the group to `isDefault=0`, then UPDATE the target to `isDefault=1`) so concurrent calls cannot leave the group in a two-default state.
+- Add admin-only endpoint `POST /api/dashboards/group/{groupId}/default` with body `{"uuid": "..."}` that invokes the service.
+- Reject the call with HTTP 404 when the target uuid does not belong to the given groupId; HTTP 403 for non-admins.
+- New `group_shared` dashboards are created with `isDefault = 0` regardless of payload contents — promotion is always explicit.
+- `PUT /api/dashboards/group/{groupId}/{uuid}` MUST NOT mutate `isDefault` even if the payload contains the field; the dedicated `POST .../default` endpoint is the only mutation path.
+- Personal `user` dashboards are unaffected — they continue to use `isActive` (REQ-DASH-006) to track which one the user has open.
+
+## Capabilities
+
+### New Capabilities
+
+(none — the feature folds into the existing `dashboards` capability)
+
+### Modified Capabilities
+
+- `dashboards`: adds REQ-DASH-015 (single default per group, transactional flip), REQ-DASH-016 (created dashboards default to `isDefault=0`), REQ-DASH-017 (PUT cannot mutate `isDefault`). Existing REQ-DASH-001..014 are untouched.
+
+The `admin-templates` capability is intentionally not modified — REQ-TMPL-008 already enforces a single default for templates and is left as-is. This change formalises the same invariant for `group_shared` records.
+
+## Impact
+
+**Affected code:**
+
+- `lib/Db/Dashboard.php` — already has `isDefault SMALLINT`; reuse for `group_shared` scope (no schema change required)
+- `lib/Db/DashboardMapper.php` — add helper for the bulk UPDATE that clears defaults inside the group
+- `lib/Service/DashboardService.php` — `setGroupDefault(string $groupId, string $uuid)` enforces the single-default invariant; also harden `saveGroupShared` to ignore any incoming `isDefault` field, and harden `updateGroupShared` to drop any `isDefault` from the patch
+- `lib/Controller/DashboardController.php` — new `setGroupDefault` action mapped to `POST /api/dashboards/group/{groupId}/default`
+- `appinfo/routes.php` — register the one new route
+- `src/views/AdminApp.vue` — "Set default" action button per dashboard row, plus a "Default" badge on the row where `isDefault === 1`
+- `src/stores/dashboards.js` — optimistic update on success, rollback on 4xx/5xx
+
+**Affected APIs:**
+
+- 1 new route: `POST /api/dashboards/group/{groupId}/default`
+- No existing routes change behaviour, but `POST` and `PUT` on the existing group endpoints are tightened to ignore the `isDefault` field in payloads (this is a documentation/serialisation change, not a contract break — the field was previously silently writable, which was the bug)
+
+**Dependencies:**
+
+- `OCP\IGroupManager` — already injected; used for the admin guard
+- `OCP\IDBConnection` — already injected; the transaction is wrapped via `beginTransaction()` / `commit()` / `rollBack()` on the existing connection
+- No new composer or npm dependencies
+
+**Migration:**
+
+- Zero schema migration required — `isDefault SMALLINT` already exists on `oc_mydash_dashboards` per the original `admin-templates` change.
+- No data backfill required; existing rows already have `isDefault = 0` by default.
+
+**Build order:**
+
+- This change MUST be applied after `multi-scope-dashboards` lands (depends on REQ-DASH-011 / REQ-DASH-014 endpoints existing).

--- a/openspec/changes/default-dashboard-flag/specs/dashboards/spec.md
+++ b/openspec/changes/default-dashboard-flag/specs/dashboards/spec.md
@@ -1,0 +1,94 @@
+---
+capability: dashboards
+delta: true
+status: draft
+---
+
+# Dashboards — Delta from change `default-dashboard-flag`
+
+## ADDED Requirements
+
+### Requirement: REQ-DASH-015 Single default group-shared dashboard per group
+
+Within each group (including the synthetic `'default'` group), at most one `group_shared` dashboard MAY have `isDefault = 1`. Switching a dashboard to default MUST atomically clear the flag on any other dashboard in the same group. The transition MUST run inside a single database transaction so concurrent calls cannot leave two dashboards with `isDefault = 1` in the same group.
+
+#### Scenario: Setting default flips others off
+
+- GIVEN group "marketing" has 3 group-shared dashboards: `A` (`isDefault=1`), `B`, `C`
+- WHEN admin sends `POST /api/dashboards/group/marketing/default` with body `{"uuid": "<C.uuid>"}`
+- THEN `C.isDefault` MUST become `1`
+- AND `A.isDefault` MUST become `0`
+- AND `B.isDefault` MUST remain `0`
+
+#### Scenario: Default cannot be set across groups
+
+- GIVEN dashboard `D1` has `groupId = 'marketing'`
+- WHEN admin sends `POST /api/dashboards/group/sales/default` with body `{"uuid": "<D1.uuid>"}`
+- THEN the system MUST return HTTP 404
+- AND no `isDefault` flag MUST be modified on any dashboard
+
+#### Scenario: Setting non-existent dashboard as default
+
+- GIVEN group "marketing" exists with no dashboards (or no dashboard with the given uuid)
+- WHEN admin sends `POST /api/dashboards/group/marketing/default` with a uuid that does not match any dashboard in the group
+- THEN the system MUST return HTTP 404
+
+#### Scenario: Non-admin cannot set default
+
+- GIVEN user "alice" who is not an administrator
+- WHEN she sends `POST /api/dashboards/group/marketing/default` with any body
+- THEN the system MUST return HTTP 403
+- AND no `isDefault` flag MUST be modified
+
+#### Scenario: Transaction safety under concurrent calls
+
+- GIVEN group "marketing" has 3 group-shared dashboards `A`, `B`, `C` with `A.isDefault=1`
+- WHEN two admins concurrently send `POST /api/dashboards/group/marketing/default` with body `{"uuid": "<B.uuid>"}` and `{"uuid": "<C.uuid>"}` respectively
+- THEN exactly one of `B` or `C` MUST end up with `isDefault=1`
+- AND the other two dashboards in the group MUST have `isDefault=0`
+- AND no row MUST be left with `isDefault=1` for two different uuids in the same group
+
+### Requirement: REQ-DASH-016 New group-shared dashboards default to non-default
+
+When a `group_shared` dashboard is created via `POST /api/dashboards/group/{groupId}`, the system MUST set `isDefault = 0` regardless of any `isDefault` field present in the request body. Promoting a dashboard to default requires an explicit `POST /api/dashboards/group/{groupId}/default` call.
+
+#### Scenario: Create-then-no-default
+
+- GIVEN group "marketing" has no dashboards
+- WHEN admin sends `POST /api/dashboards/group/marketing` with body `{"name": "First"}`
+- THEN the resulting dashboard MUST have `isDefault = 0`
+- AND no other dashboard MUST be created with `isDefault = 1`
+
+#### Scenario: Create payload cannot smuggle isDefault
+
+- GIVEN group "marketing" has no dashboards
+- WHEN admin sends `POST /api/dashboards/group/marketing` with body `{"name": "Sneaky", "isDefault": 1}`
+- THEN the resulting dashboard MUST have `isDefault = 0`
+- AND the `isDefault` field in the request body MUST be ignored by `DashboardService::saveGroupShared`
+
+#### Scenario: First dashboard in a group is not auto-promoted
+
+- GIVEN group "engineering" has zero group-shared dashboards
+- WHEN admin creates the first group-shared dashboard `D1` via `POST /api/dashboards/group/engineering`
+- THEN `D1.isDefault` MUST be `0`
+- AND the active-dashboard resolution chain MUST fall through to "first by sortOrder" semantics rather than implicitly promoting `D1`
+
+### Requirement: REQ-DASH-017 Default flag survives admin edits
+
+Updates to a group-shared dashboard via `PUT /api/dashboards/group/{groupId}/{uuid}` MUST NOT change the `isDefault` flag, regardless of payload contents. The flag is only mutated by the dedicated `POST /api/dashboards/group/{groupId}/default` endpoint.
+
+#### Scenario: PUT cannot flip the default off
+
+- GIVEN dashboard `A` has `isDefault = 1`
+- WHEN admin sends `PUT /api/dashboards/group/marketing/<A.uuid>` with body `{"name": "Renamed", "isDefault": 0}`
+- THEN `A.name` MUST become "Renamed"
+- AND `A.isDefault` MUST remain `1`
+
+#### Scenario: PUT cannot flip the default on
+
+- GIVEN dashboard `B` has `isDefault = 0`
+- AND dashboard `A` in the same group has `isDefault = 1`
+- WHEN admin sends `PUT /api/dashboards/group/marketing/<B.uuid>` with body `{"name": "Renamed", "isDefault": 1}`
+- THEN `B.name` MUST become "Renamed"
+- AND `B.isDefault` MUST remain `0`
+- AND `A.isDefault` MUST remain `1`

--- a/openspec/changes/default-dashboard-flag/tasks.md
+++ b/openspec/changes/default-dashboard-flag/tasks.md
@@ -1,0 +1,57 @@
+# Tasks — default-dashboard-flag
+
+## 1. Domain model
+
+- [ ] 1.1 Confirm `isDefault SMALLINT` already exists on the `Dashboard` entity from the original `admin-templates` change (no schema migration needed)
+- [ ] 1.2 Confirm `Dashboard::jsonSerialize()` already emits `isDefault` as an integer (0|1) — add to serialiser if missing
+
+## 2. Mapper layer
+
+- [ ] 2.1 Add `DashboardMapper::clearGroupDefaults(string $groupId, ?string $exceptUuid = null): int` — issues `UPDATE oc_mydash_dashboards SET isDefault = 0 WHERE type = 'group_shared' AND groupId = ? AND (uuid <> ? OR ? IS NULL)` and returns the row-count affected
+- [ ] 2.2 Add `DashboardMapper::setGroupDefaultUuid(string $groupId, string $uuid): int` — issues `UPDATE oc_mydash_dashboards SET isDefault = 1 WHERE type = 'group_shared' AND groupId = ? AND uuid = ?` and returns the row-count affected (0 if uuid not in group)
+
+## 3. Service layer
+
+- [ ] 3.1 Add `DashboardService::setGroupDefault(string $groupId, string $uuid): void` — admin-only via `IGroupManager::isAdmin($currentUserId)` guard; wraps both mapper calls in a single `IDBConnection::beginTransaction()` / `commit()` / `rollBack()` block
+- [ ] 3.2 If `setGroupDefaultUuid` returns 0 (uuid not in group), throw the not-found exception that maps to HTTP 404 — DO NOT clear other defaults in that case (the transaction MUST roll back so the existing default is preserved)
+- [ ] 3.3 Update `DashboardService::saveGroupShared` to drop any `isDefault` field from the incoming payload before persistence (defense-in-depth against payload smuggling)
+- [ ] 3.4 Update `DashboardService::updateGroupShared` to drop any `isDefault` field from the patch before applying it (REQ-DASH-017)
+
+## 4. Controller + routes
+
+- [ ] 4.1 Add `DashboardController::setGroupDefault(string $groupId)` accepting `uuid` from the request body, mapped to `POST /api/dashboards/group/{groupId}/default`
+- [ ] 4.2 Annotate the new method with `#[NoAdminRequired]` and perform the runtime admin check inside the body via `IGroupManager::isAdmin($currentUserId)` (matches the pattern used by `updateGroup`/`deleteGroup` in `multi-scope-dashboards`); HTTP 403 on failure
+- [ ] 4.3 Reject when target uuid does not belong to the given groupId — HTTP 404 (delegated to the service-layer exception from task 3.2)
+- [ ] 4.4 Register the new route in `appinfo/routes.php` with the same `{groupId}` regex requirement used by the `multi-scope-dashboards` group routes
+- [ ] 4.5 Confirm the new method passes `gate-route-auth` and `gate-semantic-auth`
+
+## 5. Frontend
+
+- [ ] 5.1 Add "Set Default" action button to the admin dashboard list row — only visible when `dash.isDefault === 0` and the current user is an admin
+- [ ] 5.2 Add a "Default" badge to the row where `isDefault === 1`
+- [ ] 5.3 Implement optimistic store update on click — set `isDefault=1` on the target and `isDefault=0` on all other dashboards in the same `groupId` immediately, then call the API; rollback both flips on 4xx/5xx
+- [ ] 5.4 Surface 403 / 404 error toasts using existing i18n keys
+
+## 6. PHPUnit tests
+
+- [ ] 6.1 `DashboardServiceTest::testSetGroupDefaultFlipsOthersOff` — three dashboards in a group, one is default, calling setGroupDefault on a different one moves the flag and clears the previous default
+- [ ] 6.2 `DashboardServiceTest::testSetGroupDefaultRejectsCrossGroupUuid` — uuid belongs to group A, called against group B path → throws not-found and existing default in group A is preserved
+- [ ] 6.3 `DashboardServiceTest::testSetGroupDefaultIsTransactional` — simulate failure between the two UPDATE calls and assert rollback restores the previous default
+- [ ] 6.4 `DashboardControllerTest::testSetGroupDefaultRejectsNonAdmin` — HTTP 403 for non-admin caller
+- [ ] 6.5 `DashboardControllerTest::testCreateGroupSharedIgnoresIsDefaultInBody` — POST with `isDefault: 1` in body still results in `isDefault = 0`
+- [ ] 6.6 `DashboardControllerTest::testUpdateGroupSharedDoesNotMutateIsDefault` — PUT with `isDefault: 0` on a default dashboard leaves the flag at 1; PUT with `isDefault: 1` on a non-default dashboard leaves it at 0
+
+## 7. End-to-end Playwright tests
+
+- [ ] 7.1 Admin clicks "Set Default" on a non-default group-shared dashboard row — badge moves to that row immediately (optimistic) and persists on reload
+- [ ] 7.2 Non-admin user does not see the "Set Default" button on group-shared dashboard rows
+- [ ] 7.3 Two browser tabs as the same admin: clicking "Set Default" in tab A is reflected in tab B on next reload (no two badges)
+
+## 8. Quality gates
+
+- [ ] 8.1 `composer check:strict` (PHPCS, PHPMD, Psalm, PHPStan) passes — fix any pre-existing issues encountered along the way
+- [ ] 8.2 ESLint + Stylelint clean on touched Vue/JS files
+- [ ] 8.3 Update generated OpenAPI spec / Postman collection to include `POST /api/dashboards/group/{groupId}/default`
+- [ ] 8.4 i18n keys for new error messages and the "Default" badge / "Set Default" button label exist in both `nl` and `en`
+- [ ] 8.5 SPDX headers on every new PHP file (inside the docblock per the SPDX-in-docblock convention) — `gate-spdx` must pass
+- [ ] 8.6 Run all 10 `hydra-gates` locally before opening PR

--- a/openspec/changes/fork-current-as-personal/proposal.md
+++ b/openspec/changes/fork-current-as-personal/proposal.md
@@ -1,0 +1,28 @@
+# Fork-current-layout to personal dashboard
+
+When a user is viewing a `group_shared` (or `default`) dashboard and wants to customise it, MyDash MUST allow them to one-click "fork" the current layout into a brand-new personal dashboard. The original group-shared dashboard is untouched; the fork becomes the user's active dashboard immediately.
+
+## Affected code units
+
+- `lib/Service/DashboardService.php` — `forkAsPersonal(string $userId, string $sourceUuid, string $name): Dashboard` deep-copies the source's `widget_placements` rows under a new dashboard UUID
+- `lib/Db/WidgetPlacementMapper.php` — `findByDashboardId($id)` already exists; needs a `cloneToDashboard($sourceId, $targetId)` helper
+- `lib/Controller/DashboardController.php` — `POST /api/dashboards/{uuid}/fork` action
+- `src/components/DashboardSwitcherSidebar.vue` — "+ New Dashboard" button calls fork using current layout
+- Builds on `multi-scope-dashboards` and `allow-personal-dashboards-flag`
+
+## Why a delta
+
+Forking is a creation operation but with non-trivial extra semantics (deep-copy placements, become-active side effect, gating on `allow_user_dashboards` admin setting). Worth a dedicated REQ rather than overloading REQ-DASH-001.
+
+## Approach
+
+- Single transactional service method: insert dashboard row → bulk-insert cloned placements → set as active.
+- Default name uses `t('My copy of {name}', source.name)` to make provenance obvious; user can rename later via REQ-DASH-004.
+- Gated on app setting `allow_user_dashboards = '1'`; otherwise 403.
+- Source can be ANY dashboard the user can read (user/group/default) — including their own personal dashboards (effectively duplicate).
+- Does NOT carry over `isDefault` (always 0 on fork) or `groupId` (always null — fork is personal).
+
+## Notes
+
+- Resource references inside placements (e.g. uploaded image URLs) are NOT duplicated — both dashboards reference the same `/apps/mydash/resource/...` URL. Resource lifecycle is the resource-uploads change's concern.
+- Tile fields on placements ARE copied (tileTitle, tileIcon, etc.) so a fork is a true visual clone.

--- a/openspec/changes/fork-current-as-personal/specs/dashboards/spec.md
+++ b/openspec/changes/fork-current-as-personal/specs/dashboards/spec.md
@@ -1,0 +1,71 @@
+---
+capability: dashboards
+delta: true
+status: draft
+---
+
+# Dashboards — Delta from change `fork-current-as-personal`
+
+## ADDED Requirements
+
+### Requirement: REQ-DASH-020 Fork any visible dashboard as a personal copy
+
+The system MUST expose `POST /api/dashboards/{uuid}/fork` that creates a new `user`-type dashboard owned by the calling user, deep-copying all widget placements from the source. The new dashboard MUST become the user's active dashboard. Forking MUST be gated on the admin setting `allow_user_dashboards = '1'`; otherwise the endpoint MUST return HTTP 403.
+
+#### Scenario: Fork a group-shared dashboard
+
+- GIVEN admin setting `allow_user_dashboards = '1'`
+- AND user "alice" can read group-shared dashboard `S` (groupId='marketing') containing 4 widget placements
+- WHEN she sends `POST /api/dashboards/{S.uuid}/fork` with body `{"name": "My Marketing"}`
+- THEN the system MUST create a new dashboard `F` with `userId = 'alice'`, `type = 'user'`, `groupId = null`, `isDefault = 0`, `isActive = 1` (and all other alice-owned dashboards deactivated), `gridColumns = S.gridColumns`, and `name = "My Marketing"`
+- AND `F` MUST contain 4 widget placements that are byte-for-byte clones of `S`'s placements (same gridX/Y/W/H, customTitle, styleConfig, tile fields) with new placement IDs and `dashboardId = F.id`
+- AND `S` MUST remain unchanged
+- AND the response MUST be HTTP 201 with the full `F` payload
+
+#### Scenario: Fork uses a default name when none provided
+
+- GIVEN dashboard `S` has `name = "Marketing Overview"`
+- WHEN alice sends `POST /api/dashboards/{S.uuid}/fork` with empty body
+- THEN the new dashboard's `name` MUST be `"My copy of Marketing Overview"` (translated string `t('My copy of {name}', {name: S.name})`)
+
+#### Scenario: Fork is gated on admin setting
+
+- GIVEN admin setting `allow_user_dashboards = '0'`
+- WHEN alice sends `POST /api/dashboards/{S.uuid}/fork` with any body
+- THEN the system MUST return HTTP 403 with `{error: 'Personal dashboards are not enabled'}`
+
+#### Scenario: Cannot fork a dashboard you cannot read
+
+- GIVEN group-shared dashboard `T` exists in group "executives" and alice does NOT belong to that group
+- WHEN alice sends `POST /api/dashboards/{T.uuid}/fork`
+- THEN the system MUST return HTTP 404 (do not leak existence)
+
+#### Scenario: Forking a personal dashboard creates an independent duplicate
+
+- GIVEN alice already has personal dashboard `P` with 2 placements
+- WHEN she sends `POST /api/dashboards/{P.uuid}/fork`
+- THEN the system MUST create a new dashboard `P2` that is a deep clone of `P`
+- AND mutating `P2` MUST NOT affect `P` (and vice versa)
+
+### Requirement: REQ-DASH-021 Fork is transactional
+
+The fork operation MUST execute inside a single database transaction. If any part fails (placement insert, deactivation of other dashboards, etc.) the entire fork MUST be rolled back and HTTP 500 returned.
+
+#### Scenario: Partial-failure rollback
+
+- GIVEN any database error occurs while inserting cloned placements
+- WHEN the fork endpoint catches the error
+- THEN the new dashboard row MUST also be removed (transaction rolled back)
+- AND `S`'s placements MUST remain visible to alice
+- AND alice's previously active dashboard (if any) MUST remain active
+
+### Requirement: REQ-DASH-022 Fork does not duplicate uploaded resources
+
+When cloned placements reference uploaded resources (e.g. `tileIcon` URLs starting with `/apps/mydash/resource/...`, or widget content fields with similar URLs), the fork MUST keep the same URL — it MUST NOT duplicate the underlying resource bytes. Both dashboards then reference the shared resource record.
+
+#### Scenario: Shared resource reference
+
+- GIVEN dashboard `S` has a tile placement with `tileIcon = '/apps/mydash/resource/abc123.png'`
+- WHEN alice forks `S`
+- THEN `F`'s corresponding placement MUST have `tileIcon = '/apps/mydash/resource/abc123.png'` (same URL)
+- AND no new file MUST be created in app data

--- a/openspec/changes/fork-current-as-personal/tasks.md
+++ b/openspec/changes/fork-current-as-personal/tasks.md
@@ -1,0 +1,31 @@
+# Tasks — fork-current-as-personal
+
+## 1. Backend
+
+- [ ] Add `WidgetPlacementMapper::cloneToDashboard(int $sourceDashboardId, int $targetDashboardId): void` (bulk INSERT … SELECT with new IDs)
+- [ ] Add `DashboardService::forkAsPersonal(string $userId, string $sourceUuid, ?string $name): Dashboard` wrapped in `IDBConnection::beginTransaction`
+- [ ] Add admin-setting check on `allow_user_dashboards`
+- [ ] Add 404 path for sources the user cannot read (reuse REQ-DASH-013 visibility resolver)
+- [ ] Default name uses `IL10N::t('My copy of {name}', ['name' => $source->getName()])`
+- [ ] Add `DashboardController::fork` mapped to `POST /api/dashboards/{uuid}/fork`
+
+## 2. Frontend
+
+- [ ] Wire "+ New Dashboard" button in `DashboardSwitcherSidebar` to `forkAsPersonal(activeDashboardUuid, t('My Dashboard'))`
+- [ ] On 403, surface the toast "Personal dashboards are not enabled by your administrator"
+- [ ] Optimistic add to `userDashboards` store; rollback on error
+
+## 3. Tests
+
+- [ ] PHPUnit: deep-copy preserves all placement fields including tile-* and styleConfig
+- [ ] PHPUnit: rollback on placement insert failure
+- [ ] PHPUnit: gating returns 403 when admin setting disabled
+- [ ] PHPUnit: 404 on source you cannot read
+- [ ] PHPUnit: forking your own personal dashboard works (independent duplicate)
+- [ ] Playwright: fork → switch → edit → original group dashboard untouched
+
+## 4. Quality
+
+- [ ] `composer check:strict` passes
+- [ ] OpenAPI updated for new endpoint
+- [ ] Document in `dashboards/spec.md` REQ-DASH-005 NOTE that personal dashboards from forks share resource URLs (REQ-DASH-022 cross-reference)

--- a/openspec/changes/group-priority-order/proposal.md
+++ b/openspec/changes/group-priority-order/proposal.md
@@ -1,0 +1,37 @@
+# Group priority order — admin setting
+
+## Why
+
+Multi-group users currently have no deterministic way to know which group's dashboard set they will see — group iteration order is implementation-defined. Admins also have no way to designate which Nextcloud groups are "in scope" for MyDash at all (today every group is implicitly active). This change gives admins explicit control over both the active set and the priority order, and is the foundation that the `group-routing` change consumes for primary-group resolution (REQ-TMPL-012).
+
+## What Changes
+
+- Add a new global admin setting `group_order` to `oc_mydash_admin_settings`, persisted as a JSON string list of Nextcloud group IDs in the order the admin chose.
+- Add `GET /api/admin/groups` returning `{active, inactive, allKnown}` so the admin UI can render both columns in one round-trip and surface stale (deleted) group IDs.
+- Add `POST /api/admin/groups` accepting `{groups: [id…]}` that **replaces wholesale** (no partial merge — UI sends the full ordered list after every drag).
+- Both endpoints are admin-only via `IGroupManager::isAdmin` (`GET` is also admin-gated because the inactive list reveals every group on the system).
+- Add a two-list drag-and-drop UI to `src/views/AdminApp.vue` with active-vs-inactive columns, filter inputs, auto-save on every drag, and a "(removed)" affix for stale IDs.
+
+## Capabilities
+
+- **New Capabilities**: none
+- **Modified Capabilities**:
+  - `admin-settings` — adds REQ-ASET-012 (group_order setting), REQ-ASET-013 (`GET /api/admin/groups`), REQ-ASET-014 (admin guard on both endpoints). Pure ADDED — no existing requirement is modified or removed.
+
+## Impact
+
+- **Code**:
+  - `lib/Service/AdminSettingsService.php` — new `getGroupOrder(): array`, `setGroupOrder(array $groupIds): void`; new constant `AdminSettings::KEY_GROUP_ORDER`.
+  - `lib/Controller/AdminSettingsController.php` — new `listGroups()` (GET) and `updateGroupOrder()` (POST) actions.
+  - `appinfo/routes.php` — register `GET /api/admin/groups` and `POST /api/admin/groups`.
+  - `src/views/AdminApp.vue` — new two-list drag-and-drop component (using existing `vuedraggable`).
+- **Data**: one new row in `oc_mydash_admin_settings` (key `group_order`, JSON value, default `[]`). No schema migration needed — the table already accepts arbitrary keys.
+- **APIs**: two new endpoints; existing `/api/admin/settings` is untouched.
+- **Dependencies**: no new server deps; frontend uses already-bundled `vuedraggable`.
+- **Downstream**: the `group-routing` change reads `group_order` via `AdminSettingsService::getGroupOrder()` to resolve primary group per REQ-TMPL-012.
+
+## Approach Notes
+
+- Use the existing `AdminSetting` ORM entity / mapper; the value is stored via `json_encode()` and retrieved via `json_decode()`. Corrupt JSON in the DB MUST resolve to `[]` without throwing (defensive read).
+- Validation: every ID in the payload MUST be a string and SHOULD exist in Nextcloud, but unknown IDs are tolerated — they are dropped silently from the runtime resolver (REQ-TMPL-012 stale-group scenario) but kept in the persisted setting so admins can restore them when groups come back.
+- Auto-save on every drag matches admin's expectation that drag-drop equals commit. Implies more API chatter but only during admin sessions; tasks.md tracks a 300ms debounce as the recommended throttle.

--- a/openspec/changes/group-priority-order/specs/admin-settings/spec.md
+++ b/openspec/changes/group-priority-order/specs/admin-settings/spec.md
@@ -1,0 +1,137 @@
+---
+capability: admin-settings
+delta: true
+status: draft
+---
+
+# Admin Settings — Delta from change `group-priority-order`
+
+## ADDED Requirements
+
+### Requirement: REQ-ASET-012 Group order setting
+
+The system MUST persist an ordered list of Nextcloud group IDs as the global setting `group_order` (JSON `string[]`, default `[]`). The order MUST be preserved exactly as provided. The setting determines which groups are "active" for MyDash workspace routing (REQ-TMPL-012). Corrupt or unparseable JSON in the database MUST resolve to `[]` at read time without throwing — the resolver and admin UI MUST never see a fatal error from a malformed value.
+
+#### Scenario: Persist ordered list
+
+- GIVEN admin sends `POST /api/admin/groups` with body `{"groups": ["engineering", "all-staff", "marketing"]}`
+- THEN the setting `group_order` MUST be persisted as the JSON string `["engineering","all-staff","marketing"]`
+- AND a subsequent `GET /api/admin/groups` MUST return the same order in `active`
+
+#### Scenario: Empty list clears active groups
+
+- GIVEN admin sends `POST /api/admin/groups` with body `{"groups": []}`
+- THEN the setting MUST be persisted as `[]`
+- AND `resolvePrimaryGroup` MUST return `'default'` for every user (per REQ-TMPL-012)
+
+#### Scenario: Replace-wholesale, not merge
+
+- GIVEN current `group_order = ["a", "b", "c"]`
+- WHEN admin sends `POST /api/admin/groups` with body `{"groups": ["c", "b"]}`
+- THEN the setting MUST become exactly `["c", "b"]`
+- AND `"a"` MUST be removed (no implicit merge)
+
+#### Scenario: Corrupt DB JSON falls back to empty array
+
+- GIVEN the row `group_order` exists in `oc_mydash_admin_settings` with `setting_value = '{not-json'`
+- WHEN any caller invokes `AdminSettingsService::getGroupOrder()`
+- THEN the method MUST return `[]`
+- AND MUST NOT throw an exception
+- AND `GET /api/admin/groups` MUST return `active: []` in this state
+
+#### Scenario: Default when setting absent
+
+- GIVEN no `group_order` row has ever been written to `oc_mydash_admin_settings`
+- WHEN `AdminSettingsService::getGroupOrder()` is called
+- THEN it MUST return `[]` (factory default)
+
+### Requirement: REQ-ASET-013 List groups for admin UI
+
+The system MUST expose `GET /api/admin/groups` returning `{active: [id…], inactive: [id…], allKnown: [{id, displayName}…]}`:
+
+- `active`: the persisted `group_order` list (in admin-chosen order, preserved exactly).
+- `inactive`: every Nextcloud group ID NOT in `active`, sorted by display name (case-insensitive).
+- `allKnown`: full descriptor list (`{id, displayName}`) for every Nextcloud group currently known, so the UI can render display names without a second round-trip.
+
+Stale IDs (present in `active` but no longer in Nextcloud) MUST remain in `active` so the admin can see and remove them, but MUST NOT appear in `allKnown` (no display name available). The UI is expected to render stale IDs with a "(removed)" affix.
+
+#### Scenario: Lists are disjoint and exhaustive
+
+- GIVEN Nextcloud has groups `["a", "b", "c", "d"]` and `group_order = ["b", "d"]`
+- WHEN admin sends `GET /api/admin/groups`
+- THEN the response MUST be `{active: ["b", "d"], inactive: ["a", "c"], allKnown: [{id:"a",displayName:"..."}, {id:"b",displayName:"..."}, {id:"c",displayName:"..."}, {id:"d",displayName:"..."}]}`
+- AND `active ∪ inactive` MUST equal the set of IDs in `allKnown`
+- AND `active ∩ inactive` MUST be empty
+
+#### Scenario: Order in `active` matches admin-chosen order
+
+- GIVEN `group_order = ["zebra", "alpha", "marigold"]`
+- WHEN admin sends `GET /api/admin/groups`
+- THEN `active` MUST be exactly `["zebra", "alpha", "marigold"]` (no alphabetical re-sort)
+- AND `inactive` MUST be sorted alphabetically by `displayName`
+
+#### Scenario: Empty group_order — all groups inactive
+
+- GIVEN `group_order = []` and Nextcloud has groups `["a", "b"]`
+- WHEN admin sends `GET /api/admin/groups`
+- THEN `active` MUST be `[]`
+- AND `inactive` MUST contain both `"a"` and `"b"`
+
+#### Scenario: Stale group IDs surface in active list
+
+- GIVEN `group_order = ["deleted-group", "engineering"]` and Nextcloud no longer has `"deleted-group"`
+- WHEN admin sends `GET /api/admin/groups`
+- THEN the response's `active` MUST still include `"deleted-group"` (so admin can see and remove it)
+- AND `allKnown` MUST NOT include it (no display name to show)
+- AND `inactive` MUST NOT include it
+- NOTE: The UI SHOULD render stale IDs with a "(removed)" affix.
+
+### Requirement: REQ-ASET-014 Admin guard and payload validation
+
+`POST /api/admin/groups` MUST be admin-only (`IGroupManager::isAdmin`). Non-admins MUST receive HTTP 403 with no side effects. `GET /api/admin/groups` MUST also be admin-only because the inactive list reveals every group on the system.
+
+The `POST` payload MUST be validated:
+- Top-level `groups` key MUST exist and MUST be a JSON array.
+- Every element MUST be a non-empty string.
+- Duplicate IDs in the payload MUST be deduplicated (first occurrence wins, preserving order).
+- Validation failures MUST return HTTP 400 with no side effects on the persisted setting.
+
+Unknown (not currently in Nextcloud) IDs MUST NOT cause validation failure — they are tolerated and persisted (per REQ-ASET-013 stale-ID handling).
+
+#### Scenario: Non-admin POST rejected
+
+- GIVEN user "alice" who is not an administrator
+- WHEN she sends `POST /api/admin/groups` with any body
+- THEN the system MUST return HTTP 403
+- AND the persisted `group_order` MUST be unchanged
+
+#### Scenario: Non-admin GET rejected
+
+- GIVEN user "alice" who is not an administrator
+- WHEN she sends `GET /api/admin/groups`
+- THEN the system MUST return HTTP 403
+
+#### Scenario: Missing `groups` key rejected
+
+- GIVEN admin sends `POST /api/admin/groups` with body `{}`
+- THEN the system MUST return HTTP 400
+- AND the persisted `group_order` MUST be unchanged
+
+#### Scenario: Non-string element rejected
+
+- GIVEN admin sends `POST /api/admin/groups` with body `{"groups": ["engineering", 42, "marketing"]}`
+- THEN the system MUST return HTTP 400
+- AND the persisted `group_order` MUST be unchanged
+
+#### Scenario: Duplicate IDs deduplicated
+
+- GIVEN admin sends `POST /api/admin/groups` with body `{"groups": ["a", "b", "a", "c"]}`
+- THEN the persisted `group_order` MUST be exactly `["a", "b", "c"]` (first occurrence kept, duplicates removed)
+- AND the response MUST be HTTP 200
+
+#### Scenario: Unknown IDs accepted
+
+- GIVEN admin sends `POST /api/admin/groups` with body `{"groups": ["does-not-exist", "engineering"]}`
+- AND `"does-not-exist"` is not a known Nextcloud group
+- THEN the request MUST succeed (HTTP 200)
+- AND `group_order` MUST be persisted as `["does-not-exist", "engineering"]`

--- a/openspec/changes/group-priority-order/tasks.md
+++ b/openspec/changes/group-priority-order/tasks.md
@@ -1,0 +1,42 @@
+# Tasks — group-priority-order
+
+## 1. Backend — Service & Entity
+
+- [ ] 1.1 Add constant `AdminSetting::KEY_GROUP_ORDER = 'group_order'`
+- [ ] 1.2 Add `AdminSettingsService::getGroupOrder(): array` — `json_decode` the value, return `[]` on null/missing/corrupt JSON, never throw
+- [ ] 1.3 Add `AdminSettingsService::setGroupOrder(array $groupIds): void` — validate all elements are non-empty strings, deduplicate (first occurrence wins, preserve order), persist as JSON
+
+## 2. Backend — Controller & Routes
+
+- [ ] 2.1 Add `AdminSettingsController::listGroups()` — assemble `{active, inactive, allKnown}` from `IGroupManager::search('')` and `getGroupOrder()`; sort `inactive` by displayName (case-insensitive)
+- [ ] 2.2 Add `AdminSettingsController::updateGroupOrder()` — parse body, validate `groups` is an array of strings, return HTTP 400 on validation failure, else call `setGroupOrder` and return HTTP 200
+- [ ] 2.3 Register `GET /api/admin/groups` and `POST /api/admin/groups` in `appinfo/routes.php`
+- [ ] 2.4 Both endpoints admin-only — guard via `IGroupManager::isAdmin($userId)` in controller (NOT via `#[NoAdminRequired]` absence alone, because the controller may be shared with other admin-gated methods); return HTTP 403 on non-admin
+
+## 3. Frontend
+
+- [ ] 3.1 Two-list drag-and-drop component using existing `vuedraggable` (active vs inactive columns) in `src/views/AdminApp.vue`
+- [ ] 3.2 Filter input above each list (case-insensitive substring match on `displayName || id`)
+- [ ] 3.3 Auto-save on every drag (`@change` triggers POST), with 300ms debounce to throttle drag-spam
+- [ ] 3.4 Toast success/error via `@nextcloud/dialogs`
+- [ ] 3.5 Stale ID rendering: append "(removed)" to display name when `id ∉ allKnown`
+- [ ] 3.6 i18n: all UI strings in `en` + `nl` translation files (per project i18n requirement)
+
+## 4. Tests
+
+- [ ] 4.1 PHPUnit `AdminSettingsServiceTest`: `getGroupOrder` returns `[]` when row absent
+- [ ] 4.2 PHPUnit `AdminSettingsServiceTest`: `getGroupOrder` returns `[]` on corrupt JSON without throwing
+- [ ] 4.3 PHPUnit `AdminSettingsServiceTest`: `setGroupOrder` deduplicates while preserving order
+- [ ] 4.4 PHPUnit `AdminSettingsServiceTest`: `setGroupOrder` rejects non-string elements
+- [ ] 4.5 PHPUnit `AdminSettingsControllerTest`: replace-wholesale semantics (POST `["c","b"]` over `["a","b","c"]` → `["c","b"]`)
+- [ ] 4.6 PHPUnit `AdminSettingsControllerTest`: 403 on both endpoints for non-admin
+- [ ] 4.7 PHPUnit `AdminSettingsControllerTest`: `listGroups` returns disjoint exhaustive lists with stale ID surfacing
+- [ ] 4.8 Playwright: drag from inactive → active fires POST and persists across reload
+- [ ] 4.9 Playwright: stale ID renders with "(removed)" indicator and is removable
+
+## 5. Documentation & Quality
+
+- [ ] 5.1 OpenAPI updated for `GET /api/admin/groups` and `POST /api/admin/groups`
+- [ ] 5.2 `composer check:strict` passes (PHPCS, PHPMD, Psalm, PHPStan)
+- [ ] 5.3 Frontend lint passes
+- [ ] 5.4 Throttling: confirm 300ms debounce is implemented in the Vue layer (per task 3.3)

--- a/openspec/changes/group-routing/proposal.md
+++ b/openspec/changes/group-routing/proposal.md
@@ -1,0 +1,56 @@
+# Group routing — pick primary group for a user
+
+## Why
+
+When a user opens the workspace page, MyDash MUST decide which Nextcloud group's dashboards they belong to. Many users belong to multiple groups; today there is no deterministic priority and individual call sites would each invent their own ordering, leading to drift between the workspace renderer, the dashboard resolver, and any future caller. This change locks the algorithm into a single pure resolver inside `admin-templates` (which already owns the group-targeting concept via REQ-TMPL-010) and forbids parallel implementations.
+
+The existing REQ-TMPL-010 ("Template Group Resolution") already covers picking the right template for a user via group matching, but only for the templating model. This change extends the algorithm to govern routing into `group_shared` dashboards (from `multi-scope-dashboards`) using the same `group_order` admin setting — one source of truth for both pathways.
+
+## What Changes
+
+- Add a pure function `AdminTemplateService::resolvePrimaryGroup(string $userId): string` that walks the admin-configured `group_order` setting and returns the first matching group ID OR the literal sentinel `'default'` (the same sentinel introduced by `multi-scope-dashboards` REQ-DASH-012).
+- Read `group_order` (JSON list of group IDs, default `[]`) from `oc_mydash_admin_settings` via `AdminSettingsService::getGroupOrder(): array`.
+- Resolve the user's actual group memberships via `IGroupManager::getUserGroupIds`.
+- Tolerate stale entries in `group_order` (deleted groups) without throwing — cleanup is the admin UI's responsibility.
+- Wire the resolver into `WorkspaceController::index` so the workspace renderer asks one place "what's this user's primary group?".
+- Refactor REQ-DASH-013 + REQ-DASH-018 implementations to consume this resolver instead of inlining the lookup; enforce the single-source-of-truth rule via a grep-based PHPUnit guard.
+- Surface the resolved primary group plus its display name to the frontend as `primaryGroup` initial state (display name comes from `IGroupManager::get($id)?->getDisplayName()`, or the literal `'Default'` for the sentinel).
+
+This change is strictly the read-side of the admin's `group_order` setting. The write-side (admin UI for ordering groups) ships in the parallel `group-priority-order` change.
+
+## Capabilities
+
+### New Capabilities
+
+(none — this change folds into the existing `admin-templates` capability)
+
+### Modified Capabilities
+
+- `admin-templates`: adds REQ-TMPL-012 (primary-group resolution algorithm) and REQ-TMPL-013 (resolver is the single routing authority). Existing REQ-TMPL-001..011 are untouched.
+
+The `dashboards` capability is intentionally not modified — REQ-DASH-013 and REQ-DASH-018 already own the visible-to-user resolution; this change only wires their implementations to consume the new resolver instead of duplicating the algorithm.
+
+## Impact
+
+**Affected code:**
+
+- `lib/Service/AdminTemplateService.php` — new `resolvePrimaryGroup(string $userId): string` method (read-only, pure)
+- `lib/Service/AdminTemplateService.php` — new internal helper `pickFirstMatch(array $orderedGroups, array $userGroups): ?string` for testability
+- `lib/Service/AdminSettingsService.php` — new `getGroupOrder(): array` accessor
+- `lib/Controller/WorkspaceController.php` — calls the resolver in `index()` and passes the result into dashboard resolution
+- `lib/Db/Dashboard.php` — add `Dashboard::DEFAULT_GROUP_ID = 'default'` constant so the sentinel is named in one place
+- `src/views/Workspace.vue` (or equivalent shell) — receives `primaryGroup` and `primaryGroupDisplayName` in initial state from `runtime-shell`
+
+**Affected APIs:**
+
+- No new HTTP endpoints. Pure backend resolver consumed by existing controllers; the result is exposed through the existing initial-state payload that `runtime-shell` already ships.
+
+**Dependencies:**
+
+- `OCP\IGroupManager` — already injected elsewhere, used for `getUserGroupIds` and (frontend-side) display-name lookup
+- No new composer or npm dependencies
+
+**Migration:**
+
+- Zero schema impact: the resolver only reads existing `oc_mydash_admin_settings` rows. If `group_order` is missing or empty, the resolver returns `'default'` and the existing behaviour is preserved.
+- No data backfill required.

--- a/openspec/changes/group-routing/specs/admin-templates/spec.md
+++ b/openspec/changes/group-routing/specs/admin-templates/spec.md
@@ -1,0 +1,68 @@
+---
+capability: admin-templates
+delta: true
+status: draft
+---
+
+# Admin Templates — Delta from change `group-routing`
+
+## ADDED Requirements
+
+### Requirement: REQ-TMPL-012 Primary-group resolution for workspace routing
+
+The system MUST expose a pure function `resolvePrimaryGroup(string $userId): string` that returns the Nextcloud group ID whose `group_shared` dashboards the user should see, OR the literal string `'default'` when no match is found. The algorithm MUST be:
+
+1. Read the admin-configured ordered list of group IDs from `admin_settings.group_order` (JSON `string[]`, default `[]`).
+2. Read the user's Nextcloud group memberships via `IGroupManager::getUserGroupIds($userId)`.
+3. Walk `group_order` left-to-right and return the first group ID that also appears in the user's memberships.
+4. If no match, return the literal string `'default'`.
+
+The function MUST be deterministic and idempotent (no writes).
+
+#### Scenario: First match wins by admin-configured priority
+
+- GIVEN admin has set `group_order = ["engineering", "all-staff"]`
+- AND user "alice" belongs to groups: `["all-staff", "engineering", "marketing"]`
+- WHEN `resolvePrimaryGroup("alice")` is called
+- THEN it MUST return `"engineering"` (because engineering appears first in group_order, even though all-staff is alphabetically earlier in alice's groups)
+
+#### Scenario: User in no active group falls through to default sentinel
+
+- GIVEN admin has set `group_order = ["engineering", "executives"]`
+- AND user "carol" belongs only to groups: `["support"]`
+- WHEN `resolvePrimaryGroup("carol")` is called
+- THEN it MUST return `"default"`
+
+#### Scenario: Empty group_order always returns default
+
+- GIVEN admin has not configured any active groups (`group_order = []`)
+- WHEN `resolvePrimaryGroup` is called for any user
+- THEN it MUST return `"default"` regardless of the user's actual group memberships
+
+#### Scenario: Configured group that the user is NOT in is skipped
+
+- GIVEN `group_order = ["executives", "engineering"]`
+- AND user "bob" belongs to: `["engineering", "support"]`
+- WHEN `resolvePrimaryGroup("bob")` is called
+- THEN it MUST skip "executives" and return `"engineering"`
+
+#### Scenario: Configured group that no longer exists in Nextcloud is harmless
+
+- GIVEN `group_order = ["deleted-group", "engineering"]`
+- AND the Nextcloud group "deleted-group" has been removed
+- AND user "alice" belongs to: `["engineering"]`
+- WHEN `resolvePrimaryGroup("alice")` is called
+- THEN it MUST return `"engineering"`
+- AND MUST NOT raise an error
+- NOTE: Cleanup of stale group IDs in `group_order` is the admin UI's responsibility; the resolver MUST be tolerant.
+
+### Requirement: REQ-TMPL-013 Resolver is the single routing authority
+
+All workspace-rendering and dashboard-resolution code paths (REQ-DASH-013, REQ-DASH-018) MUST consult `resolvePrimaryGroup` for the user's primary group. There MUST NOT be parallel implementations of this lookup.
+
+#### Scenario: Single source of truth
+
+- GIVEN any future capability needs the user's primary workspace group
+- WHEN it computes a group ID
+- THEN it MUST go through `AdminTemplateService::resolvePrimaryGroup` (or its declared service interface)
+- AND duplicating the algorithm inline is forbidden by code review

--- a/openspec/changes/group-routing/tasks.md
+++ b/openspec/changes/group-routing/tasks.md
@@ -1,0 +1,36 @@
+# Tasks — group-routing
+
+## 1. Backend resolver
+
+- [ ] 1.1 Add `AdminTemplateService::resolvePrimaryGroup(string $userId): string` (read-only, pure) per REQ-TMPL-012
+- [ ] 1.2 Add internal helper `AdminTemplateService::pickFirstMatch(array $orderedGroups, array $userGroups): ?string` for clarity and direct unit testing
+- [ ] 1.3 Add `AdminSettingsService::getGroupOrder(): array` returning the JSON `string[]` from `admin_settings.group_order` (default `[]`)
+- [ ] 1.4 Tolerate stale group IDs in `group_order` — never throw when an entry no longer exists in Nextcloud (REQ-TMPL-012 final scenario)
+- [ ] 1.5 Add `Dashboard::DEFAULT_GROUP_ID = 'default'` constant so the sentinel string is named in exactly one place
+
+## 2. Single source of truth wiring
+
+- [ ] 2.1 Update `WorkspaceController::index` to call `resolvePrimaryGroup` and pass the result into dashboard resolution
+- [ ] 2.2 Refactor REQ-DASH-013 implementation (visible-to-user) to consume `resolvePrimaryGroup` instead of inlining the algorithm
+- [ ] 2.3 Refactor REQ-DASH-018 implementation to consume `resolvePrimaryGroup` instead of inlining the algorithm
+- [ ] 2.4 Verify (by code review and the grep test in 4.2) that no caller invokes `IGroupManager::getUserGroupIds` outside the resolver
+
+## 3. Frontend
+
+- [ ] 3.1 Surface the resolved primary group as `primaryGroup` initial state (already plumbed by the `runtime-shell` change)
+- [ ] 3.2 Surface its display name via `IGroupManager::get($id)?->getDisplayName()` (or the literal `'Default'` for the `'default'` sentinel) as `primaryGroupDisplayName`
+- [ ] 3.3 Render the display name in the workspace header so users can see which group's dashboards they are viewing
+
+## 4. PHPUnit tests
+
+- [ ] 4.1 Table-driven `AdminTemplateServiceTest::testResolvePrimaryGroup` covering every REQ-TMPL-012 scenario: priority order wins, no match returns `'default'`, empty `group_order` returns `'default'`, configured-but-not-member is skipped, deleted-group is harmless
+- [ ] 4.2 Single-source-of-truth grep guard test: `grep -r 'getUserGroupIds' lib/` returns only the resolver — fail otherwise (REQ-TMPL-013)
+- [ ] 4.3 `AdminTemplateServiceTest::testPickFirstMatch` direct unit tests for the helper (empty inputs, no overlap, multiple overlaps)
+
+## 5. Quality gates
+
+- [ ] 5.1 `composer check:strict` (PHPCS, PHPMD, Psalm, PHPStan) passes — fix any pre-existing issues encountered along the way
+- [ ] 5.2 ESLint + Stylelint clean on touched Vue/JS files
+- [ ] 5.3 SPDX headers on every new PHP file (inside the docblock per the SPDX-in-docblock convention) — `gate-spdx` must pass
+- [ ] 5.4 Run all 10 `hydra-gates` locally before opening PR
+- [ ] 5.5 i18n keys for the `'Default'` display-name fallback in both `nl` and `en`

--- a/openspec/changes/image-widget/proposal.md
+++ b/openspec/changes/image-widget/proposal.md
@@ -1,0 +1,53 @@
+# Image widget
+
+## Why
+
+MyDash today has no first-class way to put a single image on a dashboard. Users currently jam logos, screenshots, branding, and decorative imagery into the markdown widget via `<img>` tags or rely on the iframe widget pointing at an external image URL — both workarounds. Neither path supports proper `object-fit` control, broken-image fallback, click-through to a target URL, or the upload-a-file UX users expect from a dashboard product. Competitor dashboards (Sendent, Grafana, Microsoft Power BI tiles) all ship a dedicated image widget. We need parity, with the small UX upgrade that the cell only looks clickable when there is actually a link to click.
+
+## What Changes
+
+- Add a new widget type `image` rendered via `src/components/Widgets/Renderers/ImageWidget.vue`.
+- Persisted shape: `{type: 'image', content: {url, alt, link, fit}}`. `fit` defaults to `'cover'` and is restricted to `'cover' | 'contain' | 'fill' | 'none'` by a Vue prop validator (with fallback to `'cover'` on unknown input).
+- The form (`src/components/Widgets/Forms/ImageForm.vue`) offers two ways to set `url`: file upload (handed to the resource-uploads endpoint) OR direct URL string. It also exposes `alt`, `link`, `fit`, and a live preview thumbnail.
+- Click-through: when `link` is non-empty, clicking the cell opens the link via `window.open(link, '_blank', 'noopener,noreferrer')`. When `link` is empty there is no navigation AND `cursor` stays default (deliberate fix for the Sendent UX bug where every image cell looked clickable even without a link).
+- Empty-URL placeholder: 48 px camera icon + `t('No image')` centred, in `var(--color-text-maxcontrast)`.
+- Broken-image fallback: `<img @error>` swaps in the same placeholder plus the annotation `t('Image failed to load')`. Must not crash the surrounding GridStack grid.
+- Register the new type in `src/constants/widgetRegistry.js` with defaults `{url:'', alt:'', link:'', fit:'cover'}`.
+
+## Capabilities
+
+### New Capabilities
+
+- `image-widget`: adds REQ-IMG-001 (render with object-fit), REQ-IMG-002 (empty-URL placeholder), REQ-IMG-003 (click-through link behaviour), REQ-IMG-004 (broken-image fallback), REQ-IMG-005 (add/edit form).
+
+### Modified Capabilities
+
+(none — this is a self-contained renderer + form + registry entry; existing widget capabilities are untouched.)
+
+## Impact
+
+**Affected code:**
+
+- `src/components/Widgets/Renderers/ImageWidget.vue` — new renderer (props: `content`, `placement`)
+- `src/components/Widgets/Forms/ImageForm.vue` — new form sub-component for `AddWidgetModal`
+- `src/constants/widgetRegistry.js` — register `type: 'image'` with defaults
+- Translation entries: `Image`, `No image`, `Image failed to load`, `Upload Image`, `Or enter Image URL`, `Alt Text`, `Link (optional)`, `Fit`, `Cover`, `Contain`, `Fill`, `None`, `Failed to upload image`, `Image URL is required` (both `nl` and `en` per the i18n requirement)
+
+**Affected APIs:**
+
+- No new MyDash backend routes. The form POSTs to the resource-uploads endpoint owned by the `resource-uploads` capability — see Dependencies below.
+
+**Dependencies:**
+
+- `resource-uploads` capability — owns the `/api/resources` upload endpoint that the form's file-input branch calls. The image-widget change MUST land after `resource-uploads` is in place, OR ship behind a feature flag that hides the file-input control until the endpoint exists (URL input still works either way).
+- No new composer or npm dependencies. The camera icon comes from the existing `@mdi/svg` icon set already bundled.
+
+**Migration:**
+
+- No database migration. Widget content is stored in the existing `oc_mydash_widget_placements.content` JSON blob. Old placements without `type: 'image'` are unaffected.
+
+**Out of scope:**
+
+- Lightbox / image-zoom on click (a future change can layer this onto `link === ''` cells).
+- Gallery mode (multiple images cycled in one cell).
+- Persisting the uploaded resource alongside the placement — only the URL is persisted. Resource lifecycle (orphan GC, quota accounting) is owned by `resource-uploads` and a future GC change.

--- a/openspec/changes/image-widget/specs/image-widget/spec.md
+++ b/openspec/changes/image-widget/specs/image-widget/spec.md
@@ -1,0 +1,148 @@
+---
+capability: image-widget
+delta: true
+status: draft
+---
+
+# Image Widget — Delta from change `image-widget`
+
+## ADDED Requirements
+
+### Requirement: REQ-IMG-001 Render image with object-fit
+
+The renderer MUST output an `<img :src="url" :alt="alt">` whose CSS `object-fit` MUST equal the `fit` field of the persisted content. The `<img>` MUST fill the cell with `width: 100%; height: 100%`. The cell wrapper MUST set `overflow: hidden` so over-fit images do not bleed out of the grid cell. The persisted content shape is `{type: 'image', content: {url, alt, link, fit}}` where `fit` is one of `'cover' | 'contain' | 'fill' | 'none'` (default `'cover'`). The Vue prop validator on `fit` MUST restrict the value to that enum and fall back to `'cover'` when an unknown value is passed.
+
+#### Scenario: Cover fit fills the cell
+
+- GIVEN content `{url: '/apps/mydash/resource/x.png', fit: 'cover'}`
+- WHEN the widget renders
+- THEN the `<img>` MUST have inline style `object-fit: cover`
+- AND its width and height MUST be `100%`
+- AND the cell wrapper MUST have `overflow: hidden`
+
+#### Scenario: Contain fit preserves aspect ratio
+
+- GIVEN content `{url: 'https://example.com/wide.png', fit: 'contain'}`
+- WHEN the widget renders
+- THEN the `<img>` MUST have `object-fit: contain`
+- AND letterboxing MUST be visible if the image's aspect ratio differs from the cell's
+
+#### Scenario: Invalid fit value falls back to cover
+
+- GIVEN a developer mounts the widget with `fit: 'stretch'`
+- WHEN the Vue prop validator runs
+- THEN it MUST log a Vue prop validator warning
+- AND the renderer MUST apply `object-fit: cover`
+
+#### Scenario: Default fit is cover
+
+- GIVEN content `{url: '/apps/mydash/resource/x.png'}` with no `fit` field
+- WHEN the widget renders
+- THEN the `<img>` MUST have `object-fit: cover`
+
+### Requirement: REQ-IMG-002 Empty-URL placeholder
+
+When `url` is empty or null, the renderer MUST display a placeholder consisting of a 48 px camera icon plus the translated string `t('No image')`, centred, in `var(--color-text-maxcontrast)`. The placeholder MUST occupy the full cell. The DOM MUST NOT contain an `<img>` element while the placeholder is active.
+
+#### Scenario: Empty url shows placeholder
+
+- GIVEN content `{url: ''}`
+- WHEN the widget renders
+- THEN the DOM MUST NOT contain an `<img>` element
+- AND it MUST contain a 48 px camera SVG
+- AND it MUST contain the text `'No image'`
+
+#### Scenario: Null url shows placeholder
+
+- GIVEN content `{url: null}`
+- WHEN the widget renders
+- THEN the DOM MUST NOT contain an `<img>` element
+- AND the placeholder MUST be visible
+
+#### Scenario: Placeholder uses maxcontrast token
+
+- GIVEN the empty-URL placeholder is rendered
+- WHEN inspected
+- THEN its colour MUST be `var(--color-text-maxcontrast)`
+- AND it MUST be centred horizontally and vertically inside the cell
+
+### Requirement: REQ-IMG-003 Click-through link behaviour
+
+When the persisted `link` field is non-empty, a click on the cell MUST open `link` in a new tab via `window.open(link, '_blank', 'noopener,noreferrer')`. The cell wrapper MUST set `cursor: pointer` only when `link` is non-empty — when there is no link the cursor MUST remain default so users are not given a misleading clickable affordance (this is a deliberate fix of the Sendent UX bug where every image cell looked clickable even without a link).
+
+#### Scenario: Click opens link in new tab
+
+- GIVEN content `{url: '/img/x.png', link: 'https://example.com'}`
+- WHEN the user clicks the cell
+- THEN the system MUST call `window.open('https://example.com', '_blank', 'noopener,noreferrer')`
+
+#### Scenario: No link, no click, no pointer
+
+- GIVEN content `{url: '/img/x.png', link: ''}`
+- WHEN the user clicks the cell
+- THEN no navigation MUST occur
+- AND the cell wrapper's `cursor` MUST be the default (not `pointer`)
+
+#### Scenario: Pointer cursor only with link
+
+- GIVEN content `{url: '/img/x.png', link: 'https://example.com'}`
+- WHEN the cell renders
+- THEN the cell wrapper's CSS `cursor` MUST equal `pointer`
+
+### Requirement: REQ-IMG-004 Broken-image fallback
+
+The `<img>` MUST handle the DOM `error` event by replacing itself with the empty-URL placeholder (as defined in REQ-IMG-002) plus the translated annotation `t('Image failed to load')`. The fallback MUST NOT crash, unmount, or otherwise disturb the surrounding GridStack grid.
+
+#### Scenario: Broken external URL falls back
+
+- GIVEN content `{url: 'https://example.com/missing.png'}` and the URL returns 404
+- WHEN the browser fires the `<img>` `error` event
+- THEN the renderer MUST swap to the placeholder
+- AND the placeholder MUST include the text `'Image failed to load'`
+- AND the surrounding GridStack grid MUST remain operational (other widgets still render and respond to events)
+
+#### Scenario: Broken URL does not crash grid
+
+- GIVEN any cell renders an image with a URL that triggers the `error` event
+- WHEN the error fires
+- THEN no uncaught exception MUST be raised
+- AND the dashboard MUST remain interactive (drag, resize, edit on other cells still works)
+
+### Requirement: REQ-IMG-005 Add/edit form
+
+The image sub-form for `AddWidgetModal` MUST expose the following controls: a file `<input type="file" accept="image/*">` (Upload), a text `<input>` for `url` (also written by the upload pipeline), a text `<input>` for `alt`, a text `<input>` for `link`, and a `<select>` for `fit` with options `cover`, `contain`, `fill`, `none`. Only `url` is required for save. The form MUST display a live preview thumbnail (`<img :src="url">`) below the URL input whenever `url` is non-empty. The upload pipeline MUST be: file → `FileReader.readAsDataURL` → POST to the resource-uploads endpoint (`/api/resources`) → on success, set `form.url` from the response `{url}`. The form's `validate()` MUST return `[t('Image URL is required')]` when `url.trim() === ''`. Upload errors MUST be surfaced inline under the upload input via the translated message `t('Failed to upload image')`, and `form.url` MUST remain unchanged on upload failure.
+
+#### Scenario: Upload populates URL and preview
+
+- GIVEN the user selects an image file in the file input
+- WHEN the upload POST to `/api/resources` succeeds with response `{url: '/apps/mydash/resource/abc.png'}`
+- THEN `form.url` MUST become `/apps/mydash/resource/abc.png`
+- AND the preview thumbnail `<img>` MUST become visible with that `src`
+
+#### Scenario: Direct URL string is also accepted
+
+- GIVEN the user types `https://example.com/x.png` directly into the URL input
+- WHEN the input blurs
+- THEN `form.url` MUST equal `'https://example.com/x.png'`
+- AND the preview thumbnail MUST attempt to load that URL
+
+#### Scenario: Upload error surfaces to user
+
+- GIVEN the upload POST returns HTTP 400 (e.g. file too large)
+- WHEN the form catches the error
+- THEN it MUST display the inline error message `t('Failed to upload image')` under the upload input
+- AND `form.url` MUST remain unchanged
+
+#### Scenario: Empty URL fails validation
+
+- GIVEN the user submits the form with `form.url = ''`
+- WHEN `validate()` runs
+- THEN it MUST return `[t('Image URL is required')]`
+- AND the modal MUST NOT close
+
+#### Scenario: All allowed fit values selectable
+
+- GIVEN the form is open
+- WHEN the user inspects the `fit` `<select>`
+- THEN it MUST contain exactly the four options `cover`, `contain`, `fill`, `none`
+- AND the default selected value MUST be `cover` for a new placement

--- a/openspec/changes/image-widget/tasks.md
+++ b/openspec/changes/image-widget/tasks.md
@@ -1,0 +1,46 @@
+# Tasks — image-widget
+
+## 1. Renderer
+
+- [ ] 1.1 Create `src/components/Widgets/Renderers/ImageWidget.vue` with props `content` and `placement` and the persisted shape `{url, alt, link, fit}`
+- [ ] 1.2 Add a Vue prop validator on `fit` restricting values to `['cover','contain','fill','none']` with fallback to `'cover'` on unknown input (warns via `console.warn` per Vue's standard validator behaviour)
+- [ ] 1.3 Render `<img :src="url" :alt="alt">` with `width: 100%`, `height: 100%`, and inline `object-fit` bound to `fit` (REQ-IMG-001)
+- [ ] 1.4 Set `overflow: hidden` on the cell wrapper so over-fit images do not bleed out
+- [ ] 1.5 Implement empty-URL placeholder: 48 px CameraIcon + `t('No image')`, centred, in `var(--color-text-maxcontrast)` (REQ-IMG-002)
+- [ ] 1.6 Add `@error="onImageError"` on `<img>` that swaps to placeholder + `t('Image failed to load')` and ensures no exception bubbles to the GridStack grid (REQ-IMG-004)
+- [ ] 1.7 Bind `cursor: pointer` on the cell wrapper only when `link` is non-empty (REQ-IMG-003)
+- [ ] 1.8 Wire click handler: `window.open(link, '_blank', 'noopener,noreferrer')` when `link` is non-empty, no-op otherwise (REQ-IMG-003)
+
+## 2. Form
+
+- [ ] 2.1 Create `src/components/Widgets/Forms/ImageForm.vue` with file input, URL input, alt input, link input, and fit select
+- [ ] 2.2 Implement upload pipeline: file → `FileReader.readAsDataURL` → POST `/api/resources` (resource-uploads) → on success set `form.url` from response `{url}` (REQ-IMG-005)
+- [ ] 2.3 Display live preview `<img :src="url">` thumbnail below the URL input whenever `url` is non-empty
+- [ ] 2.4 Implement `validate()` returning `[t('Image URL is required')]` when `form.url.trim() === ''`
+- [ ] 2.5 Display inline error `t('Failed to upload image')` under the upload input when the resource-uploads POST fails; leave `form.url` unchanged
+- [ ] 2.6 Wire fit `<select>` with the four options `cover, contain, fill, none` and default `cover` for new placements
+
+## 3. Registry
+
+- [ ] 3.1 Add `image` entry to `src/constants/widgetRegistry.js` with defaults `{url:'', alt:'', link:'', fit:'cover'}`
+- [ ] 3.2 Map the entry to the new renderer + form components and a label string `t('Image')`
+
+## 4. Tests
+
+- [ ] 4.1 Vitest: `object-fit` inline style equals the `fit` prop value (cover, contain, fill, none)
+- [ ] 4.2 Vitest: prop validator rejects unknown fit values (e.g. `'stretch'`) and falls back to `'cover'`
+- [ ] 4.3 Vitest: cell wrapper `cursor` toggles `pointer` ↔ default based on `link` non-empty / empty
+- [ ] 4.4 Vitest: `<img>` `error` event swaps in the placeholder with `'Image failed to load'`
+- [ ] 4.5 Vitest: form `validate()` returns `[t('Image URL is required')]` when URL is empty/whitespace
+- [ ] 4.6 Vitest: form upload-error path surfaces the inline error and leaves `form.url` untouched
+- [ ] 4.7 Playwright: upload an image → preview appears → save → reload page → image still visible on the cell
+- [ ] 4.8 Playwright: external URL with click-through opens in a new tab with `noopener,noreferrer`
+- [ ] 4.9 Playwright: empty-URL cell shows the camera placeholder and does not respond to clicks
+
+## 5. Quality
+
+- [ ] 5.1 ESLint + Stylelint clean on all new Vue/JS files
+- [ ] 5.2 Add translation entries (both `nl` and `en` per the i18n requirement): `Image`, `No image`, `Image failed to load`, `Upload Image`, `Or enter Image URL`, `Alt Text`, `Link (optional)`, `Fit`, `Cover`, `Contain`, `Fill`, `None`, `Failed to upload image`, `Image URL is required`
+- [ ] 5.3 SPDX headers in the file docblock on every new file (per the SPDX-in-docblock convention)
+- [ ] 5.4 Run all relevant `hydra-gates` locally before opening the PR (no PHP touched, but JS gates and forbidden-patterns still apply)
+- [ ] 5.5 Confirm the change does NOT depend on any backend route beyond what `resource-uploads` already ships

--- a/openspec/changes/initial-state-contract/design.md
+++ b/openspec/changes/initial-state-contract/design.md
@@ -1,0 +1,103 @@
+# Design — initial-state-contract
+
+## Overview
+
+The `initial-state-contract` capability formalises the exact set of key/value pairs PHP pushes via Nextcloud's `IInitialState::provideInitialState` for each Vue mount in MyDash (workspace + admin pages). Today these calls are scattered across `WorkspaceController` and `AdminSettings`, and the matching `loadState('mydash', ...)` reads are scattered across entry-point and component files. Drift between PHP and JS is silent — a key the backend stops sending becomes `undefined` on the frontend, a key the frontend stops reading lingers as dead PHP code, and onboarding a new page is guesswork.
+
+This change introduces a typed PHP `InitialStateBuilder` service, a typed JS `loadInitialState(page)` reader, a versioned `_schemaVersion` key, and a CI lint pair that prevents controllers and components from bypassing the central code paths.
+
+## Goals
+
+- One source of truth for the per-page initial-state key set (the spec's Data Model)
+- Compile-time-ish guarantees on the PHP side (typed setters + required-key check in `apply()`)
+- Default-filled, never-`undefined` reads on the JS side
+- A schema version that travels with the payload so deploy skew (PHP and JS bundle out of sync) shows up as a console warning instead of a mysterious bug
+- Lint enforcement so bypasses cannot land
+
+## Non-goals
+
+- Not a Pinia replacement — `provide`/`inject` only distributes the boot snapshot; reactive shared state remains the responsibility of dedicated stores
+- Not a typed-codegen pipeline — the contract is documented + grep-enforced, not generated; lower ceremony fits MyDash's size
+- No runtime per-key schema validation (e.g. JSON Schema) — type discipline lives in the PHP setters and JS table; runtime validation is overkill for an internal boot payload
+
+## Architecture
+
+### PHP side
+
+```
+WorkspaceController::index ─┐
+                            ├──> InitialStateBuilder(IInitialState, Page::WORKSPACE)
+AdminSettings::getForm    ─┘    ├─ setWidgets(...)
+                                ├─ setLayout(...)
+                                ├─ ...
+                                └─ apply()  ─→ IInitialState::provideInitialState(key, value) × N
+                                              + provideInitialState('_schemaVersion', 1)
+```
+
+- `InitialStateBuilder` is the only class allowed to call `IInitialState::provideInitialState`. A grep-based CI lint enforces this against `lib/Controller/` and any other future call sites.
+- `Page` is a PHP enum with two cases (`WORKSPACE`, `ADMIN`). Per-page required-key sets live in a `private const REQUIRED_KEYS = [...]` map keyed by enum case.
+- `apply()` walks the required set; missing keys throw `MissingInitialStateException` (a new exception class under `lib/Exception/`) with a message naming the page and the missing key.
+- `INITIAL_STATE_SCHEMA_VERSION` is a `public const int` on the builder; `apply()` always pushes it under `_schemaVersion` regardless of page.
+
+### JS side
+
+```
+src/main.js ──┐
+              ├──> loadInitialState('workspace' | 'admin')
+src/admin.js ─┘    ├─ for each declared key: loadState('mydash', key, default)
+                   ├─ if (received._schemaVersion !== INITIAL_STATE_SCHEMA_VERSION) console.warn(...)
+                   └─ return typed object
+                   
+                          │
+                          ▼
+                   for (const [k, v] of Object.entries(state)) app.provide(k, v)
+                          │
+                          ▼
+                   any descendant: const widgets = inject('widgets', [])
+```
+
+- `src/utils/loadInitialState.js` declares per-page key/default tables that mirror the spec's Data Model exactly.
+- Entry points loop over the returned object and emit `app.provide(k, v)` for each key — the key string is preserved to keep the boundary obvious to readers.
+- A grep-based CI lint forbids any `loadState\(['"]mydash['"]` call outside the reader.
+
+## Decisions
+
+### Why a builder instead of a configuration array?
+
+A typed builder catches missing-key bugs at the call site rather than at render time, and the setter signatures double as living documentation of each key's shape. An array-of-arrays approach gives no IDE help and turns every typo into a runtime `undefined`.
+
+### Why grep-lint instead of a deeper static analyser?
+
+The bypass surface is small (two specific function calls) and a 2-line shell grep in CI catches every case. A custom Psalm plugin or ESLint rule would cost more than it saves at MyDash's scale.
+
+### Why provide/inject and not Pinia for the boot payload?
+
+Boot data is read-only by definition — once the page renders, the snapshot does not change. `provide`/`inject` matches that lifetime, avoids a Pinia round-trip, and makes the read sites explicit. Pinia stores still own anything that changes after boot (REQ-INIT-005).
+
+### Why a single integer schema version instead of per-key versions?
+
+Per-key versioning sounds nice but is heavy: every key would need a version literal, and the warning logic would need to compare a map. A single integer treats the contract as one unit (which it is — the PHP and JS sides ship together), keeps the warning trivial, and forces deliberate consideration when the table changes.
+
+## Risks and mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Developer adds a key in PHP but forgets the JS reader | CI lint pair fails; the reader's missing-key default would mask the bug at runtime, but the version bump (REQ-INIT-002) is a per-key code-review checklist item |
+| Schema version not bumped on a key change | Code-review checklist item; the spec's Data Model is the single source of truth and reviewers compare against it |
+| Future page with different keys needs different required set | Add a new `Page` enum case; required-key map is keyed by case so extension is local |
+| Component tries to mutate an injected value | REQ-INIT-005 plus an ESLint hint in the entry-point file; runtime detection is not added (cost > benefit) |
+
+## Seed Data
+
+This change introduces no new OpenRegister schemas — `InitialStateBuilder` is a PHP service that reads from existing Nextcloud APIs (`IManager::getWidgets()`, `IGroupManager`, MyDash dashboard mappers) and pushes their values into Nextcloud's `IInitialState` service. There is no register, no schema, and no persisted object created by this capability.
+
+The downstream consumers of the initial-state payload (Workspace dashboards, Widgets, Group settings, Admin Settings) are seeded by their own respective changes and capabilities; this contract simply transports their already-seeded data to the Vue mount.
+
+No `_registers.json` entry is required for this change.
+
+## Test strategy
+
+- **PHPUnit (`tests/unit/Service/InitialStateBuilderTest.php`)**: per-page required-key validation, value pass-through, `_schemaVersion` always present
+- **Vitest (`src/utils/__tests__/loadInitialState.spec.js`)**: default-fill behaviour, version-mismatch warning, key set per page matches the table
+- **Vitest (`src/__tests__/provide-inject.spec.js`)**: mount the workspace entry against a stubbed `loadState`, assert each declared key is `inject`-able by a child component, assert mutating a cloned `ref` does not leak
+- **CI lint pair** (shell scripts in `.github/workflows/`): PHP-side grep for `provideInitialState` outside the builder; JS-side grep for `loadState\(['"]mydash['"]` outside the reader

--- a/openspec/changes/initial-state-contract/proposal.md
+++ b/openspec/changes/initial-state-contract/proposal.md
@@ -1,0 +1,32 @@
+# Initial-state contract
+
+A new `initial-state-contract` capability formalises the precise set of keys that PHP pushes via `IInitialState::provideInitialState` for each Vue mount, and the precise `provide()` calls that each entry point emits to expose them to the rest of the component tree. Without this contract the keys drift silently — frontend reads a key the backend stopped sending, or vice versa, and the breakage only surfaces at runtime.
+
+## Affected code units
+
+- `lib/Controller/WorkspaceController.php` — workspace page initial state
+- `lib/Settings/Admin/AdminSettings.php` — admin page initial state
+- `src/main.js` — workspace entry, `loadState` calls + `app.provide()` mirror
+- `src/admin.js` — admin entry, same
+- `lib/Service/InitialStateBuilder.php` (new) — typed builder centralising the keys
+- New capability `initial-state-contract`
+
+## Why a new capability
+
+The contract is small but load-bearing. Owning it as its own capability gives:
+1. A single source of truth listing every initial-state key
+2. A typed PHP builder so the controllers can't omit a key
+3. A typed JS reader so the entry points can't consume a key the backend never sent
+4. A spec document that reviewers can scan to understand the page-boot data flow
+
+## Approach
+
+- Define a typed PHP builder `InitialStateBuilder` whose constructor accepts the page (workspace | admin) and exposes per-key setter methods. `apply($initialStateService): void` writes everything; throws if a required key was not set.
+- Mirror builder on JS with `loadInitialState(page): InitialState` returning a typed object — same key set per page.
+- Both controllers (workspace + admin) MUST use the builder; ad-hoc `provideInitialState` calls outside it are forbidden by code review (grep).
+- Keys are versioned: bumping the schema requires updating REQ-INIT-002.
+
+## Notes
+
+- Vue `provide`/`inject` is the down-tree distribution mechanism (no Pinia required at the entry-point boundary). Components that need cross-tree reactivity adopt Pinia stores fed from the injected initial state.
+- Default values for missing keys live in the JS reader so the frontend never sees `undefined`.

--- a/openspec/changes/initial-state-contract/specs/initial-state-contract/spec.md
+++ b/openspec/changes/initial-state-contract/specs/initial-state-contract/spec.md
@@ -1,0 +1,120 @@
+---
+capability: initial-state-contract
+delta: true
+status: draft
+---
+
+# Initial State Contract — Delta from change `initial-state-contract`
+
+## ADDED Requirements
+
+### Requirement: Centralised PHP builder for initial state (REQ-INIT-001)
+
+The system MUST expose `lib/Service/InitialStateBuilder.php` with a constructor accepting an `IInitialState` and a `Page` enum (`Page::WORKSPACE` or `Page::ADMIN`). The builder MUST expose typed setter methods (e.g. `setWidgets(array $widgets): self`, `setLayout(array $layout): self`, `setIsAdmin(bool $isAdmin): self`) and a final `apply(): void` that writes every key to the initial-state service. `apply()` MUST throw `MissingInitialStateException` if any required key was not set for the chosen page. Controllers (`WorkspaceController`, `AdminSettings`) MUST use the builder; direct calls to `IInitialState::provideInitialState` from controllers are forbidden by code review (a grep lint MUST find such calls only inside `InitialStateBuilder`).
+
+#### Scenario: Builder writes all keys
+
+- **WHEN** a workspace controller calls every required setter and then `apply()` and the page renders
+- **THEN** the system MUST forward each value to `IInitialState::provideInitialState` so that `loadState('mydash', <key>)` on the JS side returns the exact values set
+- **AND** the JS bundle MUST receive all 10 workspace keys declared in the Data Model
+
+#### Scenario: Missing required key raises before render
+
+- **WHEN** a controller constructs the builder for `Page::WORKSPACE`, omits the required `setLayout()` call, and then invokes `apply()`
+- **THEN** the system MUST throw `MissingInitialStateException` with a message naming the missing key `layout`
+- **AND** the page MUST NOT render (HTTP 500 surfaces during dev; CI test catches this earlier)
+
+#### Scenario: Direct provideInitialState call rejected
+
+- **WHEN** a developer adds `$initialState->provideInitialState('foo', 'bar')` directly inside `lib/Controller/WorkspaceController.php`
+- **THEN** the lint test (grep against `lib/Controller/`) MUST fail with a message pointing to `InitialStateBuilder`
+- **AND** the change MUST NOT be merged
+
+### Requirement: Versioned key set per page (REQ-INIT-002)
+
+The exact set of initial-state keys per page is part of the contract and MUST match the Data Model documented in this spec. Adding, removing, or renaming a key is a deliberate spec change and MUST be accompanied by (1) an update to this spec's Data Model, (2) a bump of the `INITIAL_STATE_SCHEMA_VERSION` constant (currently `1`), and (3) coordinated updates to both the PHP builder and the JS reader in the same commit. The schema version MUST itself be pushed as initial state under the key `_schemaVersion`. The JS reader MUST log a console warning when the received version differs from the compiled-in version (catches caching and deploy-skew bugs).
+
+The Workspace page (mounted into `#workspace-vue`) MUST expose exactly these keys:
+
+| Key | Type | Default (if missing) |
+|---|---|---|
+| `widgets` | `Array<{id, title, iconClass, iconUrl, url}>` | `[]` |
+| `layout` | `Array<WorkspaceWidget>` | `[]` |
+| `primaryGroup` | `string` | `'default'` |
+| `primaryGroupName` | `string` | `''` |
+| `isAdmin` | `boolean` | `false` |
+| `activeDashboardId` | `string` | `''` |
+| `dashboardSource` | `'user'\|'group'\|'default'` | `'group'` |
+| `groupDashboards` | `Array<{id, name, icon, source?}>` | `[]` |
+| `userDashboards` | `Array<{id, name, icon}>` | `[]` |
+| `allowUserDashboards` | `boolean` | `false` |
+
+The Admin page (mounted into `#workspace-admin-vue`) MUST expose exactly these keys:
+
+| Key | Type | Default |
+|---|---|---|
+| `allGroups` | `Array<{id, displayName}>` | `[]` |
+| `configuredGroups` | `Array<string>` | `[]` |
+| `widgets` | `Array<{id, title, iconClass, iconUrl, url}>` | `[]` |
+| `allowUserDashboards` | `boolean` | `false` |
+
+#### Scenario: Adding a key bumps version
+
+- **WHEN** a developer adds a new workspace initial-state key `theme` and submits the change for review
+- **THEN** the spec Data Model table MUST list `theme` with type and default
+- **AND** the `INITIAL_STATE_SCHEMA_VERSION` constant MUST be bumped to `2`
+- **AND** the JS reader MUST consume `theme`
+
+#### Scenario: Schema version mismatch warning
+
+- **WHEN** PHP pushes `_schemaVersion: 2` but the loaded JS bundle was compiled against version `1` and the JS reader runs
+- **THEN** the reader MUST log a console warning of the form `MyDash initial-state schema mismatch: server v2 vs client v1 — refresh recommended`
+- **AND** the reader MUST still attempt to load known keys (graceful degradation)
+
+### Requirement: Centralised JS reader for initial state (REQ-INIT-003)
+
+The system MUST expose `src/utils/loadInitialState.js` exporting `loadInitialState(page: 'workspace' | 'admin'): InitialState`. The reader MUST call `loadState('mydash', key, default)` for every key declared for `page` in the Data Model, MUST return a typed object with default-filled fields (no `undefined` values), and MUST validate the received `_schemaVersion` against the compiled-in `INITIAL_STATE_SCHEMA_VERSION` constant per REQ-INIT-002. Entry points (`src/main.js`, `src/admin.js`) MUST use the reader; direct `loadState('mydash', ...)` calls outside the reader are forbidden by a JS-side grep lint.
+
+#### Scenario: Reader fills defaults
+
+- **WHEN** PHP pushes only `widgets` (other keys missing for any reason) and `loadInitialState('workspace')` runs
+- **THEN** every key declared for the workspace page MUST have a defined value taken from the Data Model defaults
+- **AND** no field on the returned object MUST be `undefined`
+
+#### Scenario: Direct loadState rejected
+
+- **WHEN** a Vue component under `src/` calls `loadState('mydash', 'something')` directly
+- **THEN** the lint test (grep against `src/`) MUST fail
+- **AND** the failure message MUST direct the developer to use `loadInitialState`
+
+### Requirement: Provide-down-tree convention (REQ-INIT-004)
+
+After the entry point loads the initial state, it MUST expose every key via `app.provide(key, value)` so descendant components can `inject(key, default)` without re-reading from `loadState`. The provide call MUST use the same key string as the initial-state key — no renaming at the boundary (renaming is itself a spec change and bumps the schema version).
+
+#### Scenario: Provide names match initial-state keys
+
+- **WHEN** the workspace entry loads 10 initial-state keys via the reader and calls `app.provide`
+- **THEN** the entry MUST emit exactly 10 `provide` calls, one per key, with identical key strings
+- **AND** no key renaming MUST occur at this boundary
+
+#### Scenario: Components inject by key name
+
+- **WHEN** a deep child component calls `inject('widgets', [])`
+- **THEN** the component MUST receive the value the entry point provided
+- **AND** the wiring MUST work without additional plumbing
+
+### Requirement: Reactivity boundary (REQ-INIT-005)
+
+`provide`/`inject` distributes static snapshots — values are NOT reactive across writes. Components that need to mutate shared state (for example `layout` after editing) MUST clone the injected value into a local `ref` (or hand off to a Pinia store fed from the injected value). The entry-point provides MUST NEVER be wrapped in a `ref` to "make them reactive" — that would let component code accidentally mutate the boot snapshot and break re-mount semantics.
+
+#### Scenario: Mutation does not leak through inject
+
+- **WHEN** component `A` injects `layout`, clones into `localLayout = ref([...injectedLayout])`, and mutates `localLayout`
+- **THEN** any sibling component that injects `layout` MUST still see the original (unmutated) value
+- **AND** no console error MUST fire about reactive mutation
+
+#### Scenario: Entry point does not wrap provide in ref
+
+- **WHEN** a code reviewer inspects `src/main.js` or `src/admin.js`
+- **THEN** every `app.provide(key, value)` call MUST pass a plain (non-reactive) value
+- **AND** no `app.provide(key, ref(value))` or `app.provide(key, reactive(value))` MUST appear at the entry-point boundary

--- a/openspec/changes/initial-state-contract/tasks.md
+++ b/openspec/changes/initial-state-contract/tasks.md
@@ -1,0 +1,41 @@
+# Tasks — initial-state-contract
+
+## 1. Backend — InitialStateBuilder service
+
+- [ ] 1.1 Create `lib/Service/InitialStateBuilder.php` with a `Page` enum (`WORKSPACE`, `ADMIN`) and a constructor accepting `IInitialState` + `Page`
+- [ ] 1.2 Add typed setter methods per page key (`setWidgets`, `setLayout`, `setPrimaryGroup`, `setPrimaryGroupName`, `setIsAdmin`, `setActiveDashboardId`, `setDashboardSource`, `setGroupDashboards`, `setUserDashboards`, `setAllowUserDashboards`, `setAllGroups`, `setConfiguredGroups`)
+- [ ] 1.3 Implement `apply(): void` that validates required keys per page and throws `MissingInitialStateException` (new class under `lib/Exception/`) naming the missing key
+- [ ] 1.4 Add `INITIAL_STATE_SCHEMA_VERSION = 1` constant; push it under key `_schemaVersion` in `apply()`
+- [ ] 1.5 Document the contract in the class docblock with link to REQ-INIT-002
+
+## 2. Backend — Controller refactor
+
+- [ ] 2.1 Refactor `lib/Controller/WorkspaceController::index` to construct `InitialStateBuilder(Page::WORKSPACE)`, call all setters, then `apply()`
+- [ ] 2.2 Refactor `lib/Settings/Admin/AdminSettings::getForm` to construct `InitialStateBuilder(Page::ADMIN)`, call all setters, then `apply()`
+- [ ] 2.3 Add a CI lint task (shell or PHPUnit) that greps `provideInitialState` outside `lib/Service/InitialStateBuilder.php` and fails the build if found
+
+## 3. Frontend — JS reader
+
+- [ ] 3.1 Create `src/utils/loadInitialState.js` exporting `loadInitialState(page)`; declare per-page key/default tables that mirror REQ-INIT-002
+- [ ] 3.2 Add `INITIAL_STATE_SCHEMA_VERSION = 1` constant in the reader (must equal the PHP value); compare against received `_schemaVersion` and emit a console warning on mismatch
+- [ ] 3.3 Refactor `src/main.js` (workspace entry) to call `loadInitialState('workspace')` and `app.provide(key, value)` for every key
+- [ ] 3.4 Refactor `src/admin.js` (admin entry) to call `loadInitialState('admin')` and `app.provide(key, value)` for every key
+- [ ] 3.5 Add a CI lint task (shell or Vitest) that greps `loadState\(['"]mydash['"]` outside `src/utils/loadInitialState.js` and fails the build if found
+
+## 4. Tests
+
+- [ ] 4.1 PHPUnit: builder rejects missing required keys for each page (one test per page)
+- [ ] 4.2 PHPUnit: builder writes all keys with correct values via a stub `IInitialState`
+- [ ] 4.3 PHPUnit: schema version key `_schemaVersion` is always pushed
+- [ ] 4.4 Vitest: reader fills defaults for missing keys (mock `loadState`)
+- [ ] 4.5 Vitest: reader logs warning on schema version mismatch
+- [ ] 4.6 Vitest: provide/inject pipe-through works for every workspace key
+- [ ] 4.7 Vitest: mutating a component clone of an injected value does not affect siblings (REQ-INIT-005)
+- [ ] 4.8 CI lint pair (PHP grep + JS grep) wired into the workflow
+
+## 5. Quality
+
+- [ ] 5.1 `composer check:strict` passes (PHPCS, PHPMD, Psalm, PHPStan)
+- [ ] 5.2 ESLint clean
+- [ ] 5.3 Class docblock on `InitialStateBuilder` links to REQ-INIT-002 and lists all keys for each page
+- [ ] 5.4 Add a changelog note describing the new contract and how to add a key (spec update + version bump + reader/builder update in same commit)

--- a/openspec/changes/label-widget/proposal.md
+++ b/openspec/changes/label-widget/proposal.md
@@ -1,0 +1,54 @@
+# Label widget
+
+## Why
+
+Dashboard authors today have only the `text` widget for adding non-data text to a dashboard. The text widget supports HTML (via `v-html`), is multi-line, scrolls on overflow, and carries the full XSS surface of any HTML-injection feature. None of those properties match the most common authoring need: a short, single-line, plain-text heading that titles a row of widgets or marks a dashboard zone. Folding heading-style behaviour into the existing `text` widget would either compromise its content-block semantics or bury an extra "is this a heading?" toggle in its form. A dedicated `label` widget is simpler, safer (no `v-html` at all), and leaves room for future heading semantics (`<h3>`, `aria-level`) to diverge without entangling the two types.
+
+## What Changes
+
+- Introduce a new widget type `label` with persisted shape `{type: 'label', content: {text, fontSize, color, backgroundColor, fontWeight, textAlign}}`.
+- Add `src/components/Widgets/Renderers/LabelWidget.vue` rendering `{{ text }}` (Vue interpolation only — no `v-html`) inside a flex-centred wrapper.
+- Add `src/components/Widgets/Forms/LabelForm.vue` exposing six controls (text, fontSize, color, backgroundColor, fontWeight select, textAlign select) with `validate()` requiring non-empty trimmed text.
+- Register `label` in `src/constants/widgetRegistry.js` with defaults `{text:'', fontSize:'16px', color:'', backgroundColor:'', fontWeight:'bold', textAlign:'center'}`.
+- Apply `overflow-wrap: break-word` so long single words wrap rather than overflow.
+- When `text` is empty or whitespace, render the translated literal `t('Label')` so the widget is still visible during editing.
+
+## Capabilities
+
+### New Capabilities
+
+- `label-widget`: REQ-LBL-001 (plain-text only), REQ-LBL-002 (default-styled centred bold heading), REQ-LBL-003 (long-word wrap), REQ-LBL-004 (empty-content placeholder), REQ-LBL-005 (add/edit form), REQ-LBL-006 (cell-filling layout), REQ-LBL-007 (registry registration).
+
+### Modified Capabilities
+
+(none — the existing `text-display-widget` capability is intentionally left untouched; the label widget is a parallel, separate type)
+
+## Impact
+
+**Affected code:**
+
+- `src/components/Widgets/Renderers/LabelWidget.vue` — new file, single-file Vue component
+- `src/components/Widgets/Forms/LabelForm.vue` — new file, sub-form for `AddWidgetModal`
+- `src/constants/widgetRegistry.js` — add `label` entry with renderer + form references and `defaultContent`
+- `src/l10n/en.json`, `src/l10n/nl.json` — add translation keys `Label`, `Label text is required`, `Font Weight`, `Alignment`
+
+**Affected APIs:**
+
+- No backend / HTTP API changes. The widget placement persistence layer already accepts arbitrary `{type, content}` blobs.
+
+**Dependencies:**
+
+- No new composer or npm dependencies.
+
+**Migration:**
+
+- Zero migration impact. Existing widget placements are unaffected. New label placements coexist with all other widget types in the same `oc_mydash_widget_placements.content` JSON column.
+
+**Accessibility:**
+
+- This change ships a `<div><span>...</span></div>` structure. Heading semantics (`<h3>`, `aria-level`) are intentionally deferred to a follow-up change so the admin can pick a heading level.
+
+## Notes
+
+- Considered folding into the existing `text-display-widget` capability — rejected because the intent (heading vs. content block) and the security posture (no HTML vs. sanitised HTML) differ enough to deserve a separate type.
+- `overflow-wrap: break-word` is preferred over `word-break: break-all` so normal multi-word text continues to break at word boundaries.

--- a/openspec/changes/label-widget/specs/label-widget/spec.md
+++ b/openspec/changes/label-widget/specs/label-widget/spec.md
@@ -1,0 +1,123 @@
+---
+capability: label-widget
+delta: true
+status: draft
+---
+
+# Label Widget — Delta from change `label-widget`
+
+## ADDED Requirements
+
+### Requirement: REQ-LBL-001 Plain-text only rendering
+
+The renderer MUST output `text` via Vue interpolation (`{{ text }}`). It MUST NOT use `v-html` or any other HTML-injection technique. Embedded HTML in `text` MUST appear as literal text on screen, eliminating the XSS surface entirely.
+
+#### Scenario: HTML in text appears as literal characters
+
+- **GIVEN** a label widget with `content.text = "Sales <b>Q4</b>"`
+- **WHEN** the widget renders
+- **THEN** the visible output MUST be the literal string `Sales <b>Q4</b>`
+- **AND** the DOM MUST NOT contain a `<b>` element generated from the content
+
+#### Scenario: Script tag in text appears as literal characters
+
+- **GIVEN** a label widget with `content.text = "<script>alert(1)</script>"`
+- **WHEN** the widget renders
+- **THEN** the visible output MUST be the literal string `<script>alert(1)</script>`
+- **AND** no script MUST execute
+
+### Requirement: REQ-LBL-002 Default-styled as a centred bold heading
+
+When form fields are absent, empty, or null, the renderer MUST apply these defaults: `fontSize='16px'`, `color='var(--color-main-text)'`, `backgroundColor='transparent'`, `fontWeight='bold'`, `textAlign='center'`. Provided values MUST override the matching default while leaving other defaults intact.
+
+#### Scenario: Defaults applied to bare content
+
+- **GIVEN** a label widget with `content = {text: 'Header'}` (no other fields)
+- **WHEN** the widget renders
+- **THEN** the inline style on the inner `<span>` MUST include `font-size: 16px`
+- **AND** `font-weight: bold`
+- **AND** `text-align: center`
+- **AND** a theme-aware color resolved from `var(--color-main-text)`
+
+#### Scenario: Override with custom values leaves untouched defaults intact
+
+- **GIVEN** content `{text: 'X', fontSize: '32px', fontWeight: 'normal', textAlign: 'left'}`
+- **WHEN** the widget renders
+- **THEN** the inline style MUST reflect `font-size: 32px; font-weight: normal; text-align: left`
+- **AND** `backgroundColor` MUST default to `transparent`
+- **AND** `color` MUST default to the theme-variable colour
+
+### Requirement: REQ-LBL-003 Long single words wrap
+
+The renderer MUST set `overflow-wrap: break-word` on the rendered `<span>` so that overflowing single words wrap to a new visual line within the cell rather than overflowing horizontally.
+
+#### Scenario: Very long word wraps within narrow cell
+
+- **GIVEN** content `text = "Pneumonoultramicroscopicsilicovolcanoconiosis"` placed in a 2-column-wide cell
+- **WHEN** the widget renders
+- **THEN** the word MUST wrap across multiple visual lines within the cell bounds
+- **AND** the cell MUST NOT produce a horizontal scrollbar
+
+### Requirement: REQ-LBL-004 Empty-content placeholder
+
+When `text` is empty, whitespace-only, or undefined, the renderer MUST display the translated literal `t('Label')` as a fallback so the widget remains visible during editing.
+
+#### Scenario: Empty text shows translated fallback
+
+- **GIVEN** `content = {text: ''}`
+- **WHEN** the widget renders
+- **THEN** the visible text MUST be the translation of `'Label'`
+
+#### Scenario: Whitespace-only text shows translated fallback
+
+- **GIVEN** `content = {text: '   '}`
+- **WHEN** the widget renders
+- **THEN** the visible text MUST be the translation of `'Label'`
+
+### Requirement: REQ-LBL-005 Add/edit form
+
+The label sub-form for `AddWidgetModal` MUST expose six controls: a required text input for `text`, an optional text input for `fontSize` (placeholder `16px`), a colour picker for `color`, a colour picker for `backgroundColor`, a select for `fontWeight` with options `normal`, `bold`, `600`, `700`, `800`, and a select for `textAlign` with options `left`, `center`, `right`. The form's `validate()` method MUST return `[t('Label text is required')]` when `text.trim() === ''` and an empty array otherwise. On open in edit mode the form MUST pre-fill every control from `editingWidget.content`.
+
+#### Scenario: Form rejects empty text
+
+- **GIVEN** the user opens the label sub-form with no pre-filled text
+- **WHEN** they leave the text input empty and click validate
+- **THEN** `validate()` MUST return a single-element error array containing the translation of `'Label text is required'`
+- **AND** the modal Add button MUST be disabled
+
+#### Scenario: Form pre-fills all six fields when editing
+
+- **GIVEN** an existing label widget with `content = {text: 'Hi', fontSize: '20px', color: '#ff0000', backgroundColor: '#ffffff', fontWeight: '700', textAlign: 'right'}`
+- **WHEN** the user opens that widget in the edit modal
+- **THEN** every one of the six form controls MUST display its corresponding value from `content`
+
+### Requirement: REQ-LBL-006 Layout fills cell with centred content
+
+The renderer wrapper MUST occupy the full grid cell using `width: 100%; height: 100%` and use flexbox to centre the inner `<span>` both vertically and horizontally. The wrapper MUST apply `padding: 12px`.
+
+#### Scenario: Centred in cell with padding
+
+- **GIVEN** a label widget placed in a 4-column by 2-row cell
+- **WHEN** the widget renders
+- **THEN** the visible text MUST be centred horizontally and vertically within the cell
+- **AND** the wrapper element MUST have `padding: 12px`
+- **AND** the wrapper MUST have `width: 100%` and `height: 100%`
+
+### Requirement: REQ-LBL-007 Widget registry registration
+
+The widget type `label` MUST be registered in `src/constants/widgetRegistry.js` with a renderer reference to `LabelWidget.vue`, a form reference to `LabelForm.vue`, and a `defaultContent` of `{text: '', fontSize: '16px', color: '', backgroundColor: '', fontWeight: 'bold', textAlign: 'center'}`. The persisted shape of a label placement MUST be `{type: 'label', content: {...}}`.
+
+#### Scenario: Newly added label uses registry defaults
+
+- **GIVEN** a user adds a new label widget via the Add Widget modal without overriding any field
+- **WHEN** the widget is persisted
+- **THEN** the stored placement MUST have `type = 'label'`
+- **AND** `content.fontSize` MUST equal `'16px'`
+- **AND** `content.fontWeight` MUST equal `'bold'`
+- **AND** `content.textAlign` MUST equal `'center'`
+
+#### Scenario: Registry exposes label as a selectable widget type
+
+- **GIVEN** the Add Widget modal queries the widget registry
+- **WHEN** the type list is rendered
+- **THEN** `label` MUST appear as a selectable option distinct from `text`

--- a/openspec/changes/label-widget/tasks.md
+++ b/openspec/changes/label-widget/tasks.md
@@ -1,0 +1,53 @@
+# Tasks — label-widget
+
+## 1. Renderer component
+
+- [ ] 1.1 Create `src/components/Widgets/Renderers/LabelWidget.vue` with a `<div><span>{{ displayText }}</span></div>` template — interpolation only, never `v-html`
+- [ ] 1.2 Implement `displayText` computed: returns `content.text` when `text.trim() !== ''`, else returns `t('mydash', 'Label')`
+- [ ] 1.3 Implement `wrapperStyle` computed returning `width:100%; height:100%; padding:12px; display:flex; align-items:center; justify-content:center; background-color: <bg or transparent>`
+- [ ] 1.4 Implement `spanStyle` computed returning `font-size; font-weight; text-align; color; overflow-wrap: break-word`, falling back to defaults per REQ-LBL-002 when fields are missing
+- [ ] 1.5 Default `color` MUST resolve to `var(--color-main-text)` so theming works in both light and dark mode
+- [ ] 1.6 Add component-scoped CSS for `overflow-wrap: break-word` as a safety net even if inline style is overridden
+
+## 2. Form component
+
+- [ ] 2.1 Create `src/components/Widgets/Forms/LabelForm.vue` with the six controls listed in REQ-LBL-005 (text input, fontSize text input, color picker, backgroundColor picker, fontWeight select, textAlign select)
+- [ ] 2.2 Pre-fill every control from `editingWidget.content` when in edit mode (per REQ-LBL-005)
+- [ ] 2.3 Implement `validate()` returning `[t('mydash', 'Label text is required')]` when `text.trim() === ''`, otherwise an empty array
+- [ ] 2.4 Wire form input events to `$emit('update:content', {...})` so the parent modal sees live changes
+- [ ] 2.5 Use translation keys `Font Weight` and `Alignment` for the two select labels
+
+## 3. Widget registry
+
+- [ ] 3.1 Add a `label` entry to `src/constants/widgetRegistry.js` with `renderer: LabelWidget`, `form: LabelForm`
+- [ ] 3.2 Set `defaultContent: {text: '', fontSize: '16px', color: '', backgroundColor: '', fontWeight: 'bold', textAlign: 'center'}`
+- [ ] 3.3 Add an icon and `displayName: t('mydash', 'Label')` so the type appears as a selectable option in the Add Widget modal
+- [ ] 3.4 Verify the `label` type is distinct from `text` in the modal's type-picker UI
+
+## 4. Translations
+
+- [ ] 4.1 Add the four English keys to `src/l10n/en.json`: `Label`, `Label text is required`, `Font Weight`, `Alignment`
+- [ ] 4.2 Add the four Dutch translations to `src/l10n/nl.json`: `Label` → `Label`, `Label text is required` → `Labeltekst is verplicht`, `Font Weight` → `Letterdikte`, `Alignment` → `Uitlijning`
+
+## 5. Vitest unit tests
+
+- [ ] 5.1 `LabelWidget.spec.js`: HTML in `text` appears as literal text — assert no `<b>` element appears in mounted DOM (REQ-LBL-001)
+- [ ] 5.2 `LabelWidget.spec.js`: defaults applied when `content = {text: 'Hi'}` — assert inline style contains `font-size: 16px`, `font-weight: bold`, `text-align: center` (REQ-LBL-002)
+- [ ] 5.3 `LabelWidget.spec.js`: long single word wraps — mount in narrow container, assert no horizontal overflow on inner span (REQ-LBL-003)
+- [ ] 5.4 `LabelWidget.spec.js`: empty `text` shows `t('Label')` fallback (REQ-LBL-004)
+- [ ] 5.5 `LabelForm.spec.js`: `validate()` returns error on empty text, empty array on non-empty text (REQ-LBL-005)
+- [ ] 5.6 `LabelForm.spec.js`: pre-fills all six controls from `editingWidget.content` (REQ-LBL-005)
+- [ ] 5.7 Registry test: importing `widgetRegistry.js` exposes a `label` entry with the correct `defaultContent` (REQ-LBL-007)
+
+## 6. Playwright end-to-end test
+
+- [ ] 6.1 Add `tests/e2e/label-widget.spec.ts` covering: open Add Widget modal → pick Label → fill text + change fontSize to `24px` + change colour → save
+- [ ] 6.2 Same test reopens the placement in edit mode and asserts all six fields round-trip identically
+- [ ] 6.3 Same test verifies that pasting `<b>HTML</b>` into the text field renders as literal text (no bold styling) on the dashboard
+
+## 7. Quality gates
+
+- [ ] 7.1 ESLint clean on the two new `.vue` files and the modified `widgetRegistry.js`
+- [ ] 7.2 `npm run build` succeeds without warnings
+- [ ] 7.3 No new console errors in the browser when the widget is rendered, edited, or removed
+- [ ] 7.4 Manual smoke test in `nldesign` theme to confirm the default `var(--color-main-text)` colour resolves correctly in both light and dark mode

--- a/openspec/changes/link-button-widget/proposal.md
+++ b/openspec/changes/link-button-widget/proposal.md
@@ -1,0 +1,55 @@
+# Link-button widget
+
+## Why
+
+MyDash today has no first-class action button. Users cannot drop a styled clickable tile on a dashboard to open an external URL in a new tab, kick off a registered in-app workflow, or create a fresh document in their Files app. Sendent-era code shipped an ad-hoc "internal action" placeholder with auto-detect-from-extension semantics that proved fragile (a `.docx` URL meant "create file" but a `.html` URL meant "open external", indistinguishable for opaque links). This change formalises a typed `link` widget with three explicit action types, a runtime-mutable registry of named internal actions, and a strictly-validated server endpoint for file creation, so the action set can grow safely without regressing the existing widget contract.
+
+## What Changes
+
+- Introduce a new widget `type: 'link'` registered in `widgetRegistry.js` with default content `{label:'', url:'', icon:'', actionType:'external', backgroundColor:'', textColor:''}`.
+- Add a typed `actionType` enum: `external | internal | createFile` (no auto-detect from URL extension).
+- Implement renderer `LinkButtonWidget.vue` dispatching click on `actionType`, suppressing all clicks while in admin/edit mode, disabling the button while an action is in flight.
+- Add an `IconRenderer` integration for both built-in MDI names and uploaded resource URLs (dual-mode like `dashboard-icons`).
+- Introduce a singleton frontend composable `useInternalActions()` exposing `register(id, fn)`, `invoke(id)`, `has(id)` — the registry starts empty; concrete actions are registered by other capabilities later.
+- Implement add/edit sub-form `LinkButtonForm.vue` with all six fields, placeholder text that swaps with `actionType`, and a `validate()` requiring both `label` and `url`.
+- Add a NEW server endpoint `POST /api/files/create` accepting `{filename, dir, content}` with strict regex filename validation, dir traversal rejection, an admin-configurable extension allow-list (default `txt, md, docx, xlsx, csv, odt`), overwrite-on-exists semantics, and a response payload of `{status, fileId, url}` where `url` opens the Files app viewer.
+- Translation strings for all visible UI labels and toasts (English + Dutch).
+
+## Capabilities
+
+### New Capabilities
+
+- `link-button-widget` — adds REQ-LBN-001 (renderer with three action types), REQ-LBN-002 (icon resolution), REQ-LBN-003 (createFile flow), REQ-LBN-004 (server-side file-creation endpoint), REQ-LBN-005 (internal action registry), REQ-LBN-006 (add/edit form), REQ-LBN-007 (default styling).
+
+### Modified Capabilities
+
+(none — this change is fully additive)
+
+## Impact
+
+**Affected code:**
+
+- `src/components/Widgets/Renderers/LinkButtonWidget.vue` — new renderer + inline filename-prompt modal child component
+- `src/components/Widgets/Forms/LinkButtonForm.vue` — new add/edit sub-form with six fields
+- `src/composables/useInternalActions.js` — new singleton registry composable
+- `src/constants/widgetRegistry.js` — register `type: 'link'` with default content shape
+- `lib/Controller/FileController.php` — new `createFile` action mapped to `POST /api/files/create`
+- `lib/Service/FileService.php` — new `createFile()` method with strict validation, allow-list enforcement, overwrite semantics
+- `appinfo/routes.php` — register the new POST route
+- `lib/Settings/AdminSettings.php` — surface admin-configurable extension allow-list
+- `l10n/en.js`, `l10n/nl.js` — translation strings for all new labels and toasts
+
+**Affected APIs:**
+
+- 1 new route (`POST /api/files/create`) — no existing routes changed
+
+**Dependencies:**
+
+- `OCP\Files\IRootFolder` — already injected elsewhere in the app
+- `OCP\IURLGenerator` — already injected elsewhere
+- No new composer or npm dependencies
+
+**Migration:**
+
+- Zero schema changes — widget shape lives inside the existing `content` JSON blob on widget placements.
+- Existing dashboards continue to work unchanged; the `link` type only appears once an admin explicitly adds a Link Button widget.

--- a/openspec/changes/link-button-widget/specs/link-button-widget/spec.md
+++ b/openspec/changes/link-button-widget/specs/link-button-widget/spec.md
@@ -1,0 +1,194 @@
+---
+capability: link-button-widget
+delta: true
+status: draft
+---
+
+# Link-Button Widget — Delta from change `link-button-widget`
+
+## ADDED Requirements
+
+### Requirement: REQ-LBN-001 Renderer with three action types
+
+The renderer MUST output a `<button>` whose click handler dispatches based on the `actionType` field of the persisted widget content. The three branches are:
+
+1. `external` → `window.open(url, '_blank', 'noopener,noreferrer')`
+2. `internal` → resolve `url` against the internal-action registry (REQ-LBN-005) and invoke the registered function; ignore (no-op) when no matching action is registered
+3. `createFile` → open an inline filename-prompt modal (REQ-LBN-003)
+
+The renderer MUST suppress all click handlers when `isAdmin === true` AND the surrounding dashboard is in edit mode, so that configuring the widget cannot accidentally fire actions. The button MUST carry a `disabled` attribute while an action is in flight (`isExecuting === true`).
+
+#### Scenario: External link opens in new tab
+
+- GIVEN content `{actionType: 'external', url: 'https://example.com', label: 'Docs'}`
+- WHEN the user clicks the button (not in edit mode)
+- THEN the system MUST call `window.open('https://example.com', '_blank', 'noopener,noreferrer')`
+
+#### Scenario: Click in edit mode is suppressed
+
+- GIVEN the same widget but the surrounding shell has `canEdit === true` and the widget receives `isAdmin: true`
+- WHEN the user clicks the button
+- THEN no `window.open` MUST fire
+- AND no API call MUST fire
+- AND no modal MUST open
+
+#### Scenario: Disabled while action is in flight
+
+- GIVEN a `createFile` action is in progress (POST `/api/files/create` not yet resolved)
+- WHEN the user clicks the button again
+- THEN the button MUST be `disabled` in the DOM
+- AND no second request MUST fire
+
+### Requirement: REQ-LBN-002 Icon resolution
+
+The `icon` field of a link-button widget MUST follow the same dual-mode convention as `dashboard-icons` (REQ-ICON-005..007):
+
+- A custom URL (starts with `/` or `http`) MUST render as `<img>` inside the button
+- A bare name MUST render via the shared `IconRenderer` (built-in MDI component)
+- An empty or null value MUST render no icon (label-only)
+
+Icon size MUST be 48 px square; the label MUST be vertically stacked below the icon.
+
+#### Scenario: Custom URL icon
+
+- GIVEN content `{icon: '/apps/mydash/resource/x.png', label: 'Open'}`
+- WHEN the widget renders
+- THEN the button MUST contain `<img src="/apps/mydash/resource/x.png">` 48 px tall
+- AND the label `Open` MUST appear below the image
+
+#### Scenario: No icon
+
+- GIVEN `{icon: '', label: 'Click me'}`
+- WHEN the widget renders
+- THEN no `<img>` or `<svg>` icon MUST appear
+- AND only the label MUST be visible
+
+### Requirement: REQ-LBN-003 createFile flow
+
+When `actionType === 'createFile'`, click MUST open an inline secondary modal containing:
+
+- Read-only display of the extension (`.docx` etc.) derived from `url`
+- Editable filename input prefilled with `document_<unix-timestamp>`
+- Cancel and Create buttons (Create disabled when filename empty)
+
+On Create, the system MUST POST `/api/files/create` with body `{filename: <name>.<ext>, dir: '/', content: ''}`. On HTTP 200, the response's `url` MUST be opened in a new tab via `window.open(url, '_blank')`. On error, a translated toast MUST display `t('Failed to create document')`. The modal MUST close on Cancel or after a successful create.
+
+#### Scenario: Document modal opens with prefilled name
+
+- GIVEN content `{actionType: 'createFile', url: 'docx', label: 'New report'}`
+- WHEN the user clicks the button
+- THEN the modal MUST appear with `.docx` displayed and filename `document_<timestamp>` prefilled
+- AND the Create button MUST be enabled
+
+#### Scenario: Create posts and opens result
+
+- GIVEN the modal is open and the user types `Q4-report` and clicks Create
+- WHEN the form submits
+- THEN the system MUST POST `/api/files/create` with body `{filename: 'Q4-report.docx', dir: '/', content: ''}`
+- AND on 200 with response `{url: 'https://nc/index.php/apps/files/?openfile=42'}` it MUST `window.open(url, '_blank')`
+- AND the modal MUST close
+
+#### Scenario: Empty filename disables Create
+
+- GIVEN the user clears the filename input
+- WHEN the modal renders
+- THEN the Create button MUST be `disabled`
+
+### Requirement: REQ-LBN-004 Server-side file-creation endpoint
+
+The system MUST expose `POST /api/files/create` accepting `{filename: string, dir: string = '/', content: string = ''}`. The endpoint MUST:
+
+1. Validate filename: non-empty, ≤255 chars, no `..`, no `/`, no `\`, no null byte, must match `^[a-zA-Z0-9_\-. ]+$`. Otherwise return HTTP 400 `{error: 'Invalid filename'}`.
+2. Validate dir: no `..`, no null byte. Otherwise return HTTP 400.
+3. Validate extension: must be in the admin-configured allow-list (default: `txt, md, docx, xlsx, csv, odt`). Otherwise return HTTP 400 `{error: 'File type not allowed'}`.
+4. Resolve user folder via `IRootFolder::getUserFolder($userId)` and create the subdirectory if missing.
+5. If a file with the same name already exists at the target path, OVERWRITE its content.
+6. Return `{status: 'success', fileId: int, url: string}` where `url` opens the Files app at `openfile={fileId}` via `URLGenerator::linkToRouteAbsolute('files.view.index', ['openfile' => fileId])`.
+
+Internal exceptions MUST be wrapped; raw exception messages MUST NOT be returned to the caller.
+
+#### Scenario: Path traversal rejected
+
+- GIVEN body `{filename: '../../etc/passwd'}`
+- WHEN POSTed
+- THEN the system MUST return HTTP 400 with error `Invalid filename`
+- AND no file MUST be created on disk
+
+#### Scenario: Disallowed extension rejected
+
+- GIVEN allow-list `[txt, md, docx]` AND body `{filename: 'foo.exe'}`
+- WHEN POSTed
+- THEN the system MUST return HTTP 400 with `{error: 'File type not allowed'}`
+
+#### Scenario: Existing file overwritten
+
+- GIVEN a file `report.docx` already exists at `/`
+- WHEN body `{filename: 'report.docx', content: ''}` is POSTed
+- THEN the existing file's content MUST be replaced with empty content
+- AND the response MUST return its `fileId` and a Files-app open URL
+- NOTE: This is a deliberate convenience for "create from button" workflows; UI must warn the user when overwriting.
+
+### Requirement: REQ-LBN-005 Internal action registry
+
+The system MUST expose a frontend composable `useInternalActions()` returning a singleton `Map<actionId, () => void | Promise<void>>` plus three methods: `register(id, fn)`, `invoke(id)`, and `has(id)`. Other frontend modules MAY register actions at any time. Click on an `internal` link button MUST look up `url` (the action ID) in the map and invoke the registered function. Missing IDs MUST log `console.warn('Unknown internal action: <id>')` but MUST NOT throw.
+
+#### Scenario: Register and invoke an internal action
+
+- GIVEN a module registered `useInternalActions().register('open-talk', () => router.push('/talk'))`
+- AND content `{actionType: 'internal', url: 'open-talk'}`
+- WHEN the user clicks the button
+- THEN the system MUST invoke the registered function exactly once
+
+#### Scenario: Unknown action ID warns but does not crash
+
+- GIVEN content `{actionType: 'internal', url: 'does-not-exist'}`
+- WHEN the user clicks the button
+- THEN the system MUST log `console.warn('Unknown internal action: does-not-exist')`
+- AND no error MUST propagate to break the page
+
+### Requirement: REQ-LBN-006 Add/edit form
+
+The link sub-form for `AddWidgetModal` MUST expose six fields:
+
+| Field | Control | Required |
+|---|---|---|
+| `label` | text input | yes |
+| `actionType` | select with options external/internal/createFile | yes |
+| `url` | text input; placeholder switches by actionType (`https://...`, `action-id`, `docx`) | yes |
+| `icon` | IconPicker (built-in dropdown + upload) | no |
+| `backgroundColor` | colour picker | no |
+| `textColor` | colour picker | no |
+
+Validation: `validate()` MUST require `label` AND `url` non-empty and return a non-empty error array otherwise. The form MUST pre-fill from `editingWidget.content` when editing an existing widget.
+
+#### Scenario: Validation requires both label and url
+
+- GIVEN the user has filled `label = 'X'` but left `url` empty
+- WHEN the form runs `validate()`
+- THEN it MUST return a non-empty error array
+- AND the modal Add button MUST be disabled
+
+#### Scenario: Placeholder swaps with actionType
+
+- GIVEN the user selects `actionType = 'createFile'`
+- WHEN the form re-renders
+- THEN the `url` input placeholder MUST read `docx` (or similar extension hint)
+- AND when the user switches back to `external`, the placeholder MUST read `https://...`
+
+### Requirement: REQ-LBN-007 Default styling
+
+When the colour fields are empty, the renderer MUST default to `backgroundColor: var(--color-primary)` and `textColor: var(--color-primary-text)` (Nextcloud theme primary). Hover MUST translate the button up by 2 px and add a soft drop shadow.
+
+#### Scenario: Theme defaults
+
+- GIVEN content `{label: 'X', url: 'y', actionType: 'external', backgroundColor: '', textColor: ''}`
+- WHEN the widget renders
+- THEN the button's CSS background MUST equal `var(--color-primary)`
+- AND the text colour MUST equal `var(--color-primary-text)`
+
+#### Scenario: Hover lift effect
+
+- GIVEN the rendered button is on screen
+- WHEN the user hovers the pointer over it
+- THEN the button MUST translate up by 2 px
+- AND a soft drop shadow MUST be applied

--- a/openspec/changes/link-button-widget/tasks.md
+++ b/openspec/changes/link-button-widget/tasks.md
@@ -1,0 +1,59 @@
+# Tasks — link-button-widget
+
+## 1. Backend (file creation endpoint)
+
+- [ ] 1.1 Create `lib/Service/FileService.php::createFile(string $userId, string $filename, string $dir, string $content): array`
+- [ ] 1.2 Filename validation: regex `^[a-zA-Z0-9_\-. ]+$`, ≤255 chars, no `..` or `/` or `\` or null byte
+- [ ] 1.3 Dir validation: no `..`, no null byte
+- [ ] 1.4 Extension validation against admin-configured allow-list (default `txt, md, docx, xlsx, csv, odt`)
+- [ ] 1.5 Resolve via `IRootFolder::getUserFolder`; create subdirectory if missing
+- [ ] 1.6 Overwrite if file exists; return `{status, fileId, url}` with `URLGenerator::linkToRouteAbsolute('files.view.index', ['openfile' => fileId])`
+- [ ] 1.7 Add `lib/Controller/FileController.php::createFile` mapped to `POST /api/files/create` in `appinfo/routes.php`
+- [ ] 1.8 Wrap exceptions; do not leak raw exception messages to the response
+
+## 2. Renderer
+
+- [ ] 2.1 Create `src/components/Widgets/Renderers/LinkButtonWidget.vue`
+- [ ] 2.2 Implement three click branches by `actionType` (external / internal / createFile)
+- [ ] 2.3 Suppress all click handlers in admin/edit mode (`isAdmin === true` and shell `canEdit === true`)
+- [ ] 2.4 Apply `disabled` attribute while `isExecuting === true`
+- [ ] 2.5 Add inline `createFile` modal child component (filename prompt + Cancel/Create)
+- [ ] 2.6 Resolve icon via shared `IconRenderer` (built-in MDI name OR custom URL)
+- [ ] 2.7 Apply default colour fallback to `var(--color-primary)` / `var(--color-primary-text)` when empty
+- [ ] 2.8 Add hover lift (translate up 2 px + soft drop shadow)
+
+## 3. Internal actions composable
+
+- [ ] 3.1 Create `src/composables/useInternalActions.js` exposing `register(id, fn)`, `invoke(id)`, `has(id)`
+- [ ] 3.2 Use a singleton-style module-level `Map`
+- [ ] 3.3 `invoke` MUST log `console.warn('Unknown internal action: <id>')` on missing id and not throw
+
+## 4. Form
+
+- [ ] 4.1 Create `src/components/Widgets/Forms/LinkButtonForm.vue` with all six fields
+- [ ] 4.2 Placeholder text for `url` swaps based on `actionType` (`https://...`, `action-id`, `docx`)
+- [ ] 4.3 `validate()` requires both `label` AND `url` non-empty; returns non-empty error array otherwise
+- [ ] 4.4 Pre-fill all fields from `editingWidget.content` when editing an existing widget
+
+## 5. Registry
+
+- [ ] 5.1 Add `link` entry to `src/constants/widgetRegistry.js` with defaults `{label:'', url:'', icon:'', actionType:'external', backgroundColor:'', textColor:''}`
+
+## 6. Tests
+
+- [ ] 6.1 PHPUnit: filename validation rejects path traversal, special chars, oversized input
+- [ ] 6.2 PHPUnit: extension allow-list enforced (allowed extension OK, disallowed extension HTTP 400)
+- [ ] 6.3 PHPUnit: existing file overwritten and returned `fileId` matches the existing entry
+- [ ] 6.4 PHPUnit: raw exception messages NOT leaked to caller
+- [ ] 6.5 Vitest: three click branches; admin-mode suppression; disabled-while-in-flight
+- [ ] 6.6 Vitest: internal action registry warn-on-miss; register/invoke happy path
+- [ ] 6.7 Vitest: form validation requires label + url; placeholder swaps with actionType
+- [ ] 6.8 Playwright: createFile flow end-to-end (modal opens → POST → opens Files tab)
+- [ ] 6.9 Playwright: external link opens in a `_blank` tab
+
+## 7. Quality
+
+- [ ] 7.1 `composer check:strict` passes (PHPCS, PHPMD, Psalm, PHPStan)
+- [ ] 7.2 ESLint clean
+- [ ] 7.3 OpenAPI spec updated for `POST /api/files/create`
+- [ ] 7.4 Translation entries added in `l10n/en.js` and `l10n/nl.js`: `Link Button`, `Action Type`, `External Link`, `Internal Function`, `Create File`, `Background Color`, `Text Color`, `Upload Icon (optional)`, `Create Document`, `File Name`, `Enter filename`, `Cancel`, `Create`, `Creating…`, `Failed to create document`, `Please enter a file name`

--- a/openspec/changes/multi-scope-dashboards/design.md
+++ b/openspec/changes/multi-scope-dashboards/design.md
@@ -1,0 +1,165 @@
+# Design — Multi-scope dashboards
+
+## Context
+
+MyDash currently has two dashboard scopes:
+
+1. **`user`** — personal, user-owned, freely editable. CRUD via `/api/dashboard[s]`.
+2. **`admin_template`** — admin-authored snapshot. On a user's first access, `TemplateService::createDashboardFromTemplate()` clones the template into a new `user`-type dashboard (with `basedOnTemplate` set). Subsequent admin edits do NOT propagate.
+
+Customer-facing requests have surfaced a third pattern: a **live, shared** dashboard that an admin can author once and have render in real-time for every member of a group, with admin edits visible immediately. The template scope cannot satisfy this because (a) it's copy-on-first-access and (b) once copied, the user owns the divergent record.
+
+This change adds the `group_shared` scope to fill the gap, plus a `'default'` synthetic group sentinel and a single `/api/dashboards/visible` endpoint that the frontend can call to get the deduplicated, source-tagged union of everything the user should see.
+
+The existing `admin_template` capability is intentionally untouched — it keeps its narrow "snapshot" meaning, and the two scopes coexist.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Add `group_shared` as a first-class third dashboard type without breaking any existing `user` or `admin_template` behaviour.
+- Render group-shared dashboards live (no per-user copy) so admin edits propagate on next page load.
+- Provide a single resolution endpoint (`/api/dashboards/visible`) that unions personal + group + default-group dashboards so the frontend has one source of truth.
+- Reserve `'default'` as a synthetic group meaning "visible to all" so admins don't have to maintain an "all-users" Nextcloud group.
+- Tag every returned dashboard with a `source` field so the frontend knows which mutation endpoint to call.
+- Keep delete semantics safe: prevent the admin from accidentally removing the last group-shared dashboard in a non-default group.
+
+**Non-Goals:**
+
+- A UI for managing group-shared dashboards in the admin panel — that ships in a follow-up `admin-group-management` change. This change provides only the backend + store wiring.
+- Per-user overrides on top of a group-shared dashboard — out of scope. Users wanting to customise must use the existing `fork-current-as-personal` action to clone into a personal dashboard.
+- Migrating existing `admin_template` records to `group_shared` — they continue to coexist; admins choose per-feature.
+- Multi-group sharing of one dashboard (one dashboard → one `groupId`). A dashboard intended for two groups must be created twice. Rationale: keeps the schema simple and `findVisibleToUser` cheap; the dedup-by-uuid path in REQ-DASH-013 handles the rare edge where a user is in both groups.
+- Real-time push notifications when an admin edits — propagation is on next page load, not via WebSocket.
+
+## Decisions
+
+### D1: Single column `groupId` instead of reusing `targetGroups` JSON
+
+**Decision**: Add a dedicated nullable `groupId VARCHAR(64)` column on `oc_mydash_dashboards`.
+
+**Alternatives considered:**
+
+- Reuse the existing `targetGroups` JSON column from `admin_template`. Rejected because (a) `targetGroups` is a list (admin templates can target many groups for distribution) while `group_shared` is strictly one group per dashboard, and (b) overloading the column makes `findByGroup` queries impossible to index efficiently — we'd need a JSON contains query rather than an `=` lookup.
+
+**Rationale**: A scalar `groupId` column lets us add a `(type, groupId)` composite index and keeps the WHERE clause to `WHERE type = 'group_shared' AND groupId = ?`. The cost is one extra nullable column on a table that already has 14 columns — negligible.
+
+### D2: `'default'` is a string sentinel, not a separate column
+
+**Decision**: Use the literal string `'default'` as a reserved `groupId` value meaning "visible to all".
+
+**Alternatives considered:**
+
+- Add a separate `isDefaultGroup BOOLEAN` column. Rejected because it doubles the matrix (`groupId × isDefaultGroup`) and creates ambiguous states (a row with both set).
+- Use `groupId = NULL` to mean "default". Rejected because `NULL` already has a clear meaning in this column ("not a group-shared dashboard, so this field is irrelevant"). Conflating the two would force every query to check both `type = 'group_shared'` AND `groupId IS NULL` rather than a clean equality.
+
+**Rationale**: `'default'` is short, self-documenting in the database, indexable like any other group ID, and impossible to collide with a real Nextcloud group ID because Nextcloud rejects creating a group with id `default` (reserved by IGroupManager). We document the reservation in the spec so frontend clients know not to allow it as a real group selection.
+
+### D3: `findVisibleToUser` does the union in PHP, not in SQL
+
+**Decision**: `DashboardMapper::findVisibleToUser(string $userId)` issues three separate queries (personal, group-matching, default-group) and unions/dedupes in PHP using a UUID-keyed associative array.
+
+**Alternatives considered:**
+
+- A single SQL UNION query with `WHERE (userId = ? AND type='user') OR (type='group_shared' AND groupId IN (?,?,...,'default'))`. Rejected because (a) the IN-list size is unbounded (a user can be in many groups), causing query plan instability, and (b) the SQL UNION makes it harder to tag each row with the correct `source` value.
+
+**Rationale**: Three indexed queries are fast (each hits `(userId, type)` or `(type, groupId)`), the PHP-side union is O(n) over a small result set (rarely >50 dashboards total per user), and we can attach the `source` field cleanly per result set before merging. Dedup-by-UUID is trivial in associative-array form.
+
+### D4: Source-tagging happens server-side, not client-side
+
+**Decision**: The `/api/dashboards/visible` endpoint adds `source: 'user' | 'group' | 'default'` to each returned dashboard.
+
+**Alternatives considered:**
+
+- Let the frontend infer `source` from `type` + `groupId`. Rejected because it pushes business logic into multiple frontend stores (Pinia, the page-level mounter, and the dashboard-card component) and risks divergence.
+
+**Rationale**: Server-side tagging keeps the frontend dumb — it simply checks `dashboard.source` to decide which endpoint to PUT updates to. Same logic, one place.
+
+### D5: Last-in-group delete guard only applies to `group_shared`, not personal
+
+**Decision**: `DELETE /api/dashboards/group/{groupId}/{uuid}` returns HTTP 400 if removing the row would leave the group with zero `group_shared` dashboards. Personal-dashboard deletion (REQ-DASH-005) is unchanged.
+
+**Alternatives considered:**
+
+- No guard at all. Rejected because an admin who accidentally deletes the last group dashboard would silently strip every member of that group of their default landing page (since the visible-to-user union would suddenly return only personal + default-group dashboards, none of which may be the previously-active one).
+- A guard on every delete (including personal). Rejected because users explicitly expect to be able to delete all their own personal dashboards — REQ-DASH-005 #5 ("Delete the last remaining dashboard") is an existing scenario.
+
+**Rationale**: The asymmetry mirrors the asymmetry of impact: personal dashboards affect one user, group-shared dashboards affect N users. The default group is exempt from the guard because by definition it is opt-in (admins know what they're doing when curating it).
+
+### D6: Group-shared dashboards do NOT appear in `GET /api/dashboards`
+
+**Decision**: The existing `GET /api/dashboards` endpoint continues to return only personal (`type = 'user'`) dashboards owned by the caller. Group-shared dashboards only appear in `GET /api/dashboards/visible` and `GET /api/dashboards/group/{groupId}`.
+
+**Alternatives considered:**
+
+- Make `GET /api/dashboards` return the union. Rejected because it would silently change the semantics of an endpoint that older clients rely on (currently "my personal dashboards"), risking display of admin-owned dashboards in places that assume edit rights.
+
+**Rationale**: Backward compatibility — existing API consumers (including older mobile clients and integrations) keep getting exactly what they got before. The `/visible` endpoint is the new opt-in path for clients that understand the group scope.
+
+### D7: Permission level for group-shared dashboards
+
+**Decision**: Group-shared dashboards have an effective permission level of `view_only` for non-admin members and `full` for admins, regardless of what the underlying record's `permissionLevel` field says. The field still exists on the row (for forward-compat with future per-tile editing) but is overridden at resolution time by `PermissionService`.
+
+**Rationale**: Hard-coding the rule in `PermissionService::getEffectivePermissionLevel()` keeps the auth check in one place. Non-admins literally cannot mutate (the route guard returns 403), and the UI grays out edit affordances based on the resolved level.
+
+## Data Model Changes
+
+```
+oc_mydash_dashboards (existing table)
++ groupId VARCHAR(64) NULL                    -- new column
++ INDEX idx_mydash_dash_type_group (type, groupId)   -- new composite index
+```
+
+App-level invariant (enforced in `DashboardFactory::create()` and validated in mapper insert):
+
+```
+(type = 'group_shared' AND groupId IS NOT NULL)
+   OR (type IN ('user', 'admin_template') AND groupId IS NULL)
+```
+
+We do not add a CHECK constraint at the DB level because Nextcloud's migration framework discourages portable CHECK constraints (sqlite/mysql/postgres differ). The app-level guard plus PHPUnit fixtures cover it.
+
+## API Surface
+
+| Method | Path | Auth | Purpose |
+|---|---|---|---|
+| GET | `/api/dashboards/visible` | logged-in user | Return deduplicated union of personal + group + default-group dashboards, each tagged with `source` |
+| GET | `/api/dashboards/group/{groupId}` | logged-in user | List group-shared dashboards in the given group (members + admins can list) |
+| POST | `/api/dashboards/group/{groupId}` | admin only | Create a new group-shared dashboard in the given group |
+| GET | `/api/dashboards/group/{groupId}/{uuid}` | logged-in user | Get one group-shared dashboard with placements |
+| PUT | `/api/dashboards/group/{groupId}/{uuid}` | admin only | Update name / layout / icon |
+| DELETE | `/api/dashboards/group/{groupId}/{uuid}` | admin only | Delete the dashboard (last-in-group guard applies to non-`default` groups) |
+
+The `groupId` path parameter accepts either a real Nextcloud group ID or the literal `default`.
+
+## Risks / Trade-offs
+
+- **Risk:** Admin creates many group-shared dashboards in `'default'`, cluttering every user's `/visible` response. → **Mitigation:** Frontend renders dashboards as scrollable tabs; we recommend in admin docs that `default` be reserved for one or two flagship dashboards. No hard limit enforced (would be arbitrary).
+- **Risk:** Performance degradation on `/visible` for users with many groups. → **Mitigation:** Three indexed queries; tested at 100 groups in PHPUnit fixture; expected p99 under 50 ms. Add a cache layer in a follow-up only if metrics show a hot path.
+- **Risk:** A user is removed from a group while their active dashboard is the group-shared one. → **Mitigation:** `DashboardResolver::tryGetActiveDashboard()` falls through to `tryActivateExistingDashboard()` which picks any other visible dashboard; the user sees no error, just a different active dashboard on next load.
+- **Risk:** Admin accidentally creates a real Nextcloud group called `default` despite the reservation. → **Mitigation:** Document the reservation in admin-facing docs; Nextcloud's IGroupManager already disallows the literal `default` as a group ID, but if a future Nextcloud version ever permits it the lookup still works deterministically (the `groupId='default'` query returns rows tagged for the synthetic group, and `IGroupManager::getUserGroupIds()` would also include the real group — both contribute, dedup handles overlap).
+- **Trade-off:** One dashboard cannot target multiple groups. Admins who need that must duplicate. We chose schema simplicity over flexibility here; revisit if the duplication burden becomes painful.
+- **Trade-off:** Edits don't push in real time. Admins must communicate "refresh your page" out-of-band. WebSocket push is a future enhancement, not part of this change.
+
+## Migration Plan
+
+1. **Schema migration** ships with the release: adds nullable `groupId` column + composite index. Zero-downtime, no data backfill.
+2. **Backend rolls out** with the new endpoints registered. Old clients keep working (they don't call `/visible` or `/group/...`).
+3. **Frontend rolls out** with `useDashboardsStore` extended to call `/visible` instead of `/api/dashboards` for the listing page. The old endpoint remains for compatibility but is no longer the primary list source.
+4. **Rollback strategy**: Reverting the frontend takes the user back to seeing only personal dashboards. Reverting the backend leaves the new column in place (harmless; nullable). The migration can be reversed but isn't required for rollback.
+5. **No flag** required — the new endpoints are additive and the new dashboard type only appears in records explicitly created via the new endpoints.
+
+## Seed Data
+
+Group-shared dashboards in OpenRegister-backed installations require seed records so admin developers can preview the feature locally:
+
+- **Default-group "Welcome" dashboard**: `groupId='default'`, name "Welcome to MyDash", permissionLevel=`view_only`, two placements (announcements widget + activity widget). Targets every user, including those with no group memberships.
+- **Marketing-group "Campaigns" dashboard**: `groupId='marketing'`, name "Active Campaigns", permissionLevel=`view_only`, three placements (kpi-tile + chart-widget + recent-activity). Demonstrates a real-group binding.
+- **Engineering-group "Sprint" dashboard**: `groupId='engineering'`, name "Sprint Overview", permissionLevel=`view_only`, four placements (burndown + open-prs + ci-status + recommendations). Demonstrates a denser layout.
+
+All three records have `userId = NULL`, `type = 'group_shared'`, `isActive = 0`, `basedOnTemplate = NULL`.
+
+## Open Questions
+
+- Should the `groupId='default'` dashboards be ordered before or after group-matching ones in `/visible`? Current decision: priority order is `user → group → default`, so default appears last. Frontend can re-order based on UX research after launch.
+- Should an admin be able to convert an existing `admin_template` into a `group_shared` dashboard in-place, or only create fresh? Current decision: only create fresh. Conversion deferred until customer demand surfaces.

--- a/openspec/changes/multi-scope-dashboards/proposal.md
+++ b/openspec/changes/multi-scope-dashboards/proposal.md
@@ -1,0 +1,55 @@
+# Multi-scope dashboards
+
+## Why
+
+Today MyDash only supports two dashboard scopes: `user` (personal, user-owned) and `admin_template` (admin-authored snapshot copied per-user on first access). Neither supports the common organisational need to share a single live dashboard with a group of users where edits propagate immediately. Admins currently have to choose between (a) authoring a template that diverges per-user the moment one user edits their copy or (b) asking every user to recreate the same dashboard manually. This change introduces a third scope, `group_shared`, to fill that gap, plus a `'default'` synthetic group sentinel and a single `/api/dashboards/visible` endpoint that unions the three sources so the frontend has one place to ask "what dashboards should this user see?".
+
+## What Changes
+
+- Add `Dashboard::TYPE_GROUP_SHARED = 'group_shared'` constant alongside the existing `TYPE_USER` and `TYPE_ADMIN_TEMPLATE`.
+- Add a nullable `groupId VARCHAR(64)` column on `oc_mydash_dashboards`, populated only for `group_shared` records.
+- Reserve the literal `groupId = 'default'` as a synthetic "visible to every user" sentinel — it is not a real Nextcloud group.
+- Add CRUD endpoints scoped to a group: `GET|POST /api/dashboards/group/{groupId}`, `GET|PUT|DELETE /api/dashboards/group/{groupId}/{uuid}` — admin-only for mutations.
+- Add `GET /api/dashboards/visible` that returns the deduplicated union of personal + group-matching + default-group dashboards, each annotated with a `source` field (`'user' | 'group' | 'default'`) so the frontend knows which endpoint to PUT updates to.
+- Group-shared dashboards are read-only for non-admin members — editing them requires forking to a personal dashboard via the existing `fork-current-as-personal` action.
+- Last-in-group delete guard: an admin cannot delete the last remaining group-shared dashboard in a group via the new endpoint (returns HTTP 400). Personal-dashboard delete behaviour from REQ-DASH-005 is unchanged.
+
+## Capabilities
+
+### New Capabilities
+
+(none — the feature folds into the existing `dashboards` capability)
+
+### Modified Capabilities
+
+- `dashboards`: adds REQ-DASH-011 (group_shared type), REQ-DASH-012 (default-group sentinel), REQ-DASH-013 (visible-to-user resolution endpoint), REQ-DASH-014 (group-scoped CRUD endpoints). Existing REQ-DASH-001..010 are untouched.
+
+The `admin-templates` capability is intentionally not modified — its narrow meaning ("snapshot copied per-user on first access") is preserved. The new `group_shared` type is a separate, parallel scope.
+
+## Impact
+
+**Affected code:**
+
+- `lib/Db/Dashboard.php` — extend `type` enum, add nullable `groupId` field with getter/setter
+- `lib/Db/DashboardMapper.php` — add `findByGroup(string $groupId)` and `findVisibleToUser(string $userId)`
+- `lib/Service/DashboardService.php` — group-scoped CRUD with admin guard + `IGroupManager` integration; visible-to-user resolution rules
+- `lib/Controller/DashboardController.php` — five new endpoints + the `/visible` resolution endpoint
+- `appinfo/routes.php` — register the six new routes (one is `/visible`, five are `/group/{groupId}[...]`)
+- `lib/Migration/VersionXXXXDate2026...php` — schema migration adding `groupId` column + composite index on `(type, groupId)`
+- `src/stores/dashboards.js` — add `groupSharedDashboards` and `defaultGroupDashboards` getters; track `source` per dashboard so PUT routes correctly
+- `src/views/AdminApp.vue` — admin-only UI to manage group-shared dashboards (deferred to a follow-up `admin-group-management` change; this change only ships the backend + store wiring)
+
+**Affected APIs:**
+
+- 6 new routes (no existing routes changed)
+- Existing `GET /api/dashboards` continues to return only personal dashboards — group-shared dashboards do NOT bleed into it (ensures backward compatibility for clients that don't yet know about group scopes)
+
+**Dependencies:**
+
+- `OCP\IGroupManager` — already injected elsewhere, used to resolve user → groups and to check admin status
+- No new composer or npm dependencies
+
+**Migration:**
+
+- Zero-impact: the migration only adds a nullable column and an index. Existing rows get `groupId = NULL` and continue to be classified as `user` or `admin_template` as before.
+- No data backfill required.

--- a/openspec/changes/multi-scope-dashboards/specs/dashboards/spec.md
+++ b/openspec/changes/multi-scope-dashboards/specs/dashboards/spec.md
@@ -1,0 +1,192 @@
+---
+capability: dashboards
+delta: true
+status: draft
+---
+
+# Dashboards — Delta from change `multi-scope-dashboards`
+
+## ADDED Requirements
+
+### Requirement: REQ-DASH-011 Group-shared dashboard type
+
+The system MUST support a third dashboard type `group_shared` in addition to `user` and `admin_template`. A group-shared dashboard is owned by an administrator, scoped to one Nextcloud group via a `groupId` field, and rendered live (not copied) to every member of that group. Edits made by an administrator MUST be visible to all group members on their next page load.
+
+#### Scenario: Create a group-shared dashboard
+
+- GIVEN a logged-in administrator "admin" and a Nextcloud group "marketing"
+- WHEN admin sends `POST /api/dashboards/group/marketing` with body `{"name": "Marketing Overview"}`
+- THEN the system MUST create a dashboard record with `type = 'group_shared'`, `groupId = 'marketing'`, and `userId = null`
+- AND the response MUST return HTTP 201 with the new dashboard
+
+#### Scenario: Non-admin cannot create a group-shared dashboard
+
+- GIVEN a logged-in user "alice" who is not an administrator
+- WHEN she sends `POST /api/dashboards/group/marketing` with any body
+- THEN the system MUST return HTTP 403
+
+#### Scenario: Group-shared dashboard appears for every group member
+
+- GIVEN admin has created a group-shared dashboard `D1` with `groupId = 'marketing'`
+- AND user "bob" is a member of group "marketing"
+- WHEN bob calls `GET /api/dashboards/visible`
+- THEN the response MUST include `D1`
+
+#### Scenario: Group-shared dashboards are read-only for non-admins
+
+- GIVEN bob (non-admin) is viewing group-shared dashboard `D1`
+- WHEN he sends `PUT /api/dashboards/group/marketing/{D1.uuid}` with any body
+- THEN the system MUST return HTTP 403
+- AND the dashboard MUST NOT be modified
+
+#### Scenario: Direct mutation via personal endpoint is rejected
+
+- GIVEN bob (non-admin) is viewing group-shared dashboard `D1` (owner type `group_shared`)
+- WHEN he sends `PUT /api/dashboard/{D1.id}` (the personal endpoint)
+- THEN the system MUST return HTTP 403 (ownership check fails — `D1.userId` is null, not bob)
+
+#### Scenario: Invariant — `group_shared` requires `groupId`
+
+- GIVEN any caller attempts to insert a dashboard row with `type='group_shared'` and `groupId IS NULL`
+- THEN the system MUST throw `\InvalidArgumentException` (enforced by `DashboardFactory::create()`)
+- AND no row MUST be persisted
+
+#### Scenario: Invariant — non-`group_shared` types must not have a `groupId`
+
+- GIVEN any caller attempts to insert a dashboard with `type='user'` and `groupId='marketing'`
+- THEN the system MUST throw `\InvalidArgumentException`
+- AND no row MUST be persisted
+
+### Requirement: REQ-DASH-012 Default-group sentinel
+
+The system MUST recognise the literal `groupId = 'default'` as a synthetic group meaning "visible to all users", regardless of their actual group membership. Group-shared dashboards with `groupId = 'default'` MUST be returned by every user's `/api/dashboards/visible` query in addition to the dashboards from groups they belong to.
+
+#### Scenario: Default-group dashboard visible to user with no matching groups
+
+- GIVEN admin has created group-shared dashboards: `D-default` with `groupId='default'` and `D-eng` with `groupId='engineering'`
+- AND user "carol" belongs only to group "support"
+- WHEN she calls `GET /api/dashboards/visible`
+- THEN the response MUST include `D-default`
+- AND MUST NOT include `D-eng`
+
+#### Scenario: 'default' is not a real Nextcloud group
+
+- GIVEN admin sends `POST /api/dashboards/group/default` with body `{"name": "Welcome"}`
+- THEN the system MUST accept the request even when no Nextcloud group with id "default" exists
+- AND the dashboard MUST be created with `groupId = 'default'`
+
+#### Scenario: Default-group dashboard carries `source: 'default'` not `source: 'group'`
+
+- GIVEN a default-group dashboard `D-default` exists
+- AND user "alice" is also a member of a real group (so `D-default` could in theory be tagged either way)
+- WHEN she calls `GET /api/dashboards/visible`
+- THEN `D-default` MUST appear in the response with `source: 'default'`
+- AND MUST NOT appear with `source: 'group'`
+
+### Requirement: REQ-DASH-013 Visible-to-user resolution
+
+The system MUST expose `GET /api/dashboards/visible` that returns the union of three dashboard sets, deduplicated by UUID, in this priority order:
+
+1. Personal `user`-type dashboards owned by the current user
+2. `group_shared` dashboards whose `groupId` matches one of the user's Nextcloud groups
+3. `group_shared` dashboards whose `groupId = 'default'`
+
+Each returned dashboard MUST carry an additional `source` field with values `'user'`, `'group'`, or `'default'` so the frontend can route subsequent edits to the correct endpoint.
+
+#### Scenario: Source field discriminates origin
+
+- GIVEN user "alice" has 1 personal dashboard, 2 group-shared dashboards in groups she belongs to, and 1 default-group dashboard exists
+- WHEN she calls `GET /api/dashboards/visible`
+- THEN the response MUST contain 4 dashboards
+- AND each MUST carry exactly one of `source: 'user' | 'group' | 'default'`
+- AND the personal dashboard MUST have `source: 'user'`
+
+#### Scenario: Deduplication by UUID
+
+- GIVEN a group-shared dashboard exists where the user is a member of the targeted group AND that same dashboard's UUID also appears in another result set (rare edge case from a future multi-group support or a misconfigured fixture)
+- WHEN she calls `GET /api/dashboards/visible`
+- THEN it MUST appear only once in the response
+
+#### Scenario: User with no personal dashboards still gets visible result
+
+- GIVEN user "dave" has zero personal dashboards
+- AND he is a member of group "engineering" which has 1 group-shared dashboard
+- AND 1 default-group dashboard exists
+- WHEN he calls `GET /api/dashboards/visible`
+- THEN the response MUST contain 2 dashboards (the engineering one with `source='group'`, the default one with `source='default'`)
+
+#### Scenario: User with no groups and no defaults gets only personal
+
+- GIVEN user "eve" has 1 personal dashboard
+- AND she belongs to no groups
+- AND no default-group dashboards exist
+- WHEN she calls `GET /api/dashboards/visible`
+- THEN the response MUST contain exactly 1 dashboard with `source='user'`
+
+#### Scenario: Admin gets group-shared dashboards as `source='group'` even though they own them
+
+- GIVEN admin "root" created group-shared dashboard `D1` in group "marketing"
+- AND admin "root" is a member of group "marketing"
+- WHEN admin "root" calls `GET /api/dashboards/visible`
+- THEN `D1` MUST appear with `source='group'` (not `source='user'`)
+- NOTE: ownership of `group_shared` dashboards is admin-collective, not per-user — the `userId` column is null on these rows
+
+### Requirement: REQ-DASH-014 Group-shared dashboard mutation endpoints
+
+The system MUST expose CRUD endpoints scoped to a group:
+
+- `GET /api/dashboards/group/{groupId}` — list group-shared dashboards in that group (any logged-in user can list)
+- `POST /api/dashboards/group/{groupId}` — create a new one (admin only)
+- `GET /api/dashboards/group/{groupId}/{uuid}` — get one (any logged-in user)
+- `PUT /api/dashboards/group/{groupId}/{uuid}` — update name/layout/icon (admin only)
+- `DELETE /api/dashboards/group/{groupId}/{uuid}` — remove (admin only)
+
+#### Scenario: Update propagates immediately
+
+- GIVEN admin updates the layout of group-shared dashboard `D1`
+- WHEN any group member next loads the workspace page
+- THEN the new layout MUST be served (no per-user copy interferes)
+
+#### Scenario: Group-shared dashboard cannot be deleted while it is the last one in the group
+
+- GIVEN group "marketing" has exactly one group-shared dashboard `D1`
+- WHEN admin sends `DELETE /api/dashboards/group/marketing/D1.uuid`
+- THEN the system MUST return HTTP 400 with `{error: 'Cannot delete the only dashboard in the group'}`
+- NOTE: Personal dashboards do NOT have this guard — REQ-DASH-005 deletion remains unrestricted for `user`-type
+
+#### Scenario: Default group is exempt from the last-in-group delete guard
+
+- GIVEN the `default` group has exactly one group-shared dashboard `D-default`
+- WHEN admin sends `DELETE /api/dashboards/group/default/D-default.uuid`
+- THEN the system MUST delete the dashboard
+- AND return HTTP 200
+- NOTE: the default group is curated, not user-bound — admins can intentionally clear it
+
+#### Scenario: Update on a group-shared dashboard rejects userId field changes
+
+- GIVEN admin sends `PUT /api/dashboards/group/marketing/D1.uuid` with body `{"userId": "alice"}`
+- THEN the system MUST ignore the `userId` field
+- AND `D1.userId` MUST remain null
+- AND `D1.type` MUST remain `'group_shared'`
+
+#### Scenario: GroupId mismatch between path and record returns 404
+
+- GIVEN dashboard `D1` has `groupId='marketing'`
+- WHEN admin sends `GET /api/dashboards/group/engineering/D1.uuid`
+- THEN the system MUST return HTTP 404 (the dashboard does not belong to the group named in the path)
+
+#### Scenario: GET /api/dashboards remains backward-compatible
+
+- GIVEN user "alice" has 2 personal dashboards
+- AND admin has created 3 group-shared dashboards visible to her
+- WHEN she sends `GET /api/dashboards` (the legacy listing endpoint)
+- THEN the response MUST contain only her 2 personal dashboards
+- AND MUST NOT contain any of the group-shared ones
+- NOTE: clients wanting the union must call `GET /api/dashboards/visible`; this preserves REQ-DASH-002 semantics for older API consumers
+
+#### Scenario: Group-shared dashboard serialisation includes `groupId`
+
+- GIVEN a group-shared dashboard `D1` is returned via any endpoint
+- WHEN the JSON payload is inspected
+- THEN it MUST contain `groupId` equal to the dashboard's group ID (a non-null string)
+- AND personal / admin_template dashboards in any payload MUST contain `groupId: null`

--- a/openspec/changes/multi-scope-dashboards/tasks.md
+++ b/openspec/changes/multi-scope-dashboards/tasks.md
@@ -1,0 +1,81 @@
+# Tasks — multi-scope-dashboards
+
+## 1. Schema migration
+
+- [ ] 1.1 Create `lib/Migration/VersionXXXXDate2026...AddGroupIdColumn.php` adding `groupId VARCHAR(64) NULL` to `oc_mydash_dashboards`
+- [ ] 1.2 Same migration adds composite index `idx_mydash_dash_type_group` on `(type, groupId)` for fast `findByGroup` and `findVisibleToUser` lookups
+- [ ] 1.3 Confirm migration is reversible (drop column + index in `postSchemaChange` rollback path)
+- [ ] 1.4 Run migration locally against sqlite, mysql, and postgres; verify schema applied cleanly each time
+
+## 2. Domain model
+
+- [ ] 2.1 Add `Dashboard::TYPE_GROUP_SHARED = 'group_shared'` constant alongside existing `TYPE_USER`, `TYPE_ADMIN_TEMPLATE`
+- [ ] 2.2 Add `groupId` field to `Dashboard` entity with getter/setter (Entity `__call` pattern — no named args)
+- [ ] 2.3 Add `Dashboard::SOURCE_USER`, `SOURCE_GROUP`, `SOURCE_DEFAULT` constants (used only in `/visible` serialisation)
+- [ ] 2.4 Update `Dashboard::jsonSerialize()` to include `groupId` (nullable in output)
+
+## 3. Mapper layer
+
+- [ ] 3.1 Add `DashboardMapper::findByGroup(string $groupId): array` — `WHERE type = 'group_shared' AND groupId = ?`
+- [ ] 3.2 Add `DashboardMapper::findVisibleToUser(string $userId, array $userGroupIds): array` — issues 3 indexed queries (personal, group-matching, default-group), unions in PHP, dedupes by UUID
+- [ ] 3.3 Each result row in `findVisibleToUser` is tagged with its source (`user` / `group` / `default`) before merge so the `source` field can be set on the response
+- [ ] 3.4 Add fixture-based PHPUnit test covering: user with 1 personal + 2 group + 1 default; user in 0 matching groups; UUID overlap dedup edge case
+
+## 4. Service layer
+
+- [ ] 4.1 In `DashboardFactory::create()` accept optional `type` and `groupId` kwargs; enforce the invariant `(type='group_shared' XOR groupId IS NULL)`; throw `\InvalidArgumentException` on mismatch
+- [ ] 4.2 Add `DashboardService::createGroupShared(string $groupId, string $name, ?string $description, ?int $gridColumns)` — admin-only via `IGroupManager::isAdmin($currentUserId)` guard
+- [ ] 4.3 Add `DashboardService::updateGroupShared(string $groupId, string $uuid, array $patch)` — admin guard, ownership check (`type === group_shared AND groupId matches path`)
+- [ ] 4.4 Add `DashboardService::deleteGroupShared(string $groupId, string $uuid)` with last-in-group guard (HTTP 400 when removing would leave non-`default` group with zero group-shared dashboards); `default` group exempt from the guard
+- [ ] 4.5 Add `DashboardService::getVisibleToUser(string $userId): array` that wires `IGroupManager::getUserGroupIds($userId)` into the mapper call and adds `source` to each result
+- [ ] 4.6 Update `PermissionService::getEffectivePermissionLevel()` to return `view_only` for non-admin members on `group_shared` dashboards, `full` for admins
+
+## 5. Controller + routes
+
+- [ ] 5.1 Add `DashboardController::visible()` mapped to `GET /api/dashboards/visible` (logged-in user, `#[NoAdminRequired]`)
+- [ ] 5.2 Add `DashboardController::listGroup(string $groupId)` mapped to `GET /api/dashboards/group/{groupId}` (logged-in)
+- [ ] 5.3 Add `DashboardController::createGroup(string $groupId)` mapped to `POST /api/dashboards/group/{groupId}` (admin-only via `IGroupManager::isAdmin` check inside method body, since `#[NoAdminRequired]` semantic-auth gate requires runtime check)
+- [ ] 5.4 Add `DashboardController::getGroup(string $groupId, string $uuid)` mapped to `GET /api/dashboards/group/{groupId}/{uuid}` (logged-in)
+- [ ] 5.5 Add `DashboardController::updateGroup(string $groupId, string $uuid)` mapped to `PUT /api/dashboards/group/{groupId}/{uuid}` (admin-only)
+- [ ] 5.6 Add `DashboardController::deleteGroup(string $groupId, string $uuid)` mapped to `DELETE /api/dashboards/group/{groupId}/{uuid}` (admin-only)
+- [ ] 5.7 Register all six routes in `appinfo/routes.php` with proper requirements (groupId regex allows `default` and any valid Nextcloud group ID)
+- [ ] 5.8 Confirm every new method carries the correct Nextcloud auth attribute (`#[NoAdminRequired]` + in-body admin check for mutations) — gate-route-auth + gate-semantic-auth must pass
+
+## 6. OpenRegister seed data
+
+- [ ] 6.1 Add three group-shared seed dashboards to `_registers.json` per the design's Seed Data section: Welcome (default), Campaigns (marketing), Sprint (engineering)
+- [ ] 6.2 Each seed includes its placements with appropriate widget types and grid positions
+- [ ] 6.3 Verify seed data applies cleanly via `occ mydash:seed` or whichever local command the app uses
+
+## 7. Frontend store
+
+- [ ] 7.1 Extend `src/stores/dashboards.js` with `groupSharedDashboards` and `defaultGroupDashboards` getters derived from `/api/dashboards/visible` payload
+- [ ] 7.2 Add `source` field plumbing — every dashboard tracked in the store carries `source` so the component layer can route subsequent edit calls (PUT to `/api/dashboard/{uuid}` for `source='user'`, PUT to `/api/dashboards/group/{groupId}/{uuid}` for `source='group'|'default'`)
+- [ ] 7.3 Make the listing page call `/api/dashboards/visible` instead of the older `/api/dashboards` endpoint (the old endpoint stays available for legacy clients)
+- [ ] 7.4 Defer admin-only group-shared CRUD UI to follow-up `admin-group-management` change — note this in the changelog
+
+## 8. PHPUnit tests
+
+- [ ] 8.1 `DashboardMapperTest::findByGroup` — basic lookup, empty-group case, non-existent group case
+- [ ] 8.2 `DashboardMapperTest::findVisibleToUser` — mixed personal + group + default fixtures; user with 0 group memberships still gets default-group rows; UUID overlap deduped
+- [ ] 8.3 `DashboardControllerTest` — admin-only enforcement on POST/PUT/DELETE returns 403 for non-admins
+- [ ] 8.4 `DashboardControllerTest::testDeleteLastInGroupGuard` — HTTP 400 when deleting the only dashboard in a non-default group; default group exempt
+- [ ] 8.5 `DashboardServiceTest::testCreateRejectsTypeGroupSharedWithoutGroupId` — invariant guard
+- [ ] 8.6 `PermissionServiceTest` — `view_only` for non-admin viewing group_shared, `full` for admin viewing same record
+- [ ] 8.7 Test all 3 permission levels (`view_only`, `add_only`, `full`) round-trip correctly on personal + admin_template (regression — these scopes must keep working unchanged)
+
+## 9. End-to-end Playwright tests
+
+- [ ] 9.1 Admin user creates a group-shared dashboard via the new endpoint (using API call from a fixture; UI ships in follow-up change), and a member of the targeted group sees it on `/visible`
+- [ ] 9.2 User in 0 matching groups still sees default-group dashboards in `/visible`
+- [ ] 9.3 Non-admin user attempting PUT on a group-shared dashboard via direct API call gets HTTP 403
+- [ ] 9.4 Admin update to a group-shared dashboard's name is visible to a member on next page reload (no per-user copy interference)
+
+## 10. Quality gates
+
+- [ ] 10.1 `composer check:strict` (PHPCS, PHPMD, Psalm, PHPStan) passes — fix any pre-existing issues encountered along the way
+- [ ] 10.2 ESLint + Stylelint clean on all touched Vue/JS files
+- [ ] 10.3 Update generated OpenAPI spec / Postman collection so external API consumers see the new endpoints
+- [ ] 10.4 `i18n` keys for all new error messages (`Cannot delete the only dashboard in the group`, etc.) in both `nl` and `en` per the i18n requirement
+- [ ] 10.5 SPDX headers on every new PHP file (inside the docblock per the SPDX-in-docblock convention) — gate-spdx must pass
+- [ ] 10.6 Run all 10 `hydra-gates` locally before opening PR

--- a/openspec/changes/nc-dashboard-widget-proxy/proposal.md
+++ b/openspec/changes/nc-dashboard-widget-proxy/proposal.md
@@ -1,0 +1,29 @@
+# Nextcloud Dashboard widget proxy
+
+A new widget type `nc-widget` that renders any Nextcloud Dashboard widget (Mail, Calendar, Talk, etc.) inside a MyDash grid cell. Two-mode rendering: (1) preferred — use the widget's native callback registered via `OCA.Dashboard.register` (covered by `legacy-widget-bridge`), giving full feature parity with the official `/dashboard` page; (2) fallback — fetch widget items via `IAPIWidget` / `IAPIWidgetV2` and render a flat list. A short polling window catches widgets whose script bundle loads after the workspace.
+
+## Affected code units
+
+- `src/components/Widgets/Renderers/NcDashboardWidget.vue` — the renderer
+- `src/components/Widgets/Forms/NcDashboardForm.vue` — picker + display-mode select
+- `src/services/widgetBridge.js` — adds a polling helper for "callback registered yet?"
+- `lib/Controller/WidgetItemController.php` — already exists per REQ-WDG-002; this change formalises the response shape used here
+- `src/constants/widgetRegistry.js` — register `type: 'nc-widget'`
+- Modifies `widgets` AND `legacy-widget-bridge` capabilities
+
+## Why a delta to `widgets` + `legacy-widget-bridge`
+
+The widget type lives logically inside `widgets` (it's another placement renderer in the same grid system), and the callback-bridging behaviour extends `legacy-widget-bridge` (which already covers `OCA.Dashboard.register` capture). One change touching both keeps the contract atomic.
+
+## Approach
+
+- Persisted shape: `{type: 'nc-widget', content: {widgetId, displayMode}}` where `widgetId` is the Nextcloud widget identifier (e.g. `weather_status`) and `displayMode` is `'vertical' | 'horizontal'`.
+- On mount: try `widgetBridge.hasWidgetCallback(widgetId)` first; if true, mount via REQ-LWB-002.
+- If false: start API loading (`GET /api/widgets/items?widgets[]={widgetId}&limit=7`) AND a short poll (200 ms × 15 retries = 3 s) for the callback to appear; if it does, switch to native mode and abandon API results.
+- API list rendering: 7-item flat list of `{title, subtitle, link, iconUrl, overlayIconUrl, sinceId}` cards. `vertical` = list with 32 px icons; `horizontal` = wrap of 120 px cards with 44 px icons.
+
+## Notes
+
+- We deliberately do NOT support pagination (no "load more" using `sinceIds`) in v1 — opportunity for a follow-up.
+- Header shows the widget's title + iconUrl from the discovered metadata (REQ-WDG-001 `IManager::getWidgets()` output).
+- When a widget's bundle is missing or fails to register, the API fallback is the safety net — users still see content.

--- a/openspec/changes/nc-dashboard-widget-proxy/specs/legacy-widget-bridge/spec.md
+++ b/openspec/changes/nc-dashboard-widget-proxy/specs/legacy-widget-bridge/spec.md
@@ -1,0 +1,54 @@
+---
+capability: legacy-widget-bridge
+delta: true
+status: draft
+---
+
+# Legacy Widget Bridge — Delta from change `nc-dashboard-widget-proxy`
+
+## ADDED Requirements
+
+### Requirement: REQ-LWB-005 Polling helper for late callback registration
+
+The bridge singleton MUST expose `pollForCallback(widgetId: string, options?: {intervalMs?: number, maxRetries?: number, signal?: AbortSignal}): Promise<boolean>` that periodically checks whether a callback has been registered for the given `widgetId`. Defaults: `intervalMs = 200`, `maxRetries = 15` (~3 s total). The promise MUST resolve to `true` as soon as a callback is detected, OR to `false` after the max retries are exhausted. Each call MUST be cancellable via the AbortSignal of an `AbortController` passed in `options.signal` (so callers can abort polling on unmount).
+
+This helper exists to support the `nc-widget` renderer (REQ-WDG-019), which needs to fall through to API rendering immediately while still upgrading to native-callback rendering when the widget bundle finishes loading later.
+
+#### Scenario: Resolve true when callback registers mid-poll
+
+- GIVEN no callback for `'notes'` is currently registered
+- WHEN a caller invokes `pollForCallback('notes')` (defaults)
+- AND a `OCA.Dashboard.register('notes', cb)` call happens 600 ms later
+- THEN the promise MUST resolve `true` within ~800 ms (next poll tick after registration)
+
+#### Scenario: Resolve false on timeout
+
+- GIVEN no callback for `'fictional_widget'` is ever registered
+- WHEN `pollForCallback('fictional_widget')` is invoked
+- THEN after ~3 seconds (15 x 200 ms) the promise MUST resolve `false`
+- AND no further interval ticks MUST fire
+
+#### Scenario: Abort cancels polling
+
+- GIVEN a poll is in progress for `'notes'`
+- WHEN the caller aborts via `AbortController.abort()`
+- THEN the promise MUST resolve `false` immediately
+- AND the underlying `setInterval` MUST be cleared
+- AND no further poll ticks MUST run
+
+#### Scenario: Already-registered callback resolves immediately
+
+- GIVEN a callback for `'notes'` IS already in the bridge map
+- WHEN `pollForCallback('notes')` is invoked
+- THEN the promise MUST resolve `true` synchronously (or on the very next microtask)
+- AND no `setInterval` MUST be scheduled
+
+### Requirement: REQ-LWB-006 hasWidgetCallback consistency
+
+`hasWidgetCallback(widgetId)` (already declared in REQ-LWB-004) MUST return `true` if and only if `pollForCallback` would resolve `true` immediately. The polling helper MUST use `hasWidgetCallback` internally as its check function — there MUST NOT be two parallel "is registered" code paths.
+
+#### Scenario: Single source of truth
+
+- WHEN the polling helper checks for registration
+- THEN it MUST call `this.hasWidgetCallback(widgetId)`
+- AND the result of `hasWidgetCallback` and the poll's first synchronous check MUST agree

--- a/openspec/changes/nc-dashboard-widget-proxy/specs/widgets/spec.md
+++ b/openspec/changes/nc-dashboard-widget-proxy/specs/widgets/spec.md
@@ -1,0 +1,108 @@
+---
+capability: widgets
+delta: true
+status: draft
+---
+
+# Widgets — Delta from change `nc-dashboard-widget-proxy`
+
+## ADDED Requirements
+
+### Requirement: REQ-WDG-018 nc-widget placement type
+
+The widget registry MUST include the type `nc-widget` representing a Nextcloud Dashboard widget rendered inside MyDash. Its persisted content shape MUST be:
+
+```jsonc
+{
+  "type": "nc-widget",
+  "content": {
+    "widgetId": "string (required, e.g. 'weather_status')",
+    "displayMode": "'vertical' | 'horizontal' (default 'vertical')"
+  }
+}
+```
+
+The renderer MUST be `NcDashboardWidget.vue`. The form MUST present (a) a `<select>` populated from `IManager::getWidgets()` (REQ-WDG-001 — passed in via initial state) and (b) a display-mode `<select>`.
+
+#### Scenario: Form picker lists discovered widgets
+
+- GIVEN initial state `widgets = [{id:'weather_status', title:'Weather'}, {id:'recommendations', title:'Recommended'}]`
+- WHEN the user opens the nc-widget sub-form
+- THEN the picker `<select>` MUST list both options
+- AND validation MUST require a widgetId before Add is enabled
+
+### Requirement: REQ-WDG-019 Two-mode rendering with bridge polling
+
+The renderer MUST attempt native-callback rendering (REQ-LWB-002 mountWidget) immediately on mount. If no callback is registered for the `widgetId`, the renderer MUST fall back to the API list path (REQ-WDG-002 widget items) AND start a polling watcher that re-checks for the callback every 200 ms for up to 15 retries (~3 s total). If the callback registers within the polling window, the renderer MUST switch to native-callback mode (cancelling the in-flight or completed API render).
+
+#### Scenario: Native callback already registered at mount
+
+- GIVEN a Nextcloud widget bundle has registered its callback before the workspace mounts
+- AND a placement of type `nc-widget` with `widgetId = 'notes'` mounts
+- WHEN the renderer's `onMounted` runs
+- THEN it MUST mount via `widgetBridge.mountWidget('notes', containerEl, {...})`
+- AND it MUST NOT issue any `GET /api/widgets/items` request
+
+#### Scenario: Callback registers late within the polling window
+
+- GIVEN no callback for `'notes'` is registered when the renderer mounts
+- AND the `notes` bundle finishes loading 1 second later and registers
+- WHEN the renderer mounts
+- THEN it MUST start the API fallback (issue the items request)
+- AND simultaneously start the 200-ms polling loop
+- WHEN the poll detects the registration on the next tick
+- THEN the renderer MUST switch to native-callback mode (mount via `widgetBridge.mountWidget`)
+- AND any pending or completed API list MUST be hidden (no flicker between modes)
+
+#### Scenario: Callback never registers full API fallback
+
+- GIVEN no callback for `'weather_status'` is registered within 3 seconds
+- WHEN the polling loop reaches retry 15 (~3 s elapsed)
+- THEN polling MUST stop
+- AND the API list MUST remain rendered as the final state
+- AND no further callback checks MUST occur
+
+### Requirement: REQ-WDG-020 Display modes
+
+The API list MUST render in one of two display modes:
+
+- **`vertical`** — flex-column list, 32 px square icon left, title + subtitle right; ellipsis overflow; 8 px gap between rows.
+- **`horizontal`** — flex-row wrap, 120 px square cards, 44 px icon top, centred title + subtitle below; 12 px gap.
+
+The header (above the list area) MUST always render the widget's title + iconUrl from `widgetMeta` (the `IManager::getWidgets()` descriptor).
+
+#### Scenario: Vertical mode list rendering
+
+- GIVEN content `{widgetId: 'recommendations', displayMode: 'vertical'}` and the API returns 4 items
+- WHEN the API fallback renders
+- THEN the list MUST be a flex-column with 4 `<a>` rows
+- AND each row MUST show its icon at 32 px on the left and title/subtitle on the right
+- AND long titles MUST be truncated with ellipsis
+
+#### Scenario: Horizontal mode card rendering
+
+- GIVEN the same content but `displayMode: 'horizontal'`
+- WHEN the API fallback renders
+- THEN the list MUST be a flex-row wrap with 4 cards of approximately 120 px width
+- AND each card MUST show a 44 px icon top + centred text below
+
+### Requirement: REQ-WDG-021 API call shape
+
+When falling back to the API path, the renderer MUST issue exactly:
+
+`GET /ocs/v2.php/apps/mydash/api/widgets/items?widgets[]={widgetId}&limit=7`
+
+The response MUST be parsed as `{items: {[widgetId]: WidgetItem[]}, meta: {[widgetId]: {iconUrl}}}` (the existing REQ-WDG-002 contract). When the response shape is malformed, the renderer MUST display the empty-state `t('No items available')` and MUST NOT throw.
+
+#### Scenario: Default item limit is 7
+
+- GIVEN any nc-widget renders via API fallback
+- WHEN it issues the items request
+- THEN the URL MUST include `limit=7`
+
+#### Scenario: Empty-list state
+
+- GIVEN the items response contains an empty array for the widgetId
+- WHEN the API fallback renders
+- THEN the cell MUST display `t('No items available')` centred
+- AND no `<a>` items MUST render

--- a/openspec/changes/nc-dashboard-widget-proxy/tasks.md
+++ b/openspec/changes/nc-dashboard-widget-proxy/tasks.md
@@ -1,0 +1,46 @@
+# Tasks — nc-dashboard-widget-proxy
+
+## 1. Bridge
+
+- [ ] Add `WidgetBridge::pollForCallback(widgetId, options)` returning a cancellable Promise<boolean>
+- [ ] Use `setInterval` with cleanup on resolve, abort, or max retries
+- [ ] First check is synchronous (no `setInterval` if already registered)
+- [ ] Internally calls `hasWidgetCallback` (single source of truth)
+
+## 2. Renderer
+
+- [ ] Create `src/components/Widgets/Renderers/NcDashboardWidget.vue`
+- [ ] On mount: try native; if absent, fire API request AND `pollForCallback`
+- [ ] Switch to native if poll resolves true (race winner wins, no flicker)
+- [ ] Defensive normalisation: PHP can serialise sequential arrays as objects; do `Array.isArray(injected) ? injected : Object.values(injected)`
+- [ ] Header: title + iconUrl from `widgetMeta`
+- [ ] Two display modes per REQ-WDG-020 CSS
+
+## 3. Form
+
+- [ ] Create `src/components/Widgets/Forms/NcDashboardForm.vue`
+- [ ] Picker `<select>` from initial-state `widgets`
+- [ ] Display-mode `<select>` (vertical/horizontal)
+- [ ] `validate()` requires non-empty `widgetId`
+- [ ] Pre-fill from `editingWidget.content`
+
+## 4. Registry
+
+- [ ] Add `nc-widget` to `widgetRegistry.js` with defaults `{widgetId:'', displayMode:'vertical'}`
+
+## 5. Tests
+
+- [ ] Vitest: `pollForCallback` happy path (callback registers mid-poll → resolves true)
+- [ ] Vitest: timeout (no registration → resolves false after ~3 s)
+- [ ] Vitest: abort (signal aborts → resolves false immediately)
+- [ ] Vitest: synchronous resolve when already registered
+- [ ] Vitest: renderer switches mode mid-flight when poll wins
+- [ ] Vitest: array normalisation handles object-with-numeric-keys input
+- [ ] Playwright: weather_status widget renders natively when bundle present
+- [ ] Playwright: widget falls back to API list when bundle absent
+- [ ] Playwright: empty-list state translated string
+
+## 6. Quality
+
+- [ ] ESLint clean
+- [ ] Translation entries: `Nextcloud Widget`, `Select Widget`, `Choose a widget…`, `Display Mode`, `Vertical (list)`, `Horizontal (cards)`, `Loading…`, `No items available`

--- a/openspec/changes/resource-serving/proposal.md
+++ b/openspec/changes/resource-serving/proposal.md
@@ -1,0 +1,50 @@
+# Resource serving
+
+## Why
+
+The `resource-uploads` capability today only covers the write side: an admin can upload an image asset and the upload endpoint persists it under `<appdata>/resources/<uniqid-suffixed-name>`. There is no first-party way for a logged-in user's browser to actually fetch those bytes — every dashboard render that references an uploaded resource currently has to round-trip through ad-hoc handling. This change adds the read side: a non-OCS `GET /apps/mydash/resource/{filename}` endpoint that streams the file with the right Content-Type and a one-year immutable cache header (uniqid in the filename doubles as the cache-buster), plus an OCS `GET /api/resources` listing endpoint to back a future admin gallery / cleanup UI. Path traversal is rejected with a 404, oversize files (50 MB+, only reachable via manual filesystem tampering) are refused with 413 to bound memory.
+
+## What Changes
+
+- Add `GET /apps/mydash/resource/{filename}` — non-OCS plain web route returning `StreamResponse` of the resource bytes with extension-derived Content-Type (jpeg, png, gif, svg+xml, webp; default `application/octet-stream`) and `Cache-Control: public, max-age=31536000`.
+- Add `GET /api/resources` — OCS endpoint listing uploaded resources as `{name, url, size, modifiedAt}` tuples ordered by `modifiedAt` descending; empty folder returns an empty array (HTTP 200, not 404).
+- Reject path traversal (`..`, `/` in the `{filename}` parameter) with HTTP 404 — never leak system files.
+- Refuse to load files larger than the 5 MB upload cap from REQ-RES-003 with HTTP 413 — only reachable via manual filesystem tampering, but bounds memory usage.
+- Both endpoints are authenticated (any logged-in user) and intentionally NOT admin-gated, since uploaded resources are referenced by every dashboard render.
+
+## Capabilities
+
+### New Capabilities
+
+(none — the feature folds into the existing `resource-uploads` capability)
+
+### Modified Capabilities
+
+- `resource-uploads`: adds REQ-RES-006 (public resource serving endpoint), REQ-RES-007 (list uploaded resources), REQ-RES-008 (stream-via-memory buffer, size-bounded). Existing REQ-RES-001..005 (the upload side) are untouched.
+
+## Impact
+
+**Affected code:**
+
+- `lib/Controller/ResourceController.php` — add `getResource(string $filename): StreamResponse` and `listResources(): DataResponse`
+- `appinfo/routes.php` — register `GET /resource/{filename}` (non-OCS) and `GET /api/resources` (OCS)
+
+**Affected APIs:**
+
+- 2 new routes (no existing routes changed)
+- The non-OCS `GET /resource/{filename}` is intentionally excluded from the generated OpenAPI spec (binary streaming, not API consumer surface); `GET /api/resources` IS included.
+
+**Dependencies:**
+
+- `OCP\Files\IRootFolder` / appdata folder access — already used by the upload side (REQ-RES-001..005)
+- No new composer or npm dependencies
+
+**Migration:**
+
+- Zero-impact: no database changes. Read-only access to existing `<appdata>/resources/` files written by the upload side.
+- No data backfill required.
+
+## Notes
+
+- No per-resource ACL (deliberate v1 limitation — see `resource-uploads` Notes). Any authenticated user can fetch any uploaded resource by name. Acceptable because uploaded resources are dashboard assets (icons, logos) referenced by every dashboard render, and filenames carry uniqid suffixes that aren't enumerable from outside.
+- Streaming uses an in-memory buffer (`php://memory`) bounded by the 5 MB upload cap — acceptable for icon-sized assets. The 413 guard prevents memory exhaustion from manually-installed oversize files.

--- a/openspec/changes/resource-serving/specs/resource-uploads/spec.md
+++ b/openspec/changes/resource-serving/specs/resource-uploads/spec.md
@@ -1,0 +1,98 @@
+---
+capability: resource-uploads
+delta: true
+status: draft
+---
+
+# Resource Uploads — Delta from change `resource-serving`
+
+## ADDED Requirements
+
+### Requirement: Public resource serving endpoint (REQ-RES-006)
+
+The system MUST expose `GET /apps/mydash/resource/{filename}` (a non-OCS, plain web route) returning a `StreamResponse` of the resource bytes. The route MUST be authenticated (any logged-in Nextcloud user) but MUST NOT require admin privileges. The Content-Type header MUST be derived from the file extension via this map:
+
+| Extension | Content-Type |
+|---|---|
+| `jpg`, `jpeg` | `image/jpeg` |
+| `png` | `image/png` |
+| `gif` | `image/gif` |
+| `svg` | `image/svg+xml` |
+| `webp` | `image/webp` |
+| anything else | `application/octet-stream` |
+
+The response MUST include `Cache-Control: public, max-age=31536000` (one year, immutable). Filenames produced by REQ-RES-004 already include a `uniqid` so they double as cache busting keys — when the same logical asset changes, a new upload generates a new filename.
+
+#### Scenario: Serve a PNG
+
+- GIVEN an uploaded resource at `<appdata>/resources/resource_abc123.png`
+- WHEN any authenticated user sends `GET /apps/mydash/resource/resource_abc123.png`
+- THEN the system MUST return HTTP 200 with `Content-Type: image/png`
+- AND `Cache-Control: public, max-age=31536000`
+- AND the response body MUST be the file's exact bytes
+
+#### Scenario: Serve an SVG with correct content-type
+
+- GIVEN an uploaded resource at `<appdata>/resources/resource_abc123.svg`
+- WHEN GETting it
+- THEN `Content-Type` MUST be `image/svg+xml` (NOT `application/svg+xml`)
+
+#### Scenario: Unknown extension falls back to octet-stream
+
+- GIVEN a file with extension `.bin` somehow in the resources folder (manual install, etc.)
+- WHEN GETting it
+- THEN `Content-Type` MUST be `application/octet-stream`
+
+#### Scenario: Missing file returns 404
+
+- WHEN GET `/apps/mydash/resource/does-not-exist.png`
+- THEN the system MUST return HTTP 404
+- AND the response body MAY be empty (no detail leaked)
+
+#### Scenario: Path traversal rejected
+
+- WHEN GET `/apps/mydash/resource/..%2F..%2Fetc%2Fpasswd` (URL-encoded `../../etc/passwd`)
+- THEN the system MUST return HTTP 404 (the route's `{filename}` parameter MUST be treated as a leaf name; any decoded `/` or `..` in it MUST cause a 404 — never a 200 with system file contents)
+
+#### Scenario: Unauthenticated request rejected
+
+- GIVEN an unauthenticated browser session
+- WHEN GET `/apps/mydash/resource/resource_abc123.png`
+- THEN Nextcloud MUST redirect to login (standard NC auth middleware)
+- AND no resource bytes MUST be served
+
+### Requirement: List uploaded resources (REQ-RES-007)
+
+The system MUST expose `GET /api/resources` (OCS endpoint) returning `{status: 'success', resources: [{name, url, size, modifiedAt}, …]}` ordered by `modifiedAt` descending. The endpoint MUST be authenticated (any user); admin gating is NOT required because the listed names are already referenced from rendered dashboards.
+
+When the resources folder does not yet exist, the response MUST be `{status: 'success', resources: []}` (not 404).
+
+#### Scenario: List with one resource
+
+- GIVEN one resource exists at `<appdata>/resources/resource_abc123.png` with size 12345 bytes
+- WHEN GET `/api/resources`
+- THEN the response MUST contain `resources[0] = {name: 'resource_abc123.png', url: '/apps/mydash/resource/resource_abc123.png', size: 12345, modifiedAt: <ISO timestamp>}`
+
+#### Scenario: Empty folder returns empty array
+
+- GIVEN no `resources/` folder has been created yet
+- WHEN GET `/api/resources`
+- THEN HTTP 200 with `{status: 'success', resources: []}`
+
+### Requirement: Stream-via-memory buffer, size-bounded (REQ-RES-008)
+
+The implementation MUST stream resource bytes via an in-memory buffer bounded by the upload cap (5 MB per REQ-RES-003). For larger files (which currently CANNOT be uploaded but might exist if installed manually), the implementation MUST refuse to load (return 413 with `Content-Length` from filesystem) rather than exhaust memory.
+
+#### Scenario: Stream a normal-size resource
+
+- GIVEN a 200 KB PNG resource
+- WHEN GETting it
+- THEN the implementation MUST read it into a `php://memory` stream, write the StreamResponse, and the client MUST receive the full bytes
+
+#### Scenario: Refuse to serve oversize external file
+
+- GIVEN a manually-installed 50 MB file `<appdata>/resources/huge.bin`
+- WHEN GETting it
+- THEN the system MUST return HTTP 413 with `{status: 'error', error: 'file_too_large'}` (or equivalent)
+- AND MUST NOT load the file into memory
+- NOTE: Normal uploads cannot exceed 5 MB (REQ-RES-003) so this only protects against manual filesystem tampering.

--- a/openspec/changes/resource-serving/tasks.md
+++ b/openspec/changes/resource-serving/tasks.md
@@ -1,0 +1,41 @@
+# Tasks — resource-serving
+
+## 1. Controller methods
+
+- [ ] 1.1 Add `lib/Controller/ResourceController.php::getResource(string $filename): StreamResponse`
+- [ ] 1.2 Treat `{filename}` as leaf-only — reject any decoded `/` or `..` with 404 (Symfony route param matches `[^/]+` by default; verify in route registration too)
+- [ ] 1.3 Implement Content-Type extension map (jpg/jpeg → image/jpeg, png → image/png, gif → image/gif, svg → image/svg+xml, webp → image/webp, default → application/octet-stream)
+- [ ] 1.4 Set `Cache-Control: public, max-age=31536000` on the StreamResponse
+- [ ] 1.5 413 guard: check `$file->getSize()` BEFORE loading bytes; refuse files > 5 MB with HTTP 413 `{status: 'error', error: 'file_too_large'}`
+- [ ] 1.6 Add `lib/Controller/ResourceController.php::listResources(): DataResponse` returning `{status: 'success', resources: [{name, url, size, modifiedAt}]}` ordered by `modifiedAt desc`
+- [ ] 1.7 Empty / non-existent folder → empty array (HTTP 200, NOT 404)
+- [ ] 1.8 Document the cache-busting strategy (uniqid in filename) in PHP docblocks for both methods
+
+## 2. Routes
+
+- [ ] 2.1 Register `['name' => 'resource#getResource', 'url' => '/resource/{filename}', 'verb' => 'GET']` in `appinfo/routes.php` under the NON-OCS `routes` array (plain web route)
+- [ ] 2.2 Register `['name' => 'resource#listResources', 'url' => '/api/resources', 'verb' => 'GET']` in `appinfo/routes.php` under the OCS `ocs` array
+- [ ] 2.3 Confirm both methods carry the correct Nextcloud auth attribute (`#[NoAdminRequired]` — logged-in user only) — gate-route-auth + gate-semantic-auth must pass
+
+## 3. PHPUnit tests
+
+- [ ] 3.1 `ResourceControllerTest::testServePngReturnsBytesAndHeaders` — Content-Type `image/png` + `Cache-Control: public, max-age=31536000` + exact bytes
+- [ ] 3.2 `ResourceControllerTest::testServeSvgUsesImageSvgXmlContentType` — `image/svg+xml`, NOT `application/svg+xml`
+- [ ] 3.3 `ResourceControllerTest::testUnknownExtensionFallsBackToOctetStream` — `.bin` → `application/octet-stream`
+- [ ] 3.4 `ResourceControllerTest::testMissingFileReturns404` — 404, empty body acceptable
+- [ ] 3.5 `ResourceControllerTest::testEncodedPathTraversalReturns404` — `..%2F..%2Fetc%2Fpasswd` → 404, no system file leak
+- [ ] 3.6 `ResourceControllerTest::testOversizeFileRefusedWithoutMemoryExhaustion` — 50 MB file → 413, file NOT read into memory
+- [ ] 3.7 `ResourceControllerTest::testListReturnsResourcesSortedByModifiedDesc` — newest first
+- [ ] 3.8 `ResourceControllerTest::testListWithNoFolderReturnsEmptyArray` — HTTP 200 + `{resources: []}`
+
+## 4. End-to-end Playwright tests
+
+- [ ] 4.1 Image widget renders an uploaded resource via the served `GET /apps/mydash/resource/<filename>` URL
+- [ ] 4.2 Direct browser fetch of `/apps/mydash/resource/<filename>` while unauthenticated redirects to login (no bytes served)
+
+## 5. Quality gates
+
+- [ ] 5.1 `composer check:strict` (PHPCS, PHPMD, Psalm, PHPStan) passes — fix any pre-existing issues encountered along the way
+- [ ] 5.2 OpenAPI spec updated for `GET /api/resources` (the non-OCS `/resource/{filename}` is intentionally excluded — binary streaming, not API consumer surface)
+- [ ] 5.3 SPDX headers on every new/modified PHP file (inside the docblock per the SPDX-in-docblock convention) — gate-spdx must pass
+- [ ] 5.4 Run all 10 `hydra-gates` locally before opening PR

--- a/openspec/changes/resource-uploads/proposal.md
+++ b/openspec/changes/resource-uploads/proposal.md
@@ -1,0 +1,61 @@
+# Resource uploads
+
+A new `resource-uploads` capability owns a small mini file API for binary assets (icons, widget images) that MyDash needs to host directly — separate from the user's Files. Admin-only upload via base64 data URL, raster MIME cross-check, 5 MB cap, app-data folder storage. Serving and SVG sanitisation are split into sibling changes (`resource-serving`, `svg-sanitisation`).
+
+## Why
+
+MyDash widgets (image, link-button, custom icons, dashboard icons) need to reference branding assets that the admin controls and that survive deletion of any user. The user's Files folder is the wrong home: per-user, mutable by the owner, deletable, and not addressable by a stable public URL. We need a tiny app-owned file API with a hardened upload path (admin-only, size-capped, MIME-verified) so widgets can render branded icons without inventing per-widget upload code.
+
+## What Changes
+
+- **NEW** `POST /api/resources` endpoint accepting `{base64: 'data:image/<type>;base64,...'}` (admin-only).
+- **NEW** declared/detected MIME cross-check with allowed types `jpeg, jpg, png, gif, svg, webp`.
+- **NEW** 5 MB hard cap on decoded bytes, enforced before invoking image library.
+- **NEW** Storage via `IAppData::getFolder('resources')` with `resource_<uniqid>.<ext>` filenames.
+- **NEW** Standardised success / error envelope (`{status, error, message}`) with a stable error enum.
+- Foundation for sibling changes `resource-serving` (read side) and `svg-sanitisation` (SVG hardening).
+
+## Capabilities
+
+### New Capabilities
+- `resource-uploads`: Admin-only mini file API for storing branding/icon assets in MyDash's app data, used by image widget, link-button widget, custom-icon-upload pattern, and dashboard icon picker.
+
+### Modified Capabilities
+- (none — sibling changes `resource-serving` and `svg-sanitisation` extend this capability via their own delta specs.)
+
+## Impact
+
+- New files: `lib/Controller/ResourceController.php`, `lib/Service/ResourceService.php`, `lib/Service/ImageMimeValidator.php`, plus typed exception classes under `lib/Exception/`.
+- Routes: one new `POST /api/resources` entry in `appinfo/routes.php`.
+- App data: a new `resources/` folder will be auto-created in MyDash's app-data root on first upload — no migration script needed.
+- Frontend: a thin `src/services/resourceService.js` wrapper, consumed by image widget, link-button icon picker, custom-icon-upload pattern, dashboard icon picker.
+- OpenAPI: documented endpoint + envelope.
+- No external dependencies introduced (uses built-in `getimagesizefromstring`).
+
+## Affected code units
+
+- `lib/Controller/ResourceController.php` — `POST /api/resources` handler (admin-only)
+- `lib/Service/ResourceService.php` — base64 decode + size + MIME validation + storage via `IAppData`
+- `lib/Service/ImageMimeValidator.php` — declared-type ↔ detected-MIME cross-check
+- `appinfo/info.xml` — add `resources` app-data folder declaration if needed
+- New capability `resource-uploads`
+- Consumed by: `image-widget` form, `link-button-widget` icon picker, `custom-icon-upload-pattern` icon picker, dashboard icon picker
+
+## Why a new capability
+
+The upload pipeline is a coherent surface (one endpoint + storage layer + validation) that is consumed by 4 different widget/icon flows. Folding it into any one consumer would obscure the contract; keeping it standalone lets us add features (per-resource ACL, garbage collection, image transforms) independently.
+
+## Approach
+
+- Endpoint accepts raw JSON body `{base64: 'data:image/<type>;base64,...'}` (NOT multipart) — keeps client side simple and avoids `$_FILES` quirks across PHP versions / non-POST verbs.
+- Admin-only via `IGroupManager::isAdmin`.
+- Allowed declared types: `jpeg, jpg, png, gif, svg, webp` (5 MB hard cap on decoded bytes).
+- Raster types: cross-check declared type vs `getimagesizefromstring` detected MIME.
+- SVG: route through `SvgSanitiser` (covered in `svg-sanitisation` change).
+- Storage: `IAppData` folder `resources/`, filename `resource_<uniqid>.<ext>`.
+- Response shape standardised: `{status: 'success', url: '/apps/mydash/resource/<filename>', name, size}` (NOT the bare `{url}` shape — consistent with rest of API).
+
+## Notes
+
+- Per-resource ACL is OUT of scope for v1 — anyone authenticated can read any resource by name (acceptable for branding/icon assets, not for sensitive uploads).
+- Garbage collection is OUT of scope for v1 — orphaned resources accumulate. Tracked as a follow-up.

--- a/openspec/changes/resource-uploads/specs/resource-uploads/spec.md
+++ b/openspec/changes/resource-uploads/specs/resource-uploads/spec.md
@@ -1,0 +1,130 @@
+---
+capability: resource-uploads
+status: draft
+---
+
+# Resource Uploads Specification
+
+## Purpose
+
+The `resource-uploads` capability owns a small mini file API for binary assets that MyDash widgets reference directly: dashboard icons, image-widget images, link-button icons, etc. Resources are stored in MyDash's app-data folder (NOT the user's Files), addressed by a stable URL, and uploaded admin-only via a base64-data-URL JSON request. Serving and SVG sanitisation are specified in sibling deltas (`resource-serving` change, `svg-sanitisation` change).
+
+## Data Model
+
+Resources are flat files in app data — there is no companion DB row. Layout:
+
+```
+<appdata_root>/resources/
+├─ resource_<uniqid>.png
+├─ resource_<uniqid>.svg
+└─ ...
+```
+
+Each upload produces:
+- A new file with `resource_<uniqid>.<ext>` name (where `<ext>` is the normalised extension)
+- A stable public URL `/apps/mydash/resource/<filename>` (served by REQ-RES-006, in the `resource-serving` change)
+
+## ADDED Requirements
+
+### Requirement: Admin-only base64 upload endpoint (REQ-RES-001)
+
+The system MUST expose `POST /api/resources` accepting a raw JSON body of the shape `{base64: 'data:image/<type>;base64,...'}`. The endpoint MUST be admin-only — non-admin requests MUST receive HTTP 403 with `{status: 'error', error: 'forbidden'}`. The endpoint MUST NOT accept multipart form data — only a base64-encoded data URL.
+
+#### Scenario: Admin uploads a PNG
+
+- **GIVEN** an authenticated admin user
+- **WHEN** they POST `{"base64": "data:image/png;base64,iVBORw0KGgo..."}` (valid 200×200 PNG)
+- **THEN** the system MUST return HTTP 200 with `{status: 'success', url: '/apps/mydash/resource/resource_<uniqid>.png', name: 'resource_<uniqid>.png', size: <bytes>}`
+- **AND** a file MUST exist at the corresponding app-data path
+
+#### Scenario: Non-admin rejected
+
+- **GIVEN** an authenticated non-admin user
+- **WHEN** they POST any body to `/api/resources`
+- **THEN** the system MUST return HTTP 403 with `{status: 'error', error: 'forbidden'}`
+- **AND** no file MUST be written
+
+#### Scenario: Multipart upload rejected
+
+- **WHEN** a request arrives with `Content-Type: multipart/form-data` instead of JSON
+- **THEN** the system MUST return HTTP 415 with `{status: 'error', error: 'unsupported_media_type', message: 'Use JSON body with base64 field'}`
+
+### Requirement: Allowed declared types (REQ-RES-002)
+
+The data-URL prefix MUST declare one of the allowed image types. Allowed types: `jpeg`, `jpg`, `png`, `gif`, `svg`, `webp` (case-insensitive). Anything else MUST return HTTP 400 with `{status: 'error', error: 'invalid_image_format'}`. A missing or unparseable data-URL prefix MUST return HTTP 400 with `{status: 'error', error: 'invalid_data_url'}`.
+
+The persisted file extension MUST be the normalised lowercase form (jpeg → jpeg, jpg → jpg, svg+xml → svg).
+
+#### Scenario: Disallowed type rejected
+
+- **WHEN** the client POSTs `{"base64": "data:image/bmp;base64,..."}`
+- **THEN** the system MUST return HTTP 400 with `error: 'invalid_image_format'`
+- **AND** no file MUST be written
+
+#### Scenario: Missing data-URL prefix rejected
+
+- **WHEN** the client POSTs `{"base64": "iVBORw0KGgo..."}` (raw base64, no `data:` prefix)
+- **THEN** the system MUST return HTTP 400 with `error: 'invalid_data_url'`
+
+#### Scenario: Mixed-case declared type accepted
+
+- **WHEN** the client POSTs `{"base64": "data:image/PNG;base64,..."}` (uppercase declared type)
+- **THEN** the system MUST treat it as `png`
+- **AND** the persisted extension MUST be lowercase `.png`
+
+### Requirement: Size and integrity validation (REQ-RES-003)
+
+The system MUST decode the base64 payload and enforce a 5 MB cap on the decoded bytes. For raster types (jpeg/png/gif/webp), the system MUST run `getimagesizefromstring` on the decoded bytes and reject if it returns false (corrupted) OR if the detected MIME does not match the declared type. SVG validation is delegated to the `svg-sanitisation` capability's sanitiser. The size cap MUST be enforced before invoking `getimagesizefromstring` so the server cannot be tricked into loading an oversize blob into the image library.
+
+#### Scenario: Oversize payload rejected
+
+- **WHEN** the client POSTs a base64 payload that decodes to 6 MB
+- **THEN** the system MUST return HTTP 400 with `{status: 'error', error: 'file_too_large', message: 'Maximum size is 5MB'}`
+- **AND** no file MUST be written
+- **AND** `getimagesizefromstring` MUST NOT be called
+
+#### Scenario: MIME mismatch rejected
+
+- **WHEN** the client POSTs `{"base64": "data:image/png;base64,<actually a JPEG>"}` (declared png, body is jpeg)
+- **THEN** `getimagesizefromstring` reports `image/jpeg`
+- **THEN** the system MUST return HTTP 400 with `{status: 'error', error: 'mime_mismatch'}`
+
+#### Scenario: Corrupt raster bytes rejected
+
+- **WHEN** the client POSTs `{"base64": "data:image/png;base64,<garbage>"}`
+- **THEN** `getimagesizefromstring` returns false
+- **THEN** the system MUST return HTTP 400 with `{status: 'error', error: 'corrupt_image'}`
+
+### Requirement: Storage via IAppData (REQ-RES-004)
+
+Validated bytes MUST be stored via `IAppData::getFolder('resources')` (auto-create on first use). Filenames MUST be `resource_<uniqid>.<ext>` (using PHP `uniqid('resource_', true)` for high-entropy IDs and the normalised extension). The system MUST NOT write to the user's Files folder.
+
+#### Scenario: Storage location
+
+- **GIVEN** any successful upload
+- **THEN** the file MUST be created under the app's app-data root inside a `resources/` subfolder
+- **AND** the file MUST NOT appear under the calling admin's user folder
+- **AND** the filename MUST match `resource_[a-f0-9.]+\.(jpeg|jpg|png|gif|svg|webp)`
+
+#### Scenario: Folder auto-create
+
+- **GIVEN** the `resources/` folder does not yet exist
+- **WHEN** the first upload arrives
+- **THEN** the folder MUST be created automatically
+- **AND** the upload MUST succeed normally
+
+### Requirement: Standardised response envelope (REQ-RES-005)
+
+Every successful response MUST conform to `{status: 'success', url: <string>, name: <string>, size: <int>}` (additional fields are allowed). Every error response MUST conform to `{status: 'error', error: <stable_string>, message: <translated string>}`. The `error` field is a stable enum suitable for client-side branching; `message` is for display. Raw exception messages MUST NEVER be returned to the client.
+
+#### Scenario: Error envelope shape
+
+- **WHEN** any error path triggers (admin check, validation, storage failure)
+- **THEN** the response body MUST contain `status`, `error`, `message`
+- **AND** the body MUST NOT contain raw stack traces or `$e->getMessage()` strings unsafe for display
+
+#### Scenario: Stable error enum
+
+- **GIVEN** the documented error codes are `forbidden`, `unsupported_media_type`, `invalid_data_url`, `invalid_image_format`, `file_too_large`, `mime_mismatch`, `corrupt_image`, `storage_failure`
+- **WHEN** any rejection scenario above triggers
+- **THEN** the `error` field MUST equal exactly one of those strings (no synonyms, no extras)

--- a/openspec/changes/resource-uploads/tasks.md
+++ b/openspec/changes/resource-uploads/tasks.md
@@ -1,0 +1,44 @@
+# Tasks — resource-uploads
+
+## 1. Backend
+
+- [ ] Create `lib/Service/ResourceService.php` with `upload(string $base64DataUrl): array` returning `{url, name, size}` or throwing typed exceptions
+- [ ] Create `lib/Service/ImageMimeValidator.php::validate(string $declaredType, string $bytes): void`
+- [ ] Create `lib/Controller/ResourceController.php::upload` mapped to `POST /api/resources`
+- [ ] Read raw input via `file_get_contents('php://input')` + `json_decode`
+- [ ] Admin guard via `IGroupManager::isAdmin`
+- [ ] 5 MB cap on decoded bytes (guard before `getimagesizefromstring` to bound memory)
+- [ ] Cross-MIME check for raster types
+- [ ] Delegate SVG sanitisation to `SvgSanitiser` (separate change)
+- [ ] Persist via `IAppData->getFolder('resources')` (auto-create); filename `uniqid('resource_', true) . '.' . $ext`
+- [ ] Define typed exceptions with stable error codes: `ForbiddenException`, `InvalidImageFormatException`, `InvalidDataUrlException`, `FileTooLargeException`, `MimeMismatchException`, `CorruptImageException`
+- [ ] Map exceptions to standardised error envelope in controller (no raw `$e->getMessage()`)
+
+## 2. Frontend
+
+- [ ] Add `src/services/resourceService.js::uploadDataUrl(dataUrl): Promise<{url}>` wrapper
+- [ ] Used by `image-widget` form, `link-button-widget` icon picker, `IconPicker`
+
+## 3. Tests
+
+- [ ] PHPUnit: 403 on non-admin
+- [ ] PHPUnit: each rejection path returns the exact error code
+- [ ] PHPUnit: oversize rejected before `getimagesizefromstring` (mock memory check)
+- [ ] PHPUnit: MIME mismatch table (declared png, actual jpeg/gif/webp)
+- [ ] PHPUnit: successful upload writes to app-data, returns URL
+- [ ] PHPUnit: error responses NEVER contain `Exception` / stack trace strings
+- [ ] Playwright: file upload from icon picker → URL appears in form
+
+## 4. Quality
+
+- [ ] `composer check:strict` passes
+- [ ] OpenAPI updated for `POST /api/resources`
+- [ ] Translation entries: `Personal dashboards are not enabled by your administrator`, `Failed to upload image`, error message strings (one per error code)
+- [ ] Document v1 limits in admin help text: 5 MB cap, allowed types
+
+## 5. Follow-ups (separate changes)
+
+- [ ] `resource-serving` — GET endpoint
+- [ ] `svg-sanitisation` — DOM-based whitelist sanitiser
+- [ ] (Future) `resource-gc` — cleanup of orphaned resources
+- [ ] (Future) `resource-acl` — per-resource access control if non-public assets are added

--- a/openspec/changes/responsive-grid-breakpoints/design.md
+++ b/openspec/changes/responsive-grid-breakpoints/design.md
@@ -1,0 +1,85 @@
+# Design — responsive-grid-breakpoints
+
+## Context
+
+MyDash uses GridStack 10.3.1 (per `openspec/config.yaml`) initialised on a 12-column grid with `cellHeight: 80` and a small inter-cell margin. REQ-GRID-007 currently asserts only that the grid SHOULD be responsive — there are no concrete breakpoints, no reflow algorithm, and no unit on the geometry constants. In practice the grid stays 12-column even at 480 px viewport, which makes widgets unreadably narrow on tablets and phones.
+
+This change pins down four explicit breakpoints, the `moveScale` reflow algorithm, the cell/margin geometry, and the GridStack major-version dependency — converting an aspirational requirement into a testable one.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make REQ-GRID-007 testable (concrete column counts at concrete viewport widths).
+- Centralise the geometry constants (`CELL_HEIGHT`, `GRID_MARGIN`, `BREAKPOINTS`) in the grid composable so no component duplicates literals.
+- Pick a reflow algorithm (`moveScale`) that scales widgets proportionally rather than reordering or wrapping.
+- Pin the GridStack major to a version (v12+) that supports the `columnOpts.breakpoints` shape used here.
+
+**Non-Goals:**
+
+- Changing `acceptWidgets`, `staticGrid`, or `float` — those belong to REQ-GRID-004 (view-vs-edit) and are unaffected.
+- Per-widget responsive overrides (e.g. "this widget keeps width 12 even at 4-col grid"). Future work; tracked as roadmap item if needed.
+- Changing widget collision rules — REQ-GRID-006 / REQ-GRID-014 are unaffected.
+
+## Decisions
+
+### D1: Breakpoint set — 1400 / 1100 / 768 / 480
+
+**Decision**: Four entries: `[{w:1400,c:12}, {w:1100,c:8}, {w:768,c:4}, {w:480,c:1}]`.
+
+**Alternatives considered:**
+
+- Three breakpoints (desktop / tablet / mobile, e.g. 1200/768/480): rejected — leaves too large a step from 12 to 4 columns, widgets jerk visually.
+- Five+ breakpoints with finer steps: rejected — extra reflow events on common laptop widths (1280, 1366) without a meaningful layout improvement.
+
+**Rationale**: 1400 covers full HD+ desktops; 1100 catches the common 1280/1366 laptop range (after sidebar); 768 is the iPad portrait threshold; 480 is the standard mobile breakpoint. Monotonically descending column counts (12, 8, 4, 1) keep the math even — every column count is a divisor of 24, so half/third widgets stay snapped.
+
+### D2: Reflow algorithm — `'moveScale'`
+
+**Decision**: Set `columnOpts.layout = 'moveScale'`.
+
+**Alternatives considered:**
+
+- `'list'` — collapses to a single column on column change. Rejected because it ignores the carefully picked column counts.
+- `'compact'` — re-flows top-to-bottom, may reorder widgets. Rejected because user-arranged layout is meaningful (left-of-right semantics).
+- `'none'` — preserves x/w; widgets overflow at smaller column counts. Rejected — the entire point is to reflow.
+
+**Rationale**: `'moveScale'` proportionally rescales widget widths so a half-width widget at 12 cols (`w=6`) becomes a half-width widget at 8 cols (`w=4`) and at 4 cols (`w=2`). User intent is preserved.
+
+### D3: Cell height — 60 px (vs current 80 px in config.yaml)
+
+**Decision**: `CELL_HEIGHT = 60` (px), `GRID_MARGIN = 8` (px). Spec'd as 60; flag for stakeholder confirmation in tasks 2.1.
+
+**Alternatives considered:**
+
+- Keep 80 px (current `openspec/config.yaml` documented value): more vertical breathing room per row; existing widget designs may already assume 80.
+- Move to 60 px: denser dashboards, better for multi-row info widgets common in MyDash usage.
+
+**Rationale**: 60 px fits the modern dashboard density that recent UX feedback has favoured, but the 80 vs 60 trade-off is a real product call. Tasks 2.1/2.2 hold this open until stakeholder sign-off; if 80 wins the constants and the REQ-GRID-012 height-math scenario flip together (one place each).
+
+### D4: GridStack v12 pin (vs current 10.3.1)
+
+**Decision**: Bump `gridstack` to `^12.2.1`.
+
+**Alternatives considered:**
+
+- Stay on 10.3.1: `columnOpts.breakpoints` is supported on v10+, so technically possible. Rejected because v12 ships fixes for the `moveScale` algorithm we depend on, plus security/maintenance updates.
+- Skip to v13 if released: rejected as out of scope — bump deliberately to a tested major.
+
+**Rationale**: v10 -> v12 has a small set of breaking changes (column option shape, a few removed callbacks) handled in task 1.1. REQ-GRID-013 codifies the version floor as `>= 10.0.0` so a future regression to v11 still satisfies the spec, but `package.json` declares the actual `^12.2.1` range we ship.
+
+### D5: Constants shared from the grid composable, not from a CSS file
+
+**Decision**: Constants live in JS (`useGridManager.js` or equivalent composable) and are mirrored to a CSS custom property `--mydash-cell-height` at init time.
+
+**Rationale**: GridStack reads JS values; CSS `calc()` reads CSS values. Single source-of-truth in JS, with a one-way sync to CSS, prevents the two from drifting. Avoids a SCSS/JS dual-definition that has bitten other capabilities.
+
+## Risks
+
+- **GridStack v10 -> v12 breakages.** Some callbacks were renamed; addressed in task 1.1, covered by Playwright regression in task 3.2.
+- **80 vs 60 cell height ambiguity.** Existing widget templates may visually break at 60 px if they baked-in 80 px row heights. Task 2.1 forces an explicit decision before apply; visual regression tests at task 3.2 catch any breakage.
+- **Reflow at resize is visually jarring** if the user has many widgets. `moveScale` is the least jarring algorithm available — we accept the small jump-cut.
+
+## Migration
+
+No data migration. Existing `gridX/gridY/gridWidth/gridHeight` values stay as authored at the 12-column reference scale; GridStack's `moveScale` derives the smaller-column placements at render time without rewriting persisted positions.

--- a/openspec/changes/responsive-grid-breakpoints/proposal.md
+++ b/openspec/changes/responsive-grid-breakpoints/proposal.md
@@ -1,0 +1,26 @@
+# Responsive grid breakpoints
+
+Add explicit responsive breakpoints to the GridStack instance so dashboards reflow proportionally at four viewport widths instead of staying fixed-12-column on narrow screens. Specifies the column counts, the reflow algorithm (`moveScale`), and the cell/margin geometry.
+
+## Affected code units
+
+- `src/composables/useGridManager.js` (or equivalent) — pass `columnOpts.breakpoints` and `columnOpts.layout` to `GridStack.init`
+- `src/views/WorkspaceApp.vue` and any other GridStack mount sites
+- Modifies `grid-layout` REQ-GRID-007 (Grid Responsiveness) which currently is under-specified
+
+## Why a delta
+
+REQ-GRID-007 already says the grid SHOULD be responsive. This change pins down concrete breakpoints, target column counts, the reflow strategy, and the cell/margin constants — making the requirement testable.
+
+## Approach
+
+- Pin GridStack to the `gridstack` v12.x line (the `columnOpts.breakpoints` shape used here is v10+; we already use 10.3.1 per config.yaml — bumping to v12 is in scope of this change).
+- Four breakpoints, monotonically descending column counts: 1400→12, 1100→8, 768→4, 480→1.
+- Cell height: 60 px; margins: 8 px (this differs from the 80 px documented in `openspec/config.yaml` — see Notes).
+- Reflow algorithm: `'moveScale'` — proportional widget scaling on column transitions.
+
+## Notes
+
+- **Geometry change vs current config.yaml.** `config.yaml` documents `cellHeight: 80` for the existing `grid-layout` capability. This change proposes 60 px, matching the smaller cells better suited to dense dashboards with multi-row widgets. Decide before applying: keep 80 (more vertical breathing room) or move to 60 (denser). Spec'd as 60; flip in tasks if desired.
+- GridStack v10 → v12 has a few breaking changes around column option shape — handled as part of the bump.
+- `acceptWidgets`, `staticGrid`, and `float` settings are not touched (those belong to REQ-GRID-004 view-vs-edit).

--- a/openspec/changes/responsive-grid-breakpoints/specs/grid-layout/spec.md
+++ b/openspec/changes/responsive-grid-breakpoints/specs/grid-layout/spec.md
@@ -1,0 +1,80 @@
+---
+capability: grid-layout
+delta: true
+status: draft
+---
+
+# Grid Layout — Delta from change `responsive-grid-breakpoints`
+
+## MODIFIED Requirements
+
+### Requirement: REQ-GRID-007 Grid Responsiveness (concrete breakpoints)
+
+The GridStack instance MUST be initialised with `columnOpts.breakpoints` containing exactly four entries, each `{w: <viewportWidthPx>, c: <columnCount>}`, applied in descending viewport order:
+
+| Viewport width >= | Column count |
+|---|---|
+| 1400 px | 12 |
+| 1100 px | 8 |
+| 768 px | 4 |
+| 480 px | 1 |
+
+`columnOpts.layout` MUST be set to `'moveScale'` so widgets scale proportionally when the column count changes (rather than wrapping or collapsing). Below the smallest entry the smallest column count (1) MUST apply.
+
+#### Scenario: 12 columns on wide desktop
+
+- GIVEN viewport width is 1500 px
+- WHEN the workspace renders
+- THEN the grid MUST use 12 columns
+- AND a widget originally placed at `{x: 6, w: 6}` MUST occupy the right half of the viewport
+
+#### Scenario: Reflow at 1100 px
+
+- GIVEN the workspace was rendered at 1500 px (12 columns) with widgets occupying the full grid width
+- WHEN the viewport is resized to 1100 px (8 columns)
+- THEN GridStack MUST proportionally rescale widget widths via `moveScale`
+- AND a widget originally `{x: 0, w: 6}` (half) MUST become approximately `{x: 0, w: 4}` (still half, in the 8-col grid)
+
+#### Scenario: Single-column on mobile
+
+- GIVEN viewport width is 480 px
+- WHEN the workspace renders
+- THEN the grid MUST use 1 column
+- AND every widget MUST occupy the full row width
+- AND widgets MUST stack vertically
+
+#### Scenario: Below smallest breakpoint
+
+- GIVEN viewport width is 320 px (below the 480 entry)
+- WHEN the workspace renders
+- THEN the grid MUST use the column count of the smallest matching breakpoint (1 column)
+
+## ADDED Requirements
+
+### Requirement: REQ-GRID-012 Cell geometry constants
+
+The grid MUST be initialised with `cellHeight: 60` (px) and `margin: 8` (px). These constants MUST live in a single shared module exported from the grid composable, not duplicated in component templates.
+
+#### Scenario: Cell height read from constant
+
+- GIVEN the grid composable defines `CELL_HEIGHT = 60`
+- WHEN any other module needs the cell height (e.g. for collision math or CSS calc)
+- THEN it MUST import the constant
+- AND grep for hardcoded `60` in grid contexts MUST return only the composable definition
+
+#### Scenario: 12-col, 60px, 8px margin renders predictable height
+
+- GIVEN a widget with `gridHeight: 4` is placed
+- WHEN it renders at the 12-column breakpoint
+- THEN its DOM height MUST be `(4 * 60) + (3 * 8) = 264 px` (4 rows + 3 inter-row margins)
+
+### Requirement: REQ-GRID-013 GridStack version pin
+
+The system MUST pin `gridstack` to a major version that supports `columnOpts.breakpoints` and the `moveScale` layout (currently v10 or later, target v12+). Bumping the major version MUST be a deliberate change with a regression-test pass on this capability.
+
+#### Scenario: Lockfile version
+
+- GIVEN a developer inspects `package-lock.json`
+- WHEN reading the resolved `gridstack` entry
+- THEN the resolved version MUST be `>= 10.0.0`
+- AND `package.json` MUST declare a constrained range like `"gridstack": "^12.2.1"` (or whichever major is current at apply time)

--- a/openspec/changes/responsive-grid-breakpoints/tasks.md
+++ b/openspec/changes/responsive-grid-breakpoints/tasks.md
@@ -1,0 +1,26 @@
+# Tasks — responsive-grid-breakpoints
+
+## 1. Frontend
+
+- [ ] 1.1 Bump `gridstack` to `^12.2.1` in `package.json`; resolve any v10 -> v12 breaking changes
+- [ ] 1.2 Define constants `CELL_HEIGHT = 60`, `GRID_MARGIN = 8`, `BREAKPOINTS = [{w:1400,c:12},{w:1100,c:8},{w:768,c:4},{w:480,c:1}]` in grid composable (single shared module)
+- [ ] 1.3 Pass `cellHeight`, `margin`, `columnOpts: {breakpoints, layout: 'moveScale'}` to `GridStack.init` in `useGridManager.js`
+- [ ] 1.4 Update `WorkspaceApp.vue` (and any other GridStack mount sites) to import + use the shared constants — no inline literals
+- [ ] 1.5 Update CSS `calc()` usage to read from CSS custom property `--mydash-cell-height` (set from JS at init time from `CELL_HEIGHT`)
+
+## 2. Decision: keep 80 or move to 60?
+
+- [ ] 2.1 Resolve cell-height value with stakeholder before applying — flip `CELL_HEIGHT` constant if 80 wins
+- [ ] 2.2 If keeping 80, update REQ-GRID-012 height-math scenario accordingly (replace `(4 * 60) + (3 * 8) = 264 px` with the 80-px equivalent)
+
+## 3. Tests
+
+- [ ] 3.1 Playwright: assert column count via `grid.opts.column` at 1500 / 1200 / 900 / 640 / 320 px viewport widths
+- [ ] 3.2 Playwright: visual regression for a 6-widget layout at each of the four breakpoints
+- [ ] 3.3 Vitest: composable exposes `CELL_HEIGHT`, `GRID_MARGIN`, `BREAKPOINTS` with expected values
+
+## 4. Quality
+
+- [ ] 4.1 ESLint + Stylelint clean
+- [ ] 4.2 Update `openspec/config.yaml` `cellHeight` documentation to match the resolved value (60 or 80)
+- [ ] 4.3 CHANGELOG: note the GridStack major bump for downstream consumers

--- a/openspec/changes/runtime-shell/proposal.md
+++ b/openspec/changes/runtime-shell/proposal.md
@@ -1,0 +1,59 @@
+# Runtime workspace shell
+
+## Why
+
+The mydash runtime page chrome — the GridStack mount, the admin/edit toolbar, the save button, the dashboard-name header, the hamburger that toggles the sidebar, and the `canEdit` permission rule — has no formal capability home. It currently lives bundled inside a generic dashboard view component, conflating page-level coordination with dashboard data and the grid surface. The shell coordinates four sibling capabilities (`dashboard-switcher-sidebar`, `widget-add-edit-modal`, `widget-context-menu`, `grid-layout`) and gates editing affordances based on user role and active dashboard scope; it is the page-level orchestrator and warrants its own capability so the page-level interactions (sidebar open/close, save, toolbar visibility, empty state, lifecycle cleanup) can be specified in one place. This is the LAST capability to land — it depends on virtually everything else.
+
+## What Changes
+
+- Introduce a new `runtime-shell` capability owning the user-facing workspace page chrome.
+- Add REQ-SHELL-001 (single mount point under `<div id="app-workspace">`).
+- Add REQ-SHELL-002 (computed `canEdit = isAdmin || dashboardSource === 'user'` gates the toolbar, context menu, and `staticGrid` mode).
+- Add REQ-SHELL-003 (toolbar contents: Add Widget dropdown + Save Layout button, with in-flight disable and PUT to `/api/dashboards/{uuid}`).
+- Add REQ-SHELL-004 (hamburger sidebar toggle plus active-dashboard label).
+- Add REQ-SHELL-005 (empty-state UI branching on `allowUserDashboards`).
+- Add REQ-SHELL-006 (fixed sidebar backdrop starting at `top: 50px`).
+- Add REQ-SHELL-007 (lifecycle: register `document.click` listener + GridStack init on mount, cleanup on unmount).
+- Refactor `src/views/WorkspaceApp.vue` into a four-region shell (sidebar, hamburger+title strip, toolbar, grid).
+- Update `templates/index.php` to render the dual-div mount (`#app-workspace > #workspace-vue`) and `WorkspaceController::index` to pass `'id-app-content' => '#app-workspace'` and `'id-app-navigation' => null`.
+
+## Capabilities
+
+### New Capabilities
+
+- `runtime-shell` — page-level Vue component for the workspace experience; coordinates sibling capabilities and owns the page chrome. REQ-SHELL-001..007.
+
+### Modified Capabilities
+
+(none — this change is purely additive)
+
+## Impact
+
+**Affected code:**
+
+- `templates/index.php` — Nextcloud page template: load the runtime bundle and provide `<div id="app-workspace" class="mydash-workspace"><div id="workspace-vue"></div></div>`
+- `lib/Controller/WorkspaceController.php` — `GET /` page renderer; pass the new chrome slot ids in the template parameters (initial-state push lives in the separate `initial-state-contract` change)
+- `src/views/WorkspaceApp.vue` — the shell component itself, refactored from a generic dashboard view
+- `src/styles/workspace.css` — global styles for the shell (sidebar backdrop, toolbar, empty state)
+- Consumes (no source changes here, just integration): `dashboard-switcher-sidebar`, `widget-add-edit-modal`, `widget-context-menu`, `dashboards`, `grid-layout`
+
+**Affected APIs:**
+
+- No new HTTP routes; the shell consumes existing `PUT /api/dashboards/{uuid}` and `POST /api/dashboards` endpoints.
+
+**Dependencies:**
+
+- Inherits initial-state contract from the `initial-state-contract` change (provides `isAdmin`, `dashboardSource`, `activeDashboardId`, `allowUserDashboards`, `layout` via `provide`/`inject`).
+- Sibling capabilities (`dashboard-switcher-sidebar`, `widget-add-edit-modal`, `widget-context-menu`, `grid-layout`) MUST be in place before this capability ships — this is the LAST change to land.
+- No new composer or npm dependencies.
+
+**Notes:**
+
+- The shell deliberately keeps NO local persistence layer of its own — every save delegates to existing dashboard endpoints.
+- The Add Widget dropdown is consumed from `widget-add-edit-modal` (it owns the type → submit pipeline).
+- The shell holds only local UI state (`sidebarOpen`, `saving`, `showAddDropdown`, `layout`, `activeDashboardId`, `dashboardSource`); all source-of-truth data flows from initial state via `inject()`.
+- Conditional toolbar uses `v-if="canEdit"` (NOT `v-show`) so the DOM stays clean for non-edit users.
+
+**Migration:**
+
+- No data migration; pure frontend refactor + template + controller signature update.

--- a/openspec/changes/runtime-shell/specs/runtime-shell/spec.md
+++ b/openspec/changes/runtime-shell/specs/runtime-shell/spec.md
@@ -1,0 +1,155 @@
+---
+capability: runtime-shell
+delta: true
+status: draft
+---
+
+# Runtime Shell — Delta from change `runtime-shell`
+
+## ADDED Requirements
+
+### Requirement: REQ-SHELL-001 Single mount point
+
+The system MUST render the workspace Vue app into exactly one DOM element with id `workspace-vue`, located inside a `<div id="app-workspace" class="mydash-workspace">` provided by `templates/index.php`. Nextcloud's chrome MUST treat `#app-workspace` as the main content slot (`'id-app-content' => '#app-workspace'`). No left navigation slot MUST be allocated by the chrome (`'id-app-navigation' => null`) — the shell renders its own slide-in sidebar instead.
+
+#### Scenario: Mount point present
+
+- GIVEN the user has navigated to the workspace page
+- WHEN the page HTML is rendered
+- THEN the rendered HTML MUST contain exactly one `<div id="workspace-vue">`
+- AND it MUST be a child of `<div id="app-workspace">`
+- AND no Nextcloud chrome navigation panel MUST be rendered
+
+### Requirement: REQ-SHELL-002 Edit-mode permission rule
+
+The shell MUST expose a computed `canEdit` evaluated as `isAdmin || dashboardSource === 'user'`. When `canEdit` is `false`, the edit toolbar (Add Widget + Save buttons) and the right-click context menu MUST NOT be reachable; the GridStack instance MUST be in `staticGrid: true` mode. When `canEdit` is `true`, all editing affordances MUST be visible and the grid MUST permit drag/resize.
+
+#### Scenario: Admin can edit any dashboard
+
+- GIVEN injected initial state `isAdmin: true, dashboardSource: 'group'`
+- WHEN the workspace renders
+- THEN `canEdit` MUST be `true`
+- AND the toolbar MUST be visible
+- AND the grid MUST allow drag/resize
+
+#### Scenario: User can edit own personal dashboard
+
+- GIVEN initial state `isAdmin: false, dashboardSource: 'user'`
+- WHEN the workspace renders
+- THEN `canEdit` MUST be `true`
+- AND the toolbar MUST be visible
+- AND the grid MUST allow drag/resize
+
+#### Scenario: User cannot edit a group-shared dashboard
+
+- GIVEN initial state `isAdmin: false, dashboardSource: 'group'`
+- WHEN the workspace renders
+- THEN `canEdit` MUST be `false`
+- AND the toolbar MUST NOT be present in the DOM (`v-if`, not `v-show`)
+- AND right-clicking a widget MUST NOT open the context menu
+- AND the grid MUST be in `staticGrid: true` mode
+
+### Requirement: REQ-SHELL-003 Toolbar contents
+
+When `canEdit` is true, the toolbar MUST render exactly two affordances: an **Add Widget** dropdown button (sourced from the widget type registry — see `widget-add-edit-modal`) and a **Save Layout** button. Selecting an Add Widget option opens the modal pre-filled with that type. The Save Layout button MUST be disabled while a save request is in flight, and on click it MUST call `saveLayout()` which PUTs to `/api/dashboards/{uuid}` with `{layout: layout.value}` then toasts success or error.
+
+#### Scenario: Add-widget dropdown lists all widget types
+
+- GIVEN the widget-type registry contains 5 entries
+- WHEN the user opens the Add Widget dropdown
+- THEN it MUST display 5 menu items, one per registered type
+- AND each item MUST be labelled with the type's translated display name
+
+#### Scenario: Save sends layout to correct endpoint
+
+- GIVEN `dashboardSource: 'user'` and `activeDashboardId: 'abc'`
+- WHEN the user clicks Save
+- THEN the system MUST send `PUT /api/dashboards/abc` with body `{layout: <current widgets>}`
+- AND show a success toast on 200
+- AND show an error toast on 4xx or 5xx
+
+#### Scenario: Save button disabled while in flight
+
+- GIVEN a Save request is in flight
+- WHEN the user attempts to click Save again
+- THEN the button MUST be disabled (HTML `disabled` attribute set)
+- AND no second request MUST fire
+
+### Requirement: REQ-SHELL-004 Sidebar toggle and active-dashboard label
+
+The shell MUST render a hamburger button plus a label showing the active dashboard's name (when one exists), placed immediately above the toolbar. The hamburger button MUST toggle `sidebarOpen`. The label MUST be empty when no active dashboard is resolved.
+
+#### Scenario: Hamburger toggles sidebar
+
+- GIVEN `sidebarOpen` is `false`
+- WHEN the user clicks the hamburger
+- THEN `sidebarOpen` MUST become `true`
+- AND the sidebar MUST animate in
+- AND clicking the hamburger again MUST close it
+
+#### Scenario: Active-dashboard name visible
+
+- GIVEN active dashboard `D` has `name = "Marketing Overview"`
+- WHEN the workspace renders
+- THEN the label next to the hamburger MUST display `"Marketing Overview"`
+
+#### Scenario: Empty label on empty state
+
+- GIVEN no active dashboard is resolved (resolver returned null)
+- WHEN the workspace renders
+- THEN the label MUST be empty
+- AND the empty-state component MUST render in the grid area instead
+
+### Requirement: REQ-SHELL-005 Empty state
+
+When the resolver returned no active dashboard, the shell MUST render an empty-state UI inside the grid container with: a friendly message ("You have no dashboards yet"), an explanation, and — if `allowUserDashboards` is `true` — a primary "Create your first dashboard" button that calls the create-personal flow. When `allowUserDashboards` is `false` no Create button MUST be shown.
+
+#### Scenario: Empty state with creation enabled
+
+- GIVEN no active dashboard is resolved
+- AND `allowUserDashboards` is `true`
+- WHEN the workspace renders
+- THEN the empty-state MUST render with a "Create your first dashboard" button
+- AND clicking it MUST call `POST /api/dashboards` with a default name
+
+#### Scenario: Empty state with creation disabled
+
+- GIVEN no active dashboard is resolved
+- AND `allowUserDashboards` is `false`
+- WHEN the workspace renders
+- THEN the empty-state MUST render with a message explaining personal dashboards are disabled
+- AND no "Create" button MUST be present
+
+### Requirement: REQ-SHELL-006 Sidebar backdrop
+
+When `sidebarOpen` is `true`, the shell MUST render a fixed-position backdrop that intercepts clicks and closes the sidebar. The backdrop MUST start at the same `top` offset as the Nextcloud header (50 px) and span the rest of the viewport. Clicks on the sidebar itself MUST NOT close the sidebar.
+
+#### Scenario: Backdrop closes sidebar on click
+
+- GIVEN `sidebarOpen` is `true`
+- WHEN the user clicks anywhere in the backdrop area
+- THEN `sidebarOpen` MUST become `false`
+
+#### Scenario: Click on the sidebar itself does not close it
+
+- GIVEN `sidebarOpen` is `true`
+- WHEN the user clicks on a non-actionable area of the sidebar panel
+- THEN `sidebarOpen` MUST remain `true`
+
+### Requirement: REQ-SHELL-007 Lifecycle hooks
+
+The shell MUST register a global `document.click` listener on mount (delegated to the grid composable's `handleClickOutside`) and remove it on unmount. The GridStack instance MUST be initialised after `nextTick()` (so the grid container ref is non-null) and destroyed on unmount.
+
+#### Scenario: Listener and grid registered after mount
+
+- GIVEN the shell component is being mounted
+- WHEN the `onMounted` hook runs
+- THEN `document.addEventListener('click', handleClickOutside)` MUST have been called
+- AND after `nextTick()` the GridStack instance MUST be initialised against the grid container ref
+
+#### Scenario: Listener cleanup on unmount
+
+- GIVEN the shell has mounted and registered the click listener
+- WHEN the shell unmounts (e.g. user navigates away)
+- THEN `document.removeEventListener('click', handleClickOutside)` MUST be called
+- AND the GridStack instance MUST be destroyed (no DOM leftover, no memory leak)

--- a/openspec/changes/runtime-shell/tasks.md
+++ b/openspec/changes/runtime-shell/tasks.md
@@ -1,0 +1,43 @@
+# Tasks — runtime-shell
+
+## 1. Backend (template + controller)
+
+- [ ] 1.1 Update `templates/index.php` to render `<div id="app-workspace" class="mydash-workspace"><div id="workspace-vue"></div></div>`
+- [ ] 1.2 Update `WorkspaceController::index` to pass `'id-app-content' => '#app-workspace'` and `'id-app-navigation' => null` to the template
+- [ ] 1.3 Confirm initial-state push (handled by the separate `initial-state-contract` change) wires `isAdmin`, `dashboardSource`, `activeDashboardId`, `allowUserDashboards`, `layout` into the page
+
+## 2. Frontend shell component
+
+- [ ] 2.1 Refactor `src/views/WorkspaceApp.vue` into the four-region shell (sidebar, hamburger+title strip, toolbar, grid)
+- [ ] 2.2 Add computed `canEdit = isAdmin || dashboardSource === 'user'` (REQ-SHELL-002)
+- [ ] 2.3 Conditional toolbar via `v-if="canEdit"` (NOT `v-show` — keep DOM clean for non-edit users) (REQ-SHELL-003)
+- [ ] 2.4 `saveLayout()` chooses endpoint by `dashboardSource` and PUTs `{layout}`; sets `saving = true` until response resolves (REQ-SHELL-003)
+- [ ] 2.5 Sidebar backdrop component (fixed, `top: 50px`) that closes the sidebar on click (REQ-SHELL-006)
+- [ ] 2.6 Empty-state component branching on `allowUserDashboards` (REQ-SHELL-005)
+- [ ] 2.7 Hamburger button + active-dashboard label rendered above the toolbar (REQ-SHELL-004)
+- [ ] 2.8 `onMounted`: register `document.click` listener after `nextTick`; init grid via composable (REQ-SHELL-007)
+- [ ] 2.9 `onBeforeUnmount`: remove listener; destroy grid (REQ-SHELL-007)
+
+## 3. Styles
+
+- [ ] 3.1 Add `src/styles/workspace.css` (or extend existing) with the four-region layout
+- [ ] 3.2 Style the fixed sidebar backdrop (`position: fixed; top: 50px; bottom: 0; left: 0; right: 0;`)
+- [ ] 3.3 Style the empty-state container inside the grid area
+
+## 4. Tests
+
+- [ ] 4.1 Playwright: admin sees toolbar regardless of `dashboardSource`
+- [ ] 4.2 Playwright: non-admin viewing a group dashboard does NOT see toolbar; grid is in `staticGrid: true` mode
+- [ ] 4.3 Playwright: non-admin viewing own personal dashboard sees toolbar; grid is editable
+- [ ] 4.4 Playwright: hamburger toggles sidebar; backdrop click closes it; click on the sidebar itself does not close it
+- [ ] 4.5 Playwright: empty state renders the correct CTA for both `allowUserDashboards: true` and `false`
+- [ ] 4.6 Playwright: Save button disabled while in flight; no double-submit fires
+- [ ] 4.7 Vitest: `onBeforeUnmount` removes the `document.click` listener and destroys the GridStack instance
+
+## 5. Quality
+
+- [ ] 5.1 ESLint + Stylelint clean on all touched Vue/JS/CSS files
+- [ ] 5.2 PHPCS clean on `templates/index.php` and `lib/Controller/WorkspaceController.php`
+- [ ] 5.3 Translation entries (`nl` + `en`) for all toolbar / empty-state strings per the i18n requirement
+- [ ] 5.4 SPDX headers inside the docblock on every touched/new PHP file
+- [ ] 5.5 Run all 10 `hydra-gates` locally before opening PR

--- a/openspec/changes/svg-sanitisation/proposal.md
+++ b/openspec/changes/svg-sanitisation/proposal.md
@@ -1,0 +1,45 @@
+# SVG sanitisation
+
+## Why
+
+SVG is the only upload type accepted by `resource-uploads` (REQ-RES-001) that can carry executable payloads — `<script>` elements, `<foreignObject>` with embedded HTML/JS, `on*=` event handlers, `javascript:` URLs, and `expression()` style values are all valid in the SVG spec but become stored XSS the moment a sanitised-looking SVG is rendered back into a logged-in user's browser. PNG/GIF/WebP have no executable surface; SVG does. Without server-side sanitisation any user with upload rights can plant a payload that fires for every viewer of the dashboard widget that references the resource.
+
+The frontend already uses DOMPurify for the text widget but that runs client-side and can be bypassed by talking to the API directly. The fix has to live on the server, in the upload pipeline, and it has to be conservative — failing closed when in doubt — because every persisted byte gets handed back to other users' browsers.
+
+## What Changes
+
+- Add `lib/Service/SvgSanitiser.php` exposing `sanitize(string $bytes): ?string` — DOM-based whitelist sanitiser parsing via `DOMDocument::loadXML($bytes, LIBXML_NONET | LIBXML_NOENT)` so the parser can never fetch external entities (XXE) or follow network references.
+- Whitelist 24 element types (geometry + structure + decoration); explicitly exclude `<script>`, `<foreignObject>`, `<iframe>`, `<embed>`, `<object>`.
+- Whitelist 50 attribute types (geometry, styling, transform, gradient, href). Strip every other attribute.
+- Strip ALL `on*` attributes regardless of whitelist (defence in depth — even if a future whitelist edit accidentally added one).
+- Filter `href`/`xlink:href`: reject lowercased trimmed values starting with `javascript:` or `data:`.
+- Filter `style` attribute: remove if value (lowercased) contains `expression(`, `javascript:`, or `url(data:`.
+- Wire `SvgSanitiser::sanitize()` into `ResourceService::upload()` for the SVG branch — runs BEFORE the size check so the 5 MB cap (REQ-RES-003) is measured against the persisted (sanitised) byte count, not the original.
+- Sanitised bytes (NOT the original) get persisted; null return surfaces HTTP 400 `{status:'error', error:'invalid_svg'}` and no file is written.
+- Capability `resource-uploads` gains REQ-RES-009..013 (kept distinct from REQ-RES-001..005 in the foundation change and REQ-RES-006..008 in `resource-serving`).
+
+## Impact
+
+**Affected code:**
+
+- `lib/Service/SvgSanitiser.php` — NEW. Pure service, no Nextcloud dependencies, single public method `sanitize(string $bytes): ?string`. Whitelists are private static const arrays.
+- `lib/Service/ResourceService.php` — call `SvgSanitiser::sanitize($bytes)` for SVG type; on null throw `InvalidSvgException`; persist sanitised bytes; size check moves to AFTER sanitisation
+- `lib/Exception/InvalidSvgException.php` — NEW. Mapped to HTTP 400 `{status:'error', error:'invalid_svg'}` in `ResourceController`.
+- `lib/Controller/ResourceController.php` — catch `InvalidSvgException` and return 400 JSON
+- Modifies `resource-uploads` capability (no other capability touched)
+
+**Affected APIs:**
+
+- `POST /api/resources` — new error mode `400 invalid_svg` for malformed or fully-stripped SVG
+- No new routes; no breaking changes to existing success path
+- Persisted SVG bytes may differ from uploaded bytes (clients should not assume byte-equality between upload and download)
+
+**Dependencies:**
+
+- PHP `ext-dom` and `ext-libxml` (already required by Nextcloud core) — no new composer or npm packages
+- The whitelist is conservative on purpose; adding a new element/attribute is a deliberate code change with a security review checkbox documented in CONTRIBUTING.md
+
+**Migration:**
+
+- Zero schema impact. Existing on-disk SVGs are not retroactively sanitised — they predate this change and remain as-is. A separate one-shot OCC command to re-sanitise existing files is intentionally out of scope (operator-driven, not a code migration).
+- Frontend separately uses DOMPurify for the text widget — different surface, different threat model. We could unify on a single sanitiser later but it is not blocking this change.

--- a/openspec/changes/svg-sanitisation/specs/resource-uploads/spec.md
+++ b/openspec/changes/svg-sanitisation/specs/resource-uploads/spec.md
@@ -1,0 +1,163 @@
+---
+capability: resource-uploads
+delta: true
+status: draft
+---
+
+# Resource Uploads — Delta from change `svg-sanitisation`
+
+## ADDED Requirements
+
+### Requirement: SVG sanitiser is mandatory before persistence (REQ-RES-009)
+
+The system MUST pass every uploaded SVG (declared `image/svg` or `image/svg+xml`) through `SvgSanitiser::sanitize(string $bytes): ?string` before any persistence. The sanitiser MUST return the sanitised SVG string on success OR `null` on parse failure / fully-stripped content. When `null` is returned, `ResourceService` MUST reject the upload with HTTP 400 `{status: 'error', error: 'invalid_svg'}` and MUST NOT write any file. The sanitised bytes (NOT the original) MUST be what gets persisted. Size validation (REQ-RES-003) MUST run AFTER sanitisation so the measured size is the persisted size.
+
+#### Scenario: Clean SVG accepted
+
+- GIVEN a logged-in user "alice"
+- WHEN she sends `POST /api/resources` with body `{"base64": "data:image/svg+xml;base64,<valid sanitisable SVG>"}`
+- THEN the sanitiser MUST return the (possibly modified) SVG string
+- AND `ResourceService` MUST persist the sanitised bytes (NOT the original bytes)
+- AND the response MUST be HTTP 200 with `{status: 'success', url: '/apps/mydash/resource/resource_<uniqid>.svg', ...}`
+
+#### Scenario: Sanitiser strips malicious content but accepts upload
+
+- GIVEN a logged-in user "alice"
+- WHEN she sends `POST /api/resources` with an SVG containing `<script>alert(1)</script><circle r="5"/>`
+- THEN the sanitiser MUST strip the `<script>` element
+- AND the upload MUST proceed with HTTP 200
+- AND the persisted SVG MUST NOT contain `<script>` or `alert`
+- NOTE: the sanitiser strips disallowed elements rather than failing; failure (`null`) is reserved for unparseable XML
+
+#### Scenario: Unparseable bytes rejected
+
+- GIVEN a logged-in user "alice"
+- WHEN she sends `POST /api/resources` with body `{"base64": "data:image/svg+xml;base64,<garbage non-XML>"}`
+- THEN `SvgSanitiser::sanitize` MUST return `null`
+- AND the system MUST return HTTP 400 with body `{status: 'error', error: 'invalid_svg'}`
+- AND no file MUST be written to disk
+
+#### Scenario: Size cap measured after sanitisation
+
+- GIVEN an SVG whose original byte length is 5.5 MB (over the REQ-RES-003 5 MB cap) but whose sanitised length is 4.5 MB after stripping disallowed elements
+- WHEN the upload is processed
+- THEN size validation MUST run on the 4.5 MB sanitised payload
+- AND the upload MUST succeed (HTTP 200)
+
+### Requirement: Whitelist of allowed SVG elements (REQ-RES-010)
+
+The sanitiser MUST allow ONLY these element names (lowercase): `svg`, `g`, `path`, `rect`, `circle`, `ellipse`, `line`, `polyline`, `polygon`, `text`, `tspan`, `defs`, `clippath`, `use`, `image`, `style`, `lineargradient`, `radialgradient`, `stop`, `mask`, `pattern`, `symbol`, `title`, `desc`. Any other element (including `script`, `foreignObject`, `iframe`, `embed`, `object`) MUST be removed from the parsed DOM tree (along with all its children) before serialisation.
+
+#### Scenario: script element removed
+
+- GIVEN input `<svg xmlns="http://www.w3.org/2000/svg"><script>alert(1)</script><circle r="5"/></svg>`
+- WHEN the sanitiser processes the input
+- THEN the output MUST contain `<circle r="5"/>` (or equivalent serialisation)
+- AND the output MUST NOT contain `<script>` OR the substring `alert`
+
+#### Scenario: foreignObject and nested iframe removed
+
+- GIVEN input contains `<foreignObject><iframe src="http://attacker"/></foreignObject>` inside an `<svg>` root
+- WHEN the sanitiser processes the input
+- THEN both `<foreignObject>` and the nested `<iframe>` MUST be removed
+- AND the output MUST NOT contain the substring `attacker`
+
+#### Scenario: Whitelisted elements preserved with their structure
+
+- GIVEN input is a complex SVG containing `<g>`, `<path>`, `<defs>`, `<lineargradient>`
+- WHEN the sanitiser processes the input
+- THEN all four elements MUST remain in the output (modulo attribute filtering per REQ-RES-011)
+- AND parent-child relationships MUST be preserved
+
+### Requirement: Whitelist of allowed SVG attributes (REQ-RES-011)
+
+The sanitiser MUST allow ONLY these attribute names (lowercase): `id`, `class`, `style`, `d`, `x`, `y`, `x1`, `y1`, `x2`, `y2`, `cx`, `cy`, `r`, `rx`, `ry`, `width`, `height`, `viewbox`, `fill`, `stroke`, `stroke-width`, `stroke-linecap`, `stroke-linejoin`, `stroke-dasharray`, `stroke-dashoffset`, `stroke-opacity`, `fill-opacity`, `opacity`, `transform`, `points`, `font-size`, `font-family`, `font-weight`, `text-anchor`, `dominant-baseline`, `dx`, `dy`, `clip-path`, `mask`, `filter`, `gradientunits`, `gradienttransform`, `offset`, `stop-color`, `stop-opacity`, `patternunits`, `preserveaspectratio`, `xmlns`, `xmlns:xlink`, `version`, `href`, `xlink:href`. Any other attribute MUST be removed from each element regardless of element name.
+
+In addition (defence in depth), ALL attributes whose lowercased name starts with `on` MUST be removed unconditionally — even if a future whitelist edit accidentally allowed an `on*` name.
+
+#### Scenario: Event-handler attributes always stripped
+
+- GIVEN input `<circle onclick="alert(1)" onload="x()" r="5"/>`
+- WHEN the sanitiser processes the input
+- THEN the output `<circle>` MUST NOT carry `onclick` OR `onload`
+- AND `r="5"` MUST be preserved on the same element
+
+#### Scenario: Non-whitelisted attribute stripped
+
+- GIVEN input `<circle data-payload="x" r="5"/>`
+- WHEN the sanitiser processes the input
+- THEN the `data-payload` attribute MUST be removed
+- AND `r="5"` MUST remain
+
+#### Scenario: Whitelisted geometry attributes preserved
+
+- GIVEN input `<rect x="10" y="20" width="100" height="50" fill="red" stroke="black"/>`
+- WHEN the sanitiser processes the input
+- THEN all six attributes MUST remain on the output element
+
+### Requirement: URL-bearing attributes filtered (REQ-RES-012)
+
+For attributes `href` and `xlink:href`, the sanitiser MUST reject values whose lowercased trimmed prefix matches `javascript:` OR `data:`. Rejected attributes MUST be removed (the rest of the element is preserved). For the `style` attribute, the sanitiser MUST remove the attribute entirely if its value (lowercased) contains any of: `expression(`, `javascript:`, `url(data:`.
+
+#### Scenario: javascript: href stripped
+
+- GIVEN input `<use xlink:href="javascript:alert(1)"/>` (where `<use>` is in the element whitelist)
+- WHEN the sanitiser processes the input
+- THEN the `xlink:href` attribute MUST be removed
+- AND the `<use>` element MUST remain (with no `xlink:href`)
+
+#### Scenario: data: href stripped
+
+- GIVEN input `<image href="data:image/svg+xml;base64,..."/>`
+- WHEN the sanitiser processes the input
+- THEN the `href` attribute MUST be removed
+- AND the `<image>` element MUST remain
+- NOTE: an `<image>` with no `href` renders nothing — acceptable
+
+#### Scenario: style with expression() stripped
+
+- GIVEN input `<rect style="width: expression(alert(1))" width="10" height="10"/>`
+- WHEN the sanitiser processes the input
+- THEN the `style` attribute MUST be removed entirely
+- AND `width="10"` and `height="10"` MUST remain
+
+#### Scenario: style with url(data:) stripped
+
+- GIVEN input `<g style="background: url(data:text/html,<script>alert(1)</script>)"><path d="M0 0"/></g>`
+- WHEN the sanitiser processes the input
+- THEN the `style` attribute MUST be removed entirely
+- AND the `<g>` and child `<path>` MUST remain
+
+#### Scenario: Safe http(s) href preserved
+
+- GIVEN input `<image href="https://example.com/logo.png"/>`
+- WHEN the sanitiser processes the input
+- THEN `href="https://example.com/logo.png"` MUST remain unchanged
+- NOTE: only `javascript:` and `data:` prefixes are filtered; http/https/relative URLs pass through
+
+### Requirement: XXE and network-fetch protection (REQ-RES-013)
+
+The sanitiser MUST parse SVG via `DOMDocument::loadXML($bytes, LIBXML_NONET | LIBXML_NOENT)`. The `LIBXML_NONET` flag MUST be set so the parser cannot fetch external entities or DTDs. The `LIBXML_NOENT` flag substitutes entities so they do not amplify recursively. The sanitiser MUST call `libxml_use_internal_errors(true)` BEFORE the parse and `libxml_clear_errors()` AFTER, to prevent malformed SVG from emitting libxml warnings into the HTTP response.
+
+#### Scenario: External DTD reference does not fetch
+
+- GIVEN input declares an external DTD reference (e.g. `<!DOCTYPE svg SYSTEM "http://attacker/evil.dtd">` followed by an SVG body)
+- WHEN the sanitiser parses the input
+- THEN no network request MUST be issued for `http://attacker/evil.dtd`
+- AND parsing MUST proceed without fetching the DTD
+
+#### Scenario: Billion-laughs entity expansion bounded
+
+- GIVEN input declares nested entities expanding exponentially (XML billion-laughs payload)
+- WHEN the sanitiser parses the input
+- THEN the parser MUST NOT exhaust memory
+- AND the call MUST return within a bounded time
+- NOTE: `LIBXML_NOENT` substitutes entities once but libxml has internal expansion limits that protect against billion-laughs in modern PHP/libxml — verified in tests
+
+#### Scenario: libxml warnings are suppressed from response
+
+- GIVEN input is malformed XML that triggers libxml parse warnings
+- WHEN the sanitiser processes the input
+- THEN `libxml_use_internal_errors(true)` MUST have been called before parse
+- AND `libxml_clear_errors()` MUST have been called after parse
+- AND no libxml warning text MUST appear in the HTTP response body

--- a/openspec/changes/svg-sanitisation/tasks.md
+++ b/openspec/changes/svg-sanitisation/tasks.md
@@ -1,0 +1,60 @@
+# Tasks — svg-sanitisation
+
+## 1. Sanitiser service
+
+- [ ] 1.1 Create `lib/Service/SvgSanitiser.php` with public method `sanitize(string $bytes): ?string`
+- [ ] 1.2 Define private static const `ALLOWED_ELEMENTS` containing the 24 element names from REQ-RES-010 (lowercase)
+- [ ] 1.3 Define private static const `ALLOWED_ATTRIBUTES` containing the 50 attribute names from REQ-RES-011 (lowercase)
+- [ ] 1.4 Call `libxml_use_internal_errors(true)` BEFORE parse and `libxml_clear_errors()` AFTER per REQ-RES-013
+- [ ] 1.5 Parse via `DOMDocument::loadXML($bytes, LIBXML_NONET | LIBXML_NOENT)`; return `null` on parse failure
+- [ ] 1.6 Walk the DOM recursively; snapshot the child node list BEFORE mutation so removals are safe during iteration
+- [ ] 1.7 Remove any element whose lowercased localName is not in `ALLOWED_ELEMENTS` (along with its children)
+- [ ] 1.8 Remove any attribute whose lowercased name is not in `ALLOWED_ATTRIBUTES`
+- [ ] 1.9 Strip ALL attributes whose lowercased name starts with `on` regardless of whitelist (REQ-RES-011 defence in depth)
+- [ ] 1.10 Filter `href` and `xlink:href`: trim + lowercase + reject `javascript:` / `data:` prefixes (REQ-RES-012)
+- [ ] 1.11 Filter `style`: regex `/expression\s*\(|javascript\s*:|url\s*\(\s*["\']?\s*data\s*:/i` — full attribute removal on match
+- [ ] 1.12 Serialise back via `DOMDocument::saveXML($root)`; return `null` if result is empty or has no root element
+- [ ] 1.13 Document the whitelist policy in the class docblock with a link to REQ-RES-010 / REQ-RES-011
+
+## 2. Exception + controller wiring
+
+- [ ] 2.1 Create `lib/Exception/InvalidSvgException.php` extending `\RuntimeException`
+- [ ] 2.2 In `lib/Service/ResourceService.php::upload()` detect SVG MIME (`image/svg` or `image/svg+xml`) BEFORE the size check
+- [ ] 2.3 For SVG branch: call `SvgSanitiser::sanitize($bytes)`; on `null` throw `InvalidSvgException`; otherwise replace `$bytes` with the sanitised string
+- [ ] 2.4 Run the existing REQ-RES-003 size check AFTER sanitisation so the 5 MB cap measures the persisted bytes
+- [ ] 2.5 In `lib/Controller/ResourceController.php` catch `InvalidSvgException` and return `JSONResponse(['status'=>'error','error'=>'invalid_svg'], Http::STATUS_BAD_REQUEST)`
+- [ ] 2.6 Confirm no file is written when the exception is thrown (filesystem write happens AFTER sanitiser returns non-null)
+
+## 3. PHPUnit tests — sanitiser unit
+
+- [ ] 3.1 Clean SVG round-trips with semantically equivalent output (whitespace differences allowed)
+- [ ] 3.2 `<script>` element removed
+- [ ] 3.3 `<foreignObject>` and any nested `<iframe>` removed
+- [ ] 3.4 Every `on*` attribute (`onclick`, `onload`, `onmouseover`, `onfocus`) stripped
+- [ ] 3.5 `javascript:` href stripped from `xlink:href`
+- [ ] 3.6 `data:` href stripped from `href` on `<image>`
+- [ ] 3.7 `expression(...)` style attribute stripped entirely
+- [ ] 3.8 `url(data:...)` style attribute stripped entirely
+- [ ] 3.9 Safe `https://` `href` preserved unchanged
+- [ ] 3.10 Whitelisted geometry attributes (`x`, `y`, `width`, `height`, `fill`, `stroke`) preserved on `<rect>`
+- [ ] 3.11 Non-whitelisted `data-*` attribute stripped
+- [ ] 3.12 External DTD reference does not trigger network fetch (assert via libxml error capture, no real network)
+- [ ] 3.13 Billion-laughs payload returns within bounded time and does not exhaust memory (PHPUnit time-limited test)
+- [ ] 3.14 Unparseable bytes (`"<not xml"`) → `null`
+- [ ] 3.15 Empty string → `null`
+
+## 4. PHPUnit tests — integration
+
+- [ ] 4.1 `POST /api/resources` with malicious SVG containing `<script>` → HTTP 200 (script stripped) and persisted bytes do not contain `<script>`
+- [ ] 4.2 `POST /api/resources` with garbage non-XML payload → HTTP 400 `{error:'invalid_svg'}` and no file on disk
+- [ ] 4.3 `POST /api/resources` with 5.5 MB SVG that sanitises down to 4.5 MB → HTTP 200 (size check measured after sanitisation per REQ-RES-009)
+- [ ] 4.4 `POST /api/resources` with 4.9 MB SVG that sanitises down to 4.8 MB → HTTP 200 (well under cap)
+- [ ] 4.5 Round-trip: upload sanitised SVG, then `GET /apps/mydash/resource/...` returns the sanitised bytes (NOT the original)
+
+## 5. Quality gates
+
+- [ ] 5.1 `composer check:strict` (PHPCS, PHPMD, Psalm, PHPStan) passes — fix any pre-existing issues touched along the way
+- [ ] 5.2 SPDX header (`SPDX-License-Identifier` + `SPDX-FileCopyrightText`) inside the main file docblock on every new PHP file — gate-spdx must pass
+- [ ] 5.3 Translation entry for `invalid_svg` error message in both `nl` and `en` per the i18n requirement
+- [ ] 5.4 Add a "Security review required when extending the SVG whitelist" note to `CONTRIBUTING.md` referencing REQ-RES-010 / REQ-RES-011
+- [ ] 5.5 Run all 10 `hydra-gates` locally before opening PR

--- a/openspec/changes/text-display-widget/design.md
+++ b/openspec/changes/text-display-widget/design.md
@@ -1,0 +1,115 @@
+# Design — text-display-widget
+
+## Context
+
+MyDash widget placements today are bound to widgets discovered via Nextcloud's `IManager::getWidgets()` (see `widgets` capability) — every placement points at a registered Nextcloud dashboard widget by id and renders whatever that widget callback emits. There is no first-class concept of an "annotation" widget: a static, user-authored block of text the user can drop on a dashboard to label a section, leave instructions, list contact details, or call out an important note.
+
+Customers have asked for this repeatedly. Workarounds (using a tile with a long title, or a custom HTML widget shipped from another app) are awkward and don't survive theming. The right primitive is a built-in MyDash widget type whose entire content lives in the placement record's `styleConfig` JSON, with no external widget callback.
+
+This change introduces that primitive as a new widget type `text` and a new capability `text-display-widget`. The capability is intentionally narrow — one widget type, one renderer, one sub-form, one registry entry — so it can be evolved or deprecated independently of the broader widget-rendering machinery.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Ship a `text` widget type that renders multi-line user-authored text with limited HTML formatting.
+- Sanitise rendered HTML via DOMPurify so authors can use `<b>`, `<i>`, `<a>`, `<br>`, `<p>`, `<ul>`, `<li>` without opening an XSS hole.
+- Provide inline style controls (font size, text colour, background colour, alignment) so the widget integrates visually with surrounding theming.
+- Default to theme-aware values (`var(--color-main-text)`, transparent background) so the widget looks correct out-of-the-box in light, dark, and admin-themed Nextcloud instances.
+- Keep the widget type self-contained — no new database tables, no new backend services, no new API endpoints. The persisted content lives in the existing `oc_mydash_widget_placements.styleConfig` JSON column.
+
+**Non-Goals:**
+
+- A WYSIWYG / rich-text editor — the textarea accepts raw HTML; a rich editor is a possible later enhancement but out of scope here.
+- Markdown support — would conflict with HTML pass-through and require a second sanitisation path. Future change if demanded.
+- Server-side sanitisation — sanitisation is client-side at render time. Backend stores whatever the user submitted (after the existing styleConfig validation). Rationale: the same content might be rendered in other contexts later (export, print) where the sanitisation rules differ; storing raw lets the renderer decide.
+- A typed font-size picker (rem/em/px dropdown) — the free-form text input intentionally allows any CSS length, including `1.2em`, `clamp(0.8rem, 2vw, 2rem)`, etc.
+- Cross-widget templating, variable interpolation, or live data binding — text is static.
+- Per-locale text variants — the user authors one body of text; localisation is the user's responsibility.
+
+## Decisions
+
+### D1: Use `v-html` with DOMPurify rather than a sandboxed iframe
+
+**Decision**: Render via `<div v-html="DOMPurify.sanitize(text)">` directly inside the widget cell.
+
+**Alternatives considered:**
+
+- Render the user content inside a sandboxed `<iframe sandbox>`. Rejected because (a) iframes break theme variable inheritance — the user's text would not pick up `var(--color-main-text)` etc. unless we manually rehydrate every CSS variable, and (b) iframes add layout overhead (separate document, scrollbar, focus trap) that fights GridStack's resize behaviour.
+- Render only as escaped plain text (no HTML at all). Rejected because it removes the most-requested affordance — the ability to bold a word or add a link inside an annotation.
+- Render via a markdown library. Rejected per Non-Goals — would force a parallel pipeline and a markdown ↔ HTML round-trip whenever the user edits.
+
+**Rationale**: DOMPurify is the de facto sanitiser for client-side HTML in browsers — Mozilla Observatory recommends it, the OpenCatalogi app already uses it for catalog descriptions, and it ships a single ~20KB minified bundle. The trade-off (deliberate use of `v-html`) is acknowledged in the proposal and validated by the renderer test that asserts `<script>` and `on*` are stripped.
+
+### D2: Persist content in the existing `styleConfig` JSON column
+
+**Decision**: The widget's content lives at `oc_mydash_widget_placements.styleConfig` as `{type: 'text', content: {...}}`. No schema migration.
+
+**Alternatives considered:**
+
+- Add a dedicated `oc_mydash_text_widgets` table keyed by placement id. Rejected because it (a) requires a new mapper, service, and JOIN on every placement read, and (b) hardcodes one widget type into the schema — inconsistent with how other potential built-in widget types (e.g. spacer, separator, image) would land later.
+- Add a generic `content TEXT NULL` column to `widget_placements`. Rejected because `styleConfig` already exists as the catch-all per-widget-type JSON blob (see `widgets` capability data model). Adding a parallel column would be redundant.
+
+**Rationale**: `styleConfig` is the right place — it is already the per-placement extension point, already JSON-serialisable, already round-trips through the existing CRUD endpoints. Other built-in widget types added later can use the same `{type, content}` envelope to discriminate.
+
+### D3: Free-form `fontSize` text input rather than a typed picker
+
+**Decision**: Render `<input type="text" placeholder="14px">` for fontSize; pass the value through verbatim into the inline style.
+
+**Alternatives considered:**
+
+- Number input + unit dropdown (px/em/rem). Rejected because it cannot express `clamp(...)` or `min(...)` and forces a discrete-unit model that's poorer than CSS.
+- Slider 8–48 px. Rejected for the same reason — discrete, px-locked.
+
+**Rationale**: Power-users want CSS expressiveness; novice users see the placeholder `14px` and can type `16px` or `large`. The inline style passes any string the browser will accept. The renderer falls back to `14px` when the field is empty, so a blank value never produces a broken widget.
+
+### D4: Default colours via Nextcloud theme variables
+
+**Decision**: When `color` or `backgroundColor` is empty, use `var(--color-main-text)` and `transparent` respectively. Never hardcode `#000000` or `#ffffff`.
+
+**Alternatives considered:**
+
+- Hardcode black-on-white defaults. Rejected because the widget would look wrong in the dark theme and in admin-themed instances.
+
+**Rationale**: Theme-aware defaults make the widget invisible-by-design when the user adds it without configuring colours — it inherits the surrounding dashboard look. Explicit colour values still win when the user picks them, so customisation works the same.
+
+### D5: Empty `text` shows a localised italic placeholder, not a hidden widget
+
+**Decision**: When `text.trim() === ''`, render an italic `t('mydash', 'No text content')` in `var(--color-text-maxcontrast)`. The wrapper still occupies 100% of the cell.
+
+**Alternatives considered:**
+
+- Render nothing (empty cell). Rejected because the widget is then invisible — users who add it then forget to fill it in have no signal that anything is there, and the cell is not a drop target hint.
+- Show a default "Edit me" string. Rejected because that string would persist into screenshots and exports if the user never edits — a placeholder must look obviously like a placeholder.
+
+**Rationale**: Italic + low-contrast colour reads instantly as "empty state", matches the convention used elsewhere in MyDash (empty-tile placeholder), and keeps the cell as a valid GridStack drop target.
+
+### D6: Sub-form `validate()` returns array of errors, modal-controlled disabling
+
+**Decision**: The sub-form exposes a `validate(): string[]` method matching the existing AddWidgetModal contract — returns `[]` when valid, otherwise an array of localised error strings. The modal uses array length to enable/disable its primary button.
+
+**Alternatives considered:**
+
+- Boolean `isValid()`. Rejected because the modal cannot then surface the specific reason ("Text is required") to the user.
+- Vuelidate / Vee-Validate. Rejected because the rest of the codebase uses the simple array-of-strings pattern; a new validation library would be inconsistent.
+
+**Rationale**: Matches the existing pattern (REQ-WDG-010 / REQ-WDG-012 in the `widgets` capability). One method, one return shape, easy to test in isolation.
+
+## Risks / Trade-offs
+
+| Risk | Mitigation |
+|---|---|
+| `v-html` is a Vue anti-pattern in general — reviewers may flag it | Sanitisation is mandatory and tested; the use is documented in the spec scenarios; a non-sanitising fallback is impossible to ship because a Vitest test asserts script stripping |
+| DOMPurify version drift could regress sanitisation (rare but happened in 2024 with ALLOWED_URI_REGEXP changes) | Pin to `^3.x` in package.json; tests assert specific dangerous patterns (`<script>`, `onclick`, `javascript:`) are stripped — a regression breaks CI |
+| Free-form fontSize lets users type bad CSS (`fontsize: 99999px`, `red`) | Browser silently ignores invalid values; worst case is the wrapper renders at the default — no security or layout-corruption risk |
+| Bundle size: DOMPurify adds ~20KB minified | Acceptable — only loads when at least one text widget is on the dashboard; lazy-loaded with the renderer chunk |
+| Free-form HTML invites users to paste arbitrary `<style>` or `<link>` tags that could affect dashboard layout | DOMPurify default config strips `<style>` and `<link>` — confirmed in the test suite |
+
+## Migration
+
+No data migration. The `styleConfig` column already exists; existing placements continue to work unchanged. New `text`-type placements simply use a new shape inside that JSON column.
+
+## Open Questions
+
+- Should the renderer support a target=_blank affordance for links? DOMPurify's default config preserves `<a target>` but the surrounding modal does not yet have a "open links in new tab" toggle. Out of scope here; can land in a follow-up.
+- Should the sub-form offer a small set of preset themes (e.g. "Warning", "Info", "Success") that prefill colour + background combos? Out of scope; user demand will tell us.

--- a/openspec/changes/text-display-widget/proposal.md
+++ b/openspec/changes/text-display-widget/proposal.md
@@ -1,0 +1,27 @@
+# Text-display widget
+
+A new widget type `text` that renders multi-line text content with HTML allowed (sanitised via DOMPurify). Supports inline styling controls (font size, colour, background, alignment) for ad-hoc dashboard annotations, instructions, or callouts.
+
+## Affected code units
+
+- `src/components/Widgets/Renderers/TextDisplayWidget.vue` — renderer
+- `src/components/Widgets/Forms/TextDisplayForm.vue` — sub-form for AddWidgetModal
+- `src/constants/widgetRegistry.js` — register `type: 'text'`
+- New capability `text-display-widget`
+
+## Why a new capability
+
+Each widget type is a stable feature contract with its own persisted content schema, validation, defaults, and renderer. Co-locating these in a per-widget capability makes the type easy to evolve, test, and document independently.
+
+## Approach
+
+- Persisted shape: `{type: 'text', content: {text, fontSize, color, backgroundColor, textAlign}}` inside a widget placement record.
+- Renderer wraps `<div v-html="DOMPurify.sanitize(text)">` — explicitly allows HTML so users can use `<b>`, `<a>`, etc.
+- Sub-form: textarea (4 rows) + font-size text input + colour pickers + alignment select.
+- Defaults: `fontSize: '14px'`, `textAlign: 'left'`, `color`/`backgroundColor` inherit theme variables.
+- Validation: `text` MUST be non-empty.
+
+## Notes
+
+- Use of `v-html` is the deliberate trade-off — without it the widget can't render formatted text. DOMPurify mitigates XSS.
+- Free-form `fontSize` text input is intentional (allows `1.2em`, `clamp(...)`, etc.) — could be replaced with a typed picker later.

--- a/openspec/changes/text-display-widget/specs/text-display-widget/spec.md
+++ b/openspec/changes/text-display-widget/specs/text-display-widget/spec.md
@@ -1,0 +1,157 @@
+---
+capability: text-display-widget
+delta: true
+status: draft
+---
+
+# Text-Display Widget — Delta from change `text-display-widget`
+
+## Purpose
+
+The text-display widget renders user-authored text content inside a dashboard cell, with limited HTML support for inline formatting (bold, italics, links, line breaks). It is the primary "annotation" widget — useful for section captions, instructions, contact details, callouts.
+
+## Data Model
+
+The widget's persisted content lives in `oc_mydash_widget_placements.styleConfig` (JSON blob), as an object of shape:
+
+```jsonc
+{
+  "type": "text",
+  "content": {
+    "text": "string (required, may contain HTML)",
+    "fontSize": "string (CSS length, default '14px')",
+    "color": "string (CSS colour, default theme variable)",
+    "backgroundColor": "string (CSS colour, default 'transparent')",
+    "textAlign": "'left' | 'center' | 'right' | 'justify' (default 'left')"
+  }
+}
+```
+
+## ADDED Requirements
+
+### Requirement: Widget renders HTML-sanitised content (REQ-TXT-001)
+
+The renderer MUST run `text` through `DOMPurify.sanitize` before injecting into the DOM via `v-html`. Tags and attributes that pose XSS risk (`<script>`, `on*` handlers, `javascript:` URLs) MUST be stripped. Common formatting tags (`<b>`, `<i>`, `<a>`, `<br>`, `<p>`, `<ul>`, `<li>`) MUST be preserved.
+
+#### Scenario: Allow safe formatting
+
+- GIVEN content `text = "Hello <b>world</b>"`
+- WHEN the widget renders
+- THEN the DOM MUST contain `<b>world</b>` exactly
+- AND the visual output MUST show "world" in bold
+
+#### Scenario: Strip script tag
+
+- GIVEN content `text = "Click <script>alert(1)</script> me"`
+- WHEN the widget renders
+- THEN the DOM MUST NOT contain a `<script>` element
+- AND the visible text MUST be "Click  me" (or equivalent — sanitisation strips the tag and contents)
+
+#### Scenario: Strip event handler attribute
+
+- GIVEN content `text = '<a href="x" onclick="alert(1)">x</a>'`
+- WHEN the widget renders
+- THEN the rendered `<a>` element MUST NOT have an `onclick` attribute
+- AND the `href="x"` attribute MUST be preserved
+
+#### Scenario: Strip javascript: URL
+
+- GIVEN content `text = '<a href="javascript:alert(1)">x</a>'`
+- WHEN the widget renders
+- THEN the rendered `<a>` element MUST NOT have an `href` attribute starting with `javascript:`
+
+### Requirement: Style application with theme-aware fallbacks (REQ-TXT-002)
+
+The renderer MUST apply `fontSize`, `color`, `backgroundColor`, and `textAlign` from `content` as inline styles on the wrapper element. When a field is null or empty, the renderer MUST fall back to: `fontSize='14px'`, `color='var(--color-main-text)'`, `backgroundColor='transparent'`, `textAlign='left'`.
+
+#### Scenario: Custom font size and colour
+
+- GIVEN `content = {text: 'X', fontSize: '24px', color: '#ff0000'}`
+- WHEN the widget renders
+- THEN the wrapper element's inline style MUST include `font-size: 24px` and `color: #ff0000`
+- AND `background-color` MUST resolve to `transparent`
+- AND `text-align` MUST resolve to `left`
+
+#### Scenario: Theme-aware default colour
+
+- GIVEN `content = {text: 'X', color: ''}`
+- WHEN the widget renders
+- THEN the wrapper's CSS `color` MUST be `var(--color-main-text)` (Nextcloud theme variable, adapts to light/dark mode)
+
+#### Scenario: Free-form font size accepted
+
+- GIVEN `content = {text: 'X', fontSize: '1.2em'}`
+- WHEN the widget renders
+- THEN the wrapper element's inline style MUST include `font-size: 1.2em` verbatim
+- AND the renderer MUST NOT reject or coerce non-px units
+
+### Requirement: Empty-content placeholder (REQ-TXT-003)
+
+When `text` is empty, missing, or whitespace-only, the renderer MUST display an italic translated placeholder `t('mydash', 'No text content')` in `var(--color-text-maxcontrast)` colour. The wrapper MUST still occupy the full cell so the widget remains a valid drop target.
+
+#### Scenario: Empty content shows placeholder
+
+- GIVEN `content = {text: ''}`
+- WHEN the widget renders
+- THEN the visible text MUST be the localised value of `t('mydash', 'No text content')`
+- AND the placeholder text MUST be styled `font-style: italic` with `color: var(--color-text-maxcontrast)`
+- AND the wrapper MUST fill the cell with `width: 100%; height: 100%`
+
+#### Scenario: Whitespace-only content treated as empty
+
+- GIVEN `content = {text: '   \n  '}`
+- WHEN the widget renders
+- THEN the placeholder MUST be shown (whitespace does not count as content)
+
+### Requirement: Add/edit sub-form for AddWidgetModal (REQ-TXT-004)
+
+The text sub-form for `AddWidgetModal` MUST expose these controls and validation rules:
+
+| Field | Control | Required |
+|---|---|---|
+| `text` | `<textarea rows="4">` | yes |
+| `fontSize` | `<input type="text" placeholder="14px">` | no |
+| `color` | `<input type="color">` | no |
+| `backgroundColor` | `<input type="color">` | no |
+| `textAlign` | `<select>` with options `left` / `center` / `right` / `justify` | no |
+
+The component MUST expose a `validate()` method that returns `[t('mydash', 'Text is required')]` when `text.trim() === ''`, and `[]` otherwise. The parent modal disables its `Add` / `Save` button while `validate()` returns a non-empty array.
+
+#### Scenario: Form rejects empty text
+
+- GIVEN the user opens the text sub-form in add mode
+- WHEN they leave the textarea empty and press the modal's Add button
+- THEN `validate()` MUST return a non-empty array containing `t('mydash', 'Text is required')`
+- AND the modal's Add button MUST be disabled
+
+#### Scenario: Form pre-fills in edit mode
+
+- GIVEN the modal opens with `editingWidget = {type: 'text', content: {text: 'Hi', fontSize: '20px', color: '#00ff00'}}`
+- WHEN the sub-form mounts
+- THEN the textarea value MUST equal `'Hi'`
+- AND the font-size input value MUST equal `'20px'`
+- AND the color input value MUST equal `'#00ff00'`
+
+#### Scenario: Form emits content updates reactively
+
+- GIVEN the sub-form is mounted with empty initial content
+- WHEN the user types `Hello` in the textarea
+- THEN the parent modal MUST receive an updated `content.text === 'Hello'` via the standard sub-form contract
+- AND `validate()` MUST now return `[]`
+
+### Requirement: Layout — fill cell with padded scrollable content (REQ-TXT-005)
+
+The widget MUST fill its grid cell (`width: 100%, height: 100%`) with `padding: 16px` and `overflow: auto`. Content MUST be horizontally aligned per `textAlign` and vertically centred when content height is less than cell height (flex centred).
+
+#### Scenario: Overflow scrolls within the cell
+
+- GIVEN `text` is long enough to overflow the cell vertically
+- WHEN the widget renders
+- THEN the wrapper element MUST show a scrollbar (CSS `overflow: auto`)
+- AND content above and below the visible region MUST be reachable by scrolling within the cell
+
+#### Scenario: Short content vertically centred
+
+- GIVEN `text` is a single short line and the cell is much taller than the content
+- WHEN the widget renders
+- THEN the rendered text MUST be vertically centred in the cell

--- a/openspec/changes/text-display-widget/tasks.md
+++ b/openspec/changes/text-display-widget/tasks.md
@@ -1,0 +1,59 @@
+# Tasks — text-display-widget
+
+## 1. Dependencies
+
+- [ ] 1.1 Add `dompurify ^3.x` to `package.json` `dependencies`
+- [ ] 1.2 Run `npm install` and commit `package-lock.json`
+- [ ] 1.3 Verify `dompurify` license is permitted by repo policy (Apache-2.0/MPL-2.0 dual — approved)
+
+## 2. Renderer component
+
+- [ ] 2.1 Create `src/components/Widgets/Renderers/TextDisplayWidget.vue`
+- [ ] 2.2 Compute `sanitizedHtml` via `DOMPurify.sanitize(content.text)` in a Vue computed
+- [ ] 2.3 Emit `<div v-html="sanitizedHtml">` only when `text.trim() !== ''`; otherwise render the placeholder span
+- [ ] 2.4 Apply inline style with theme-variable fallbacks per REQ-TXT-002 (`fontSize=14px`, `color=var(--color-main-text)`, `backgroundColor=transparent`, `textAlign=left`)
+- [ ] 2.5 Wrap in a flex container that fills 100% width / 100% height with `padding: 16px` and `overflow: auto` per REQ-TXT-005
+- [ ] 2.6 Empty-content placeholder uses `t('mydash', 'No text content')`, italic, in `var(--color-text-maxcontrast)`
+
+## 3. Sub-form component
+
+- [ ] 3.1 Create `src/components/Widgets/Forms/TextDisplayForm.vue`
+- [ ] 3.2 Implement props/emit contract matching the existing AddWidgetModal sub-form pattern (props: `editingWidget`; emit: `update:content` on every input)
+- [ ] 3.3 Render textarea (4 rows), text input for fontSize, two `<input type="color">`, and `<select>` for textAlign
+- [ ] 3.4 Pre-fill all five fields from `editingWidget.content` on `mounted()`
+- [ ] 3.5 Expose `validate()` that returns `[t('mydash', 'Text is required')]` when `text.trim() === ''`, otherwise `[]`
+- [ ] 3.6 All labels use translation: `t('mydash', 'Text')`, `t('mydash', 'Font Size')`, `t('mydash', 'Text Color')`, `t('mydash', 'Background Color')`, `t('mydash', 'Alignment')`
+
+## 4. Widget registry
+
+- [ ] 4.1 Add `text` entry to `src/constants/widgetRegistry.js` with `component: TextDisplayWidget`, `form: TextDisplayForm`, `label: t('mydash', 'Text')`
+- [ ] 4.2 Provide defaults `{text: '', fontSize: '14px', color: '', backgroundColor: '', textAlign: 'left'}`
+- [ ] 4.3 Confirm registry entry is consumed by AddWidgetModal's type-picker so `text` appears as a selectable widget type
+
+## 5. i18n
+
+- [ ] 5.1 Add to `l10n/en.json`: `Text`, `No text content`, `Text is required`, `Font Size`, `Text Color`, `Background Color`, `Alignment`
+- [ ] 5.2 Add Dutch equivalents to `l10n/nl.json`: `Tekst`, `Geen tekstinhoud`, `Tekst is verplicht`, `Tekengrootte`, `Tekstkleur`, `Achtergrondkleur`, `Uitlijning`
+- [ ] 5.3 Run the project's i18n extraction script if one exists; verify keys land in both locales
+
+## 6. Vitest unit tests
+
+- [ ] 6.1 `TextDisplayWidget.spec.js` — DOMPurify strips `<script>`, `on*` attributes, and `javascript:` URLs while preserving `<b>`, `<i>`, `<a href>`, `<br>`, `<p>`, `<ul>`, `<li>`
+- [ ] 6.2 `TextDisplayWidget.spec.js` — empty and whitespace-only `text` shows the localised placeholder
+- [ ] 6.3 `TextDisplayWidget.spec.js` — inline style applies provided values verbatim and falls back to theme variables when fields empty
+- [ ] 6.4 `TextDisplayForm.spec.js` — `validate()` returns `[t('mydash', 'Text is required')]` on empty text, `[]` when populated
+- [ ] 6.5 `TextDisplayForm.spec.js` — pre-fills all five fields from `editingWidget.content` on mount
+- [ ] 6.6 `TextDisplayForm.spec.js` — emits `update:content` reactively on each input
+
+## 7. Playwright end-to-end test
+
+- [ ] 7.1 Add a text widget via AddWidgetModal, save, reload page, confirm rendered text matches input
+- [ ] 7.2 Edit the widget (open modal in edit mode), change text and font size, save, confirm new values render
+- [ ] 7.3 Confirm an empty-text widget shows the localised placeholder
+
+## 8. Quality gates
+
+- [ ] 8.1 ESLint clean on all new/touched `.vue` and `.js` files
+- [ ] 8.2 Stylelint clean on inline `<style>` blocks
+- [ ] 8.3 `npm run build` succeeds with no new warnings
+- [ ] 8.4 No new dependencies beyond `dompurify` introduced

--- a/openspec/changes/widget-add-edit-modal/proposal.md
+++ b/openspec/changes/widget-add-edit-modal/proposal.md
@@ -1,0 +1,49 @@
+# Widget add/edit modal
+
+## Why
+
+Today MyDash has separate code paths for "add a widget" (toolbar dropdown → per-type creator) and "edit a widget" (per-widget edit dialogs scattered across the codebase). Both flows duplicate field definitions, validation logic, and modal chrome. Adding a new widget type today means touching at least three places: the toolbar dropdown, the creation flow, and an ad-hoc edit dialog. This change collapses both flows into a single registry-driven modal whose only job is orchestration (open/close, type switch, edit pre-fill, validation routing). Per-type sub-forms become small components owned by their respective widget capabilities, and one frontend registry becomes the single source of truth for "what widget types exist".
+
+## What Changes
+
+- Add a unified `AddWidgetModal.vue` host component that handles both creation and editing flows.
+- Add `useWidgetForm.js` composable exposing `resetForm`, `loadEditingWidget`, `validate`, `assembleContent`.
+- Add `widgetRegistry.js` mapping `type → { component, label, defaults }` for the 5 widget types (`text`, `label`, `image`, `linkButton`, `ncDashboardProxy`); the toolbar dropdown, modal type selector, and grid renderer MUST all consult this registry.
+- Per-type sub-form components (one per widget capability) expose `validate(): string[]`; the modal disables submit when validation returns errors.
+- Modal close triggers: cancel button, backdrop click, `Escape` key — none submit.
+- Type-switch in create mode resets form state (no cross-type field leakage).
+- Edit mode hides the type selector (placement type is immutable) and pre-fills from `editingWidget.content`.
+
+## Capabilities
+
+### New Capabilities
+
+(none — folds into the existing `widgets` capability)
+
+### Modified Capabilities
+
+- `widgets`: extends REQ-WDG-010 (Widget Picker) with modal orchestration semantics, and adds REQ-WDG-012 (per-type validation contract), REQ-WDG-013 (modal close discipline), REQ-WDG-014 (sub-form registry as single source of truth).
+
+## Impact
+
+**Affected code:**
+
+- `src/components/Widgets/AddWidgetModal.vue` — the host modal (new)
+- `src/components/Widgets/forms/<Type>Form.vue` — per-type sub-forms (one per widget capability: TextDisplay, Label, Image, LinkButton, NcDashboardProxy)
+- `src/composables/useWidgetForm.js` — shared validation + submit pipeline (new)
+- `src/constants/widgetRegistry.js` — single registry of widget types (new)
+- `src/components/Toolbar/*` — toolbar dropdown rewired to consume the registry
+- Any existing per-widget edit dialogs are removed in favour of the unified modal
+
+**Affected APIs:**
+
+- None. This is a pure frontend refactor; placement CRUD endpoints from the existing `widgets` capability remain unchanged.
+
+**Dependencies:**
+
+- No new composer or npm dependencies. `<component :is>` is native Vue 2.
+
+**Trade-offs:**
+
+- Switching widget type mid-form discards in-progress field input (explicit choice — recovery would require retaining shadow state per type, doubling complexity).
+- Edit mode cannot change a placement's type; users must delete + re-add to switch type.

--- a/openspec/changes/widget-add-edit-modal/specs/widgets/spec.md
+++ b/openspec/changes/widget-add-edit-modal/specs/widgets/spec.md
@@ -1,0 +1,124 @@
+---
+capability: widgets
+delta: true
+status: draft
+---
+
+# Widgets — Delta from change `widget-add-edit-modal`
+
+## MODIFIED Requirements
+
+### Requirement: Widget Picker (REQ-WDG-010)
+
+The widget picker MUST be implemented as a single modal that handles both creation and editing flows. The modal MUST present a type selector at the top (unless a type was preselected by the caller) followed by the per-type configuration sub-form for the currently selected type. Submit MUST emit `{type, content}` where `content` carries only the fields relevant to the selected type — fields belonging to other types MUST NOT be included.
+
+#### Scenario: Open in create mode without preselected type
+
+- GIVEN no widget is being edited and no type was preselected
+- WHEN the user opens the modal with `show=true, preselectedType=null, editingWidget=null`
+- THEN the modal MUST render a `<select>` listing every registered widget type
+- AND the form area MUST render the sub-form for the first type (alphabetical or registry order)
+- AND the action button MUST read `t('Add')`
+
+#### Scenario: Open in create mode with preselected type
+
+- GIVEN the toolbar dropdown invoked the modal with a specific type
+- WHEN the user opens the modal with `show=true, preselectedType='text', editingWidget=null`
+- THEN the type `<select>` MUST NOT be visible
+- AND the form area MUST render the text sub-form
+- AND the action button MUST read `t('Add')`
+
+#### Scenario: Open in edit mode
+
+- GIVEN an existing widget placement is being edited
+- WHEN the user opens the modal with `editingWidget={type:'image', content:{url:'/img/x.png', alt:'X', fit:'cover'}}`
+- THEN the type `<select>` MUST be hidden (cannot change a placement's type via edit)
+- AND the image sub-form's fields MUST be pre-filled from the editing widget's `content`
+- AND the action button MUST read `t('Save')`
+- AND the modal title MUST read `t('Edit Widget')` instead of `t('Add Widget')`
+
+#### Scenario: Switching type resets form state
+
+- GIVEN the modal is open in create mode with `text` type and the user has typed text
+- WHEN the user switches the type to `image` via the `<select>`
+- THEN the form MUST swap to the image sub-form
+- AND any previously-entered text MUST NOT leak into the image sub-form
+- AND switching back to `text` MUST reset its fields to defaults (no recovery of the lost input — explicit trade-off)
+
+#### Scenario: Submit emits only relevant fields
+
+- GIVEN the user fills the text sub-form with `{text: "Hello", fontSize: "16px"}`
+- WHEN they click `Add`
+- THEN the modal MUST emit `submit({type: 'text', content: {text: 'Hello', fontSize: '16px'}})`
+- AND `content` MUST NOT contain image fields like `url`, `alt`, etc.
+
+## ADDED Requirements
+
+### Requirement: Per-type validation contract (REQ-WDG-012)
+
+Each per-type sub-form component MUST expose a `validate(): string[]` method that returns an array of human-readable error messages (empty array = valid). The modal MUST disable its primary action button when the active sub-form's `validate()` returns a non-empty array. The button MUST re-enable as soon as `validate()` returns empty (reactive on form input).
+
+#### Scenario: Required field empty disables submit
+
+- GIVEN the text sub-form requires `text` to be non-empty
+- AND the user has not entered any text
+- WHEN the modal renders
+- THEN the `Add` button MUST be disabled
+- AND tooltip / aria-describedby MAY surface the validation message (UX choice)
+
+#### Scenario: Filling required field enables submit
+
+- GIVEN the `Add` button is disabled because text is empty
+- WHEN the user types `Hello`
+- THEN the button MUST become enabled within the next render cycle
+
+### Requirement: Modal close discipline (REQ-WDG-013)
+
+The modal MUST close on three triggers:
+
+1. Click on the cancel button (emit `close`)
+2. Click on the backdrop overlay (emit `close`)
+3. Press the `Escape` key while the modal is focused (emit `close`)
+
+Closing the modal MUST NOT submit. Reopening after a close MUST reset all form state to defaults (or re-load `editingWidget` if still set).
+
+#### Scenario: Backdrop click closes without submit
+
+- GIVEN the modal is open with valid form state
+- WHEN the user clicks the backdrop
+- THEN the modal MUST emit `close` only
+- AND MUST NOT emit `submit`
+
+#### Scenario: Esc key closes modal
+
+- GIVEN the modal is open
+- WHEN the user presses `Escape`
+- THEN the modal MUST emit `close`
+- AND focus MUST return to the element that triggered the open
+
+#### Scenario: Cancel button closes without submit
+
+- GIVEN the modal is open with valid form state
+- WHEN the user clicks the cancel button
+- THEN the modal MUST emit `close` only
+- AND MUST NOT emit `submit`
+
+### Requirement: Sub-form registry (REQ-WDG-014)
+
+The set of supported widget types MUST come from a single in-frontend registry that maps `type → { component, label, defaults }`. The toolbar dropdown, the modal type selector, and the grid renderer MUST all consult the same registry.
+
+#### Scenario: Adding a new widget type
+
+- GIVEN a developer needs to register a new widget type
+- WHEN they add a new entry to the widget registry (`{component, label, defaults}`)
+- THEN the new type MUST automatically appear in the toolbar dropdown
+- AND the modal type selector MUST list it
+- AND the grid renderer MUST render placements of the new type
+- AND no other UI code MUST need to be changed to support the new type
+
+#### Scenario: Registry is the single source of truth
+
+- GIVEN the widget registry contains exactly 5 entries (`text`, `label`, `image`, `linkButton`, `ncDashboardProxy`)
+- WHEN any consumer (toolbar, modal, renderer) enumerates widget types
+- THEN it MUST list those 5 types
+- AND MUST NOT hard-code any type name elsewhere in the codebase

--- a/openspec/changes/widget-add-edit-modal/tasks.md
+++ b/openspec/changes/widget-add-edit-modal/tasks.md
@@ -1,0 +1,56 @@
+# Tasks — widget-add-edit-modal
+
+## 1. Registry + composable foundations
+
+- [ ] 1.1 Create `src/constants/widgetRegistry.js` mapping `type → {component, label, defaults}` for the 5 widget types (`text`, `label`, `image`, `linkButton`, `ncDashboardProxy`)
+- [ ] 1.2 Create `src/composables/useWidgetForm.js` exposing `resetForm()`, `loadEditingWidget(widget)`, `validate()`, `assembleContent()` helpers
+- [ ] 1.3 Add a `getActiveSubForm()` ref accessor so the modal can call `validate()` on the currently-mounted sub-form via `<component :is ref="...">`
+- [ ] 1.4 Verify the toolbar dropdown is rewired to consume `widgetRegistry` rather than a local hard-coded list — REQ-WDG-014 single-source-of-truth
+
+## 2. Modal host component
+
+- [ ] 2.1 Create `src/components/Widgets/AddWidgetModal.vue` with header (`Add Widget` / `Edit Widget` based on `editingWidget` prop), conditional type `<select>`, `<component :is="activeSubFormComponent">` slot, action buttons (`Cancel` + `Add`/`Save`)
+- [ ] 2.2 Implement open lifecycle: `show: false → true` triggers `resetForm()`; if `editingWidget` non-null also calls `loadEditingWidget(editingWidget)`
+- [ ] 2.3 Hide type selector when `preselectedType` non-null OR `editingWidget` non-null
+- [ ] 2.4 Implement type-switch handler: on `<select>` change, swap active sub-form and reset form state (no cross-type leakage)
+- [ ] 2.5 Submit button computes `{type, content}` via `assembleContent()` and emits `submit` — modal performs no API calls itself
+
+## 3. Close discipline
+
+- [ ] 3.1 Cancel button click emits `close` (no submit)
+- [ ] 3.2 Backdrop overlay click emits `close` (do not bubble inner clicks — guard via `@click.self`)
+- [ ] 3.3 Esc key listener registered on `mounted` (`document.addEventListener('keydown')`) and removed on `beforeDestroy` / when `show=false` to prevent leaks; emits `close` when fired
+- [ ] 3.4 On close, restore focus to the element that triggered the open (track via prop or a `data-trigger-id` attribute)
+
+## 4. Validation pipeline
+
+- [ ] 4.1 Each per-type sub-form exposes `validate(): string[]` — empty array == valid
+- [ ] 4.2 Modal computed `isValid = activeSubFormRef.value?.validate().length === 0`
+- [ ] 4.3 Action button binds `:disabled="!isValid"` so it re-enables reactively on form input
+- [ ] 4.4 Optional UX: surface first validation error as button `title` / aria-describedby
+
+## 5. Per-type sub-forms
+
+- [ ] 5.1 `src/components/Widgets/forms/TextForm.vue` — fields per `text-display-widget` capability spec
+- [ ] 5.2 `src/components/Widgets/forms/LabelForm.vue` — fields per `label-widget` capability spec
+- [ ] 5.3 `src/components/Widgets/forms/ImageForm.vue` — fields per `image-widget` capability spec
+- [ ] 5.4 `src/components/Widgets/forms/LinkButtonForm.vue` — fields per `link-button-widget` capability spec
+- [ ] 5.5 `src/components/Widgets/forms/NcDashboardProxyForm.vue` — fields per `nc-dashboard-widget-proxy` capability spec
+- [ ] 5.6 Each sub-form imports its defaults from `widgetRegistry`'s `defaults` entry on mount (single source of truth)
+
+## 6. Tests
+
+- [ ] 6.1 Vitest: registry-driven type select renders 5 options
+- [ ] 6.2 Vitest: type switch clears irrelevant fields (no leak from `text` to `image`)
+- [ ] 6.3 Vitest: edit mode pre-fills correctly per type (image, text)
+- [ ] 6.4 Vitest: submit emits `{type, content}` containing only the selected type's fields
+- [ ] 6.5 Vitest: validation gating — submit disabled until required fields complete; re-enables on input
+- [ ] 6.6 Playwright: backdrop click, Esc key, cancel button — all emit `close`, none submit
+- [ ] 6.7 Playwright: open in edit mode then close — reopen restores `editingWidget` content (not stale state)
+
+## 7. Quality
+
+- [ ] 7.1 ESLint clean (no warnings)
+- [ ] 7.2 WCAG: focus trap inside modal, ARIA `labelledby` and `describedby` on modal root
+- [ ] 7.3 Translation entries (nl + en) for `Add Widget`, `Edit Widget`, `Add`, `Save`, `Cancel`, `Type`
+- [ ] 7.4 Remove any pre-existing per-widget edit dialogs replaced by the unified modal

--- a/openspec/changes/widget-collision-placement/design.md
+++ b/openspec/changes/widget-collision-placement/design.md
@@ -1,0 +1,102 @@
+# Design — Widget Collision Placement
+
+## Context
+
+MyDash uses GridStack 10.3.1 as the grid engine for dashboard layout. The user can add widgets to a dashboard via three entry points: the toolbar dropdown, a keyboard shortcut, and drag-from-picker. Today, each entry point computes its own placement — some pass `autoPosition: true` to GridStack, some hard-code `(0, 0)`, and a few drop the widget at the cursor position. The result is inconsistent UX: in a densely packed dashboard, "Add widget" sometimes silently overflows the visible viewport (placing the new widget far below the fold), sometimes overlaps existing widgets, and sometimes fails outright when GridStack rejects the position.
+
+REQ-GRID-006 already declares the intent ("widget auto-layout") but does not specify the algorithm or the fallback behaviour when the grid is fully occupied. This change formalises the algorithm so the UX is predictable across browsers, viewport sizes, and dashboard density.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make widget placement deterministic and predictable: same dashboard state + same widget spec → same final position.
+- Always place new widgets where the user can see them — never below the visible viewport rows.
+- Centralise placement logic in a single composable function so it is testable, auditable, and impossible to bypass.
+- Keep the existing `addWidget` GridStack call working for the common case (empty space available) — the change is additive, not a rewrite.
+
+**Non-Goals:**
+
+- Smart packing (bin-packing optimal placement). The push-down fallback is intentionally naive — predictable beats optimal for first-time discoverability.
+- Animations or visual transitions when widgets are pushed. Out of scope; can be a follow-up purely-cosmetic change.
+- Widget grouping or relative-position constraints (e.g. "always place next to widget X"). Out of scope.
+- Per-widget-type custom placement strategies. All widgets follow the same algorithm — type-specific size hints come via `spec.w` / `spec.h`.
+- Conflict resolution when two simultaneous "add widget" calls race. Frontend serialises modal interactions so this cannot happen in practice.
+
+## Decisions
+
+### D1: Top-left + push-down, not bottom-append
+
+**Decision**: When auto-position fails, place the new widget at `(0, 0)` and push overlapping widgets down by `newH` rows.
+
+**Alternatives considered:**
+
+- Append to the bottom of the grid (max-y of all widgets + 1). Rejected because on dense dashboards the new widget lands below the viewport — users assume the click did nothing because they don't see the widget appear.
+- Place at the cursor position. Rejected because the toolbar dropdown and keyboard shortcut have no meaningful cursor position.
+- Open a "where do you want it?" dialog. Rejected as user-hostile for what should be a one-click action.
+
+**Rationale**: "New things appear at the top-left" matches first-run expectations from spreadsheets, kanban boards, and most CMS layouts. Pushing existing widgets down preserves them all and keeps the new one immediately visible.
+
+### D2: Single helper `placeNewWidget(spec)` is the only entry point
+
+**Decision**: Export `placeNewWidget(spec)` from `useGridManager.js`. All three add-widget code paths route through it. Inline `grid.addWidget(...)` outside the helper is forbidden and enforced by a grep test.
+
+**Alternatives considered:**
+
+- Let each component compute placement and call `grid.addWidget` directly. Rejected — that's the status quo and the source of the inconsistency.
+- Bake the algorithm into a Vue mixin. Rejected — composables are the modern pattern in Vue 2.7 + Composition API and align with REQ-GRID-005's existing helpers.
+
+**Rationale**: One function = one place to test = one place to audit. The grep test is cheap insurance against regressions when a new "Add widget" path is added in future.
+
+### D3: Default size `w=4, h=4` when caller omits dimensions
+
+**Decision**: If `spec.w` or `spec.h` is undefined, default to `4, 4`.
+
+**Alternatives considered:**
+
+- Per-widget-type defaults (e.g. text widget = 3×2, chart = 6×4). Rejected — adds another lookup table and the widget-types config doesn't currently expose default sizes. Can be layered on later via the `spec` object.
+- Smallest possible (1×1). Rejected — nearly every widget is unreadable at 1×1 cells.
+
+**Rationale**: 4×4 in a 12-column grid is a third of the row width and 4 cells tall — readable for charts and lists, not so big that it dominates a half-empty dashboard. Matches the existing default in `AddWidgetModal.vue`.
+
+### D4: Push by `newH`, not by 1 row
+
+**Decision**: Overlapping widgets are pushed to `gridY = newH` (just below the new widget's bottom edge), not shifted by 1 row at a time.
+
+**Alternatives considered:**
+
+- One-row shift in a loop until no overlap. Rejected — produces O(n²) updates and visually janky reflows.
+- Compute minimum required shift per overlapper. Rejected — the trade-off of "perfectly minimal disruption" isn't worth the algorithmic complexity for a fallback path that should fire rarely.
+
+**Rationale**: Single-pass push by `newH` is O(n) and produces a visually clean result: every previously-overlapping widget snaps to one consistent y-coordinate.
+
+### D5: Detect "no fit" by checking returned slot against `viewportRows`
+
+**Decision**: After `grid.addWidget({autoPosition: true, ...})`, check the returned slot's `y` value. If `y >= viewportRows` (slot is below the fold), treat it as a failed auto-position and trigger the push-down fallback.
+
+**Alternatives considered:**
+
+- Trust GridStack's return value verbatim and never fall back. Rejected — this is the bug we're fixing.
+- Always fall back to top-left and never use auto-position. Rejected — auto-position is great when there is empty space and avoids unnecessary widget movement.
+
+**Rationale**: GridStack's `autoPosition` is well-suited for the common "empty space exists" case. The viewport check converts a UX-failure case (widget below fold) into the fallback path without changing the success path.
+
+## Risks / Trade-offs
+
+- **Risk:** Push-down on a dense dashboard disrupts layout the user spent time arranging. → **Mitigation:** Document the behaviour in the user-facing docs; the user can drag pushed widgets back. The alternative (silently placing off-screen) is worse.
+- **Risk:** `viewportRows` definition varies by browser zoom and window size. → **Mitigation:** Compute `viewportRows` once at composable setup time from the GridStack container height; recompute on `resize` events. Tested at 720p, 1080p, and 1440p.
+- **Trade-off:** Push-down is naive (single pass, fixed shift). On a dashboard that is dense everywhere (not just at top), some pushed widgets may now overlap others further down. We accept this — REQ-GRID-006 step 1 (auto-position) handles the common case, and step 2 only fires when the dashboard is already nearly-full at the top, where some disruption is unavoidable.
+- **Trade-off:** Inline `grid.addWidget(...)` enforcement is grep-based, not type-system-based. A determined developer could rename the import to bypass it. We accept this — the grep test catches the common case and code review catches the exotic.
+
+## Migration Plan
+
+1. **Composable + tests land first** — add `placeNewWidget` and Vitest coverage in one PR. No behaviour change yet (no callers).
+2. **Refactor `AddWidgetModal.vue` to call the helper** in the same PR or a follow-up.
+3. **Audit other add-widget code paths** (toolbar dropdown, keyboard shortcut, drag-from-picker) and route them through the helper.
+4. **Add the grep test** to CI as the final step so the enforcement is live before any new add-widget paths can land.
+5. **Rollback**: pure frontend change, no schema migration. Reverting the PR restores the previous (buggy) behaviour with no data loss.
+
+## Open Questions
+
+- Should the helper return the final position synchronously, or wait for the persistence round-trip? Current decision: return synchronously (the caller gets `{x, y, w, h}` immediately for optimistic UI), and persistence happens in a fire-and-forget debounced batch. Revisit if the persistence layer ever needs to reject placements (e.g., quota enforcement).
+- Should `viewportRows` be a configurable constant or auto-computed? Current decision: auto-compute from container height, with a fallback constant of `8` if the container is not yet measured (e.g., during initial mount).

--- a/openspec/changes/widget-collision-placement/proposal.md
+++ b/openspec/changes/widget-collision-placement/proposal.md
@@ -1,0 +1,35 @@
+# Widget collision placement
+
+When a user adds a new widget to a non-empty dashboard, MyDash MUST decide where to place it without overlapping existing widgets and without dropping it off-grid. This change formalises the algorithm: try GridStack's `autoPosition: true` first; if no fit is found (or the picked slot is below the visible viewport), fall back to top-left `(x:0, y:0)` and push overlapping widgets down by `newH` rows. All add-widget code paths MUST funnel through a single placement helper so the behaviour is testable and auditable.
+
+## Affected code units
+
+- `src/composables/useGridManager.js` — new exported helper `placeNewWidget(spec)` is the only legal caller of `grid.addWidget(...)`
+- `src/components/AddWidgetModal.vue` — submit handler delegates to `placeNewWidget`, no longer touches GridStack directly
+- Toolbar dropdown, keyboard shortcut, and drag-from-picker code paths — all routed through `placeNewWidget`
+- Modifies `grid-layout` REQ-GRID-006 (Widget Auto-Layout)
+- Adds `grid-layout` REQ-GRID-014 (Placement helper is the single placement authority)
+
+## Why a delta
+
+REQ-GRID-006 already declares "auto-layout" but does not specify the algorithm or the fallback behaviour when the grid is fully occupied at the top. Today, three separate add-widget code paths each compute placement differently — some hard-code `(0, 0)`, some pass `autoPosition: true`, some use the cursor position. The result is inconsistent UX and silent failures (widgets landing below the viewport on dense dashboards). This change spells out the algorithm and centralises the entry point so the UX is predictable across browsers and entry methods.
+
+## Approach
+
+- **Primary** — call `grid.addWidget({...spec, autoPosition: true})`. GridStack scans for the first empty rectangle that fits.
+- **Fallback** — when GridStack returns no slot OR the picked slot is below `viewportRows`, place the new widget at `(x:0, y:0)` with size `(newW, newH)` and shift every overlapping existing widget to `gridY = newH`. Non-overlapping widgets are not moved. This matches the user expectation "new things appear at the top-left" without losing any existing widget.
+- **Default size** — `w=4, h=4` when caller omits `spec.w` / `spec.h`.
+- **Single entry point** — `placeNewWidget(spec)` exported from `useGridManager.js`. Inline `grid.addWidget(...)` outside the helper is forbidden and enforced by a grep test.
+- **Persistence** — all position writes (new widget + pushed widgets) MUST be persisted via the existing REQ-GRID-005 + REQ-WDG-008 batch update path with the standard 300ms debounce.
+
+## Capabilities
+
+**Modified Capabilities:**
+
+- `grid-layout` (modifies REQ-GRID-006, adds REQ-GRID-014)
+
+## Notes
+
+- We deliberately do NOT push to the bottom of the grid (which would put the new widget off-screen on small grids) — top-left + push-down is more discoverable for first-time users.
+- The shift-down algorithm is naive (single pass, push to `newH`) and may cause minor layout disruption when the dashboard is densely packed everywhere. Acceptable trade-off; documented in the user-facing docs and in a scenario.
+- See `design.md` for the detailed decision log (D1 through D5) covering algorithm choice, default size rationale, and the helper-as-single-authority rule.

--- a/openspec/changes/widget-collision-placement/specs/grid-layout/spec.md
+++ b/openspec/changes/widget-collision-placement/specs/grid-layout/spec.md
@@ -1,0 +1,73 @@
+---
+capability: grid-layout
+delta: true
+status: draft
+---
+
+# Grid Layout — Delta from change `widget-collision-placement`
+
+## MODIFIED Requirements
+
+### Requirement: REQ-GRID-006 Widget Auto-Layout (collision placement algorithm)
+
+When a new widget is added to an existing dashboard, the system MUST place it without overlapping any existing widget and without leaving it outside the visible grid region. The algorithm MUST be:
+
+1. **Try GridStack auto-position** — call `grid.addWidget({x: 0, y: 0, w: newW, h: newH, autoPosition: true, ...})`. GridStack scans for the first empty rectangle that fits and uses it.
+2. **Fallback: top-left with push-down** — if step 1 fails (GridStack returns no slot, or the picked slot is below `viewportRows`), place the new widget at `(x: 0, y: 0)` with size `(newW, newH)` AND for every existing widget whose rectangle overlaps `[0..newW] × [0..newH]`, set its `gridY` to `newH` (pushing it just below the new one). Existing widgets that do not overlap MUST NOT be moved.
+
+Default size when the caller omits `w`/`h` MUST be `w=4, h=4`. Position writes MUST trigger the persistence path of REQ-GRID-005.
+
+#### Scenario: Auto-position into empty space
+
+- **GIVEN** a dashboard with one widget at `(x:0, y:0, w:6, h:4)`
+- **WHEN** a new 4×4 widget is added
+- **THEN** GridStack MUST place it at `(x:6, y:0)` (the empty right-half)
+- **AND** no existing widget MUST be moved
+
+#### Scenario: Push-down fallback when grid is full at top
+
+- **GIVEN** a dashboard with widgets occupying the entire `[0..12] × [0..4]` region
+- **WHEN** a new 4×4 widget is added
+- **THEN** it MUST be placed at `(x:0, y:0, w:4, h:4)`
+- **AND** every previously-overlapping widget MUST have `gridY = 4` (just below the new one)
+- **AND** non-overlapping widgets (already at `y >= 4`) MUST NOT have their `gridY` changed
+
+#### Scenario: Default size on omitted dimensions
+
+- **GIVEN** a caller invokes `placeNewWidget({type: 'text'})` with no `w` or `h`
+- **WHEN** the placement runs
+- **THEN** the placement MUST use `w=4, h=4`
+
+#### Scenario: Persistence after placement
+
+- **GIVEN** a new widget has been placed (via either step 1 or step 2)
+- **WHEN** the placement completes
+- **THEN** the new widget AND any pushed-down widgets MUST be persisted via the standard placement-update API (REQ-WDG-008 batch update or per-placement PUT)
+- **AND** a single network round-trip SHOULD be used for the batch (debounce 300 ms per the design rule in `openspec/config.yaml`)
+
+#### Scenario: Pushed widgets remain within their column lane
+
+- **GIVEN** existing widget at `(x:8, y:0, w:4, h:2)` overlaps a new 6×3 widget being placed at top-left
+- **WHEN** the push-down fallback runs
+- **THEN** the existing widget's `gridX` and `gridW` MUST remain `8` and `4` respectively
+- **AND** only `gridY` MUST be increased to `3`
+
+## ADDED Requirements
+
+### Requirement: REQ-GRID-014 Placement helper is the single placement authority
+
+All "add widget" code paths (toolbar dropdown, keyboard shortcut, drag-from-picker) MUST go through a single `placeNewWidget(spec)` helper exported from the grid composable. Inline calls to `grid.addWidget` outside this helper are forbidden.
+
+#### Scenario: Single source of truth
+
+- **GIVEN** the codebase under `src/`
+- **WHEN** `grep -r 'grid.addWidget' src/` is run
+- **THEN** matches MUST occur only inside `useGridManager.js` (or its test file)
+- **AND** component templates MUST NOT call GridStack APIs directly
+
+#### Scenario: Add-widget submit handler routes through the helper
+
+- **GIVEN** a user clicks the "Add widget" button in `AddWidgetModal.vue`
+- **WHEN** the submit handler runs
+- **THEN** it MUST call `placeNewWidget(spec)` exported from `useGridManager.js`
+- **AND** MUST NOT call `grid.addWidget(...)` directly

--- a/openspec/changes/widget-collision-placement/tasks.md
+++ b/openspec/changes/widget-collision-placement/tasks.md
@@ -1,0 +1,47 @@
+# Tasks — widget-collision-placement
+
+## 1. Frontend composable
+
+- [ ] 1.1 Add `placeNewWidget(spec): {x, y, w, h}` exported from `src/composables/useGridManager.js`
+- [ ] 1.2 Step 1 — try `grid.addWidget({autoPosition: true, ...spec})` and capture the resulting position
+- [ ] 1.3 Step 2 — if step 1 returns no slot OR slot is below `viewportRows`, fall back to push-down
+- [ ] 1.4 Push-down implementation — iterate `layout.value`, compute overlap with `[0..newW] × [0..newH]`, set `widget.gridY = newH` for overlappers, call `grid.update(el, {y})` for each
+- [ ] 1.5 Define default size constants `DEFAULT_W = 4`, `DEFAULT_H = 4` and use them when caller omits `w`/`h`
+- [ ] 1.6 Inline comment on the helper linking REQ-GRID-006 + REQ-GRID-014 and the "top-left + push-down" rationale from design.md
+
+## 2. Add-widget UI integration
+
+- [ ] 2.1 Refactor `src/components/AddWidgetModal.vue` submit handler to call `placeNewWidget(spec)` only
+- [ ] 2.2 Remove any direct `grid.addWidget(...)` calls from component templates
+- [ ] 2.3 Confirm toolbar dropdown, keyboard shortcut, and drag-from-picker code paths all funnel through the helper
+
+## 3. Persistence
+
+- [ ] 3.1 Trigger batch placement-update API after placement (debounced 300ms — reuse existing pattern from REQ-WDG-008)
+- [ ] 3.2 Single round-trip carrying both the new widget and all pushed-down widgets
+- [ ] 3.3 Verify the persisted positions match the in-memory `layout.value` after the round-trip resolves
+
+## 4. Vitest unit coverage
+
+- [ ] 4.1 `placeNewWidget` auto-positions into empty space when GridStack finds a slot (no pushes)
+- [ ] 4.2 Push-down fallback runs when the top region is full — overlapping widgets gain `gridY = newH`
+- [ ] 4.3 Non-overlapping widgets are unchanged after fallback runs
+- [ ] 4.4 Default size `(4, 4)` is applied when `spec.w` / `spec.h` are omitted
+- [ ] 4.5 Pushed widgets keep their `gridX` and `gridW` (only `gridY` changes)
+
+## 5. Playwright e2e
+
+- [ ] 5.1 Add 5 widgets in sequence to a 12-col empty dashboard; verify visually-correct positions
+- [ ] 5.2 Add a 6th widget to a top-full dashboard; verify the push-down fallback shifts overlappers down
+- [ ] 5.3 Verify position writes survive a page reload (REQ-GRID-005 persistence)
+
+## 6. Architectural enforcement
+
+- [ ] 6.1 Add a grep test (Vitest or CI script) asserting `grid.addWidget` only appears inside `useGridManager.js` and its test file
+- [ ] 6.2 Document the rule in the composable file's header comment so reviewers see it during code review
+
+## 7. Quality gates
+
+- [ ] 7.1 ESLint clean on touched JS / Vue files
+- [ ] 7.2 No new PHPCS/PHPMD/PHPStan/Psalm regressions (frontend-only change, but run `composer check:strict` to confirm)
+- [ ] 7.3 i18n review — no new user-facing strings expected; if any are introduced, add them to both `nl` and `en` per the i18n requirement

--- a/openspec/changes/widget-context-menu/proposal.md
+++ b/openspec/changes/widget-context-menu/proposal.md
@@ -1,0 +1,52 @@
+# Widget context menu
+
+## Why
+
+In edit mode users need a quick, discoverable way to edit or remove an existing widget placement. Today the only affordances are drag handles and (implicit) keyboard flows; there is no right-click surface, so users instinctively try right-click and either get the browser's native menu (in view mode that's fine, in edit mode it's noise) or nothing useful. A small popover with `Edit / Remove / Cancel` brings widget management to the cursor and makes the existing REQ-WDG-004 (edit) and REQ-WDG-005 (remove) operations directly reachable from any placement on the grid.
+
+## What Changes
+
+- Add a `WidgetContextMenu.vue` popover component (three buttons, absolute-positioned at cursor, `min-width: 150px`, `z-index: 10000`).
+- Add `onWidgetRightClick(event, widget)` to `useGridManager.js` — early-returns when `!canEdit`, calls `event.preventDefault()`, captures `clientX/Y`, sets `selectedWidget`, opens the popover.
+- Wire `@contextmenu.prevent="onWidgetRightClick($event, widget)"` on every grid item in the workspace shell.
+- Manage a single document-level `click` listener (mount/unmount in the composable) that closes the popover on outside click; right-clicking a different widget switches the popover to the new position rather than stacking.
+- Clamp the computed `left` / `top` so the popover stays fully visible at viewport edges.
+- `Edit` reuses the existing `AddWidgetModal` (REQ-WDG-010) with `editingWidget`; `Remove` calls the placement-delete path of REQ-WDG-005; `Cancel` is a no-op close.
+- View mode is untouched: the right-click event falls through to the browser's native context menu.
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `widgets`: adds REQ-WDG-015 (right-click context menu in edit mode), REQ-WDG-016 (auto-close on outside interaction), REQ-WDG-017 (position constraints). Existing REQ-WDG-001..014 are untouched — this change is purely additive UI surface around the already-specified edit (REQ-WDG-004) and remove (REQ-WDG-005) operations.
+
+## Impact
+
+**Affected code:**
+
+- `src/components/Widgets/WidgetContextMenu.vue` (new) — the popover component, three buttons, absolute-positioned, viewport-clamped
+- `src/composables/useGridManager.js` — adds `onWidgetRightClick(event, widget)`, `closeContextMenu()`; extends `handleClickOutside` to close the popover when the click target is not inside `.widget-context-menu`; mounts/unmounts the document-level `click` listener
+- `src/views/Workspace.vue` (or wherever grid items render) — adds `@contextmenu.prevent` binding on each placement
+- Translation entries: `Edit`, `Remove`, `Cancel` (en + nl)
+
+**Affected APIs:**
+
+- None. This change is purely frontend; `Edit` reuses REQ-WDG-010 (modal) and `Remove` reuses REQ-WDG-005 (`DELETE /api/placements/{id}`) — no new endpoints, no schema changes.
+
+**Dependencies:**
+
+- Builds on `widget-add-edit-modal` (L2, done) for the edit modal surface.
+- Soft-depends on `runtime-shell` for the `canEdit` flag (REQ-SHELL-002). The validation of this change does not require runtime-shell to be archived; integration testing does.
+- No new npm or composer dependencies.
+
+**Migration:**
+
+- None — purely additive UI; no data, no schema, no route changes.
+
+**Out of scope (follow-ups):**
+
+- Keyboard navigation in the popover (Up/Down/Enter/Esc) is deferred to a future change. v1 is mouse-only by design.

--- a/openspec/changes/widget-context-menu/specs/widgets/spec.md
+++ b/openspec/changes/widget-context-menu/specs/widgets/spec.md
@@ -1,0 +1,101 @@
+---
+capability: widgets
+delta: true
+status: draft
+---
+
+# Widgets — Delta from change `widget-context-menu`
+
+## ADDED Requirements
+
+### Requirement: REQ-WDG-015 Right-click context menu in edit mode
+
+When the user is in edit mode (per REQ-SHELL-002 `canEdit === true`), right-clicking any widget placement on the grid MUST open a small popover at the cursor position offering at least these three actions: **Edit**, **Remove**, **Cancel**. The popover MUST suppress the browser's native context menu via `event.preventDefault()`. In view mode the right-click MUST fall through to native behaviour (no popover).
+
+#### Scenario: Right-click in edit mode opens popover
+
+- GIVEN `canEdit === true` and a widget placement is rendered at coordinates (300, 400) on screen
+- WHEN the user right-clicks anywhere within that widget's content area
+- THEN the system MUST emit a popover at the click position (300, 400)
+- AND the popover MUST contain three buttons: `t('Edit')`, `t('Remove')`, `t('Cancel')`
+- AND the browser's native context menu MUST NOT appear
+
+#### Scenario: Right-click in view mode does nothing
+
+- GIVEN `canEdit === false`
+- WHEN the user right-clicks any widget
+- THEN the popover MUST NOT open
+- AND the browser's native context menu MUST appear normally
+
+#### Scenario: Edit click opens the add/edit modal
+
+- GIVEN the popover is open for widget `W`
+- WHEN the user clicks `Edit`
+- THEN the system MUST close the popover
+- AND MUST open the add/edit modal (REQ-WDG-010) with `editingWidget = W`
+
+#### Scenario: Remove click deletes the placement
+
+- GIVEN the popover is open for widget `W`
+- WHEN the user clicks `Remove`
+- THEN the system MUST close the popover
+- AND MUST trigger the placement deletion path of REQ-WDG-005 (DELETE `/api/placements/{id}`)
+- AND on success MUST remove the widget's DOM via GridStack `removeWidget`
+
+#### Scenario: Cancel click closes without action
+
+- GIVEN the popover is open
+- WHEN the user clicks `Cancel`
+- THEN the popover MUST close
+- AND no API call MUST fire
+- AND no widget state MUST change
+
+### Requirement: REQ-WDG-016 Auto-close on outside interaction
+
+The popover MUST close when the user clicks anywhere outside its bounding box (including on another widget). Right-clicking a different widget while the popover is open MUST close the current popover and open a new one at the new cursor position. Closing on outside click MUST be wired via a single document-level listener that the grid composable manages on mount/unmount.
+
+#### Scenario: Click outside closes
+
+- GIVEN the popover is open
+- WHEN the user clicks anywhere not inside `.widget-context-menu`
+- THEN the popover MUST close
+
+#### Scenario: Right-click another widget switches popover
+
+- GIVEN the popover is open for widget `W1`
+- WHEN the user right-clicks widget `W2`
+- THEN the popover MUST close for `W1` and reopen for `W2` at the new cursor position
+- AND only one popover MUST be visible at a time
+
+#### Scenario: Listener cleanup on unmount
+
+- GIVEN the workspace shell unmounts
+- WHEN the unmount lifecycle runs
+- THEN the document-level `click` listener MUST be removed
+- AND no popover state MUST leak into a subsequent mount
+
+### Requirement: REQ-WDG-017 Position constraints
+
+The popover MUST be absolutely positioned at the click coordinates with `min-width: 150px`. If the popover would overflow the viewport on the right or bottom edge, the system SHOULD shift it left/up so it remains fully visible. Z-index MUST be `10000` (above grid, level with modals — popover-then-modal interaction is acceptable since clicking a popover item closes it before the modal opens).
+
+#### Scenario: Popover stays within viewport on right edge
+
+- GIVEN the user right-clicks at `(viewportWidth - 50, 200)` (50 px from right edge)
+- AND the popover's `min-width` is 150 px
+- WHEN the popover renders
+- THEN its `right` edge MUST NOT exceed `viewportWidth`
+- AND its rendered `left` MUST be adjusted to keep it on-screen
+
+#### Scenario: Popover stays within viewport on bottom edge
+
+- GIVEN the user right-clicks at `(400, viewportHeight - 20)` (20 px from bottom edge)
+- WHEN the popover renders
+- THEN its `bottom` edge MUST NOT exceed `viewportHeight`
+- AND its rendered `top` MUST be adjusted upward so the popover is fully visible
+
+#### Scenario: Z-index sits at 10000
+
+- GIVEN the popover is open over a widget
+- WHEN computed styles are inspected
+- THEN the popover element MUST have `z-index: 10000`
+- AND MUST have `min-width: 150px`

--- a/openspec/changes/widget-context-menu/tasks.md
+++ b/openspec/changes/widget-context-menu/tasks.md
@@ -1,0 +1,41 @@
+# Tasks — widget-context-menu
+
+## 1. Frontend component
+
+- [ ] 1.1 Create `src/components/Widgets/WidgetContextMenu.vue` with three buttons (`Edit`, `Remove`, `Cancel`) and `top` / `left` props
+- [ ] 1.2 Style: `position: absolute`, `min-width: 150px`, `z-index: 10000`, NC-themed background, rounded corners, subtle shadow
+- [ ] 1.3 Emit `edit`, `remove`, `close` events; each click closes the popover via `closeContextMenu()`
+- [ ] 1.4 Use `t('mydash', 'Edit' | 'Remove' | 'Cancel')` for button labels (i18n-ready)
+
+## 2. Composable wiring
+
+- [ ] 2.1 In `useGridManager.js` add reactive state: `contextMenuOpen`, `contextMenuPosition` (`{x, y}`), `selectedWidget`
+- [ ] 2.2 Add `onWidgetRightClick(event, widget)` — early-return when `!canEdit.value`; call `event.preventDefault()`; capture `clientX/clientY`; set `selectedWidget` and `contextMenuPosition`; set `contextMenuOpen = true`
+- [ ] 2.3 Add `closeContextMenu()` — sets `contextMenuOpen = false`, clears `selectedWidget`
+- [ ] 2.4 Extend existing `handleClickOutside` to also close the context menu when the click target is not inside `.widget-context-menu`
+- [ ] 2.5 Add `onMounted` / `onUnmounted` hooks for the document-level `click` listener (single shared listener for grid + popover)
+- [ ] 2.6 Viewport overflow correction: when computing the rendered `left` / `top`, subtract overflow from `viewportWidth` / `viewportHeight` so popover stays on-screen
+
+## 3. Shell wiring
+
+- [ ] 3.1 In the workspace shell template, bind `@contextmenu.prevent="onWidgetRightClick($event, widget)"` on each grid item
+- [ ] 3.2 Render `<WidgetContextMenu>` once at the shell root, conditional on `contextMenuOpen`, with `:top` / `:left` from `contextMenuPosition`
+- [ ] 3.3 Wire `@edit` → `editWidget(widget)` (opens `AddWidgetModal` with `editingWidget`); `@remove` → call placement-delete path of REQ-WDG-005, on success splice from `layout` and call `grid.removeWidget(el)`; `@close` → `closeContextMenu()` only
+
+## 4. Tests
+
+- [ ] 4.1 Vitest: in view mode (`canEdit = false`), right-click does NOT open the popover and does NOT call `preventDefault`
+- [ ] 4.2 Vitest: in edit mode, right-click opens the popover at the captured `clientX/clientY`
+- [ ] 4.3 Vitest: clicking `Edit` closes the popover and emits `edit(widget)` once
+- [ ] 4.4 Vitest: clicking `Remove` closes the popover, calls the placement-delete path, then removes from `layout`
+- [ ] 4.5 Vitest: clicking `Cancel` closes the popover and fires no API call
+- [ ] 4.6 Vitest: outside click closes the popover; the document listener is removed on unmount
+- [ ] 4.7 Vitest: right-clicking a second widget switches the popover (only one visible at a time)
+- [ ] 4.8 Playwright: popover stays fully on-screen when right-clicking near the right edge and near the bottom edge
+- [ ] 4.9 Playwright: removing a widget through the popover persists across reload
+
+## 5. Quality
+
+- [ ] 5.1 ESLint clean (no new warnings)
+- [ ] 5.2 Translation entries `Edit`, `Remove`, `Cancel` present in `l10n/en.js` and `l10n/nl.js`
+- [ ] 5.3 File a follow-up issue: keyboard navigation (Up/Down/Enter/Esc) for the context menu (deferred from v1)

--- a/openspec/specs/dashboard-sharing/spec.md
+++ b/openspec/specs/dashboard-sharing/spec.md
@@ -1,0 +1,154 @@
+---
+status: implemented
+---
+
+# Dashboard Sharing Specification
+
+## Purpose
+
+Dashboard sharing lets a dashboard owner grant read or edit access on a personal (`type: 'user'`) dashboard to specific Nextcloud users or groups. It complements the existing dashboard scopes (`user`, `admin_template`, `group_shared`) by enabling **ad-hoc peer-to-peer collaboration** without needing administrator involvement: any user can decide to share their own dashboard with a colleague or a group, with view, add, or full access. The recipient sees the shared dashboard alongside their own in the dashboard switcher and can act on it according to the share's permission level. Only the owner can manage shares; only the owner can rename, change description, or delete the dashboard.
+
+## Concepts
+
+A **share** grants a single recipient (user or group) one permission level on one dashboard. Recipients can be reached via direct user shares OR via group membership. When a user matches multiple shares for the same dashboard (e.g. a direct user share AND a group share), the most permissive level wins, ranked `view_only < add_only < full`.
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `dashboardId` | int | The shared dashboard. Owner-side reference. |
+| `shareType` | enum `'user' \| 'group'` | Recipient kind. |
+| `shareWith` | string | Nextcloud user id or group id. |
+| `permissionLevel` | enum `'view_only' \| 'add_only' \| 'full'` | What the recipient can do. Reuses the existing permission enum from `permissions/spec.md`. |
+| `createdAt` | datetime | Audit trail; not exposed in UI. |
+
+The unique tuple `(dashboardId, shareType, shareWith)` enforces that a recipient gets exactly one share row per dashboard — re-sharing the same recipient updates the existing row instead of inserting.
+
+## Requirements
+
+### REQ-SHARE-001: Owner-only share management
+
+Only the owner of a dashboard MUST be allowed to list, create, update, or delete shares on that dashboard. All share-management endpoints MUST return HTTP 403 for any caller that is not the dashboard owner, including users who themselves have a `full`-level share on the dashboard.
+
+#### Scenario: Owner adds a share
+
+- GIVEN a logged-in user "alice" who owns dashboard id `5`
+- WHEN she sends `POST /api/dashboard/5/shares` with body `{"shareType": "user", "shareWith": "bob", "permissionLevel": "view_only"}`
+- THEN the system MUST insert a row in `oc_mydash_dashboard_shares` with the four fields plus `createdAt = now()`
+- AND respond with HTTP 201 and the new share's id, displayName, and serialized fields
+
+#### Scenario: Recipient cannot manage shares
+
+- GIVEN dashboard `5` is owned by "alice" and shared with "bob" at `full` level
+- WHEN bob sends `POST /api/dashboard/5/shares` to add another recipient
+- THEN the system MUST return HTTP 403
+- AND no share row MUST be created
+
+#### Scenario: Updating an existing share replaces, does not duplicate
+
+- GIVEN alice has shared dashboard `5` with "bob" at `view_only`
+- WHEN she sends `POST /api/dashboard/5/shares` with the same `shareType` and `shareWith` but `permissionLevel: "full"`
+- THEN the system MUST update the existing share row, not create a second one
+- AND only one share row MUST exist for `(dashboardId=5, shareType=user, shareWith=bob)`
+
+### REQ-SHARE-002: Listing dashboards visible to a user
+
+`GET /api/dashboards` MUST return both dashboards owned by the caller AND dashboards the caller has access to via a direct or group share. Each entry MUST be decorated with `isOwner: bool`, `sharedBy: string|null` (the owner's userId when not the caller's own dashboard), and `effectivePermissionLevel: 'view_only'|'add_only'|'full'`.
+
+#### Scenario: Recipient sees a shared dashboard in their list
+
+- GIVEN dashboard `5` ("My Dashboard", owned by "alice") is shared with "bob" at `add_only`
+- WHEN bob fetches `GET /api/dashboards`
+- THEN the response MUST include an entry with `id: 5`, `isOwner: false`, `sharedBy: "alice"`, `effectivePermissionLevel: "add_only"`
+- AND bob's own dashboards MUST also be present, each with `isOwner: true`, `sharedBy: null`
+
+#### Scenario: Group share grants visibility to all group members
+
+- GIVEN dashboard `5` is shared with group `marketing` at `view_only`
+- AND user "carol" is a member of group `marketing`
+- WHEN carol fetches `GET /api/dashboards`
+- THEN the entry for dashboard `5` MUST be present with `effectivePermissionLevel: "view_only"`
+
+#### Scenario: Most-permissive level wins when a user matches multiple shares
+
+- GIVEN dashboard `5` is shared with user "carol" at `view_only` AND with group `marketing` at `full`
+- AND carol is a member of `marketing`
+- WHEN carol fetches `GET /api/dashboards`
+- THEN the entry for dashboard `5` MUST report `effectivePermissionLevel: "full"`
+
+### REQ-SHARE-003: Loading a shared dashboard with placements
+
+`GET /api/dashboard/{id}` MUST return the dashboard, its widget placements, and the caller's effective permission level for any dashboard the caller can view (owned or shared). Callers without ownership AND without any matching share MUST receive HTTP 403.
+
+#### Scenario: Recipient loads a shared dashboard
+
+- GIVEN dashboard `5` (with 4 widget placements) is shared with bob at `view_only`
+- WHEN bob fetches `GET /api/dashboard/5`
+- THEN the response body MUST contain `dashboard`, `placements` (4 entries), `permissionLevel: "view_only"`, `isOwner: false`, `sharedBy: "alice"`
+
+#### Scenario: Non-recipient is denied
+
+- GIVEN dashboard `5` is owned by alice and not shared with carol
+- WHEN carol fetches `GET /api/dashboard/5`
+- THEN the system MUST return HTTP 403
+
+### REQ-SHARE-004: Per-share permission resolution overrides admin defaults
+
+When a user accesses a dashboard via a share, the system MUST evaluate widget/tile/layout permission checks against **the share's** `permissionLevel` rather than the dashboard's globally-set `permissionLevel` field. The dashboard's own `permissionLevel` continues to apply only to the owner.
+
+#### Scenario: Owner has `view_only`, recipient has `full`
+
+- GIVEN dashboard `5` has `permissionLevel = "view_only"` and is owned by alice
+- AND it is shared with bob at `full`
+- WHEN bob sends `POST /api/dashboard/5/widgets` to add a widget
+- THEN the system MUST allow the operation (HTTP 201)
+- AND when alice attempts the same call, the system MUST return HTTP 403
+
+### REQ-SHARE-005: Owner-only metadata and lifecycle operations
+
+Even with a `full`-level share, recipients MUST NOT be able to:
+
+- Rename the dashboard or change its description (`canEditDashboardMetadata` returns false for non-owners)
+- Delete the dashboard (`DELETE /api/dashboard/{id}` returns HTTP 403 for non-owners)
+- Persist the dashboard as their "active" dashboard (the `is_active` flag is keyed on the owner's row; `POST /api/dashboard/{id}/activate` MUST be a successful no-op for recipients but MUST NOT change DB state)
+
+#### Scenario: `full`-level recipient cannot rename
+
+- GIVEN dashboard `5` is shared with bob at `full`
+- WHEN bob sends `PUT /api/dashboard/5` with body `{"name": "New Name"}`
+- THEN the system MUST return HTTP 403
+- AND the dashboard's name MUST remain unchanged
+
+#### Scenario: `full`-level recipient cannot delete
+
+- GIVEN dashboard `5` is shared with bob at `full`
+- WHEN bob sends `DELETE /api/dashboard/5`
+- THEN the system MUST return HTTP 403
+
+#### Scenario: Activation by recipient is a soft success
+
+- GIVEN dashboard `5` (owned by alice) is shared with bob at `view_only`
+- WHEN bob sends `POST /api/dashboard/5/activate`
+- THEN the system MUST return HTTP 200 with the dashboard payload
+- AND no row's `is_active` flag MUST change as a result
+
+### REQ-SHARE-006: Sharee autocomplete
+
+`GET /api/sharees?query={q}` MUST return up to 10 matching users and 10 matching groups whose name (display name or id) contains `q`. The endpoint MUST exclude the caller from the user results to prevent self-shares. Recipients are matched server-side via `IUserManager::search` and `IGroupManager::search`.
+
+#### Scenario: Search returns matching users and groups
+
+- GIVEN users `jan.pietersen`, `jan.vandeberg`, `mark.jansen` and groups `marketing`, `sales`
+- WHEN alice fetches `GET /api/sharees?query=jan`
+- THEN the response MUST include the matching users in the `users` array and any matching groups in the `groups` array
+- AND alice MUST NOT appear in the `users` array
+
+### REQ-SHARE-007: Cascade on dashboard delete
+
+When a dashboard is deleted (by its owner), every share row referencing that dashboard MUST be deleted in the same transaction. No orphan share rows MAY remain.
+
+#### Scenario: Shares are removed when the dashboard is deleted
+
+- GIVEN dashboard `5` has 3 share rows
+- WHEN alice (owner) sends `DELETE /api/dashboard/5`
+- THEN the dashboard row MUST be deleted
+- AND all 3 share rows in `oc_mydash_dashboard_shares` referencing `dashboard_id = 5` MUST also be deleted
+- AND a query for shares on dashboard `5` MUST return 0 rows

--- a/src/components/Dashboard/IconRenderer.vue
+++ b/src/components/Dashboard/IconRenderer.vue
@@ -1,0 +1,80 @@
+<!--
+  - SPDX-FileCopyrightText: 2026 MyDash Contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<!--
+	IconRenderer — capability `dashboard-icons`
+
+	Renders an icon for any field that follows the dashboards.icon
+	convention (see src/constants/dashboardIcons.js):
+
+	  - null / '' / unknown → DEFAULT_ICON component
+	  - registry key (e.g. 'Star') → that component
+	  - URL (starts with '/' or 'http') → <img> tag
+
+	The URL branch is the foundation for the sibling capability
+	`custom-icon-upload-pattern`. For THIS change the branch exists in
+	the template (so consumers don't have to be rewritten when uploads
+	land), but isCustomIconUrl() returns false for any registry key, so
+	the image branch only fires once uploaded URLs start being persisted.
+
+	TODO(custom-icon-upload-pattern): no behavioural change required here
+	— that change adds the upload + URL-persistence path; this template
+	already handles the discriminator.
+-->
+
+<template>
+	<img
+		v-if="isUrl"
+		:src="name"
+		:width="size"
+		:height="size"
+		alt="">
+	<component
+		:is="iconComponent"
+		v-else
+		:size="size" />
+</template>
+
+<script>
+import {
+	getIconComponent,
+	isCustomIconUrl,
+} from '../../constants/dashboardIcons.js'
+
+export default {
+	name: 'IconRenderer',
+
+	props: {
+		/**
+		 * Icon identifier — either a registry key, a URL (handled by the
+		 * `custom-icon-upload-pattern` capability), or null/empty for the
+		 * default icon.
+		 */
+		name: {
+			type: String,
+			default: null,
+		},
+
+		/**
+		 * Icon size in pixels. Applied as the `size` prop on built-in
+		 * MDI components and as `width`/`height` on `<img>`.
+		 */
+		size: {
+			type: Number,
+			default: 20,
+		},
+	},
+
+	computed: {
+		isUrl() {
+			return isCustomIconUrl(this.name)
+		},
+
+		iconComponent() {
+			return getIconComponent(this.name)
+		},
+	},
+}
+</script>

--- a/src/constants/dashboardIcons.js
+++ b/src/constants/dashboardIcons.js
@@ -1,0 +1,119 @@
+/**
+ * SPDX-FileCopyrightText: 2026 MyDash Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Dashboard icons registry — capability `dashboard-icons`
+ *
+ * Curated registry of built-in Material Design Icons used across MyDash
+ * dashboard surfaces (sidebar switcher, admin list, tile editor). The
+ * `icon` field on a dashboard record may hold one of three values:
+ *
+ *   - `null` / `''` — render the `DEFAULT_ICON`
+ *   - A registry key (e.g. `'ViewDashboard'`) — looked up in `DASHBOARD_ICONS`
+ *   - A URL (starts with `/` or `http`) — handled by the sibling capability
+ *     `custom-icon-upload-pattern`. Use `isCustomIconUrl()` as the
+ *     discriminator.
+ *
+ * REQ-ICON-001: Curated registry of at least 15 named built-in icons.
+ * REQ-ICON-002: `getIconComponent` MUST tolerate null/undefined/empty/unknown
+ *               and resolve to `DEFAULT_ICON` without throwing.
+ * REQ-ICON-003: Admin pickers MUST enumerate options from
+ *               `Object.keys(DASHBOARD_ICONS)` to stay in lock-step.
+ * REQ-ICON-004: Each icon MUST be a separate `import` (no wildcard / barrel)
+ *               to keep the production bundle tree-shake-friendly.
+ */
+
+import ViewDashboardIcon from 'vue-material-design-icons/ViewDashboard.vue'
+import HomeIcon from 'vue-material-design-icons/Home.vue'
+import ChartBarIcon from 'vue-material-design-icons/ChartBar.vue'
+import CogIcon from 'vue-material-design-icons/Cog.vue'
+import AccountGroupIcon from 'vue-material-design-icons/AccountGroup.vue'
+import CalendarIcon from 'vue-material-design-icons/Calendar.vue'
+import FileDocumentIcon from 'vue-material-design-icons/FileDocument.vue'
+import BellIcon from 'vue-material-design-icons/Bell.vue'
+import StarIcon from 'vue-material-design-icons/Star.vue'
+import HeartIcon from 'vue-material-design-icons/Heart.vue'
+import BookOpenVariantIcon from 'vue-material-design-icons/BookOpenVariant.vue'
+import LightbulbIcon from 'vue-material-design-icons/Lightbulb.vue'
+import RocketLaunchIcon from 'vue-material-design-icons/RocketLaunch.vue'
+import EarthIcon from 'vue-material-design-icons/Earth.vue'
+import BriefcaseIcon from 'vue-material-design-icons/Briefcase.vue'
+
+/**
+ * Map of icon registry name → Vue component reference.
+ *
+ * The keys are the canonical strings persisted on `dashboards.icon`.
+ * Iteration order is the order options should appear in pickers.
+ *
+ * @type {Record<string, object>}
+ */
+export const DASHBOARD_ICONS = Object.freeze({
+	ViewDashboard: ViewDashboardIcon,
+	Home: HomeIcon,
+	ChartBar: ChartBarIcon,
+	Cog: CogIcon,
+	AccountGroup: AccountGroupIcon,
+	Calendar: CalendarIcon,
+	FileDocument: FileDocumentIcon,
+	Bell: BellIcon,
+	Star: StarIcon,
+	Heart: HeartIcon,
+	BookOpenVariant: BookOpenVariantIcon,
+	Lightbulb: LightbulbIcon,
+	RocketLaunch: RocketLaunchIcon,
+	Earth: EarthIcon,
+	Briefcase: BriefcaseIcon,
+})
+
+/**
+ * The fallback icon name used when no icon is set or the requested name
+ * is not in the registry.
+ *
+ * @type {string}
+ */
+export const DEFAULT_ICON = 'ViewDashboard'
+
+// Module-load assertion — guarantees the default is always resolvable.
+// REQ-ICON-001 scenario: "Default icon is 'ViewDashboard'".
+if (!DASHBOARD_ICONS[DEFAULT_ICON]) {
+	throw new Error(
+		`dashboardIcons: DEFAULT_ICON "${DEFAULT_ICON}" is not present in DASHBOARD_ICONS`,
+	)
+}
+
+/**
+ * Resolve an icon name to a Vue component reference.
+ *
+ * Tolerates null, undefined, empty string, and unknown names — all of
+ * these resolve to `DASHBOARD_ICONS[DEFAULT_ICON]`. Never throws and
+ * never returns null.
+ *
+ * @param {string|null|undefined} name - Icon registry key, or null/empty.
+ * @return {object} A Vue component suitable for `<component :is>`.
+ */
+export function getIconComponent(name) {
+	if (typeof name !== 'string' || name.length === 0) {
+		return DASHBOARD_ICONS[DEFAULT_ICON]
+	}
+	return DASHBOARD_ICONS[name] || DASHBOARD_ICONS[DEFAULT_ICON]
+}
+
+/**
+ * Discriminator for the `icon` field — true when the value should be
+ * rendered as an `<img>` (a URL) rather than looked up in the registry.
+ *
+ * The URL branch itself is implemented by the sibling capability
+ * `custom-icon-upload-pattern`. This helper is exported here so that
+ * any consumer (including this capability's own `IconRenderer`) can
+ * safely branch without depending on the upload code.
+ *
+ * @param {string|null|undefined} name - Value from `dashboards.icon`.
+ * @return {boolean} True if `name` is a non-empty string starting with
+ *                   `/` or `http`.
+ */
+export function isCustomIconUrl(name) {
+	if (typeof name !== 'string' || name.length === 0) {
+		return false
+	}
+	return name.startsWith('/') || name.startsWith('http')
+}


### PR DESCRIPTION
## Summary

Adds 25 OpenSpec change proposals at the **proposal + refinement + validation** stage modelling a complete dashboard sharing and runtime experience for MyDash. Specs are organised in 4 dependency layers; all 25 pass \`openspec validate --strict\`.

Includes the baseline \`dashboard-sharing\` capability spec under \`openspec/specs/dashboard-sharing/\` (referenced by \`dashboard-sharing-followups\`).

## Capabilities touched

| Capability | Changes |
|---|---|
| \`dashboards\` | multi-scope-dashboards, default-dashboard-flag, active-dashboard-resolution, fork-current-as-personal |
| \`admin-settings\` | group-priority-order, allow-personal-dashboards-flag |
| \`admin-templates\` | group-routing |
| \`grid-layout\` | responsive-grid-breakpoints, widget-collision-placement |
| \`widgets\` | widget-add-edit-modal, widget-context-menu, nc-dashboard-widget-proxy |
| \`legacy-widget-bridge\` | nc-dashboard-widget-proxy (pollForCallback helper) |
| \`dashboard-sharing\` | dashboard-sharing-followups |
| **NEW** \`dashboard-icons\` | dashboard-icons, custom-icon-upload-pattern |
| **NEW** \`dashboard-switcher\` | dashboard-switcher-sidebar |
| **NEW** \`runtime-shell\` | runtime-shell |
| **NEW** \`text-display-widget\` | text-display-widget |
| **NEW** \`label-widget\` | label-widget |
| **NEW** \`image-widget\` | image-widget |
| **NEW** \`link-button-widget\` | link-button-widget |
| **NEW** \`resource-uploads\` | resource-uploads, resource-serving, svg-sanitisation |
| **NEW** \`initial-state-contract\` | initial-state-contract |

## Status

- ✅ All 25 changes validate (\`openspec validate --strict\`)
- ⏳ Implementation (\`opsx-apply\`) is the next step per change

## Recommended apply order (dependency layers)

1. **Foundations** (parallel): multi-scope-dashboards, group-priority-order, allow-personal-dashboards-flag, dashboard-icons, resource-uploads, responsive-grid-breakpoints, widget-collision-placement, initial-state-contract, text-display-widget, label-widget
2. **Foundation extensions**: default-dashboard-flag, group-routing, custom-icon-upload-pattern, image-widget, nc-dashboard-widget-proxy, resource-serving, svg-sanitisation, link-button-widget, dashboard-sharing-followups
3. **UI surfaces**: active-dashboard-resolution, fork-current-as-personal, dashboard-switcher-sidebar, widget-add-edit-modal
4. **Sequential last**: widget-context-menu, runtime-shell

## Note on extra commits

This branch was cut from \`chore/phpstan-phpunit-screenshots\` so the PR diff also shows those 2 unrelated commits — they're separate WIP and will land via their own PR.

## Test plan

- [ ] \`openspec validate <change> --strict\` passes for all 25 changes (verified locally before commit)
- [ ] Reviewers spot-check 1–2 spec deltas per capability for clarity / correctness
- [ ] Confirm baseline \`openspec/specs/dashboard-sharing/spec.md\` is the intended REQ-SHARE-001..007 baseline