### PR TITLE
chore(phpstan): fix OCP autoload (725->0 errors, 17 in baseline)

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,81 @@
+parameters:
+	ignoreErrors:
+		-
+			message: "#^Parameter \\#1 \\$createdAt of method OCA\\\\MyDash\\\\Db\\\\Dashboard\\:\\:setCreatedAt\\(\\) expects string\\|null, DateTime given\\.$#"
+			count: 1
+			path: lib/Service/AdminTemplateService.php
+
+		-
+			message: "#^Parameter \\#1 \\$isDefault of method OCA\\\\MyDash\\\\Db\\\\Dashboard\\:\\:setIsDefault\\(\\) expects int, bool given\\.$#"
+			count: 1
+			path: lib/Service/AdminTemplateService.php
+
+		-
+			message: "#^Parameter \\#1 \\$updatedAt of method OCA\\\\MyDash\\\\Db\\\\Dashboard\\:\\:setUpdatedAt\\(\\) expects string\\|null, DateTime given\\.$#"
+			count: 2
+			path: lib/Service/AdminTemplateService.php
+
+		-
+			message: "#^Strict comparison using \\=\\=\\= between int and false will always evaluate to false\\.$#"
+			count: 1
+			path: lib/Service/ConditionalService.php
+
+		-
+			message: "#^Parameter \\#1 \\$isActive of method OCA\\\\MyDash\\\\Db\\\\Dashboard\\:\\:setIsActive\\(\\) expects int, true given\\.$#"
+			count: 1
+			path: lib/Service/DashboardResolver.php
+
+		-
+			message: "#^Property OCA\\\\MyDash\\\\Service\\\\DashboardResolver\\:\\:\\$settingMapper is never read, only written\\.$#"
+			count: 1
+			path: lib/Service/DashboardResolver.php
+
+		-
+			message: "#^Unreachable statement \\- code above always terminates\\.$#"
+			count: 1
+			path: lib/Service/DashboardResolver.php
+
+		-
+			message: "#^Method OCA\\\\MyDash\\\\Service\\\\DashboardService\\:\\:createDefaultPlacements\\(\\) has invalid return type OCA\\\\MyDash\\\\Service\\\\WidgetPlacement\\.$#"
+			count: 1
+			path: lib/Service/DashboardService.php
+
+		-
+			message: "#^Method OCA\\\\MyDash\\\\Service\\\\DashboardService\\:\\:createDefaultPlacements\\(\\) should return array\\<OCA\\\\MyDash\\\\Service\\\\WidgetPlacement\\> but returns array\\<int, OCA\\\\MyDash\\\\Db\\\\WidgetPlacement\\>\\.$#"
+			count: 1
+			path: lib/Service/DashboardService.php
+
+		-
+			message: "#^Parameter \\#1 \\$isActive of method OCA\\\\MyDash\\\\Db\\\\Dashboard\\:\\:setIsActive\\(\\) expects int, true given\\.$#"
+			count: 1
+			path: lib/Service/DashboardService.php
+
+		-
+			message: "#^Strict comparison using \\=\\=\\= between int and false will always evaluate to false\\.$#"
+			count: 1
+			path: lib/Service/PermissionService.php
+
+		-
+			message: "#^Parameter \\#1 \\$createdAt of method OCA\\\\MyDash\\\\Db\\\\Dashboard\\:\\:setCreatedAt\\(\\) expects string\\|null, DateTime given\\.$#"
+			count: 1
+			path: lib/Service/TemplateService.php
+
+		-
+			message: "#^Parameter \\#1 \\$createdAt of method OCA\\\\MyDash\\\\Db\\\\WidgetPlacement\\:\\:setCreatedAt\\(\\) expects string\\|null, DateTime given\\.$#"
+			count: 1
+			path: lib/Service/TemplateService.php
+
+		-
+			message: "#^Parameter \\#1 \\$isActive of method OCA\\\\MyDash\\\\Db\\\\Dashboard\\:\\:setIsActive\\(\\) expects int, true given\\.$#"
+			count: 1
+			path: lib/Service/TemplateService.php
+
+		-
+			message: "#^Parameter \\#1 \\$updatedAt of method OCA\\\\MyDash\\\\Db\\\\Dashboard\\:\\:setUpdatedAt\\(\\) expects string\\|null, DateTime given\\.$#"
+			count: 1
+			path: lib/Service/TemplateService.php
+
+		-
+			message: "#^Parameter \\#1 \\$updatedAt of method OCA\\\\MyDash\\\\Db\\\\WidgetPlacement\\:\\:setUpdatedAt\\(\\) expects string\\|null, DateTime given\\.$#"
+			count: 1
+			path: lib/Service/TemplateService.php

--- a/phpstan-bootstrap.php
+++ b/phpstan-bootstrap.php
@@ -1,0 +1,13 @@
+<?php
+
+/**
+ * PHPStan bootstrap file - registers OCP autoloader for static analysis.
+ *
+ * The nextcloud/ocp package ships PHP class stubs at vendor/nextcloud/ocp/OCP/
+ * but its composer.json does not register a PSR-4 autoload mapping. We add the
+ * mappings here so PHPStan can resolve OCP\* and NCU\* class references.
+ */
+
+$autoloader = require __DIR__ . '/vendor/autoload.php';
+$autoloader->addPsr4('OCP\\', __DIR__ . '/vendor/nextcloud/ocp/OCP/');
+$autoloader->addPsr4('NCU\\', __DIR__ . '/vendor/nextcloud/ocp/NCU/');

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,16 +1,29 @@
+includes:
+    - phpstan-baseline.neon
+
 parameters:
     level: 5
     paths:
         - lib
     bootstrapFiles:
-        - vendor/autoload.php
+        - phpstan-bootstrap.php
     excludePaths:
         - vendor
-    scanDirectories:
-        - vendor/nextcloud/ocp
     reportUnmatchedIgnoredErrors: false
     ignoreErrors:
         # Nextcloud internal classes that PHPStan might not recognize
         - '#Call to an undefined method OC::#'
         - '#Class OC not found#'
         - '#Access to static property \$server on an unknown class OC#'
+        # Doctrine DBAL is provided by Nextcloud at runtime but not in composer require
+        - '#unknown class Doctrine\\DBAL\\#'
+        - '#Doctrine\\DBAL\\[a-zA-Z\\]+.*not found#'
+        - '#on an unknown class Doctrine\\DBAL\\#'
+        - '#invalid type Doctrine\\DBAL\\#'
+        # Dynamic HTTP status codes from business rule validation results
+        - '#Parameter \$statusCode of class OCP\\AppFramework\\Http\\JSONResponse constructor expects#'
+        # registerRepairStep / getLanguage exist on server but not in nextcloud/ocp stub
+        - '#Call to an undefined method OCP\\AppFramework\\Bootstrap\\IRegistrationContext::registerRepairStep#'
+        - '#Call to an undefined method OCP\\IUser::getLanguage#'
+        # OCP\AppFramework\Db\Entity implements JsonSerializable at runtime but stub omits it
+        - '#Call to an undefined method OCP\\AppFramework\\Db\\Entity::jsonSerialize#'

--- a/sbom.cdx.json
+++ b/sbom.cdx.json
@@ -2,14 +2,14 @@
   "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.5",
-  "serialNumber": "urn:uuid:b08b9ab1-75b0-4b81-af4e-5882a337df20",
+  "serialNumber": "urn:uuid:388a0eb0-b171-4af8-ad2a-9b3607de7672",
   "version": 1,
   "metadata": {
-    "timestamp": "2026-03-19T17:50:04Z",
+    "timestamp": "2026-04-30T11:58:37Z",
     "tools": [
       {
         "name": "composer",
-        "version": "2.9.5"
+        "version": "2.9.7"
       },
       {
         "vendor": "cyclonedx",
@@ -82,10 +82,10 @@
       }
     ],
     "component": {
-      "bom-ref": "mydash/mydash-dev-fix/ci-quality-checks",
+      "bom-ref": "mydash/mydash-dev-chore/fix-phpstan-ocp-autoload",
       "type": "application",
       "name": "mydash",
-      "version": "dev-fix/ci-quality-checks",
+      "version": "dev-chore/fix-phpstan-ocp-autoload",
       "group": "mydash",
       "description": "Enhanced dashboard with grid layout and admin controls for Nextcloud",
       "author": "MyDash Contributors",
@@ -96,15 +96,15 @@
           }
         }
       ],
-      "purl": "pkg:composer/mydash/mydash@dev-fix/ci-quality-checks",
+      "purl": "pkg:composer/mydash/mydash@dev-chore/fix-phpstan-ocp-autoload",
       "properties": [
         {
           "name": "cdx:composer:package:distReference",
-          "value": "2dc7b3f49dc378ebd0a263b89036d790fbf63eec"
+          "value": "ba8a0759c1cbb204e95d28999d3ab6df45f8bff0"
         },
         {
           "name": "cdx:composer:package:sourceReference",
-          "value": "2dc7b3f49dc378ebd0a263b89036d790fbf63eec"
+          "value": "ba8a0759c1cbb204e95d28999d3ab6df45f8bff0"
         },
         {
           "name": "cdx:composer:package:type",
@@ -17993,7 +17993,7 @@
       ]
     },
     {
-      "ref": "mydash/mydash-dev-fix/ci-quality-checks",
+      "ref": "mydash/mydash-dev-chore/fix-phpstan-ocp-autoload",
       "dependsOn": [
         "ramsey/uuid-4.9.2.0"
       ]


### PR DESCRIPTION
## Summary

PHPStan was reporting ~725 errors of the form `Class OCP\... not found` because the `nextcloud/ocp` package ships PHP class stubs at `vendor/nextcloud/ocp/OCP/` but registers no PSR-4 autoload mapping. PHPStan therefore could not resolve any OCP class reference, masking the real findings.

## Changes

- **New `phpstan-bootstrap.php`** — registers PSR-4 mappings for `OCP\\` and `NCU\\` against the stub directories. Same pattern as the working `decidesk` setup.
- **`phpstan.neon`**:
  - `bootstrapFiles` now points to `phpstan-bootstrap.php` (was `vendor/autoload.php`).
  - Removed the broken `scanDirectories: vendor/nextcloud/ocp` (the stubs needed PSR-4, not symbol scanning).
  - Added framework-level `ignoreErrors` for `Doctrine\\DBAL\\*` (Nextcloud-runtime-provided, not in `composer require`), JSONResponse status code constraints (dynamic codes), and a few stub gaps (`registerRepairStep`, `IUser::getLanguage`, `Entity::jsonSerialize`).
  - `includes: phpstan-baseline.neon` — captures remaining real findings.
- **New `phpstan-baseline.neon`** — 81 lines, 17 entries, all real logic findings (see "Out of scope" below).

## Error counts

| Stage | Errors |
|---|---|
| Before any changes | 719 |
| After autoload fix only | 82 |
| After autoload + framework `ignoreErrors` | 17 |
| After baseline | 0 (clean) |

`composer phpstan` now exits 0.

## Out of scope (real bugs to fix in feature PRs)

The 17 baseline entries are genuine type/logic issues — explicitly NOT touched here per the chore's "config-only" constraint:

- `Dashboard::setIsActive(true)` / `setIsDefault(true)` — bool passed where `int` expected (5 callsites across `DashboardResolver`, `DashboardService`, `TemplateService`, `AdminTemplateService`)
- `Dashboard::setCreatedAt(new DateTime())` / `setUpdatedAt(...)` — `DateTime` passed where `string|null` expected (7 callsites across `AdminTemplateService`, `TemplateService`)
- `WidgetPlacement::setCreatedAt/setUpdatedAt` — same DateTime/string mismatch (2 callsites)
- `ConditionalService.php:60`, `PermissionService.php:196` — strict `===` between `int` and `false`, always false
- `DashboardResolver.php:47` — `$settingMapper` written but never read (dead injection)
- `DashboardResolver.php:199` — unreachable statement after termination
- `DashboardService::createDefaultPlacements()` — wrong PHPDoc return type (claims `Service\WidgetPlacement`, returns `Db\WidgetPlacement`)

These should be cleaned up in a follow-up PR (likely combine type fixes with a small refactor of the dashboard mappers' setters to accept `DateTime` directly).

## Test plan

- [x] `composer phpstan` exits 0 locally
- [x] No code under `lib/`, `src/`, `tests/`, `appinfo/` was modified
- [ ] CI green on this branch