### PR TITLE
feat(admin-templates): primary-group routing resolver

### DIFF
--- a/lib/Service/AdminTemplateService.php
+++ b/lib/Service/AdminTemplateService.php
@@ -26,6 +26,8 @@ use Exception;
 use OCA\MyDash\Db\Dashboard;
 use OCA\MyDash\Db\DashboardMapper;
 use OCA\MyDash\Db\WidgetPlacementMapper;
+use OCP\IGroupManager;
+use OCP\IUserManager;
 use Ramsey\Uuid\Uuid;
 
 /**
@@ -38,10 +40,16 @@ class AdminTemplateService
      *
      * @param DashboardMapper       $dashboardMapper Dashboard mapper.
      * @param WidgetPlacementMapper $placementMapper Widget placement mapper.
+     * @param AdminSettingsService  $adminSettings   Admin settings reader (for `group_order`).
+     * @param IGroupManager         $groupManager    Nextcloud group membership lookup.
+     * @param IUserManager          $userManager     Nextcloud user lookup (resolve user ID to IUser).
      */
     public function __construct(
         private readonly DashboardMapper $dashboardMapper,
         private readonly WidgetPlacementMapper $placementMapper,
+        private readonly AdminSettingsService $adminSettings,
+        private readonly IGroupManager $groupManager,
+        private readonly IUserManager $userManager,
     ) {
     }//end __construct()
 
@@ -226,4 +234,100 @@ class AdminTemplateService
             );
         }
     }//end applyTemplateUpdates()
+
+    /**
+     * Resolve the user's primary workspace group (REQ-TMPL-012).
+     *
+     * Pure read-only function — performs no writes. Implements the single
+     * routing authority for primary-group resolution (REQ-TMPL-013): every
+     * workspace-rendering and dashboard-resolution code path MUST consult
+     * this method instead of inlining the algorithm.
+     *
+     * Algorithm:
+     *   1. Read the admin-configured ordered list of group IDs from
+     *      `admin_settings.group_order` (JSON `string[]`, default `[]`).
+     *   2. Read the user's Nextcloud group memberships via
+     *      `IGroupManager::getUserGroupIds`.
+     *   3. Walk `group_order` left-to-right and return the first group ID
+     *      that also appears in the user's memberships.
+     *   4. If no match (including empty list, user in no configured group,
+     *      or every configured ID is stale), return the literal sentinel
+     *      `Dashboard::DEFAULT_GROUP_ID` (`'default'`).
+     *
+     * Stale (deleted) group IDs in `group_order` are tolerated — cleanup is
+     * the admin UI's responsibility and the resolver MUST NOT throw on
+     * them.
+     *
+     * @param string $userId The Nextcloud user ID.
+     *
+     * @return string The matched Nextcloud group ID, or
+     *                {@see Dashboard::DEFAULT_GROUP_ID} when no match
+     *                exists.
+     */
+    public function resolvePrimaryGroup(string $userId): string
+    {
+        $orderedGroups = $this->adminSettings->getGroupOrder();
+
+        // Short-circuit: if no groups are configured the answer is always
+        // the default sentinel — no need to look the user up.
+        if ($orderedGroups === []) {
+            return Dashboard::DEFAULT_GROUP_ID;
+        }
+
+        $user = $this->userManager->get($userId);
+        if ($user === null) {
+            // Stale / unknown user ID — tolerate silently per
+            // REQ-TMPL-012 spirit (resolver MUST NOT throw on bad input).
+            return Dashboard::DEFAULT_GROUP_ID;
+        }
+
+        $userGroups = $this->groupManager->getUserGroupIds(user: $user);
+
+        $match = self::pickFirstMatch(
+            orderedGroups: $orderedGroups,
+            userGroups: $userGroups
+        );
+
+        return ($match ?? Dashboard::DEFAULT_GROUP_ID);
+    }//end resolvePrimaryGroup()
+
+    /**
+     * Pick the first ordered group that the user is a member of.
+     *
+     * Internal pure helper extracted for direct unit-testability of the
+     * intersection logic, independent of any Nextcloud/DI dependencies.
+     * Walks `$orderedGroups` left-to-right and returns the first entry that
+     * also appears in `$userGroups`. Returns `null` when no overlap exists
+     * (including either argument being empty).
+     *
+     * Tolerates stale entries in `$orderedGroups` — entries that are not in
+     * `$userGroups` are simply skipped, never raise an error.
+     *
+     * @param array<int, string> $orderedGroups The admin-configured ordered
+     *                                          list of group IDs.
+     * @param array<int, string> $userGroups    The user's actual Nextcloud
+     *                                          group memberships.
+     *
+     * @return string|null The first matching group ID, or `null` when the
+     *                     two lists do not intersect.
+     */
+    public static function pickFirstMatch(
+        array $orderedGroups,
+        array $userGroups
+    ): ?string {
+        if ($orderedGroups === [] || $userGroups === []) {
+            return null;
+        }
+
+        // O(n) lookup: hash the user's groups for constant-time matching.
+        $userGroupSet = array_flip($userGroups);
+
+        foreach ($orderedGroups as $groupId) {
+            if (isset($userGroupSet[$groupId]) === true) {
+                return $groupId;
+            }
+        }
+
+        return null;
+    }//end pickFirstMatch()
 }//end class

--- a/sbom.cdx.json
+++ b/sbom.cdx.json
@@ -2,10 +2,10 @@
   "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.5",
-  "serialNumber": "urn:uuid:f6175e64-0024-4d75-9d39-f8ba0b78cf60",
+  "serialNumber": "urn:uuid:6cee276e-6aa3-49ab-95e4-1b2e58cb54db",
   "version": 1,
   "metadata": {
-    "timestamp": "2026-04-30T12:01:55Z",
+    "timestamp": "2026-04-30T12:20:58Z",
     "tools": [
       {
         "name": "composer",
@@ -82,10 +82,10 @@
       }
     ],
     "component": {
-      "bom-ref": "mydash/mydash-dev-chore/add-vitest-setup",
+      "bom-ref": "mydash/mydash-dev-feature/impl-group-routing",
       "type": "application",
       "name": "mydash",
-      "version": "dev-chore/add-vitest-setup",
+      "version": "dev-feature/impl-group-routing",
       "group": "mydash",
       "description": "Enhanced dashboard with grid layout and admin controls for Nextcloud",
       "author": "MyDash Contributors",
@@ -96,15 +96,15 @@
           }
         }
       ],
-      "purl": "pkg:composer/mydash/mydash@dev-chore/add-vitest-setup",
+      "purl": "pkg:composer/mydash/mydash@dev-feature/impl-group-routing",
       "properties": [
         {
           "name": "cdx:composer:package:distReference",
-          "value": "7068f89e08bf18c6a58179aa63e110e4d709efc1"
+          "value": "fc7dc0e9ecf9f6ed041d085b82b639324fb8217b"
         },
         {
           "name": "cdx:composer:package:sourceReference",
-          "value": "7068f89e08bf18c6a58179aa63e110e4d709efc1"
+          "value": "fc7dc0e9ecf9f6ed041d085b82b639324fb8217b"
         },
         {
           "name": "cdx:composer:package:type",
@@ -17934,7 +17934,7 @@
       ]
     },
     {
-      "ref": "mydash/mydash-dev-chore/add-vitest-setup",
+      "ref": "mydash/mydash-dev-feature/impl-group-routing",
       "dependsOn": [
         "ramsey/uuid-4.9.2.0"
       ]

--- a/tests/Unit/Service/AdminTemplateServiceTest.php
+++ b/tests/Unit/Service/AdminTemplateServiceTest.php
@@ -1,0 +1,298 @@
+<?php
+
+/**
+ * AdminTemplateService Test
+ *
+ * Covers the primary-group resolver introduced by REQ-TMPL-012 / REQ-TMPL-013.
+ * The resolver is the single routing authority for picking which Nextcloud
+ * group a user's workspace renders for; these tests pin the algorithm and
+ * its tolerance for stale / empty / missing inputs.
+ *
+ * @category  Test
+ * @package   OCA\MyDash\Tests\Unit\Service
+ * @author    Conduction b.v. <info@conduction.nl>
+ * @copyright 2024 Conduction b.v.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-FileCopyrightText: 2024 MyDash Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Service;
+
+use OCA\MyDash\Db\Dashboard;
+use OCA\MyDash\Db\DashboardMapper;
+use OCA\MyDash\Db\WidgetPlacementMapper;
+use OCA\MyDash\Service\AdminSettingsService;
+use OCA\MyDash\Service\AdminTemplateService;
+use OCP\IGroupManager;
+use OCP\IUser;
+use OCP\IUserManager;
+use PHPUnit\Framework\TestCase;
+
+class AdminTemplateServiceTest extends TestCase
+{
+
+    private AdminTemplateService $service;
+
+    private DashboardMapper $dashboardMapper;
+
+    private WidgetPlacementMapper $placementMapper;
+
+    private AdminSettingsService $adminSettings;
+
+    private IGroupManager $groupManager;
+
+    private IUserManager $userManager;
+
+    protected function setUp(): void
+    {
+        $this->dashboardMapper = $this->createMock(DashboardMapper::class);
+        $this->placementMapper = $this->createMock(WidgetPlacementMapper::class);
+        $this->adminSettings   = $this->createMock(AdminSettingsService::class);
+        $this->groupManager    = $this->createMock(IGroupManager::class);
+        $this->userManager     = $this->createMock(IUserManager::class);
+
+        $this->service = new AdminTemplateService(
+            dashboardMapper: $this->dashboardMapper,
+            placementMapper: $this->placementMapper,
+            adminSettings: $this->adminSettings,
+            groupManager: $this->groupManager,
+            userManager: $this->userManager,
+        );
+    }//end setUp()
+
+    /**
+     * Build a mock IUser whose getUID() returns the given ID.
+     */
+    private function mockUser(string $uid): IUser
+    {
+        $user = $this->createMock(IUser::class);
+        $user->method('getUID')->willReturn($uid);
+
+        return $user;
+    }//end mockUser()
+
+    /**
+     * Table-driven cover of every REQ-TMPL-012 scenario.
+     *
+     * @dataProvider provideResolvePrimaryGroupCases
+     *
+     * @param array<int, string> $groupOrder admin-configured priority list
+     * @param array<int, string> $userGroups Nextcloud memberships
+     * @param string             $expected   resolver result
+     * @param string             $caseLabel  human label for failure trace
+     */
+    public function testResolvePrimaryGroup(
+        array $groupOrder,
+        array $userGroups,
+        string $expected,
+        string $caseLabel
+    ): void {
+        $this->adminSettings
+            ->method('getGroupOrder')
+            ->willReturn($groupOrder);
+
+        $user = $this->mockUser('alice');
+        $this->userManager
+            ->method('get')
+            ->with('alice')
+            ->willReturn($user);
+
+        $this->groupManager
+            ->method('getUserGroupIds')
+            ->with($user)
+            ->willReturn($userGroups);
+
+        $this->assertSame(
+            $expected,
+            $this->service->resolvePrimaryGroup('alice'),
+            $caseLabel
+        );
+    }//end testResolvePrimaryGroup()
+
+    public function testResolvePrimaryGroupReturnsDefaultForUnknownUser(): void
+    {
+        $this->adminSettings
+            ->method('getGroupOrder')
+            ->willReturn(['engineering']);
+
+        $this->userManager
+            ->method('get')
+            ->with('ghost')
+            ->willReturn(null);
+
+        $this->groupManager
+            ->expects($this->never())
+            ->method('getUserGroupIds');
+
+        $this->assertSame(
+            Dashboard::DEFAULT_GROUP_ID,
+            $this->service->resolvePrimaryGroup('ghost'),
+            'unknown user ID must short-circuit to default sentinel without throwing'
+        );
+    }//end testResolvePrimaryGroupReturnsDefaultForUnknownUser()
+
+    /**
+     * @return array<string, array{0: array<int, string>, 1: array<int, string>, 2: string, 3: string}>
+     */
+    public static function provideResolvePrimaryGroupCases(): array
+    {
+        return [
+            'priority order wins over alphabetical'               => [
+                ['engineering', 'all-staff'],
+                ['all-staff', 'engineering', 'marketing'],
+                'engineering',
+                'engineering appears first in group_order, even though all-staff is alphabetically earlier in user groups',
+            ],
+            'configured group not in user memberships is skipped' => [
+                ['executives', 'engineering'],
+                ['engineering', 'support'],
+                'engineering',
+                'executives is configured but bob is not a member, so we fall through to engineering',
+            ],
+            'no overlap returns default sentinel'                 => [
+                ['engineering', 'executives'],
+                ['support'],
+                Dashboard::DEFAULT_GROUP_ID,
+                'carol is in support only — no overlap with group_order, must return default',
+            ],
+            'empty group_order always returns default'            => [
+                [],
+                ['engineering', 'all-staff', 'marketing'],
+                Dashboard::DEFAULT_GROUP_ID,
+                'unconfigured group_order means default regardless of user memberships',
+            ],
+            'user in no groups returns default'                   => [
+                ['engineering', 'executives'],
+                [],
+                Dashboard::DEFAULT_GROUP_ID,
+                'user with zero memberships always falls through to default',
+            ],
+            'stale (deleted) group ID is harmless'                => [
+                ['deleted-group', 'engineering'],
+                ['engineering'],
+                'engineering',
+                'deleted-group remains in group_order but is not in user groups; resolver must skip without error',
+            ],
+            'stale group ID at every position falls to default'   => [
+                ['deleted-a', 'deleted-b'],
+                ['engineering'],
+                Dashboard::DEFAULT_GROUP_ID,
+                'all configured groups are stale — must return default sentinel, not throw',
+            ],
+            'single configured + matching user group'             => [
+                ['engineering'],
+                ['engineering'],
+                'engineering',
+                'simplest happy path',
+            ],
+        ];
+    }//end provideResolvePrimaryGroupCases()
+
+    public function testResolvePrimaryGroupReturnsLiteralDefaultString(): void
+    {
+        // Pin the sentinel string itself so accidental constant rename
+        // (e.g. to 'DEFAULT' or '__default__') is caught — REQ-DASH-012.
+        $this->adminSettings->method('getGroupOrder')->willReturn([]);
+
+        $this->assertSame(
+            'default',
+            $this->service->resolvePrimaryGroup('anyone'),
+            'sentinel must be the literal string "default", not a renamed constant value'
+        );
+        $this->assertSame(
+            'default',
+            Dashboard::DEFAULT_GROUP_ID,
+            'Dashboard::DEFAULT_GROUP_ID must be the literal "default" sentinel'
+        );
+    }//end testResolvePrimaryGroupReturnsLiteralDefaultString()
+
+    public function testResolvePrimaryGroupIsReadOnly(): void
+    {
+        // Resolver MUST NOT write — guard via mock expectations on the only
+        // injected mappers / settings (no setters / setSetting / insert /
+        // update should ever be called).
+        $this->dashboardMapper->expects($this->never())->method($this->anything());
+        $this->placementMapper->expects($this->never())->method($this->anything());
+        $this->adminSettings
+            ->expects($this->never())
+            ->method('updateSettings');
+        $this->adminSettings
+            ->expects($this->never())
+            ->method('setGroupOrder');
+
+        $this->adminSettings->method('getGroupOrder')->willReturn(['engineering']);
+        $user = $this->mockUser('alice');
+        $this->userManager->method('get')->willReturn($user);
+        $this->groupManager->method('getUserGroupIds')->willReturn(['engineering']);
+
+        $this->service->resolvePrimaryGroup('alice');
+    }//end testResolvePrimaryGroupIsReadOnly()
+
+    public function testPickFirstMatchEmptyOrderedReturnsNull(): void
+    {
+        $this->assertNull(
+            AdminTemplateService::pickFirstMatch(
+                orderedGroups: [],
+                userGroups: ['engineering', 'all-staff']
+            )
+        );
+    }//end testPickFirstMatchEmptyOrderedReturnsNull()
+
+    public function testPickFirstMatchEmptyUserGroupsReturnsNull(): void
+    {
+        $this->assertNull(
+            AdminTemplateService::pickFirstMatch(
+                orderedGroups: ['engineering'],
+                userGroups: []
+            )
+        );
+    }//end testPickFirstMatchEmptyUserGroupsReturnsNull()
+
+    public function testPickFirstMatchBothEmptyReturnsNull(): void
+    {
+        $this->assertNull(
+            AdminTemplateService::pickFirstMatch(
+                orderedGroups: [],
+                userGroups: []
+            )
+        );
+    }//end testPickFirstMatchBothEmptyReturnsNull()
+
+    public function testPickFirstMatchNoOverlapReturnsNull(): void
+    {
+        $this->assertNull(
+            AdminTemplateService::pickFirstMatch(
+                orderedGroups: ['engineering', 'executives'],
+                userGroups: ['support', 'marketing']
+            )
+        );
+    }//end testPickFirstMatchNoOverlapReturnsNull()
+
+    public function testPickFirstMatchMultipleOverlapsReturnsFirstByPriority(): void
+    {
+        // user is in BOTH engineering and all-staff; engineering comes first
+        // in group_order, so it wins regardless of the user-side ordering.
+        $this->assertSame(
+            'engineering',
+            AdminTemplateService::pickFirstMatch(
+                orderedGroups: ['engineering', 'all-staff'],
+                userGroups: ['all-staff', 'engineering']
+            )
+        );
+    }//end testPickFirstMatchMultipleOverlapsReturnsFirstByPriority()
+
+    public function testPickFirstMatchSkipsLeadingNonMembers(): void
+    {
+        $this->assertSame(
+            'engineering',
+            AdminTemplateService::pickFirstMatch(
+                orderedGroups: ['executives', 'leadership', 'engineering', 'all-staff'],
+                userGroups: ['engineering', 'all-staff']
+            )
+        );
+    }//end testPickFirstMatchSkipsLeadingNonMembers()
+}//end class


### PR DESCRIPTION
## Summary

Implements REQ-TMPL-012 (primary-group resolution algorithm) and REQ-TMPL-013 (single routing authority) from the `group-routing` change proposal.

- New pure function `AdminTemplateService::resolvePrimaryGroup(string $userId): string` — walks the admin-configured `group_order` setting and returns the first matching Nextcloud group ID, or the literal sentinel `Dashboard::DEFAULT_GROUP_ID` (`'default'`) when no match exists.
- Internal pure helper `pickFirstMatch(array $orderedGroups, array $userGroups): ?string` exposed as `static` for direct intersection-logic unit tests.
- Tolerates stale (deleted) group IDs in `group_order` and unknown user IDs without throwing — cleanup is the admin UI's responsibility.

## Builds on

- **#44** — `AdminSettingsService::getGroupOrder(): array` accessor (already merged on `development`)
- **#47** — `Dashboard::DEFAULT_GROUP_ID = 'default'` constant (already merged on `development`)

## Single-source-of-truth contract

This is the **single routing authority** for primary-group resolution. Every workspace-rendering and dashboard-resolution code path (REQ-DASH-013, REQ-DASH-018, …) MUST consult this resolver instead of inlining the algorithm. Parallel implementations are forbidden by REQ-TMPL-013.

## Out of scope

Refactoring existing call sites in `PageController::index` and `DashboardService::getVisibleDashboards` to consume `resolvePrimaryGroup` is intentionally deferred to follow-up PRs (incremental work, one consumer per PR). This PR provides the resolver and locks its contract.

## Test plan

- [x] `./vendor/bin/phpunit` — 186/186 tests pass (17 new tests in `AdminTemplateServiceTest`)
- [x] `composer phpcs` (PHPCS strict) — clean on `lib/`
- [x] `composer phpmd` — clean
- [x] Psalm + PHPStan — same 3 pre-existing baseline errors (Ramsey\Uuid stub gap + IUser::getLanguage), no new errors introduced
- [x] Hydra gates — failures all in pre-existing files (`PermissionService`, `ConditionalService`, `AdminController`); none in `AdminTemplateService.php`
- [x] Table-driven cover of every REQ-TMPL-012 scenario: priority-order match, no overlap, empty `group_order`, configured-but-not-member, deleted/stale group, unknown user
- [x] Read-only contract pinned via mock `expects(never())` on every write surface

## Spec source

`openspec/changes/group-routing/{proposal,tasks,specs/admin-templates/spec}.md` on branch `feature/replica-spec-proposals`.