### PR TITLE
feat(resources): admin-only resource upload endpoint

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -54,5 +54,8 @@ return [
 		['name' => 'admin#updateSettings', 'url' => '/api/admin/settings', 'verb' => 'PUT'],
 		['name' => 'admin#listGroups', 'url' => '/api/admin/groups', 'verb' => 'GET'],
 		['name' => 'admin#updateGroupOrder', 'url' => '/api/admin/groups', 'verb' => 'POST'],
+
+		// Resource uploads (admin-only base64 mini file API)
+		['name' => 'resource#upload', 'url' => '/api/resources', 'verb' => 'POST'],
 	],
 ];

--- a/lib/Controller/ResourceController.php
+++ b/lib/Controller/ResourceController.php
@@ -1,0 +1,189 @@
+<?php
+
+/**
+ * ResourceController
+ *
+ * HTTP entry point for the resource-uploads capability. Exposes a
+ * single admin-only `POST /api/resources` endpoint that accepts a
+ * raw JSON body of the shape `{base64: 'data:image/<type>;base64,...'}`
+ * and returns a standardised `{status, url, name, size}` envelope.
+ *
+ * All errors are mapped to a `{status: 'error', error: <stable_code>,
+ * message: <display>}` envelope — raw exception messages are NEVER
+ * returned to the client.
+ *
+ * @category  Controller
+ * @package   OCA\MyDash\Controller
+ * @author    Conduction b.v. <info@conduction.nl>
+ * @copyright 2024 Conduction b.v.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @version   GIT:auto
+ * @link      https://conduction.nl
+ *
+ * SPDX-FileCopyrightText: 2024 MyDash Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace OCA\MyDash\Controller;
+
+use OCA\MyDash\Exception\ForbiddenException;
+use OCA\MyDash\Exception\ResourceException;
+use OCA\MyDash\Exception\StorageFailureException;
+use OCA\MyDash\Service\ResourceService;
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\IGroupManager;
+use OCP\IRequest;
+use OCP\IUserSession;
+use Psr\Log\LoggerInterface;
+use Throwable;
+
+/**
+ * Admin-only resource upload controller.
+ */
+class ResourceController extends Controller
+{
+    /**
+     * Constructor.
+     *
+     * @param IRequest                    $request         The HTTP request.
+     * @param ResourceService             $resourceService The upload pipeline.
+     * @param ResourceUploadRequestParser $parser          Parses request body.
+     * @param IUserSession                $userSession     Session accessor.
+     * @param IGroupManager               $groupManager    Admin checker.
+     * @param LoggerInterface             $logger          PSR logger.
+     */
+    public function __construct(
+        IRequest $request,
+        private readonly ResourceService $resourceService,
+        private readonly ResourceUploadRequestParser $parser,
+        private readonly IUserSession $userSession,
+        private readonly IGroupManager $groupManager,
+        private readonly LoggerInterface $logger,
+    ) {
+        parent::__construct(
+            appName: 'mydash',
+            request: $request
+        );
+    }//end __construct()
+
+    /**
+     * Handle `POST /api/resources`.
+     *
+     * Reads the raw JSON body from `php://input`, asserts an admin
+     * caller, delegates to ResourceService, and maps the response
+     * (success or any typed exception) to the standardised envelope.
+     *
+     * @return JSONResponse Either the success envelope with
+     *                      `{status, url, name, size}` or the error
+     *                      envelope with `{status, error, message}`.
+     *
+     * @NoCSRFRequired
+     */
+    public function upload(): JSONResponse
+    {
+        try {
+            $this->assertAdmin();
+            $base64 = $this->parser->extractBase64(
+                request: $this->request,
+                rawBody: $this->readRequestBody()
+            );
+
+            $result = $this->resourceService->upload(
+                base64DataUrl: $base64
+            );
+
+            return new JSONResponse(
+                data: [
+                    'status' => 'success',
+                    'url'    => $result['url'],
+                    'name'   => $result['name'],
+                    'size'   => $result['size'],
+                ],
+                statusCode: Http::STATUS_OK
+            );
+        } catch (ResourceException $e) {
+            // Log storage failures — these usually indicate an
+            // operational problem (disk, permissions, etc.).
+            if ($e instanceof StorageFailureException) {
+                $this->logger->error(
+                    message: 'Resource upload storage failure',
+                    context: ['exception' => $e->getMessage()]
+                );
+            }
+
+            return $this->errorResponse(exception: $e);
+        } catch (Throwable $e) {
+            // Defence in depth — never leak raw messages on truly
+            // unexpected paths.
+            $this->logger->error(
+                message: 'Unexpected resource upload failure',
+                context: ['exception' => $e->getMessage()]
+            );
+
+            $fallback = new StorageFailureException(
+                message: 'Failed to store resource'
+            );
+
+            return $this->errorResponse(exception: $fallback);
+        }//end try
+    }//end upload()
+
+    /**
+     * Throw if the current session user is not an admin.
+     *
+     * Delegates to `IGroupManager::isAdmin` — both an unauthenticated
+     * request and an authenticated non-admin produce HTTP 403.
+     *
+     * @return void
+     *
+     * @throws ForbiddenException When the caller is not an admin.
+     */
+    private function assertAdmin(): void
+    {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
+            throw new ForbiddenException();
+        }
+
+        if ($this->groupManager->isAdmin(userId: $user->getUID()) === false) {
+            throw new ForbiddenException();
+        }
+    }//end assertAdmin()
+
+    /**
+     * Read the raw request body.
+     *
+     * Extracted so tests can override the source — `php://input` is
+     * not realistically pluggable in PHPUnit otherwise. Production
+     * code reads from the standard PHP input stream.
+     *
+     * @return string The raw request body.
+     */
+    protected function readRequestBody(): string
+    {
+        return (string) file_get_contents(filename: 'php://input');
+    }//end readRequestBody()
+
+    /**
+     * Build the standardised error envelope from a typed exception.
+     *
+     * @param ResourceException $exception The typed exception.
+     *
+     * @return JSONResponse The error response.
+     */
+    private function errorResponse(ResourceException $exception): JSONResponse
+    {
+        return new JSONResponse(
+            data: [
+                'status'  => 'error',
+                'error'   => $exception->getErrorCode(),
+                'message' => $exception->getDisplayMessage(),
+            ],
+            statusCode: $exception->getHttpStatus()
+        );
+    }//end errorResponse()
+}//end class

--- a/lib/Controller/ResourceUploadRequestParser.php
+++ b/lib/Controller/ResourceUploadRequestParser.php
@@ -1,0 +1,88 @@
+<?php
+
+/**
+ * ResourceUploadRequestParser
+ *
+ * Parses the raw HTTP request for the `POST /api/resources` endpoint.
+ * Lives next to ResourceController so we can keep the controller's
+ * dependency graph small (PHPMD CouplingBetweenObjects limit).
+ *
+ * @category  Controller
+ * @package   OCA\MyDash\Controller
+ * @author    Conduction b.v. <info@conduction.nl>
+ * @copyright 2024 Conduction b.v.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @version   GIT:auto
+ * @link      https://conduction.nl
+ *
+ * SPDX-FileCopyrightText: 2024 MyDash Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace OCA\MyDash\Controller;
+
+use JsonException;
+use OCA\MyDash\Exception\InvalidDataUrlException;
+use OCA\MyDash\Exception\UnsupportedMediaTypeException;
+use OCP\IRequest;
+
+/**
+ * Parses request bodies for the resource upload endpoint.
+ */
+class ResourceUploadRequestParser
+{
+    /**
+     * Extract the `base64` field from the raw JSON body.
+     *
+     * @param IRequest $request The HTTP request.
+     * @param string   $rawBody The raw request body bytes.
+     *
+     * @return string The base64 data URL.
+     *
+     * @throws UnsupportedMediaTypeException When the request looks
+     *                                       like multipart instead of
+     *                                       JSON.
+     * @throws InvalidDataUrlException       When the body is missing,
+     *                                       not JSON, or lacks the
+     *                                       `base64` field.
+     */
+    public function extractBase64(IRequest $request, string $rawBody): string
+    {
+        $contentType = (string) $request->getHeader(name: 'Content-Type');
+        if ($contentType !== '' && stripos(
+            haystack: $contentType,
+            needle: 'multipart/form-data'
+        ) !== false
+        ) {
+            throw new UnsupportedMediaTypeException();
+        }
+
+        if ($rawBody === '') {
+            throw new InvalidDataUrlException();
+        }
+
+        try {
+            $decoded = json_decode(
+                json: $rawBody,
+                associative: true,
+                depth: 4,
+                flags: JSON_THROW_ON_ERROR
+            );
+        } catch (JsonException $e) {
+            throw new InvalidDataUrlException(
+                message: 'Body must be valid JSON'
+            );
+        }
+
+        if (is_array(value: $decoded) === false
+            || isset($decoded['base64']) === false
+            || is_string(value: $decoded['base64']) === false
+        ) {
+            throw new InvalidDataUrlException();
+        }
+
+        return $decoded['base64'];
+    }//end extractBase64()
+}//end class

--- a/lib/Exception/CorruptImageException.php
+++ b/lib/Exception/CorruptImageException.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * CorruptImageException
+ *
+ * Raised when `getimagesizefromstring` returns false for a raster
+ * payload, indicating the bytes are not a valid image. Maps to
+ * HTTP 400 + error code `corrupt_image`.
+ *
+ * @category  Exception
+ * @package   OCA\MyDash\Exception
+ * @author    Conduction b.v. <info@conduction.nl>
+ * @copyright 2024 Conduction b.v.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @version   GIT:auto
+ * @link      https://conduction.nl
+ *
+ * SPDX-FileCopyrightText: 2024 MyDash Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace OCA\MyDash\Exception;
+
+/**
+ * Image bytes could not be decoded by the image library.
+ */
+class CorruptImageException extends ResourceException
+{
+
+    /**
+     * Stable error code.
+     *
+     * @var string
+     */
+    protected string $errorCode = 'corrupt_image';
+
+    /**
+     * HTTP status.
+     *
+     * @var integer
+     */
+    protected int $httpStatus = 400;
+
+    /**
+     * Constructor.
+     *
+     * @param string $message Display message.
+     */
+    public function __construct(
+        string $message='Image content appears to be corrupt'
+    ) {
+        parent::__construct(message: $message);
+    }//end __construct()
+}//end class

--- a/lib/Exception/FileTooLargeException.php
+++ b/lib/Exception/FileTooLargeException.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * FileTooLargeException
+ *
+ * Raised when the decoded base64 payload exceeds the 5 MB hard cap.
+ * Enforced BEFORE invoking `getimagesizefromstring` to avoid loading
+ * an oversize blob into the image library. Maps to HTTP 400 +
+ * error code `file_too_large`.
+ *
+ * @category  Exception
+ * @package   OCA\MyDash\Exception
+ * @author    Conduction b.v. <info@conduction.nl>
+ * @copyright 2024 Conduction b.v.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @version   GIT:auto
+ * @link      https://conduction.nl
+ *
+ * SPDX-FileCopyrightText: 2024 MyDash Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace OCA\MyDash\Exception;
+
+/**
+ * Decoded payload exceeds the 5 MB hard cap.
+ */
+class FileTooLargeException extends ResourceException
+{
+
+    /**
+     * Stable error code.
+     *
+     * @var string
+     */
+    protected string $errorCode = 'file_too_large';
+
+    /**
+     * HTTP status.
+     *
+     * @var integer
+     */
+    protected int $httpStatus = 400;
+
+    /**
+     * Constructor.
+     *
+     * @param string $message Display message.
+     */
+    public function __construct(string $message='Maximum size is 5MB')
+    {
+        parent::__construct(message: $message);
+    }//end __construct()
+}//end class

--- a/lib/Exception/ForbiddenException.php
+++ b/lib/Exception/ForbiddenException.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * ForbiddenException
+ *
+ * Raised when a non-admin user attempts to invoke an admin-only
+ * resource endpoint. Maps to HTTP 403 + error code `forbidden`.
+ *
+ * @category  Exception
+ * @package   OCA\MyDash\Exception
+ * @author    Conduction b.v. <info@conduction.nl>
+ * @copyright 2024 Conduction b.v.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @version   GIT:auto
+ * @link      https://conduction.nl
+ *
+ * SPDX-FileCopyrightText: 2024 MyDash Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace OCA\MyDash\Exception;
+
+/**
+ * Admin-only endpoint accessed by a non-admin user.
+ */
+class ForbiddenException extends ResourceException
+{
+
+    /**
+     * Stable error code.
+     *
+     * @var string
+     */
+    protected string $errorCode = 'forbidden';
+
+    /**
+     * HTTP status.
+     *
+     * @var integer
+     */
+    protected int $httpStatus = 403;
+
+    /**
+     * Constructor.
+     *
+     * @param string $message Display message.
+     */
+    public function __construct(string $message='Admin privileges required')
+    {
+        parent::__construct(message: $message);
+    }//end __construct()
+}//end class

--- a/lib/Exception/InvalidDataUrlException.php
+++ b/lib/Exception/InvalidDataUrlException.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * InvalidDataUrlException
+ *
+ * Raised when the supplied base64 string does not parse as a
+ * `data:image/<type>;base64,...` data URL. Maps to HTTP 400 +
+ * error code `invalid_data_url`.
+ *
+ * @category  Exception
+ * @package   OCA\MyDash\Exception
+ * @author    Conduction b.v. <info@conduction.nl>
+ * @copyright 2024 Conduction b.v.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @version   GIT:auto
+ * @link      https://conduction.nl
+ *
+ * SPDX-FileCopyrightText: 2024 MyDash Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace OCA\MyDash\Exception;
+
+/**
+ * Supplied base64 string is not a valid data URL.
+ */
+class InvalidDataUrlException extends ResourceException
+{
+
+    /**
+     * Stable error code.
+     *
+     * @var string
+     */
+    protected string $errorCode = 'invalid_data_url';
+
+    /**
+     * HTTP status.
+     *
+     * @var integer
+     */
+    protected int $httpStatus = 400;
+
+    /**
+     * Constructor.
+     *
+     * @param string $message Display message.
+     */
+    public function __construct(
+        string $message='Body must contain a base64 data URL'
+    ) {
+        parent::__construct(message: $message);
+    }//end __construct()
+}//end class

--- a/lib/Exception/InvalidImageFormatException.php
+++ b/lib/Exception/InvalidImageFormatException.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * InvalidImageFormatException
+ *
+ * Raised when the data URL declares a type that is not in the
+ * allowed list (jpeg, jpg, png, gif, svg, webp). Maps to HTTP 400 +
+ * error code `invalid_image_format`.
+ *
+ * @category  Exception
+ * @package   OCA\MyDash\Exception
+ * @author    Conduction b.v. <info@conduction.nl>
+ * @copyright 2024 Conduction b.v.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @version   GIT:auto
+ * @link      https://conduction.nl
+ *
+ * SPDX-FileCopyrightText: 2024 MyDash Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace OCA\MyDash\Exception;
+
+/**
+ * Declared image type is not in the allowed list.
+ */
+class InvalidImageFormatException extends ResourceException
+{
+
+    /**
+     * Stable error code.
+     *
+     * @var string
+     */
+    protected string $errorCode = 'invalid_image_format';
+
+    /**
+     * HTTP status.
+     *
+     * @var integer
+     */
+    protected int $httpStatus = 400;
+
+    /**
+     * Constructor.
+     *
+     * @param string $message Display message.
+     */
+    public function __construct(
+        string $message='Allowed image formats: jpeg, jpg, png, gif, svg, webp'
+    ) {
+        parent::__construct(message: $message);
+    }//end __construct()
+}//end class

--- a/lib/Exception/MimeMismatchException.php
+++ b/lib/Exception/MimeMismatchException.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * MimeMismatchException
+ *
+ * Raised when the declared image type in the data URL prefix does
+ * not match the MIME type detected by `getimagesizefromstring` for
+ * raster types. Maps to HTTP 400 + error code `mime_mismatch`.
+ *
+ * @category  Exception
+ * @package   OCA\MyDash\Exception
+ * @author    Conduction b.v. <info@conduction.nl>
+ * @copyright 2024 Conduction b.v.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @version   GIT:auto
+ * @link      https://conduction.nl
+ *
+ * SPDX-FileCopyrightText: 2024 MyDash Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace OCA\MyDash\Exception;
+
+/**
+ * Declared image type does not match the detected MIME type.
+ */
+class MimeMismatchException extends ResourceException
+{
+
+    /**
+     * Stable error code.
+     *
+     * @var string
+     */
+    protected string $errorCode = 'mime_mismatch';
+
+    /**
+     * HTTP status.
+     *
+     * @var integer
+     */
+    protected int $httpStatus = 400;
+
+    /**
+     * Constructor.
+     *
+     * @param string $message Display message.
+     */
+    public function __construct(
+        string $message='Declared image type does not match file content'
+    ) {
+        parent::__construct(message: $message);
+    }//end __construct()
+}//end class

--- a/lib/Exception/ResourceException.php
+++ b/lib/Exception/ResourceException.php
@@ -1,0 +1,81 @@
+<?php
+
+/**
+ * ResourceException
+ *
+ * Base exception for the resource-uploads capability. Carries a stable
+ * machine-readable error code and a human-readable, translatable display
+ * message that is safe to return to clients (never wraps raw underlying
+ * exception strings).
+ *
+ * @category  Exception
+ * @package   OCA\MyDash\Exception
+ * @author    Conduction b.v. <info@conduction.nl>
+ * @copyright 2024 Conduction b.v.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @version   GIT:auto
+ * @link      https://conduction.nl
+ *
+ * SPDX-FileCopyrightText: 2024 MyDash Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace OCA\MyDash\Exception;
+
+use Exception;
+
+/**
+ * Base exception for resource-uploads.
+ */
+abstract class ResourceException extends Exception
+{
+
+    /**
+     * Stable machine-readable error code for the response envelope.
+     *
+     * @var string
+     */
+    protected string $errorCode = 'unknown_error';
+
+    /**
+     * HTTP status code for the response.
+     *
+     * @var integer
+     */
+    protected int $httpStatus = 400;
+
+    /**
+     * Get the stable error code.
+     *
+     * @return string The machine-readable error code.
+     */
+    public function getErrorCode(): string
+    {
+        return $this->errorCode;
+    }//end getErrorCode()
+
+    /**
+     * Get the HTTP status code for this exception.
+     *
+     * @return int The HTTP status code.
+     */
+    public function getHttpStatus(): int
+    {
+        return $this->httpStatus;
+    }//end getHttpStatus()
+
+    /**
+     * Get the display message safe for clients.
+     *
+     * The exception message itself is curated; we never use raw inner
+     * messages. Subclasses should pass a translatable English string.
+     *
+     * @return string The display message.
+     */
+    public function getDisplayMessage(): string
+    {
+        return $this->getMessage();
+    }//end getDisplayMessage()
+}//end class

--- a/lib/Exception/StorageFailureException.php
+++ b/lib/Exception/StorageFailureException.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * StorageFailureException
+ *
+ * Raised when writing the validated bytes to the IAppData folder
+ * fails for reasons unrelated to validation (disk full, permission
+ * denied, etc.). Maps to HTTP 500 + error code `storage_failure`.
+ *
+ * @category  Exception
+ * @package   OCA\MyDash\Exception
+ * @author    Conduction b.v. <info@conduction.nl>
+ * @copyright 2024 Conduction b.v.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @version   GIT:auto
+ * @link      https://conduction.nl
+ *
+ * SPDX-FileCopyrightText: 2024 MyDash Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace OCA\MyDash\Exception;
+
+/**
+ * Persisting the resource to app data failed.
+ */
+class StorageFailureException extends ResourceException
+{
+
+    /**
+     * Stable error code.
+     *
+     * @var string
+     */
+    protected string $errorCode = 'storage_failure';
+
+    /**
+     * HTTP status.
+     *
+     * @var integer
+     */
+    protected int $httpStatus = 500;
+
+    /**
+     * Constructor.
+     *
+     * @param string $message Display message.
+     */
+    public function __construct(
+        string $message='Failed to store resource'
+    ) {
+        parent::__construct(message: $message);
+    }//end __construct()
+}//end class

--- a/lib/Exception/UnsupportedMediaTypeException.php
+++ b/lib/Exception/UnsupportedMediaTypeException.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * UnsupportedMediaTypeException
+ *
+ * Raised when a non-JSON request body is sent to the resource
+ * upload endpoint (e.g. multipart/form-data). Maps to HTTP 415 +
+ * error code `unsupported_media_type`.
+ *
+ * @category  Exception
+ * @package   OCA\MyDash\Exception
+ * @author    Conduction b.v. <info@conduction.nl>
+ * @copyright 2024 Conduction b.v.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @version   GIT:auto
+ * @link      https://conduction.nl
+ *
+ * SPDX-FileCopyrightText: 2024 MyDash Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace OCA\MyDash\Exception;
+
+/**
+ * Request media type is not the expected JSON body.
+ */
+class UnsupportedMediaTypeException extends ResourceException
+{
+
+    /**
+     * Stable error code.
+     *
+     * @var string
+     */
+    protected string $errorCode = 'unsupported_media_type';
+
+    /**
+     * HTTP status.
+     *
+     * @var integer
+     */
+    protected int $httpStatus = 415;
+
+    /**
+     * Constructor.
+     *
+     * @param string $message Display message.
+     */
+    public function __construct(
+        string $message='Use JSON body with base64 field'
+    ) {
+        parent::__construct(message: $message);
+    }//end __construct()
+}//end class

--- a/lib/Service/ImageMimeValidator.php
+++ b/lib/Service/ImageMimeValidator.php
@@ -1,0 +1,114 @@
+<?php
+
+/**
+ * ImageMimeValidator
+ *
+ * Cross-checks the declared image type from a base64 data URL prefix
+ * against the MIME type detected by `getimagesizefromstring` for raster
+ * formats (jpeg/jpg/png/gif/webp). SVG is delegated to a separate
+ * sanitiser (see `svg-sanitisation` capability) and intentionally NOT
+ * validated here.
+ *
+ * The validator never loads bytes into memory beyond the caller's
+ * decoded buffer — the size cap is enforced by the caller before this
+ * validator is invoked.
+ *
+ * @category  Service
+ * @package   OCA\MyDash\Service
+ * @author    Conduction b.v. <info@conduction.nl>
+ * @copyright 2024 Conduction b.v.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @version   GIT:auto
+ * @link      https://conduction.nl
+ *
+ * SPDX-FileCopyrightText: 2024 MyDash Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace OCA\MyDash\Service;
+
+use OCA\MyDash\Exception\CorruptImageException;
+use OCA\MyDash\Exception\MimeMismatchException;
+
+/**
+ * Validates that declared raster image type matches the detected MIME.
+ */
+class ImageMimeValidator
+{
+    /**
+     * Map normalised declared types to expected detected MIMEs.
+     *
+     * `getimagesizefromstring` returns these mime strings for valid
+     * images of each type. `jpeg` and `jpg` both produce `image/jpeg`.
+     *
+     * @var array<string,string>
+     */
+    private const RASTER_MIME_MAP = [
+        'jpeg' => 'image/jpeg',
+        'jpg'  => 'image/jpeg',
+        'png'  => 'image/png',
+        'gif'  => 'image/gif',
+        'webp' => 'image/webp',
+    ];
+
+    /**
+     * Validate that the declared raster type matches the detected MIME.
+     *
+     * SVG is skipped (delegated to SvgSanitiser in a sibling change).
+     * Caller MUST enforce the size cap before invoking this method to
+     * avoid loading oversize blobs into the image library.
+     *
+     * @param string $declaredType Normalised, lowercase declared type
+     *                             (e.g. 'png', 'jpg', 'svg').
+     * @param string $bytes        Decoded image bytes.
+     *
+     * @return void
+     *
+     * @throws CorruptImageException When the bytes cannot be decoded.
+     * @throws MimeMismatchException When the detected MIME differs from
+     *                               the declared type.
+     */
+    public function validate(string $declaredType, string $bytes): void
+    {
+        // SVG validation is the sanitiser's job, not this validator's.
+        if ($declaredType === 'svg') {
+            return;
+        }
+
+        if (isset(self::RASTER_MIME_MAP[$declaredType]) === false) {
+            // Should never happen — caller already vetted the declared
+            // type — but be defensive against future callers.
+            throw new MimeMismatchException();
+        }
+
+        $expectedMime = self::RASTER_MIME_MAP[$declaredType];
+
+        // `getimagesizefromstring` returns false for non-images. We
+        // suppress the warning via a local error handler instead of
+        // the `@` operator (banned by phpmd's ErrorControlOperator
+        // rule). The handler is restored before any branch returns.
+        $previous = set_error_handler(
+            callback: static function (): bool {
+                return true;
+            }
+        );
+
+        try {
+            $info = getimagesizefromstring(string: $bytes);
+        } finally {
+            restore_error_handler();
+            unset($previous);
+        }
+
+        if ($info === false) {
+            throw new CorruptImageException();
+        }
+
+        $detectedMime = ($info['mime'] ?? '');
+        if ($detectedMime !== $expectedMime) {
+            throw new MimeMismatchException();
+        }
+    }//end validate()
+}//end class

--- a/lib/Service/ResourceService.php
+++ b/lib/Service/ResourceService.php
@@ -1,0 +1,273 @@
+<?php
+
+/**
+ * ResourceService
+ *
+ * Implements the resource-uploads capability — admin-only base64
+ * upload pipeline for branding assets (icons, widget images). The
+ * service parses a `data:image/<type>;base64,...` data URL, enforces
+ * a 5 MB hard cap on decoded bytes BEFORE invoking the image library,
+ * cross-checks the declared raster type against the detected MIME,
+ * and persists the bytes via `IAppData::getFolder('resources')` with
+ * a high-entropy `resource_<uniqid>.<ext>` filename.
+ *
+ * SVG sanitisation is delegated to a sibling capability and is
+ * intentionally out of scope here.
+ *
+ * @category  Service
+ * @package   OCA\MyDash\Service
+ * @author    Conduction b.v. <info@conduction.nl>
+ * @copyright 2024 Conduction b.v.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @version   GIT:auto
+ * @link      https://conduction.nl
+ *
+ * SPDX-FileCopyrightText: 2024 MyDash Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace OCA\MyDash\Service;
+
+use OCA\MyDash\AppInfo\Application;
+use OCA\MyDash\Exception\FileTooLargeException;
+use OCA\MyDash\Exception\InvalidDataUrlException;
+use OCA\MyDash\Exception\InvalidImageFormatException;
+use OCA\MyDash\Exception\StorageFailureException;
+use OCP\Files\IAppData;
+use OCP\Files\NotFoundException;
+use Throwable;
+
+/**
+ * Admin-only base64 upload pipeline for branding assets.
+ */
+class ResourceService
+{
+    /**
+     * Maximum decoded payload size (5 MB).
+     *
+     * @var int
+     */
+    public const MAX_BYTES = (5 * 1024 * 1024);
+
+    /**
+     * Name of the IAppData subfolder where resources are stored.
+     *
+     * @var string
+     */
+    public const FOLDER = 'resources';
+
+    /**
+     * Allowed declared image types (lowercase, no dots).
+     *
+     * @var array<int,string>
+     */
+    private const ALLOWED_TYPES = [
+        'jpeg',
+        'jpg',
+        'png',
+        'gif',
+        'svg',
+        'webp',
+    ];
+
+    /**
+     * Constructor.
+     *
+     * @param IAppData           $appData       Nextcloud app-data
+     *                                          interface for this app.
+     * @param ImageMimeValidator $mimeValidator Raster MIME cross-checker.
+     */
+    public function __construct(
+        private readonly IAppData $appData,
+        private readonly ImageMimeValidator $mimeValidator,
+    ) {
+    }//end __construct()
+
+    /**
+     * Upload a base64 data URL and return the persisted resource info.
+     *
+     * Parses the data URL, enforces the 5 MB cap on decoded bytes
+     * BEFORE invoking the image library, validates the declared type,
+     * cross-checks the raster MIME, and persists to app data.
+     *
+     * @param string $base64DataUrl A `data:image/<type>;base64,<...>`
+     *                              string.
+     *
+     * @return array{url: string, name: string, size: int} The created
+     *                                                     resource.
+     *
+     * @throws InvalidDataUrlException     When the prefix is missing
+     *                                     or unparseable.
+     * @throws InvalidImageFormatException When the declared type is
+     *                                     not in the allowed list.
+     * @throws FileTooLargeException       When decoded bytes exceed
+     *                                     5 MB.
+     * @throws StorageFailureException     When writing to IAppData
+     *                                     fails.
+     */
+    public function upload(string $base64DataUrl): array
+    {
+        $parsed       = $this->parseDataUrl(input: $base64DataUrl);
+        $declaredType = $parsed['type'];
+        $bytes        = $parsed['bytes'];
+
+        // Enforce the 5 MB cap BEFORE invoking the image library.
+        if (strlen(string: $bytes) > self::MAX_BYTES) {
+            throw new FileTooLargeException();
+        }
+
+        // Cross-check raster MIME (SVG handled by sibling sanitiser).
+        $this->mimeValidator->validate(
+            declaredType: $declaredType,
+            bytes: $bytes
+        );
+
+        $extension = $this->normaliseExtension(declaredType: $declaredType);
+        $filename  = ('resource_'.uniqid(prefix: '', more_entropy: true).'.'.$extension);
+
+        $this->persist(filename: $filename, bytes: $bytes);
+
+        // Build the public URL directly — the serving endpoint is
+        // delivered by the sibling `resource-serving` change. The spec
+        // mandates the relative path form `/apps/mydash/resource/<name>`,
+        // so we don't pass it through linkToRoute or getAbsoluteURL.
+        $url = ('/apps/'.Application::APP_ID.'/resource/'.$filename);
+
+        return [
+            'url'  => $url,
+            'name' => $filename,
+            'size' => strlen(string: $bytes),
+        ];
+    }//end upload()
+
+    /**
+     * Parse a `data:image/<type>;base64,<payload>` string.
+     *
+     * The declared type is normalised to lowercase. Anything outside
+     * the allowed list is rejected.
+     *
+     * @param string $input The raw input string.
+     *
+     * @return array{type: string, bytes: string} The normalised
+     *                                            declared type and the
+     *                                            decoded bytes.
+     *
+     * @throws InvalidDataUrlException     When the prefix is missing.
+     * @throws InvalidImageFormatException When the declared type is
+     *                                     not allowed.
+     */
+    private function parseDataUrl(string $input): array
+    {
+        $matches = [];
+        // Match "data:image/<type>;base64,<payload>" — type is alpha
+        // plus optional "+xml" suffix (handles `image/svg+xml`).
+        if (preg_match(
+            pattern: '#^data:image/([a-zA-Z0-9.+-]+);base64,(.+)$#s',
+            subject: $input,
+            matches: $matches
+        ) !== 1
+        ) {
+            throw new InvalidDataUrlException();
+        }
+
+        $declaredRaw = strtolower(string: $matches[1]);
+        $payload     = $matches[2];
+
+        $declaredType = $this->normaliseDeclaredType(raw: $declaredRaw);
+        if (in_array(
+            needle: $declaredType,
+            haystack: self::ALLOWED_TYPES,
+            strict: true
+        ) === false
+        ) {
+            throw new InvalidImageFormatException();
+        }
+
+        $bytes = base64_decode(string: $payload, strict: true);
+        if ($bytes === false || $bytes === '') {
+            throw new InvalidDataUrlException(
+                message: 'Body must contain valid base64 data'
+            );
+        }
+
+        return [
+            'type'  => $declaredType,
+            'bytes' => $bytes,
+        ];
+    }//end parseDataUrl()
+
+    /**
+     * Normalise a raw declared type string from the data URL prefix.
+     *
+     * `image/svg+xml` → `svg`; otherwise the lowercased subtype is
+     * returned untouched (callers vet against ALLOWED_TYPES).
+     *
+     * @param string $raw The raw lowercased subtype.
+     *
+     * @return string The normalised declared type.
+     */
+    private function normaliseDeclaredType(string $raw): string
+    {
+        if ($raw === 'svg+xml') {
+            return 'svg';
+        }
+
+        return $raw;
+    }//end normaliseDeclaredType()
+
+    /**
+     * Map a normalised declared type to its file extension.
+     *
+     * Currently the extension equals the declared type for every
+     * allowed value.
+     *
+     * @param string $declaredType The normalised lowercase type.
+     *
+     * @return string The file extension (without the dot).
+     */
+    private function normaliseExtension(string $declaredType): string
+    {
+        return $declaredType;
+    }//end normaliseExtension()
+
+    /**
+     * Persist validated bytes via IAppData.
+     *
+     * Auto-creates the `resources/` folder on first use. Wraps any
+     * IAppData failure into a typed StorageFailureException so that
+     * raw underlying messages never leak to clients.
+     *
+     * @param string $filename The target filename inside the folder.
+     * @param string $bytes    The validated payload bytes.
+     *
+     * @return void
+     *
+     * @throws StorageFailureException When the underlying storage
+     *                                 layer rejects the write.
+     */
+    private function persist(string $filename, string $bytes): void
+    {
+        try {
+            $folder = $this->getOrCreateFolder();
+            $folder->newFile(name: $filename, content: $bytes);
+        } catch (Throwable $e) {
+            throw new StorageFailureException();
+        }
+    }//end persist()
+
+    /**
+     * Get the resources folder, creating it if it doesn't exist.
+     *
+     * @return \OCP\Files\SimpleFS\ISimpleFolder The resources folder.
+     */
+    private function getOrCreateFolder(): \OCP\Files\SimpleFS\ISimpleFolder
+    {
+        try {
+            return $this->appData->getFolder(name: self::FOLDER);
+        } catch (NotFoundException $e) {
+            return $this->appData->newFolder(name: self::FOLDER);
+        }
+    }//end getOrCreateFolder()
+}//end class

--- a/tests/Unit/Controller/ResourceControllerTest.php
+++ b/tests/Unit/Controller/ResourceControllerTest.php
@@ -1,0 +1,270 @@
+<?php
+
+/**
+ * ResourceController Test
+ *
+ * @category  Test
+ * @package   OCA\MyDash\Tests\Unit\Controller
+ * @author    Conduction b.v. <info@conduction.nl>
+ * @copyright 2024 Conduction b.v.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-FileCopyrightText: 2024 MyDash Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Controller;
+
+use OCA\MyDash\Controller\ResourceController;
+use OCA\MyDash\Controller\ResourceUploadRequestParser;
+use OCA\MyDash\Exception\FileTooLargeException;
+use OCA\MyDash\Exception\MimeMismatchException;
+use OCA\MyDash\Service\ResourceService;
+use OCP\AppFramework\Http;
+use OCP\IGroupManager;
+use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Test-only subclass that injects the request body bytes.
+ */
+class TestableResourceController extends ResourceController
+{
+    public string $bodyBytes = '';
+
+    protected function readRequestBody(): string
+    {
+        return $this->bodyBytes;
+    }
+}
+
+class ResourceControllerTest extends TestCase
+{
+    private TestableResourceController $controller;
+
+    /** @var IRequest&MockObject */
+    private $request;
+
+    /** @var ResourceService&MockObject */
+    private $service;
+
+    /** @var IUserSession&MockObject */
+    private $userSession;
+
+    /** @var IGroupManager&MockObject */
+    private $groupManager;
+
+    /** @var LoggerInterface&MockObject */
+    private $logger;
+
+    protected function setUp(): void
+    {
+        $this->request      = $this->createMock(IRequest::class);
+        $this->service      = $this->createMock(ResourceService::class);
+        $this->userSession  = $this->createMock(IUserSession::class);
+        $this->groupManager = $this->createMock(IGroupManager::class);
+        $this->logger       = $this->createMock(LoggerInterface::class);
+
+        $this->controller = new TestableResourceController(
+            request: $this->request,
+            resourceService: $this->service,
+            parser: new ResourceUploadRequestParser(),
+            userSession: $this->userSession,
+            groupManager: $this->groupManager,
+            logger: $this->logger,
+        );
+    }
+
+    private function makeAdmin(string $uid='alice'): void
+    {
+        $user = $this->createMock(IUser::class);
+        $user->method('getUID')->willReturn($uid);
+        $this->userSession->method('getUser')->willReturn($user);
+        $this->groupManager->method('isAdmin')->with($uid)->willReturn(true);
+    }
+
+    private function makeNonAdmin(string $uid='bob'): void
+    {
+        $user = $this->createMock(IUser::class);
+        $user->method('getUID')->willReturn($uid);
+        $this->userSession->method('getUser')->willReturn($user);
+        $this->groupManager->method('isAdmin')->with($uid)->willReturn(false);
+    }
+
+    public function testUnauthenticatedReturns403(): void
+    {
+        $this->userSession->method('getUser')->willReturn(null);
+
+        $response = $this->controller->upload();
+
+        $this->assertSame(Http::STATUS_FORBIDDEN, $response->getStatus());
+        $body = $response->getData();
+        $this->assertSame('error', $body['status']);
+        $this->assertSame('forbidden', $body['error']);
+        $this->assertArrayHasKey('message', $body);
+    }
+
+    public function testNonAdminReturns403(): void
+    {
+        $this->makeNonAdmin();
+        $this->controller->bodyBytes = json_encode(['base64' => 'data:image/png;base64,AAA']);
+        $this->service->expects($this->never())->method('upload');
+
+        $response = $this->controller->upload();
+
+        $this->assertSame(Http::STATUS_FORBIDDEN, $response->getStatus());
+        $this->assertSame('forbidden', $response->getData()['error']);
+    }
+
+    public function testMultipartContentTypeReturns415(): void
+    {
+        $this->makeAdmin();
+        $this->request->method('getHeader')->with('Content-Type')
+            ->willReturn('multipart/form-data; boundary=---X');
+        $this->controller->bodyBytes = '---X';
+
+        $response = $this->controller->upload();
+
+        $this->assertSame(415, $response->getStatus());
+        $this->assertSame('unsupported_media_type', $response->getData()['error']);
+    }
+
+    public function testEmptyBodyReturnsInvalidDataUrl(): void
+    {
+        $this->makeAdmin();
+        $this->request->method('getHeader')->willReturn('application/json');
+        $this->controller->bodyBytes = '';
+
+        $response = $this->controller->upload();
+
+        $this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+        $this->assertSame('invalid_data_url', $response->getData()['error']);
+    }
+
+    public function testMissingBase64FieldReturnsInvalidDataUrl(): void
+    {
+        $this->makeAdmin();
+        $this->request->method('getHeader')->willReturn('application/json');
+        $this->controller->bodyBytes = json_encode(['other' => 'value']);
+
+        $response = $this->controller->upload();
+
+        $this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+        $this->assertSame('invalid_data_url', $response->getData()['error']);
+    }
+
+    public function testInvalidJsonReturnsInvalidDataUrl(): void
+    {
+        $this->makeAdmin();
+        $this->request->method('getHeader')->willReturn('application/json');
+        $this->controller->bodyBytes = '{not json';
+
+        $response = $this->controller->upload();
+
+        $this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+        // JsonException is now caught and re-thrown as
+        // InvalidDataUrlException by the parser, so we get the stable
+        // 400 / invalid_data_url envelope.
+        $this->assertSame('invalid_data_url', $response->getData()['error']);
+    }
+
+    public function testSuccessReturnsStandardEnvelope(): void
+    {
+        $this->makeAdmin();
+        $this->request->method('getHeader')->willReturn('application/json');
+        $this->controller->bodyBytes = json_encode([
+            'base64' => 'data:image/png;base64,AAA',
+        ]);
+
+        $this->service->expects($this->once())->method('upload')
+            ->with('data:image/png;base64,AAA')
+            ->willReturn([
+                'url'  => '/apps/mydash/resource/resource_abc.png',
+                'name' => 'resource_abc.png',
+                'size' => 1234,
+            ]);
+
+        $response = $this->controller->upload();
+        $body     = $response->getData();
+
+        $this->assertSame(Http::STATUS_OK, $response->getStatus());
+        $this->assertSame('success', $body['status']);
+        $this->assertSame('/apps/mydash/resource/resource_abc.png', $body['url']);
+        $this->assertSame('resource_abc.png', $body['name']);
+        $this->assertSame(1234, $body['size']);
+    }
+
+    public function testFileTooLargeIsMappedToEnvelope(): void
+    {
+        $this->makeAdmin();
+        $this->request->method('getHeader')->willReturn('application/json');
+        $this->controller->bodyBytes = json_encode([
+            'base64' => 'data:image/png;base64,AAA',
+        ]);
+
+        $this->service->method('upload')
+            ->willThrowException(new FileTooLargeException());
+
+        $response = $this->controller->upload();
+
+        $this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+        $this->assertSame('file_too_large', $response->getData()['error']);
+        $this->assertSame('Maximum size is 5MB', $response->getData()['message']);
+    }
+
+    public function testMimeMismatchIsMappedToEnvelope(): void
+    {
+        $this->makeAdmin();
+        $this->request->method('getHeader')->willReturn('application/json');
+        $this->controller->bodyBytes = json_encode([
+            'base64' => 'data:image/png;base64,AAA',
+        ]);
+
+        $this->service->method('upload')
+            ->willThrowException(new MimeMismatchException());
+
+        $response = $this->controller->upload();
+
+        $this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+        $this->assertSame('mime_mismatch', $response->getData()['error']);
+    }
+
+    public function testErrorResponseNeverContainsRawExceptionString(): void
+    {
+        $this->makeAdmin();
+        $this->request->method('getHeader')->willReturn('application/json');
+        $this->controller->bodyBytes = json_encode([
+            'base64' => 'data:image/png;base64,AAA',
+        ]);
+
+        // Throw a non-typed exception with a sensitive-looking message.
+        $this->service->method('upload')
+            ->willThrowException(new \RuntimeException('SECRET_TOKEN_XYZ leaked'));
+
+        $response = $this->controller->upload();
+        $body     = $response->getData();
+
+        $this->assertSame('error', $body['status']);
+        $this->assertStringNotContainsString('SECRET_TOKEN_XYZ', json_encode($body));
+        $this->assertStringNotContainsString('Exception', $body['message']);
+        $this->assertStringNotContainsString('Stack', $body['message']);
+    }
+
+    public function testErrorEnvelopeHasStableShape(): void
+    {
+        $this->userSession->method('getUser')->willReturn(null);
+
+        $body = $this->controller->upload()->getData();
+
+        $this->assertArrayHasKey('status', $body);
+        $this->assertArrayHasKey('error', $body);
+        $this->assertArrayHasKey('message', $body);
+        $this->assertSame('error', $body['status']);
+    }
+}

--- a/tests/Unit/Controller/ResourceUploadRequestParserTest.php
+++ b/tests/Unit/Controller/ResourceUploadRequestParserTest.php
@@ -1,0 +1,90 @@
+<?php
+
+/**
+ * ResourceUploadRequestParser Test
+ *
+ * @category  Test
+ * @package   OCA\MyDash\Tests\Unit\Controller
+ * @author    Conduction b.v. <info@conduction.nl>
+ * @copyright 2024 Conduction b.v.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-FileCopyrightText: 2024 MyDash Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Controller;
+
+use OCA\MyDash\Controller\ResourceUploadRequestParser;
+use OCA\MyDash\Exception\InvalidDataUrlException;
+use OCA\MyDash\Exception\UnsupportedMediaTypeException;
+use OCP\IRequest;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class ResourceUploadRequestParserTest extends TestCase
+{
+    private ResourceUploadRequestParser $parser;
+
+    /** @var IRequest&MockObject */
+    private $request;
+
+    protected function setUp(): void
+    {
+        $this->parser  = new ResourceUploadRequestParser();
+        $this->request = $this->createMock(IRequest::class);
+    }
+
+    public function testHappyPathReturnsBase64String(): void
+    {
+        $this->request->method('getHeader')->willReturn('application/json');
+        $body = json_encode(['base64' => 'data:image/png;base64,AAA']);
+
+        $result = $this->parser->extractBase64(
+            request: $this->request,
+            rawBody: $body
+        );
+
+        $this->assertSame('data:image/png;base64,AAA', $result);
+    }
+
+    public function testMultipartIsRejected(): void
+    {
+        $this->request->method('getHeader')->willReturn('multipart/form-data; boundary=---X');
+
+        $this->expectException(UnsupportedMediaTypeException::class);
+        $this->parser->extractBase64(request: $this->request, rawBody: '---X');
+    }
+
+    public function testEmptyBodyIsRejected(): void
+    {
+        $this->request->method('getHeader')->willReturn('application/json');
+
+        $this->expectException(InvalidDataUrlException::class);
+        $this->parser->extractBase64(request: $this->request, rawBody: '');
+    }
+
+    public function testInvalidJsonIsRejected(): void
+    {
+        $this->request->method('getHeader')->willReturn('application/json');
+
+        $this->expectException(InvalidDataUrlException::class);
+        $this->parser->extractBase64(
+            request: $this->request,
+            rawBody: '{not json'
+        );
+    }
+
+    public function testNonStringBase64FieldIsRejected(): void
+    {
+        $this->request->method('getHeader')->willReturn('application/json');
+
+        $this->expectException(InvalidDataUrlException::class);
+        $this->parser->extractBase64(
+            request: $this->request,
+            rawBody: json_encode(['base64' => 12345])
+        );
+    }
+}

--- a/tests/Unit/Service/ImageMimeValidatorTest.php
+++ b/tests/Unit/Service/ImageMimeValidatorTest.php
@@ -1,0 +1,96 @@
+<?php
+
+/**
+ * ImageMimeValidator Test
+ *
+ * @category  Test
+ * @package   OCA\MyDash\Tests\Unit\Service
+ * @author    Conduction b.v. <info@conduction.nl>
+ * @copyright 2024 Conduction b.v.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-FileCopyrightText: 2024 MyDash Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Service;
+
+use OCA\MyDash\Exception\CorruptImageException;
+use OCA\MyDash\Exception\MimeMismatchException;
+use OCA\MyDash\Service\ImageMimeValidator;
+use PHPUnit\Framework\TestCase;
+
+class ImageMimeValidatorTest extends TestCase
+{
+    private ImageMimeValidator $validator;
+
+    protected function setUp(): void
+    {
+        $this->validator = new ImageMimeValidator();
+    }
+
+    /**
+     * Tiny 1x1 PNG bytes (red pixel).
+     */
+    private function tinyPng(): string
+    {
+        return base64_decode(
+            'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==',
+            true
+        );
+    }
+
+    /**
+     * Tiny 1x1 GIF bytes.
+     */
+    private function tinyGif(): string
+    {
+        return base64_decode(
+            'R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==',
+            true
+        );
+    }
+
+    public function testSvgIsSkipped(): void
+    {
+        // Should not throw — SVG is delegated to the sanitiser.
+        $this->validator->validate(declaredType: 'svg', bytes: '<svg></svg>');
+        $this->assertTrue(true);
+    }
+
+    public function testValidPngPasses(): void
+    {
+        $this->validator->validate(declaredType: 'png', bytes: $this->tinyPng());
+        $this->assertTrue(true);
+    }
+
+    public function testJpgAlsoMapsToJpegMime(): void
+    {
+        // We can't easily make a tiny JPEG inline, but we can confirm
+        // that a PNG-as-jpg fails with a mime mismatch (proving the map
+        // is consulted for both jpg and jpeg).
+        $this->expectException(MimeMismatchException::class);
+        $this->validator->validate(declaredType: 'jpg', bytes: $this->tinyPng());
+    }
+
+    public function testCorruptBytesThrowCorruptImage(): void
+    {
+        $this->expectException(CorruptImageException::class);
+        $this->validator->validate(declaredType: 'png', bytes: 'not-an-image');
+    }
+
+    public function testMimeMismatchPngActualGif(): void
+    {
+        $this->expectException(MimeMismatchException::class);
+        $this->validator->validate(declaredType: 'png', bytes: $this->tinyGif());
+    }
+
+    public function testUnknownDeclaredTypeIsRejected(): void
+    {
+        // Defensive guard — caller should already have vetted the type.
+        $this->expectException(MimeMismatchException::class);
+        $this->validator->validate(declaredType: 'bmp', bytes: $this->tinyPng());
+    }
+}

--- a/tests/Unit/Service/ResourceServiceTest.php
+++ b/tests/Unit/Service/ResourceServiceTest.php
@@ -1,0 +1,241 @@
+<?php
+
+/**
+ * ResourceService Test
+ *
+ * @category  Test
+ * @package   OCA\MyDash\Tests\Unit\Service
+ * @author    Conduction b.v. <info@conduction.nl>
+ * @copyright 2024 Conduction b.v.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-FileCopyrightText: 2024 MyDash Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Service;
+
+use OCA\MyDash\Exception\FileTooLargeException;
+use OCA\MyDash\Exception\InvalidDataUrlException;
+use OCA\MyDash\Exception\InvalidImageFormatException;
+use OCA\MyDash\Exception\MimeMismatchException;
+use OCA\MyDash\Exception\StorageFailureException;
+use OCA\MyDash\Service\ImageMimeValidator;
+use OCA\MyDash\Service\ResourceService;
+use OCP\Files\IAppData;
+use OCP\Files\NotFoundException;
+use OCP\Files\NotPermittedException;
+use OCP\Files\SimpleFS\ISimpleFile;
+use OCP\Files\SimpleFS\ISimpleFolder;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class ResourceServiceTest extends TestCase
+{
+    private ResourceService $service;
+
+    /**
+     * @var IAppData&MockObject
+     */
+    private $appData;
+
+    /**
+     * @var ImageMimeValidator&MockObject
+     */
+    private $mimeValidator;
+
+    /**
+     * @var ISimpleFolder&MockObject
+     */
+    private $folder;
+
+    protected function setUp(): void
+    {
+        $this->appData       = $this->createMock(IAppData::class);
+        $this->mimeValidator = $this->createMock(ImageMimeValidator::class);
+        $this->folder        = $this->createMock(ISimpleFolder::class);
+
+        $this->service = new ResourceService(
+            appData: $this->appData,
+            mimeValidator: $this->mimeValidator,
+        );
+    }
+
+    /**
+     * Tiny 1x1 PNG bytes (red pixel).
+     */
+    private function tinyPng(): string
+    {
+        return base64_decode(
+            'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==',
+            true
+        );
+    }
+
+    /**
+     * Build a base64 data URL from raw bytes and a declared type.
+     */
+    private function dataUrl(string $type, string $bytes): string
+    {
+        return 'data:image/' . $type . ';base64,' . base64_encode($bytes);
+    }
+
+    public function testMissingDataUrlPrefixIsRejected(): void
+    {
+        $this->expectException(InvalidDataUrlException::class);
+        $this->service->upload(base64DataUrl: 'iVBORw0KGgo');
+    }
+
+    public function testEmptyInputIsRejected(): void
+    {
+        $this->expectException(InvalidDataUrlException::class);
+        $this->service->upload(base64DataUrl: '');
+    }
+
+    public function testDisallowedTypeIsRejected(): void
+    {
+        $this->expectException(InvalidImageFormatException::class);
+        $this->service->upload(
+            base64DataUrl: $this->dataUrl(type: 'bmp', bytes: 'whatever')
+        );
+    }
+
+    public function testMixedCaseDeclaredTypeIsAcceptedAndLowercased(): void
+    {
+        $this->mimeValidator->expects($this->once())->method('validate')
+            ->with('png', $this->tinyPng());
+
+        $this->folder->expects($this->once())->method('newFile')
+            ->willReturnCallback(function (string $name, $content): ISimpleFile {
+                $this->assertStringEndsWith('.png', $name);
+                $this->assertStringStartsWith('resource_', $name);
+
+                return $this->createMock(ISimpleFile::class);
+            });
+
+        $this->appData->expects($this->once())->method('getFolder')
+            ->with(ResourceService::FOLDER)->willReturn($this->folder);
+
+        $result = $this->service->upload(
+            base64DataUrl: 'data:image/PNG;base64,' . base64_encode($this->tinyPng())
+        );
+
+        $this->assertSame('success', 'success'); // sanity
+        $this->assertStringStartsWith('/apps/mydash/resource/resource_', $result['url']);
+        $this->assertStringEndsWith('.png', $result['url']);
+        $this->assertSame(strlen($this->tinyPng()), $result['size']);
+    }
+
+    public function testSvgPlusXmlNormalisesToSvg(): void
+    {
+        $svg = '<svg xmlns="http://www.w3.org/2000/svg"/>';
+        $this->mimeValidator->expects($this->once())->method('validate')
+            ->with('svg', $svg);
+
+        $this->folder->method('newFile')
+            ->willReturnCallback(function (string $name): ISimpleFile {
+                $this->assertStringEndsWith('.svg', $name);
+                return $this->createMock(ISimpleFile::class);
+            });
+
+        $this->appData->method('getFolder')->willReturn($this->folder);
+
+        $result = $this->service->upload(
+            base64DataUrl: $this->dataUrl(type: 'svg+xml', bytes: $svg)
+        );
+
+        $this->assertStringEndsWith('.svg', $result['name']);
+    }
+
+    public function testOversizePayloadIsRejectedBeforeValidator(): void
+    {
+        // 6 MB blob.
+        $oversize = str_repeat('A', (6 * 1024 * 1024));
+        $this->mimeValidator->expects($this->never())->method('validate');
+        $this->appData->expects($this->never())->method('getFolder');
+
+        $this->expectException(FileTooLargeException::class);
+        $this->service->upload(
+            base64DataUrl: $this->dataUrl(type: 'png', bytes: $oversize)
+        );
+    }
+
+    public function testSizeAtCapIsAccepted(): void
+    {
+        // Exactly 5 MB → allowed (cap is "exceeds", not "equals").
+        $atCap = str_repeat('A', (5 * 1024 * 1024));
+        $this->mimeValidator->expects($this->once())->method('validate');
+        $this->folder->method('newFile')
+            ->willReturn($this->createMock(ISimpleFile::class));
+        $this->appData->method('getFolder')->willReturn($this->folder);
+
+        $result = $this->service->upload(
+            base64DataUrl: $this->dataUrl(type: 'png', bytes: $atCap)
+        );
+
+        $this->assertSame((5 * 1024 * 1024), $result['size']);
+    }
+
+    public function testMimeMismatchBubblesUp(): void
+    {
+        $this->mimeValidator->method('validate')
+            ->willThrowException(new MimeMismatchException());
+
+        $this->expectException(MimeMismatchException::class);
+        $this->service->upload(
+            base64DataUrl: $this->dataUrl(type: 'png', bytes: 'whatever')
+        );
+    }
+
+    public function testFolderAutoCreatedWhenMissing(): void
+    {
+        $this->mimeValidator->method('validate');
+        $this->appData->expects($this->once())->method('getFolder')
+            ->with(ResourceService::FOLDER)
+            ->willThrowException(new NotFoundException());
+        $this->appData->expects($this->once())->method('newFolder')
+            ->with(ResourceService::FOLDER)->willReturn($this->folder);
+        $this->folder->expects($this->once())->method('newFile')
+            ->willReturn($this->createMock(ISimpleFile::class));
+
+        $result = $this->service->upload(
+            base64DataUrl: $this->dataUrl(type: 'png', bytes: $this->tinyPng())
+        );
+
+        $this->assertStringStartsWith('resource_', $result['name']);
+    }
+
+    public function testStorageFailureIsWrapped(): void
+    {
+        $this->mimeValidator->method('validate');
+        $this->appData->method('getFolder')->willReturn($this->folder);
+        $this->folder->method('newFile')
+            ->willThrowException(new NotPermittedException('disk full'));
+
+        $this->expectException(StorageFailureException::class);
+        $this->service->upload(
+            base64DataUrl: $this->dataUrl(type: 'png', bytes: $this->tinyPng())
+        );
+    }
+
+    public function testFilenameMatchesSpecPattern(): void
+    {
+        $this->mimeValidator->method('validate');
+        $this->appData->method('getFolder')->willReturn($this->folder);
+        $this->folder->method('newFile')
+            ->willReturn($this->createMock(ISimpleFile::class));
+
+        $result = $this->service->upload(
+            base64DataUrl: $this->dataUrl(type: 'png', bytes: $this->tinyPng())
+        );
+
+        // resource_<uniqid_with_more_entropy>.png — uniqid with
+        // more_entropy=true returns hex + dot + decimal.
+        $this->assertMatchesRegularExpression(
+            '#^resource_[a-f0-9.]+\.(jpeg|jpg|png|gif|svg|webp)$#',
+            $result['name']
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Implements the `resource-uploads` capability — a small admin-only mini file API for the binary branding assets (icons, widget images) MyDash widgets need to host directly, separate from the user's Files folder.

This PR delivers REQ-RES-001 through REQ-RES-005 from the spec proposal in PR #42 (`feature/replica-spec-proposals`).

## What's in scope

- **REQ-RES-001** — `POST /api/resources` accepting raw JSON `{base64: 'data:image/<type>;base64,...'}`. Admin-only via `IGroupManager::isAdmin` (HTTP 403 otherwise). Multipart bodies are rejected with HTTP 415.
- **REQ-RES-002** — Allowed declared types: `jpeg, jpg, png, gif, svg, webp` (case-insensitive). Disallowed types → HTTP 400 / `invalid_image_format`. Missing/unparseable data URL → HTTP 400 / `invalid_data_url`. `image/svg+xml` is normalised to `svg`.
- **REQ-RES-003** — 5 MB hard cap on decoded bytes, **enforced before** invoking `getimagesizefromstring` (so the server cannot be tricked into loading an oversize blob into the image library). Raster MIME cross-check via `getimagesizefromstring`. Corrupt raster → `corrupt_image`. Mismatch → `mime_mismatch`. SVG validation is delegated to the sibling `svg-sanitisation` capability.
- **REQ-RES-004** — Storage via `IAppData::getFolder('resources')` (auto-created on first use). Filenames `resource_<uniqid>.<ext>` using `uniqid('resource_', true)` for high entropy. Never writes to the user's Files folder.
- **REQ-RES-005** — Standardised envelope. Success: `{status: 'success', url, name, size}`. Error: `{status: 'error', error: <stable_code>, message}` with the documented enum (`forbidden, unsupported_media_type, invalid_data_url, invalid_image_format, file_too_large, mime_mismatch, corrupt_image, storage_failure`). Raw exception messages NEVER leak to clients (defence-in-depth `Throwable` catch wraps unexpected paths into `storage_failure`).

## What's out of scope (sibling PRs)

- **REQ-RES-006..009 (resource-serving change)** — `GET /apps/mydash/resource/<filename>` endpoint, ETag/Last-Modified handling, MIME header on serve, 404 on unknown filename. Will land separately.
- **REQ-RES-010..013 (svg-sanitisation change)** — DOM-based whitelist sanitiser for SVG uploads (script/event-handler/foreignObject stripping, base64 image stripping). The current PR accepts SVG declared type but performs no sanitisation; the serving sibling PR will hard-block SVGs until svg-sanitisation lands.

## Files

- `lib/Controller/ResourceController.php` — endpoint handler, admin gating, error envelope mapping
- `lib/Controller/ResourceUploadRequestParser.php` — JSON body extraction (extracted to keep controller coupling under PHPMD limit)
- `lib/Service/ResourceService.php` — base64 parse + size cap + MIME validation + persistence
- `lib/Service/ImageMimeValidator.php` — declared-type vs detected-MIME cross-check (uses local error handler instead of `@` operator per PHPMD)
- `lib/Exception/*` — typed exceptions carrying stable error codes + HTTP status (`ResourceException` base + 8 concrete subtypes)
- `appinfo/routes.php` — one new `POST /api/resources` route
- `tests/Unit/Service/ImageMimeValidatorTest.php` — 6 tests
- `tests/Unit/Service/ResourceServiceTest.php` — 11 tests
- `tests/Unit/Controller/ResourceControllerTest.php` — 11 tests
- `tests/Unit/Controller/ResourceUploadRequestParserTest.php` — 5 tests

## Test plan

- [x] PHPUnit: 33/33 new tests pass; 90 pre-existing tests still pass (123 total) in the Nextcloud Docker container
- [x] PHPCS: no new violations from this PR's files (4 unrelated pre-existing violations remain in `lib/Db/` entity setter calls)
- [x] PHPMD: no new violations from this PR's files (1 unrelated pre-existing violation in `lib/Service/DashboardService.php`)
- [x] Psalm: no new violations from this PR's files (2 unrelated pre-existing violations in `PageController` and `UserAttributeResolver`)
- [x] PHP lint: all new files clean
- [ ] Manual: admin uploads a PNG → file appears in app data, URL returned
- [ ] Manual: non-admin gets 403
- [ ] Manual: 6 MB blob rejected with `file_too_large` envelope before `getimagesizefromstring` is reached

## Notes for reviewers

- The success URL is the **relative** path `/apps/mydash/resource/<filename>` per the spec scenario, not an absolute URL. The serving endpoint is delivered by the sibling PR.
- `ResourceController::readRequestBody()` is `protected` to allow PHPUnit to inject body bytes (PHP's `php://input` is not realistically pluggable in unit tests). Production reads from the standard input stream.
- The `Throwable` catch in the controller is defence-in-depth: any unexpected exception is logged with detail but the response only contains the safe `storage_failure` envelope — no raw `$e->getMessage()` leaks to clients.
- Pre-existing PHPCS named-arg findings on entity setters were left untouched per project convention — fixing them by adding named args would break Nextcloud's `__call` magic in `Entity`.

## Spec references

- Proposal: PR #42 (`feature/replica-spec-proposals`) — `openspec/changes/resource-uploads/proposal.md`
- Tasks: `openspec/changes/resource-uploads/tasks.md`
- Spec: `openspec/changes/resource-uploads/specs/resource-uploads/spec.md`