### PR TITLE
feat(resources): SVG sanitiser plugged into upload pipeline

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -54,3 +54,17 @@ npm start            # Dev server at http://localhost:3000 with hot reload
 ### Adding documentation
 
 Simply add or edit Markdown files in the `docs/` folder. The sidebar is auto-generated from the folder structure. Changes will appear on the product page after pushing to `development`.
+
+## Security review checkboxes
+
+### Extending the SVG whitelist
+
+`lib/Service/SvgSanitiser.php` ships a deliberately conservative whitelist of 24 element types and 50 attribute types — see `ALLOWED_ELEMENTS` and `ALLOWED_ATTRIBUTES` (REQ-RES-010 / REQ-RES-011 in the `resource-uploads` capability).
+
+Adding any element or attribute to either constant is a **security review checkbox**, not an editorial change. Before merging an addition, confirm:
+
+- the element / attribute carries no executable surface (no script, no event handler, no foreign content, no URL fetch outside the existing `href` filter);
+- the addition is justified by a real upload that is currently being rejected, not a speculative future need;
+- a corresponding unit test covers the new whitelist entry.
+
+The sanitiser runs server-side BEFORE the size cap (REQ-RES-009), so an over-permissive whitelist becomes stored XSS the moment a sanitised-looking SVG is rendered back into a logged-in user's browser.

--- a/l10n/en.js
+++ b/l10n/en.js
@@ -1,6 +1,7 @@
 OC.L10N.register(
     "mydash",
     {
+    "SVG could not be parsed or contained no allowed content" : "SVG could not be parsed or contained no allowed content",
     "Active" : "Active",
     "Add" : "Add",
     "Add only" : "Add only",

--- a/l10n/en.json
+++ b/l10n/en.json
@@ -1,5 +1,6 @@
 {
     "translations": {
+        "SVG could not be parsed or contained no allowed content": "SVG could not be parsed or contained no allowed content",
         "Active": "Active",
         "Add": "Add",
         "Add only": "Add only",

--- a/l10n/nl.js
+++ b/l10n/nl.js
@@ -1,6 +1,7 @@
 OC.L10N.register(
     "mydash",
     {
+    "SVG could not be parsed or contained no allowed content" : "SVG kon niet worden verwerkt of bevatte geen toegestane inhoud",
     "Active" : "Actief",
     "Add" : "Toevoegen",
     "Add only" : "Alleen toevoegen",

--- a/l10n/nl.json
+++ b/l10n/nl.json
@@ -1,5 +1,6 @@
 {
     "translations": {
+        "SVG could not be parsed or contained no allowed content": "SVG kon niet worden verwerkt of bevatte geen toegestane inhoud",
         "Active": "Actief",
         "Add": "Toevoegen",
         "Add only": "Alleen toevoegen",

--- a/lib/Exception/InvalidSvgException.php
+++ b/lib/Exception/InvalidSvgException.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * InvalidSvgException
+ *
+ * Raised when an uploaded SVG cannot be parsed by libxml or is fully
+ * stripped to an empty document by `SvgSanitiser::sanitize()`. Maps to
+ * HTTP 400 + stable error code `invalid_svg`. Spec: REQ-RES-009.
+ *
+ * @category  Exception
+ * @package   OCA\MyDash\Exception
+ * @author    Conduction b.v. <info@conduction.nl>
+ * @copyright 2024 Conduction b.v.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @version   GIT:auto
+ * @link      https://conduction.nl
+ *
+ * SPDX-FileCopyrightText: 2024 MyDash Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace OCA\MyDash\Exception;
+
+/**
+ * Uploaded SVG bytes failed to parse or sanitised to an empty document.
+ */
+class InvalidSvgException extends ResourceException
+{
+
+    /**
+     * Stable error code.
+     *
+     * @var string
+     */
+    protected string $errorCode = 'invalid_svg';
+
+    /**
+     * HTTP status.
+     *
+     * @var integer
+     */
+    protected int $httpStatus = 400;
+
+    /**
+     * Constructor.
+     *
+     * @param string $message Display message.
+     */
+    public function __construct(
+        string $message='SVG could not be parsed or contained no allowed content'
+    ) {
+        parent::__construct(message: $message);
+    }//end __construct()
+}//end class

--- a/lib/Service/ResourceService.php
+++ b/lib/Service/ResourceService.php
@@ -11,8 +11,10 @@
  * and persists the bytes via `IAppData::getFolder('resources')` with
  * a high-entropy `resource_<uniqid>.<ext>` filename.
  *
- * SVG sanitisation is delegated to a sibling capability and is
- * intentionally out of scope here.
+ * For SVG uploads the bytes are first passed through `SvgSanitiser`
+ * (REQ-RES-009..013); the sanitised bytes are what get persisted, and
+ * the 5 MB size cap is measured AFTER sanitisation. A null sanitiser
+ * return is surfaced as HTTP 400 `invalid_svg`.
  *
  * @category  Service
  * @package   OCA\MyDash\Service
@@ -34,6 +36,7 @@ use OCA\MyDash\AppInfo\Application;
 use OCA\MyDash\Exception\FileTooLargeException;
 use OCA\MyDash\Exception\InvalidDataUrlException;
 use OCA\MyDash\Exception\InvalidImageFormatException;
+use OCA\MyDash\Exception\InvalidSvgException;
 use OCA\MyDash\Exception\StorageFailureException;
 use OCP\Files\IAppData;
 use OCP\Files\NotFoundException;
@@ -78,10 +81,12 @@ class ResourceService
      * @param IAppData           $appData       Nextcloud app-data
      *                                          interface for this app.
      * @param ImageMimeValidator $mimeValidator Raster MIME cross-checker.
+     * @param SvgSanitiser       $svgSanitiser  DOM whitelist SVG sanitiser.
      */
     public function __construct(
         private readonly IAppData $appData,
         private readonly ImageMimeValidator $mimeValidator,
+        private readonly SvgSanitiser $svgSanitiser,
     ) {
     }//end __construct()
 
@@ -102,8 +107,11 @@ class ResourceService
      *                                     or unparseable.
      * @throws InvalidImageFormatException When the declared type is
      *                                     not in the allowed list.
-     * @throws FileTooLargeException       When decoded bytes exceed
-     *                                     5 MB.
+     * @throws InvalidSvgException         When an SVG payload fails
+     *                                     to parse or is fully stripped.
+     * @throws FileTooLargeException       When decoded bytes (or the
+     *                                     SANITISED bytes for SVG)
+     *                                     exceed 5 MB.
      * @throws StorageFailureException     When writing to IAppData
      *                                     fails.
      */
@@ -113,12 +121,25 @@ class ResourceService
         $declaredType = $parsed['type'];
         $bytes        = $parsed['bytes'];
 
+        // SVG branch: sanitise BEFORE the size check so the 5 MB cap
+        // is measured against the persisted (sanitised) byte count
+        // (REQ-RES-009). Sanitiser returns null on parse failure or
+        // an empty document — surface as HTTP 400 invalid_svg.
+        if ($declaredType === 'svg') {
+            $sanitised = $this->svgSanitiser->sanitize(bytes: $bytes);
+            if ($sanitised === null) {
+                throw new InvalidSvgException();
+            }
+
+            $bytes = $sanitised;
+        }
+
         // Enforce the 5 MB cap BEFORE invoking the image library.
         if (strlen(string: $bytes) > self::MAX_BYTES) {
             throw new FileTooLargeException();
         }
 
-        // Cross-check raster MIME (SVG handled by sibling sanitiser).
+        // Cross-check raster MIME (SVG short-circuits inside validate).
         $this->mimeValidator->validate(
             declaredType: $declaredType,
             bytes: $bytes

--- a/lib/Service/SvgSanitiser.php
+++ b/lib/Service/SvgSanitiser.php
@@ -1,0 +1,351 @@
+<?php
+
+/**
+ * SvgSanitiser
+ *
+ * DOM-based whitelist sanitiser for uploaded SVG bytes. Parses input
+ * via `DOMDocument::loadXML($bytes, LIBXML_NONET | LIBXML_NOENT)` so
+ * the parser cannot fetch external entities or DTDs (XXE protection),
+ * walks the resulting tree, and strips:
+ *
+ * - any element whose lowercased localName is not in `ALLOWED_ELEMENTS`
+ *   (24 element types — geometry + structure + decoration);
+ * - any attribute whose lowercased name is not in `ALLOWED_ATTRIBUTES`
+ *   (50 attribute types — geometry, styling, transform, gradient, href);
+ * - ALL `on*` attributes regardless of whitelist (defence in depth);
+ * - `href` / `xlink:href` values starting with `javascript:` or `data:`
+ *   (after trim + lowercase);
+ * - `style` attribute values containing `expression(`, `javascript:`,
+ *   or `url(data:`.
+ *
+ * Returns `null` on parse failure or an empty serialised result.
+ *
+ * The whitelist is intentionally conservative — adding a new element
+ * or attribute is a deliberate code change with a security review
+ * checkbox. See REQ-RES-010 / REQ-RES-011 in the resource-uploads
+ * capability and the note in CONTRIBUTING.md.
+ *
+ * @category  Service
+ * @package   OCA\MyDash\Service
+ * @author    Conduction b.v. <info@conduction.nl>
+ * @copyright 2024 Conduction b.v.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @version   GIT:auto
+ * @link      https://conduction.nl
+ *
+ * SPDX-FileCopyrightText: 2024 MyDash Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace OCA\MyDash\Service;
+
+use DOMAttr;
+use DOMDocument;
+use DOMElement;
+use DOMNode;
+
+/**
+ * Whitelist-based SVG sanitiser. No Nextcloud dependencies — pure PHP.
+ */
+class SvgSanitiser
+{
+
+    /**
+     * Allowed element local-names (lowercase). Anything not in this
+     * list is removed from the tree along with its children. See
+     * REQ-RES-010 in the resource-uploads capability.
+     *
+     * @var array<int,string>
+     */
+    private const ALLOWED_ELEMENTS = [
+        'svg',
+        'g',
+        'path',
+        'rect',
+        'circle',
+        'ellipse',
+        'line',
+        'polyline',
+        'polygon',
+        'text',
+        'tspan',
+        'defs',
+        'clippath',
+        'use',
+        'image',
+        'style',
+        'lineargradient',
+        'radialgradient',
+        'stop',
+        'mask',
+        'pattern',
+        'symbol',
+        'title',
+        'desc',
+    ];
+
+    /**
+     * Allowed attribute names (lowercase). Anything not in this list
+     * is removed from each element regardless of element name. See
+     * REQ-RES-011 in the resource-uploads capability.
+     *
+     * @var array<int,string>
+     */
+    private const ALLOWED_ATTRIBUTES = [
+        'id',
+        'class',
+        'style',
+        'd',
+        'x',
+        'y',
+        'x1',
+        'y1',
+        'x2',
+        'y2',
+        'cx',
+        'cy',
+        'r',
+        'rx',
+        'ry',
+        'width',
+        'height',
+        'viewbox',
+        'fill',
+        'stroke',
+        'stroke-width',
+        'stroke-linecap',
+        'stroke-linejoin',
+        'stroke-dasharray',
+        'stroke-dashoffset',
+        'stroke-opacity',
+        'fill-opacity',
+        'opacity',
+        'transform',
+        'points',
+        'font-size',
+        'font-family',
+        'font-weight',
+        'text-anchor',
+        'dominant-baseline',
+        'dx',
+        'dy',
+        'clip-path',
+        'mask',
+        'filter',
+        'gradientunits',
+        'gradienttransform',
+        'offset',
+        'stop-color',
+        'stop-opacity',
+        'patternunits',
+        'preserveaspectratio',
+        'xmlns',
+        'xmlns:xlink',
+        'version',
+        'href',
+        'xlink:href',
+    ];
+
+    /**
+     * Sanitise SVG bytes; return the sanitised serialisation or `null`
+     * when the input is unparseable / fully stripped to an empty tree.
+     *
+     * Parse flags `LIBXML_NONET | LIBXML_NOENT` ensure the libxml
+     * parser cannot fetch external DTDs / entities (XXE) and that
+     * entity expansion is bounded by libxml's internal limits
+     * (defends against billion-laughs).
+     *
+     * @param string $bytes The raw uploaded SVG bytes.
+     *
+     * @return string|null The sanitised SVG, or null when unparseable
+     *                     or sanitised to an empty result.
+     */
+    public function sanitize(string $bytes): ?string
+    {
+        if ($bytes === '') {
+            return null;
+        }
+
+        $previousErrors = libxml_use_internal_errors(use_errors: true);
+
+        $document = new DOMDocument();
+        $document->preserveWhiteSpace = false;
+        $document->formatOutput       = false;
+
+        $loaded = $document->loadXML(
+            source: $bytes,
+            options: (LIBXML_NONET | LIBXML_NOENT)
+        );
+
+        libxml_clear_errors();
+        libxml_use_internal_errors(use_errors: $previousErrors);
+
+        if ($loaded === false) {
+            return null;
+        }
+
+        $root = $document->documentElement;
+        if ($root === null) {
+            return null;
+        }
+
+        // Validate the root element itself — reject if it is not in
+        // the whitelist (the recursive walker only inspects children).
+        if (in_array(
+            needle: strtolower(string: $root->localName),
+            haystack: self::ALLOWED_ELEMENTS,
+            strict: true
+        ) === false
+        ) {
+            return null;
+        }
+
+        $this->cleanElement(element: $root);
+        $this->walkChildren(node: $root);
+
+        $serialised = $document->saveXML($root);
+        if ($serialised === false || $serialised === '') {
+            return null;
+        }
+
+        return $serialised;
+    }//end sanitize()
+
+    /**
+     * Recursively walk children of $node, removing disallowed elements
+     * and cleaning the attributes of allowed ones. Snapshots the child
+     * list before mutation so removals during iteration are safe.
+     *
+     * @param DOMNode $node The parent node whose children to walk.
+     *
+     * @return void
+     */
+    private function walkChildren(DOMNode $node): void
+    {
+        $children = [];
+        foreach ($node->childNodes as $child) {
+            $children[] = $child;
+        }
+
+        foreach ($children as $child) {
+            if ($child instanceof DOMElement === false) {
+                continue;
+            }
+
+            $localName = strtolower(string: $child->localName);
+            if (in_array(
+                needle: $localName,
+                haystack: self::ALLOWED_ELEMENTS,
+                strict: true
+            ) === false
+            ) {
+                $node->removeChild(child: $child);
+                continue;
+            }
+
+            $this->cleanElement(element: $child);
+            $this->walkChildren(node: $child);
+        }
+    }//end walkChildren()
+
+    /**
+     * Strip every disallowed attribute from $element, plus any `on*`
+     * attribute (defence in depth) and any `href` / `xlink:href` /
+     * `style` whose value is on the URL or CSS denylist.
+     *
+     * @param DOMElement $element The element whose attributes to clean.
+     *
+     * @return void
+     */
+    private function cleanElement(DOMElement $element): void
+    {
+        if ($element->hasAttributes() === false) {
+            return;
+        }
+
+        $attributes = [];
+        foreach ($element->attributes as $attribute) {
+            if ($attribute instanceof DOMAttr) {
+                $attributes[] = $attribute;
+            }
+        }
+
+        foreach ($attributes as $attribute) {
+            $name      = $attribute->nodeName;
+            $lowerName = strtolower(string: $name);
+
+            // Defence in depth — strip every `on*` attribute regardless
+            // of whitelist (REQ-RES-011).
+            if (str_starts_with(haystack: $lowerName, needle: 'on') === true) {
+                $element->removeAttributeNode(attr: $attribute);
+                continue;
+            }
+
+            if (in_array(
+                needle: $lowerName,
+                haystack: self::ALLOWED_ATTRIBUTES,
+                strict: true
+            ) === false
+            ) {
+                $element->removeAttributeNode(attr: $attribute);
+                continue;
+            }
+
+            if ($lowerName === 'href' || $lowerName === 'xlink:href') {
+                if ($this->isDangerousUrl(value: $attribute->value) === true) {
+                    $element->removeAttributeNode(attr: $attribute);
+                }
+
+                continue;
+            }
+
+            if ($lowerName === 'style') {
+                if ($this->isDangerousStyle(value: $attribute->value) === true) {
+                    $element->removeAttributeNode(attr: $attribute);
+                }
+
+                continue;
+            }
+        }//end foreach
+    }//end cleanElement()
+
+    /**
+     * Whether the supplied URL value is on the denylist. Trims +
+     * lowercases before comparing; matches `javascript:` and `data:`
+     * prefixes (REQ-RES-012).
+     *
+     * @param string $value The raw attribute value.
+     *
+     * @return boolean True when the value should be rejected.
+     */
+    private function isDangerousUrl(string $value): bool
+    {
+        $normalised = strtolower(string: trim(string: $value));
+        if (str_starts_with(haystack: $normalised, needle: 'javascript:') === true) {
+            return true;
+        }
+
+        if (str_starts_with(haystack: $normalised, needle: 'data:') === true) {
+            return true;
+        }
+
+        return false;
+    }//end isDangerousUrl()
+
+    /**
+     * Whether the supplied style value contains a forbidden CSS
+     * construct: `expression(`, `javascript:`, or `url(data:`. Match
+     * is case-insensitive with optional whitespace per REQ-RES-012.
+     *
+     * @param string $value The raw style attribute value.
+     *
+     * @return boolean True when the style attribute should be removed.
+     */
+    private function isDangerousStyle(string $value): bool
+    {
+        $pattern = '/expression\s*\(|javascript\s*:|url\s*\(\s*["\']?\s*data\s*:/i';
+        return (preg_match(pattern: $pattern, subject: $value) === 1);
+    }//end isDangerousStyle()
+}//end class

--- a/tests/Unit/Service/ResourceServiceSvgIntegrationTest.php
+++ b/tests/Unit/Service/ResourceServiceSvgIntegrationTest.php
@@ -1,0 +1,185 @@
+<?php
+
+/**
+ * ResourceService SVG Integration Test
+ *
+ * Wires the real `SvgSanitiser` into a real `ResourceService` against a
+ * mocked `IAppData` so we can verify the integration scenarios from
+ * tasks 4.1..4.5 of the svg-sanitisation change (REQ-RES-009..013):
+ *
+ * - malicious `<script>` SVG → upload succeeds; persisted bytes have
+ *   no `<script>` (4.1)
+ * - garbage non-XML payload → InvalidSvgException; no file written (4.2)
+ * - 5.5 MB SVG that sanitises down to ≤5 MB → upload succeeds (4.3)
+ * - 4.9 MB SVG that sanitises down to ≤4.9 MB → upload succeeds (4.4)
+ * - persisted content equals sanitised bytes, NOT original (4.5)
+ *
+ * @category  Test
+ * @package   OCA\MyDash\Tests\Unit\Service
+ * @author    Conduction b.v. <info@conduction.nl>
+ * @copyright 2024 Conduction b.v.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-FileCopyrightText: 2024 MyDash Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Service;
+
+use OCA\MyDash\Exception\InvalidSvgException;
+use OCA\MyDash\Service\ImageMimeValidator;
+use OCA\MyDash\Service\ResourceService;
+use OCA\MyDash\Service\SvgSanitiser;
+use OCP\Files\IAppData;
+use OCP\Files\SimpleFS\ISimpleFile;
+use OCP\Files\SimpleFS\ISimpleFolder;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class ResourceServiceSvgIntegrationTest extends TestCase
+{
+    private ResourceService $service;
+
+    /** @var IAppData&MockObject */
+    private $appData;
+
+    /** @var ISimpleFolder&MockObject */
+    private $folder;
+
+    /** Captures whatever bytes the service writes to disk. */
+    private string $persistedBytes = '';
+
+    protected function setUp(): void
+    {
+        $this->appData = $this->createMock(IAppData::class);
+        $this->folder  = $this->createMock(ISimpleFolder::class);
+        $this->appData->method('getFolder')->willReturn($this->folder);
+
+        $this->folder->method('newFile')->willReturnCallback(
+            function (string $name, $content): ISimpleFile {
+                $this->persistedBytes = (string) $content;
+                return $this->createMock(ISimpleFile::class);
+            }
+        );
+
+        $this->service = new ResourceService(
+            appData: $this->appData,
+            mimeValidator: new ImageMimeValidator(),
+            svgSanitiser: new SvgSanitiser(),
+        );
+    }
+
+    private function dataUrl(string $bytes): string
+    {
+        return 'data:image/svg+xml;base64,' . base64_encode($bytes);
+    }
+
+    public function testMaliciousSvgUploadStripsScriptAndPersists(): void
+    {
+        $svg = '<svg xmlns="http://www.w3.org/2000/svg">'
+             . '<script>alert(1)</script>'
+             . '<circle r="5"/>'
+             . '</svg>';
+
+        $result = $this->service->upload(
+            base64DataUrl: $this->dataUrl($svg)
+        );
+
+        $this->assertStringStartsWith('/apps/mydash/resource/resource_', $result['url']);
+        $this->assertStringNotContainsString('<script', $this->persistedBytes);
+        $this->assertStringNotContainsString('alert', $this->persistedBytes);
+        $this->assertStringContainsString('<circle', $this->persistedBytes);
+    }
+
+    public function testGarbagePayloadThrowsInvalidSvg(): void
+    {
+        $this->folder->expects($this->never())->method('newFile');
+
+        $this->expectException(InvalidSvgException::class);
+        $this->service->upload(
+            base64DataUrl: $this->dataUrl('<not xml')
+        );
+    }
+
+    public function testInvalidSvgExceptionCarriesStableErrorCode(): void
+    {
+        try {
+            $this->service->upload(
+                base64DataUrl: $this->dataUrl('<not xml')
+            );
+            $this->fail('Expected InvalidSvgException');
+        } catch (InvalidSvgException $exception) {
+            $this->assertSame('invalid_svg', $exception->getErrorCode());
+            $this->assertSame(400, $exception->getHttpStatus());
+        }
+    }
+
+    public function testOversizeSvgBelowCapAfterSanitisationIsAccepted(): void
+    {
+        // Build an SVG whose original bytes exceed 5 MB but whose
+        // sanitised form (script stripped) drops below the cap. Pad
+        // a stripped-out <script> block with ~5.4 MB of payload then
+        // append a tiny circle.
+        $payload = str_repeat('A', (int) (5.4 * 1024 * 1024));
+        $svg     = '<svg xmlns="http://www.w3.org/2000/svg">'
+                 . '<script>' . $payload . '</script>'
+                 . '<circle r="5"/>'
+                 . '</svg>';
+
+        $this->assertGreaterThan(
+            (5 * 1024 * 1024),
+            strlen($svg),
+            'Original payload must exceed the 5 MB cap'
+        );
+
+        $result = $this->service->upload(
+            base64DataUrl: $this->dataUrl($svg)
+        );
+
+        // Sanitised result MUST be under the cap.
+        $this->assertLessThan(
+            ResourceService::MAX_BYTES,
+            $result['size'],
+            'Sanitised payload size must be under 5 MB'
+        );
+        $this->assertStringNotContainsString($payload, $this->persistedBytes);
+        $this->assertStringContainsString('<circle', $this->persistedBytes);
+    }
+
+    public function testNearCapCleanSvgIsAccepted(): void
+    {
+        // A clean 4.9 MB-ish SVG whose sanitised output is roughly the
+        // same size — must succeed, well under the 5 MB cap.
+        $padding = str_repeat(' ', (int) (4.8 * 1024 * 1024));
+        $svg     = '<svg xmlns="http://www.w3.org/2000/svg">'
+                 . '<title>' . $padding . '</title>'
+                 . '<circle r="5"/>'
+                 . '</svg>';
+
+        $result = $this->service->upload(
+            base64DataUrl: $this->dataUrl($svg)
+        );
+
+        $this->assertLessThan(ResourceService::MAX_BYTES, $result['size']);
+        $this->assertStringContainsString('<circle', $this->persistedBytes);
+    }
+
+    public function testPersistedBytesAreSanitisedNotOriginal(): void
+    {
+        $svg = '<svg xmlns="http://www.w3.org/2000/svg">'
+             . '<script>EVIL_MARKER_42</script>'
+             . '<rect x="1" y="2" width="3" height="4"/>'
+             . '</svg>';
+
+        $this->service->upload(
+            base64DataUrl: $this->dataUrl($svg)
+        );
+
+        // Persisted bytes MUST NOT be byte-equal to the original.
+        $this->assertNotSame($svg, $this->persistedBytes);
+        $this->assertStringNotContainsString('EVIL_MARKER_42', $this->persistedBytes);
+        $this->assertStringContainsString('<rect', $this->persistedBytes);
+    }
+}

--- a/tests/Unit/Service/ResourceServiceTest.php
+++ b/tests/Unit/Service/ResourceServiceTest.php
@@ -24,6 +24,7 @@ use OCA\MyDash\Exception\MimeMismatchException;
 use OCA\MyDash\Exception\StorageFailureException;
 use OCA\MyDash\Service\ImageMimeValidator;
 use OCA\MyDash\Service\ResourceService;
+use OCA\MyDash\Service\SvgSanitiser;
 use OCP\Files\IAppData;
 use OCP\Files\NotFoundException;
 use OCP\Files\NotPermittedException;
@@ -60,6 +61,7 @@ class ResourceServiceTest extends TestCase
         $this->service = new ResourceService(
             appData: $this->appData,
             mimeValidator: $this->mimeValidator,
+            svgSanitiser: new SvgSanitiser(),
         );
     }
 

--- a/tests/Unit/Service/SvgSanitiserTest.php
+++ b/tests/Unit/Service/SvgSanitiserTest.php
@@ -1,0 +1,267 @@
+<?php
+
+/**
+ * SvgSanitiser Test
+ *
+ * Covers the 15 unit scenarios from the svg-sanitisation change
+ * (REQ-RES-009..013): clean SVG round-trips, script / foreignObject /
+ * on* / javascript:/data: / expression() / url(data:) all stripped,
+ * safe http(s) preserved, geometry attributes preserved, non-whitelisted
+ * attributes stripped, external DTD does NOT fetch, billion-laughs
+ * payload bounded, unparseable bytes / empty string return null.
+ *
+ * @category  Test
+ * @package   OCA\MyDash\Tests\Unit\Service
+ * @author    Conduction b.v. <info@conduction.nl>
+ * @copyright 2024 Conduction b.v.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-FileCopyrightText: 2024 MyDash Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Service;
+
+use OCA\MyDash\Service\SvgSanitiser;
+use PHPUnit\Framework\Attributes\Small;
+use PHPUnit\Framework\TestCase;
+
+class SvgSanitiserTest extends TestCase
+{
+    private SvgSanitiser $sanitiser;
+
+    protected function setUp(): void
+    {
+        $this->sanitiser = new SvgSanitiser();
+    }
+
+    public function testCleanSvgRoundTrips(): void
+    {
+        $svg = '<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10">'
+             . '<rect x="0" y="0" width="10" height="10" fill="red"/>'
+             . '</svg>';
+
+        $result = $this->sanitiser->sanitize($svg);
+
+        $this->assertNotNull($result);
+        $this->assertStringContainsString('<rect', $result);
+        $this->assertStringContainsString('fill="red"', $result);
+    }
+
+    public function testScriptElementRemoved(): void
+    {
+        $svg = '<svg xmlns="http://www.w3.org/2000/svg">'
+             . '<script>alert(1)</script>'
+             . '<circle r="5"/>'
+             . '</svg>';
+
+        $result = $this->sanitiser->sanitize($svg);
+
+        $this->assertNotNull($result);
+        $this->assertStringNotContainsString('<script', $result);
+        $this->assertStringNotContainsString('alert', $result);
+        $this->assertStringContainsString('<circle', $result);
+    }
+
+    public function testForeignObjectAndNestedIframeRemoved(): void
+    {
+        $svg = '<svg xmlns="http://www.w3.org/2000/svg">'
+             . '<foreignObject><iframe src="http://attacker"/></foreignObject>'
+             . '<circle r="5"/>'
+             . '</svg>';
+
+        $result = $this->sanitiser->sanitize($svg);
+
+        $this->assertNotNull($result);
+        $this->assertStringNotContainsString('foreignObject', $result);
+        $this->assertStringNotContainsString('iframe', $result);
+        $this->assertStringNotContainsString('attacker', $result);
+        $this->assertStringContainsString('<circle', $result);
+    }
+
+    public function testEventHandlerAttributesStripped(): void
+    {
+        $svg = '<svg xmlns="http://www.w3.org/2000/svg">'
+             . '<circle onclick="alert(1)" onload="x()" onmouseover="y()" '
+             . 'onfocus="z()" r="5"/>'
+             . '</svg>';
+
+        $result = $this->sanitiser->sanitize($svg);
+
+        $this->assertNotNull($result);
+        $this->assertStringNotContainsString('onclick', $result);
+        $this->assertStringNotContainsString('onload', $result);
+        $this->assertStringNotContainsString('onmouseover', $result);
+        $this->assertStringNotContainsString('onfocus', $result);
+        $this->assertStringContainsString('r="5"', $result);
+    }
+
+    public function testJavascriptHrefStrippedFromXlinkHref(): void
+    {
+        $svg = '<svg xmlns="http://www.w3.org/2000/svg" '
+             . 'xmlns:xlink="http://www.w3.org/1999/xlink">'
+             . '<use xlink:href="javascript:alert(1)"/>'
+             . '</svg>';
+
+        $result = $this->sanitiser->sanitize($svg);
+
+        $this->assertNotNull($result);
+        $this->assertStringNotContainsString('javascript', $result);
+        $this->assertStringContainsString('<use', $result);
+    }
+
+    public function testDataHrefStrippedFromImageHref(): void
+    {
+        $svg = '<svg xmlns="http://www.w3.org/2000/svg">'
+             . '<image href="data:image/svg+xml;base64,PHN2Zy8+"/>'
+             . '</svg>';
+
+        $result = $this->sanitiser->sanitize($svg);
+
+        $this->assertNotNull($result);
+        $this->assertStringNotContainsString('data:', $result);
+        $this->assertStringContainsString('<image', $result);
+    }
+
+    public function testExpressionStyleStripped(): void
+    {
+        $svg = '<svg xmlns="http://www.w3.org/2000/svg">'
+             . '<rect style="width: expression(alert(1))" width="10" height="10"/>'
+             . '</svg>';
+
+        $result = $this->sanitiser->sanitize($svg);
+
+        $this->assertNotNull($result);
+        $this->assertStringNotContainsString('expression', $result);
+        $this->assertStringNotContainsString('style=', $result);
+        $this->assertStringContainsString('width="10"', $result);
+        $this->assertStringContainsString('height="10"', $result);
+    }
+
+    public function testUrlDataStyleStripped(): void
+    {
+        $svg = '<svg xmlns="http://www.w3.org/2000/svg">'
+             . '<g style="background: url(data:text/html,foo)"><path d="M0 0"/></g>'
+             . '</svg>';
+
+        $result = $this->sanitiser->sanitize($svg);
+
+        $this->assertNotNull($result);
+        $this->assertStringNotContainsString('style=', $result);
+        $this->assertStringNotContainsString('data:', $result);
+        $this->assertStringContainsString('<g', $result);
+        $this->assertStringContainsString('<path', $result);
+    }
+
+    public function testSafeHttpsHrefPreserved(): void
+    {
+        $svg = '<svg xmlns="http://www.w3.org/2000/svg">'
+             . '<image href="https://example.com/logo.png"/>'
+             . '</svg>';
+
+        $result = $this->sanitiser->sanitize($svg);
+
+        $this->assertNotNull($result);
+        $this->assertStringContainsString('https://example.com/logo.png', $result);
+    }
+
+    public function testWhitelistedGeometryAttributesPreserved(): void
+    {
+        $svg = '<svg xmlns="http://www.w3.org/2000/svg">'
+             . '<rect x="10" y="20" width="100" height="50" fill="red" stroke="black"/>'
+             . '</svg>';
+
+        $result = $this->sanitiser->sanitize($svg);
+
+        $this->assertNotNull($result);
+        $this->assertStringContainsString('x="10"', $result);
+        $this->assertStringContainsString('y="20"', $result);
+        $this->assertStringContainsString('width="100"', $result);
+        $this->assertStringContainsString('height="50"', $result);
+        $this->assertStringContainsString('fill="red"', $result);
+        $this->assertStringContainsString('stroke="black"', $result);
+    }
+
+    public function testNonWhitelistedAttributeStripped(): void
+    {
+        $svg = '<svg xmlns="http://www.w3.org/2000/svg">'
+             . '<circle data-payload="x" r="5"/>'
+             . '</svg>';
+
+        $result = $this->sanitiser->sanitize($svg);
+
+        $this->assertNotNull($result);
+        $this->assertStringNotContainsString('data-payload', $result);
+        $this->assertStringContainsString('r="5"', $result);
+    }
+
+    public function testExternalDtdDoesNotFetchNetwork(): void
+    {
+        // DOCTYPE referencing a remote DTD that does NOT exist on the
+        // network. With LIBXML_NONET the parser MUST NOT attempt the
+        // fetch — the test passes if the call returns within bounded
+        // time and produces either null or a sanitised string without
+        // hanging on a real network request.
+        $svg = '<?xml version="1.0"?>'
+             . '<!DOCTYPE svg SYSTEM "http://10.255.255.1/evil.dtd">'
+             . '<svg xmlns="http://www.w3.org/2000/svg"><circle r="1"/></svg>';
+
+        $start  = microtime(true);
+        $result = $this->sanitiser->sanitize($svg);
+        $elapsed = (microtime(true) - $start);
+
+        // 2 seconds is generous — a real network fetch to 10.255.255.1
+        // would block for ~30 seconds before timing out.
+        $this->assertLessThan(2.0, $elapsed, 'External DTD must not be fetched');
+        // Result MAY be a sanitised SVG (libxml accepts the doctype
+        // but does not resolve it) or null (libxml rejected the parse)
+        // — either is acceptable; what matters is no network fetch.
+        if ($result !== null) {
+            $this->assertStringContainsString('<circle', $result);
+        }
+    }
+
+    public function testBillionLaughsBoundedTime(): void
+    {
+        // Classic billion-laughs payload — modern libxml has internal
+        // expansion limits that protect against memory exhaustion.
+        $svg = '<?xml version="1.0"?>'
+             . '<!DOCTYPE lolz ['
+             . '<!ENTITY lol "lol">'
+             . '<!ENTITY lol2 "&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;">'
+             . '<!ENTITY lol3 "&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;">'
+             . '<!ENTITY lol4 "&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;">'
+             . '<!ENTITY lol5 "&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;">'
+             . ']>'
+             . '<svg xmlns="http://www.w3.org/2000/svg"><title>&lol5;</title></svg>';
+
+        $start = microtime(true);
+        // We don't care about the return value — only that this returns
+        // within bounded time without exhausting memory.
+        $this->sanitiser->sanitize($svg);
+        $elapsed = (microtime(true) - $start);
+
+        $this->assertLessThan(5.0, $elapsed, 'Billion-laughs must be bounded');
+    }
+
+    public function testUnparseableBytesReturnNull(): void
+    {
+        $this->assertNull($this->sanitiser->sanitize('<not xml'));
+    }
+
+    public function testEmptyStringReturnsNull(): void
+    {
+        $this->assertNull($this->sanitiser->sanitize(''));
+    }
+
+    public function testNonSvgRootRejected(): void
+    {
+        // A well-formed XML document with a non-svg root MUST be rejected
+        // — the sanitiser only accepts <svg> as the root element.
+        $xml = '<html xmlns="http://www.w3.org/1999/xhtml"><body/></html>';
+
+        $this->assertNull($this->sanitiser->sanitize($xml));
+    }
+}


### PR DESCRIPTION
## Summary

Implements REQ-RES-009..013 from the `svg-sanitisation` change. Adds a server-side DOM-based whitelist sanitiser for uploaded SVG bytes and plugs it into the `resource-uploads` pipeline.

Builds on top of [#46](https://github.com/ConductionNL/mydash/pull/46) (now merged) — reuses the `ResourceException` base class so `ResourceController::errorResponse()` automatically renders the `400 invalid_svg` envelope without any controller-level change.

## What changed

- **`lib/Service/SvgSanitiser.php`** (new) — pure-PHP DOM-based sanitiser. No Nextcloud dependencies. Conservative whitelist of **24 element types** (REQ-RES-010) and **50 attribute types** (REQ-RES-011). Strips:
  - any element / attribute not on the whitelist (children removed with the parent);
  - **all** `on*` attributes regardless of whitelist (defence in depth, in case a future whitelist edit accidentally adds one);
  - `href` / `xlink:href` values starting with `javascript:` or `data:` (REQ-RES-012);
  - `style` values containing `expression(`, `javascript:`, or `url(data:`.
- **`lib/Exception/InvalidSvgException.php`** (new) — extends the existing `ResourceException` base from PR #46 with stable error code `invalid_svg` and HTTP 400.
- **`lib/Service/ResourceService.php`** — injects `SvgSanitiser`; for the SVG branch, sanitises **before** the size check; throws `InvalidSvgException` on `null`; persists the **sanitised** bytes (NOT the original).
- **`l10n/en` + `l10n/nl`** — translation entry for the `invalid_svg` display message.
- **`DEVELOPMENT.md`** — security-review checkbox documenting that adding to the SVG whitelist is a deliberate code change, not an editorial one.

## Notes for future contributors

- **Size cap is measured AFTER sanitisation.** A 5.5 MB SVG that sanitises down to 4.5 MB is accepted; the 5 MB REQ-RES-003 cap applies to what gets persisted, not what was uploaded. Spec scenario `Size cap measured after sanitisation` covers this.
- **Whitelist is conservative on purpose** — 24 elements + 50 attributes covers every common SVG drawing primitive without permitting `<script>`, `<foreignObject>`, `<iframe>`, `<embed>`, `<object>`, or any of the 60+ exotic SVG elements that carry executable surface. Adding any element / attribute is a security review checkbox per `DEVELOPMENT.md` (Security review checkboxes section).
- **XXE protection** via `LIBXML_NONET | LIBXML_NOENT` parse flags. The `LIBXML_NONET` flag prevents the parser from fetching external DTDs / entities; `LIBXML_NOENT` substitutes entities so they do not amplify recursively. Modern libxml internal expansion limits also protect against billion-laughs (verified in tests).
- **`null` return → 400 `invalid_svg`** is reserved for unparseable XML or fully-stripped documents. Disallowed elements alone do not fail the upload — they are stripped silently and the request proceeds.

## Test plan

- [x] `composer phpcs` passes (42 / 42 files clean)
- [x] `composer lint` passes (no syntax errors)
- [x] PHPUnit suite: **145 tests, 394 assertions, 0 failures** (16 new sanitiser unit + 6 new integration + 123 pre-existing)
- [x] Sanitiser unit covers all 16 spec scenarios (clean round-trip, script / foreignObject / on* / javascript: / data: / expression() / url(data:) stripped; safe https preserved; geometry preserved; data-* stripped; external DTD does not fetch; billion-laughs bounded; unparseable → null; empty → null; non-svg root → null)
- [x] Integration covers tasks 4.1–4.5 (malicious upload sanitised, garbage rejected, oversize-but-sanitises-down accepted, near-cap clean accepted, persisted bytes ≠ original)
- [x] `InvalidSvgException` carries the stable error code `invalid_svg` + HTTP 400 (asserted in integration test)

## Pre-existing issues observed (NOT touched by this PR)

- `lib/Service/UserAttributeResolver.php:59` — Psalm `UndefinedInterfaceMethod` on `IUser::getLanguage()`
- `lib/Service/ImageMimeValidator.php:109` — PHPStan offset-on-array notice

These predate this change and live in files this PR does not modify; left for a separate fix-in-passing pass on those files.

## Spec

- `openspec/changes/svg-sanitisation/proposal.md`
- `openspec/changes/svg-sanitisation/tasks.md`
- `openspec/changes/svg-sanitisation/specs/resource-uploads/spec.md` (REQ-RES-009..013)