### PR TITLE
feat(dashboards): per-group default dashboard

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -38,6 +38,9 @@ return [
 		 'requirements' => ['groupId' => '[^/]+', 'uuid' => '[A-Za-z0-9\-]+']],
 		['name' => 'dashboard_api#deleteGroup', 'url' => '/api/dashboards/group/{groupId}/{uuid}', 'verb' => 'DELETE',
 		 'requirements' => ['groupId' => '[^/]+', 'uuid' => '[A-Za-z0-9\-]+']],
+		// Default-flip endpoint (REQ-DASH-015). Body: {"uuid": "..."}.
+		['name' => 'dashboard_api#setGroupDefault', 'url' => '/api/dashboards/group/{groupId}/default', 'verb' => 'POST',
+		 'requirements' => ['groupId' => '[^/]+']],
 
 		// Widget endpoints
 		['name' => 'widget_api#listAvailable', 'url' => '/api/widgets', 'verb' => 'GET'],

--- a/lib/Controller/DashboardApiController.php
+++ b/lib/Controller/DashboardApiController.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace OCA\MyDash\Controller;
 
+use InvalidArgumentException;
 use OCA\MyDash\AppInfo\Application;
 use OCA\MyDash\Service\DashboardService;
 use OCA\MyDash\Service\PermissionService;
@@ -535,6 +536,71 @@ class DashboardApiController extends Controller
             return ResponseHelper::error(exception: $e);
         }//end try
     }//end deleteGroup()
+
+    /**
+     * Promote a single group-shared dashboard to the group's default.
+     *
+     * Admin-only — the route attribute is `#[NoAdminRequired]` so
+     * gate-route-auth passes; the in-body admin check is the actual
+     * authorization point (gate-semantic-auth). The body payload is
+     * `{"uuid": "..."}`. Returns 404 when the uuid does not belong to
+     * the given groupId. REQ-DASH-015.
+     *
+     * @param string      $groupId The group ID from the URL.
+     * @param string|null $uuid    The dashboard UUID from the body.
+     *
+     * @return JSONResponse The status payload.
+     */
+    #[NoAdminRequired]
+    public function setGroupDefault(
+        string $groupId,
+        ?string $uuid=null
+    ): JSONResponse {
+        if ($this->userId === null) {
+            return ResponseHelper::unauthorized();
+        }
+
+        if ($this->dashboardService->isAdmin(
+            userId: $this->userId
+        ) === false
+        ) {
+            return ResponseHelper::forbidden(
+                message: DashboardService::ERR_FORBIDDEN_NOT_ADMIN
+            );
+        }
+
+        if ($uuid === null || $uuid === '') {
+            return ResponseHelper::error(
+                exception: new InvalidArgumentException(
+                    'Missing required field: uuid'
+                ),
+                statusCode: Http::STATUS_BAD_REQUEST
+            );
+        }
+
+        try {
+            $this->dashboardService->setGroupDefault(
+                actorUserId: $this->userId,
+                groupId: $groupId,
+                uuid: $uuid
+            );
+
+            return ResponseHelper::success(
+                data: [
+                    'status'  => 'ok',
+                    'groupId' => $groupId,
+                    'uuid'    => $uuid,
+                ]
+            );
+        } catch (DoesNotExistException $e) {
+            return new JSONResponse(
+                data: ['error' => $e->getMessage()],
+                statusCode: Http::STATUS_NOT_FOUND
+            );
+        } catch (\Exception $e) {
+            return ResponseHelper::error(exception: $e);
+        }//end try
+    }//end setGroupDefault()
 
     /**
      * Resolve create parameters from JSON body or individual params.

--- a/lib/Db/DashboardMapper.php
+++ b/lib/Db/DashboardMapper.php
@@ -523,6 +523,124 @@ class DashboardMapper extends QBMapper
     }//end countByGroup()
 
     /**
+     * Clear default flag on every group-shared dashboard in a group.
+     *
+     * Issues `UPDATE oc_mydash_dashboards SET is_default = 0 WHERE
+     * type = 'group_shared' AND group_id = ? [AND uuid <> ?]`. Used by
+     * {@see \OCA\MyDash\Service\DashboardService::setGroupDefault()} as
+     * the first half of the transactional flip. REQ-DASH-015.
+     *
+     * @param string      $groupId    The group ID (real or
+     *                                {@see Dashboard::DEFAULT_GROUP_ID}).
+     * @param string|null $exceptUuid Optional uuid to leave untouched
+     *                                (avoids a no-op write on the row that
+     *                                will immediately be set to 1).
+     *
+     * @return int The number of rows affected.
+     */
+    public function clearGroupDefaults(
+        string $groupId,
+        ?string $exceptUuid=null
+    ): int {
+        $qb = $this->db->getQueryBuilder();
+        $qb->update(update: $this->getTableName())
+            ->set(
+                key: 'is_default',
+                value: $qb->createNamedParameter(
+                    value: 0,
+                    type: IQueryBuilder::PARAM_INT
+                )
+            )
+            ->set(
+                key: 'updated_at',
+                value: $qb->createNamedParameter(
+                    value: (new DateTime())->format(format: 'Y-m-d H:i:s')
+                )
+            )
+            ->where(
+                $qb->expr()->eq(
+                    x: 'type',
+                    y: $qb->createNamedParameter(
+                        value: Dashboard::TYPE_GROUP_SHARED
+                    )
+                )
+            )
+            ->andWhere(
+                $qb->expr()->eq(
+                    x: 'group_id',
+                    y: $qb->createNamedParameter(value: $groupId)
+                )
+            );
+
+        if ($exceptUuid !== null) {
+            $qb->andWhere(
+                $qb->expr()->neq(
+                    x: 'uuid',
+                    y: $qb->createNamedParameter(value: $exceptUuid)
+                )
+            );
+        }
+
+        return $qb->executeStatement();
+    }//end clearGroupDefaults()
+
+    /**
+     * Set the default flag on a single group-shared dashboard.
+     *
+     * Issues `UPDATE oc_mydash_dashboards SET is_default = 1 WHERE
+     * type = 'group_shared' AND group_id = ? AND uuid = ?`. Returns the
+     * row-count affected — `0` when the uuid does not belong to the
+     * given group (caller treats as 404). REQ-DASH-015.
+     *
+     * @param string $groupId The group ID from the URL.
+     * @param string $uuid    The dashboard UUID from the URL.
+     *
+     * @return int The number of rows affected (0 or 1).
+     */
+    public function setGroupDefaultUuid(
+        string $groupId,
+        string $uuid
+    ): int {
+        $qb = $this->db->getQueryBuilder();
+        $qb->update(update: $this->getTableName())
+            ->set(
+                key: 'is_default',
+                value: $qb->createNamedParameter(
+                    value: 1,
+                    type: IQueryBuilder::PARAM_INT
+                )
+            )
+            ->set(
+                key: 'updated_at',
+                value: $qb->createNamedParameter(
+                    value: (new DateTime())->format(format: 'Y-m-d H:i:s')
+                )
+            )
+            ->where(
+                $qb->expr()->eq(
+                    x: 'type',
+                    y: $qb->createNamedParameter(
+                        value: Dashboard::TYPE_GROUP_SHARED
+                    )
+                )
+            )
+            ->andWhere(
+                $qb->expr()->eq(
+                    x: 'group_id',
+                    y: $qb->createNamedParameter(value: $groupId)
+                )
+            )
+            ->andWhere(
+                $qb->expr()->eq(
+                    x: 'uuid',
+                    y: $qb->createNamedParameter(value: $uuid)
+                )
+            );
+
+        return $qb->executeStatement();
+    }//end setGroupDefaultUuid()
+
+    /**
      * Clear default flag on all admin templates.
      *
      * @return void

--- a/lib/Service/DashboardService.php
+++ b/lib/Service/DashboardService.php
@@ -31,8 +31,10 @@ use OCA\MyDash\Db\DashboardMapper;
 use OCA\MyDash\Db\WidgetPlacement;
 use OCA\MyDash\Db\WidgetPlacementMapper;
 use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\IDBConnection;
 use OCP\IGroupManager;
 use OCP\IUserManager;
+use Throwable;
 
 /**
  * Service for managing dashboards.
@@ -63,6 +65,13 @@ class DashboardService
     public const ERR_GROUP_MISMATCH = 'Dashboard does not belong to this group';
 
     /**
+     * Error message returned when the default-flip target is not found.
+     *
+     * @var string
+     */
+    public const ERR_DEFAULT_TARGET_NOT_IN_GROUP = 'Dashboard not found in group';
+
+    /**
      * Constructor
      *
      * @param DashboardMapper       $dashboardMapper  Dashboard mapper.
@@ -73,6 +82,9 @@ class DashboardService
      * @param DashboardResolver     $dashResolver     Dashboard resolver.
      * @param IGroupManager         $groupManager     Group manager.
      * @param IUserManager          $userManager      User manager.
+     * @param IDBConnection         $db               DB connection (for the
+     *                                                transactional default
+     *                                                flip — REQ-DASH-015).
      */
     public function __construct(
         private readonly DashboardMapper $dashboardMapper,
@@ -83,6 +95,7 @@ class DashboardService
         private readonly DashboardResolver $dashResolver,
         private readonly IGroupManager $groupManager,
         private readonly IUserManager $userManager,
+        private readonly IDBConnection $db,
     ) {
     }//end __construct()
 
@@ -321,6 +334,10 @@ class DashboardService
             gridColumns: $gridColumns
         );
         $dashboard->setPermissionLevel(Dashboard::PERMISSION_VIEW_ONLY);
+        // REQ-DASH-016: new group-shared rows always start non-default.
+        // Promotion is only possible via the dedicated
+        // POST /api/dashboards/group/{groupId}/default endpoint.
+        $dashboard->setIsDefault(0);
 
         return $this->dashboardMapper->insert(entity: $dashboard);
     }//end createGroupShared()
@@ -357,6 +374,13 @@ class DashboardService
             groupId: $groupId,
             uuid: $uuid
         );
+
+        // REQ-DASH-017: PUT MUST NOT mutate `isDefault` regardless of
+        // payload contents. Drop the field defensively before applying
+        // updates — even though `applyDashboardUpdates` already ignores
+        // unknown keys, we strip it explicitly so the contract is
+        // visible at the service boundary.
+        unset($patch['isDefault']);
 
         $this->applyDashboardUpdates(
             dashboard: $dashboard,
@@ -412,6 +436,74 @@ class DashboardService
         );
         $this->dashboardMapper->delete(entity: $dashboard);
     }//end deleteGroupShared()
+
+    /**
+     * Promote a single group-shared dashboard to the group's default.
+     *
+     * Admin-only. Wraps both mapper writes — clear the existing default
+     * on every other dashboard in the group, then set the target to
+     * `is_default = 1` — in a single DB transaction so concurrent
+     * promotions cannot leave two rows with `is_default = 1` in the
+     * same group. REQ-DASH-015.
+     *
+     * Order of operations matters: we issue the SET first; if the
+     * target uuid does not belong to the group the row count is `0`
+     * and we throw {@see DoesNotExistException} (mapped to HTTP 404 by
+     * the controller). The transaction is then rolled back, leaving
+     * the previous default untouched.
+     *
+     * @param string $actorUserId The acting user ID (for the admin
+     *                            check).
+     * @param string $groupId     The group ID from the URL.
+     * @param string $uuid        The dashboard UUID from the URL.
+     *
+     * @return void
+     *
+     * @throws Exception              When the actor is not an admin.
+     * @throws DoesNotExistException  When the uuid does not belong to
+     *                                the given group.
+     */
+    public function setGroupDefault(
+        string $actorUserId,
+        string $groupId,
+        string $uuid
+    ): void {
+        if ($this->isAdmin(userId: $actorUserId) === false) {
+            throw new Exception(message: self::ERR_FORBIDDEN_NOT_ADMIN);
+        }
+
+        $this->db->beginTransaction();
+        try {
+            $affected = $this->dashboardMapper->setGroupDefaultUuid(
+                groupId: $groupId,
+                uuid: $uuid
+            );
+
+            if ($affected === 0) {
+                // The target uuid does not belong to this group — roll
+                // back so the existing default in the group is
+                // preserved. REQ-DASH-015 scenario "Default cannot be
+                // set across groups".
+                $this->db->rollBack();
+                throw new DoesNotExistException(
+                    msg: self::ERR_DEFAULT_TARGET_NOT_IN_GROUP
+                );
+            }
+
+            $this->dashboardMapper->clearGroupDefaults(
+                groupId: $groupId,
+                exceptUuid: $uuid
+            );
+
+            $this->db->commit();
+        } catch (DoesNotExistException $e) {
+            // Already rolled back above — re-throw for the controller.
+            throw $e;
+        } catch (Throwable $t) {
+            $this->db->rollBack();
+            throw $t;
+        }//end try
+    }//end setGroupDefault()
 
     /**
      * Get all dashboards visible to a user, source-tagged.

--- a/tests/Stubs/DoctrineStubs.php
+++ b/tests/Stubs/DoctrineStubs.php
@@ -1,0 +1,85 @@
+<?php
+
+/**
+ * Doctrine DBAL stubs for unit tests.
+ *
+ * The Nextcloud OCP signature stubs at
+ * `vendor/nextcloud/ocp/OCP/IDBConnection.php` and
+ * `vendor/nextcloud/ocp/OCP/DB/QueryBuilder/IQueryBuilder.php`
+ * reference Doctrine DBAL classes in their type-hints. Doctrine DBAL
+ * is provided at runtime by Nextcloud (not as a composer dependency
+ * of this app), so when PHPUnit's automatic mock generator
+ * introspects `IDBConnection` to build a test double, the autoloader
+ * fails on the missing Doctrine classes.
+ *
+ * Loading this file before `createMock(IDBConnection::class)` defines
+ * minimal placeholder classes so the type-hints resolve. Inside the
+ * Nextcloud Docker container the real Doctrine classes are already
+ * loaded, so the `class_exists` guards turn this into a no-op.
+ *
+ * SPDX-FileCopyrightText: 2026 MyDash Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL {
+    if (class_exists(__NAMESPACE__ . '\\ParameterType', false) === false) {
+        class ParameterType
+        {
+            public const NULL         = 0;
+            public const INTEGER      = 1;
+            public const STRING       = 2;
+            public const LARGE_OBJECT = 3;
+            public const BOOLEAN      = 5;
+            public const BINARY       = 16;
+            public const ASCII        = 17;
+        }
+        class ArrayParameterType
+        {
+            public const INTEGER = 101;
+            public const STRING  = 102;
+            public const ASCII   = 103;
+            public const BINARY  = 116;
+        }
+        class Connection
+        {
+        }
+    }
+}
+
+namespace Doctrine\DBAL\Types {
+    if (class_exists(__NAMESPACE__ . '\\Types', false) === false) {
+        class Types
+        {
+            public const BOOLEAN              = 'boolean';
+            public const DATETIME_MUTABLE     = 'datetime';
+            public const DATETIME_IMMUTABLE   = 'datetime_immutable';
+            public const DATETIMETZ_MUTABLE   = 'datetimetz';
+            public const DATETIMETZ_IMMUTABLE = 'datetimetz_immutable';
+            public const DATE_MUTABLE         = 'date';
+            public const DATE_IMMUTABLE       = 'date_immutable';
+            public const TIME_MUTABLE         = 'time';
+            public const TIME_IMMUTABLE       = 'time_immutable';
+        }
+    }
+}
+
+namespace Doctrine\DBAL\Schema {
+    if (class_exists(__NAMESPACE__ . '\\Schema', false) === false) {
+        class Schema
+        {
+        }
+    }
+}
+
+namespace OC\DB\QueryBuilder\Sharded {
+    if (class_exists(__NAMESPACE__ . '\\CrossShardMoveHelper', false) === false) {
+        class CrossShardMoveHelper
+        {
+        }
+        class ShardDefinition
+        {
+        }
+    }
+}

--- a/tests/Unit/Controller/DashboardApiControllerDefaultFlagTest.php
+++ b/tests/Unit/Controller/DashboardApiControllerDefaultFlagTest.php
@@ -1,0 +1,235 @@
+<?php
+
+/**
+ * DashboardApiController Default-Flag Test
+ *
+ * Covers the new `setGroupDefault` action and the contract that the
+ * existing `createGroup`/`updateGroup` actions never expose the
+ * `isDefault` field as a writable parameter (REQ-DASH-015..017).
+ *
+ * @category  Test
+ * @package   OCA\MyDash\Tests\Unit\Controller
+ * @author    Conduction b.v. <info@conduction.nl>
+ * @copyright 2026 Conduction b.v.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-FileCopyrightText: 2026 MyDash Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Controller;
+
+use OCA\MyDash\Controller\DashboardApiController;
+use OCA\MyDash\Db\Dashboard;
+use OCA\MyDash\Service\DashboardService;
+use OCA\MyDash\Service\PermissionService;
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\AppFramework\Http;
+use OCP\IRequest;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+
+/**
+ * Unit tests for the default-dashboard-flag controller surface.
+ */
+class DashboardApiControllerDefaultFlagTest extends TestCase
+{
+    /** @var IRequest&MockObject */
+    private $request;
+    /** @var DashboardService&MockObject */
+    private $dashboardService;
+    /** @var PermissionService&MockObject */
+    private $permissionService;
+
+    protected function setUp(): void
+    {
+        $this->request           = $this->createMock(IRequest::class);
+        $this->dashboardService  = $this->createMock(DashboardService::class);
+        $this->permissionService = $this->createMock(PermissionService::class);
+    }//end setUp()
+
+    /**
+     * Build the controller with the supplied logged-in user ID (or
+     * `null` for an anonymous session).
+     */
+    private function makeController(?string $userId): DashboardApiController
+    {
+        return new DashboardApiController(
+            request: $this->request,
+            dashboardService: $this->dashboardService,
+            permissionService: $this->permissionService,
+            userId: $userId,
+        );
+    }//end makeController()
+
+    /**
+     * REQ-DASH-015: non-admin caller MUST get 403 with no service call.
+     *
+     * @return void
+     */
+    public function testSetGroupDefaultRejectsNonAdmin(): void
+    {
+        $this->dashboardService->method('isAdmin')
+            ->with('alice')
+            ->willReturn(false);
+        $this->dashboardService->expects($this->never())
+            ->method('setGroupDefault');
+
+        $controller = $this->makeController('alice');
+        $response   = $controller->setGroupDefault(
+            groupId: 'marketing',
+            uuid: 'uuid-a'
+        );
+
+        $this->assertSame(
+            Http::STATUS_FORBIDDEN,
+            $response->getStatus()
+        );
+    }//end testSetGroupDefaultRejectsNonAdmin()
+
+    /**
+     * Anonymous caller MUST get 401 — the route attribute alone is not
+     * enough; the in-body guard runs first.
+     *
+     * @return void
+     */
+    public function testSetGroupDefaultRejectsAnonymousWith401(): void
+    {
+        $this->dashboardService->expects($this->never())
+            ->method('setGroupDefault');
+
+        $controller = $this->makeController(null);
+        $response   = $controller->setGroupDefault(
+            groupId: 'marketing',
+            uuid: 'uuid-a'
+        );
+
+        $this->assertSame(
+            Http::STATUS_UNAUTHORIZED,
+            $response->getStatus()
+        );
+    }//end testSetGroupDefaultRejectsAnonymousWith401()
+
+    /**
+     * REQ-DASH-015: missing uuid in body → HTTP 400.
+     *
+     * @return void
+     */
+    public function testSetGroupDefaultRejectsMissingUuid(): void
+    {
+        $this->dashboardService->method('isAdmin')->willReturn(true);
+        $this->dashboardService->expects($this->never())
+            ->method('setGroupDefault');
+
+        $controller = $this->makeController('admin');
+        $response   = $controller->setGroupDefault(
+            groupId: 'marketing',
+            uuid: null
+        );
+
+        $this->assertSame(
+            Http::STATUS_BAD_REQUEST,
+            $response->getStatus()
+        );
+    }//end testSetGroupDefaultRejectsMissingUuid()
+
+    /**
+     * REQ-DASH-015 happy path — service is invoked, response is 200.
+     *
+     * @return void
+     */
+    public function testSetGroupDefaultHappyPath(): void
+    {
+        $this->dashboardService->method('isAdmin')->willReturn(true);
+        $this->dashboardService->expects($this->once())
+            ->method('setGroupDefault')
+            ->with(
+                actorUserId: 'admin',
+                groupId: 'marketing',
+                uuid: 'uuid-c'
+            );
+
+        $controller = $this->makeController('admin');
+        $response   = $controller->setGroupDefault(
+            groupId: 'marketing',
+            uuid: 'uuid-c'
+        );
+
+        $this->assertSame(Http::STATUS_OK, $response->getStatus());
+        $body = $response->getData();
+        $this->assertSame('ok', $body['status']);
+        $this->assertSame('marketing', $body['groupId']);
+        $this->assertSame('uuid-c', $body['uuid']);
+    }//end testSetGroupDefaultHappyPath()
+
+    /**
+     * REQ-DASH-015 scenario: cross-group uuid → service throws
+     * DoesNotExistException → controller returns HTTP 404.
+     *
+     * @return void
+     */
+    public function testSetGroupDefaultMapsDoesNotExistTo404(): void
+    {
+        $this->dashboardService->method('isAdmin')->willReturn(true);
+        $this->dashboardService->method('setGroupDefault')
+            ->willThrowException(
+                new DoesNotExistException(msg: 'not in group')
+            );
+
+        $controller = $this->makeController('admin');
+        $response   = $controller->setGroupDefault(
+            groupId: 'sales',
+            uuid: 'uuid-from-marketing'
+        );
+
+        $this->assertSame(
+            Http::STATUS_NOT_FOUND,
+            $response->getStatus()
+        );
+    }//end testSetGroupDefaultMapsDoesNotExistTo404()
+
+    /**
+     * REQ-DASH-016: the controller `createGroup` signature MUST NOT
+     * expose `isDefault` as a parameter — Nextcloud's parameter binder
+     * would otherwise pull it from the JSON body and the service would
+     * see it. Reflection-level check for defense-in-depth.
+     *
+     * @return void
+     */
+    public function testCreateGroupSignatureDoesNotExposeIsDefault(): void
+    {
+        $reflection = new ReflectionMethod(
+            DashboardApiController::class,
+            'createGroup'
+        );
+        $paramNames = array_map(
+            static fn ($p) => $p->getName(),
+            $reflection->getParameters()
+        );
+
+        $this->assertNotContains('isDefault', $paramNames);
+    }//end testCreateGroupSignatureDoesNotExposeIsDefault()
+
+    /**
+     * REQ-DASH-017: the controller `updateGroup` signature MUST NOT
+     * expose `isDefault` as a parameter — same reasoning.
+     *
+     * @return void
+     */
+    public function testUpdateGroupSignatureDoesNotExposeIsDefault(): void
+    {
+        $reflection = new ReflectionMethod(
+            DashboardApiController::class,
+            'updateGroup'
+        );
+        $paramNames = array_map(
+            static fn ($p) => $p->getName(),
+            $reflection->getParameters()
+        );
+
+        $this->assertNotContains('isDefault', $paramNames);
+    }//end testUpdateGroupSignatureDoesNotExposeIsDefault()
+}//end class

--- a/tests/Unit/Service/DashboardServiceDefaultFlagTest.php
+++ b/tests/Unit/Service/DashboardServiceDefaultFlagTest.php
@@ -1,0 +1,326 @@
+<?php
+
+/**
+ * DashboardService Default-Flag Test
+ *
+ * Covers REQ-DASH-015 (transactional single-default flip),
+ * REQ-DASH-016 (creation always sets isDefault=0), and
+ * REQ-DASH-017 (PUT MUST NOT mutate isDefault).
+ *
+ * @category  Test
+ * @package   OCA\MyDash\Tests\Unit\Service
+ * @author    Conduction b.v. <info@conduction.nl>
+ * @copyright 2026 Conduction b.v.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-FileCopyrightText: 2026 MyDash Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Service;
+
+use Exception;
+use OCA\MyDash\Db\AdminSettingMapper;
+use OCA\MyDash\Db\Dashboard;
+use OCA\MyDash\Db\DashboardMapper;
+use OCA\MyDash\Db\WidgetPlacementMapper;
+use OCA\MyDash\Service\DashboardFactory;
+use OCA\MyDash\Service\DashboardResolver;
+use OCA\MyDash\Service\DashboardService;
+use OCA\MyDash\Service\TemplateService;
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\IDBConnection;
+use OCP\IGroupManager;
+use OCP\IUserManager;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+/**
+ * Unit tests for the default-dashboard-flag change.
+ */
+class DashboardServiceDefaultFlagTest extends TestCase
+{
+    /** @var DashboardMapper&MockObject */
+    private $dashboardMapper;
+    /** @var WidgetPlacementMapper&MockObject */
+    private $placementMapper;
+    /** @var AdminSettingMapper&MockObject */
+    private $settingMapper;
+    /** @var TemplateService&MockObject */
+    private $templateService;
+    /** @var DashboardFactory&MockObject */
+    private $dashboardFactory;
+    /** @var DashboardResolver&MockObject */
+    private $dashResolver;
+    /** @var IGroupManager&MockObject */
+    private $groupManager;
+    /** @var IUserManager&MockObject */
+    private $userManager;
+    /** @var IDBConnection&MockObject */
+    private $db;
+
+    private DashboardService $service;
+
+    protected function setUp(): void
+    {
+        $this->dashboardMapper  = $this->createMock(DashboardMapper::class);
+        $this->placementMapper  = $this->createMock(WidgetPlacementMapper::class);
+        $this->settingMapper    = $this->createMock(AdminSettingMapper::class);
+        $this->templateService  = $this->createMock(TemplateService::class);
+        $this->dashboardFactory = $this->createMock(DashboardFactory::class);
+        $this->dashResolver     = $this->createMock(DashboardResolver::class);
+        $this->groupManager     = $this->createMock(IGroupManager::class);
+        $this->userManager      = $this->createMock(IUserManager::class);
+        $this->db               = $this->createMock(IDBConnection::class);
+
+        $this->service = new DashboardService(
+            dashboardMapper: $this->dashboardMapper,
+            placementMapper: $this->placementMapper,
+            settingMapper: $this->settingMapper,
+            templateService: $this->templateService,
+            dashboardFactory: $this->dashboardFactory,
+            dashResolver: $this->dashResolver,
+            groupManager: $this->groupManager,
+            userManager: $this->userManager,
+            db: $this->db,
+        );
+    }//end setUp()
+
+    /**
+     * REQ-DASH-015: setGroupDefault flips others off and target on, in a
+     * single transaction.
+     *
+     * @return void
+     */
+    public function testSetGroupDefaultFlipsOthersOff(): void
+    {
+        $this->groupManager->method('isAdmin')
+            ->with('admin')
+            ->willReturn(true);
+
+        $this->db->expects($this->once())->method('beginTransaction');
+        $this->db->expects($this->once())->method('commit');
+        $this->db->expects($this->never())->method('rollBack');
+
+        // Order matters: SET-target first (so we can detect 0-row 404),
+        // then clear-others.
+        $this->dashboardMapper->expects($this->once())
+            ->method('setGroupDefaultUuid')
+            ->with('marketing', 'uuid-c')
+            ->willReturn(1);
+        $this->dashboardMapper->expects($this->once())
+            ->method('clearGroupDefaults')
+            ->with('marketing', 'uuid-c')
+            ->willReturn(1);
+
+        $this->service->setGroupDefault(
+            actorUserId: 'admin',
+            groupId: 'marketing',
+            uuid: 'uuid-c'
+        );
+    }//end testSetGroupDefaultFlipsOthersOff()
+
+    /**
+     * REQ-DASH-015 scenario: target uuid does not belong to the group.
+     * Service must throw DoesNotExistException AND roll the transaction
+     * back so the previous default is preserved.
+     *
+     * @return void
+     */
+    public function testSetGroupDefaultRejectsCrossGroupUuid(): void
+    {
+        $this->groupManager->method('isAdmin')
+            ->with('admin')
+            ->willReturn(true);
+
+        $this->db->expects($this->once())->method('beginTransaction');
+        $this->db->expects($this->never())->method('commit');
+        $this->db->expects($this->once())->method('rollBack');
+
+        // setGroupDefaultUuid finds no row → returns 0.
+        $this->dashboardMapper->expects($this->once())
+            ->method('setGroupDefaultUuid')
+            ->with('sales', 'uuid-from-marketing')
+            ->willReturn(0);
+        // clearGroupDefaults must NOT be called when the target is
+        // missing — otherwise we'd nuke the existing default in the
+        // wrong group.
+        $this->dashboardMapper->expects($this->never())
+            ->method('clearGroupDefaults');
+
+        $this->expectException(DoesNotExistException::class);
+
+        $this->service->setGroupDefault(
+            actorUserId: 'admin',
+            groupId: 'sales',
+            uuid: 'uuid-from-marketing'
+        );
+    }//end testSetGroupDefaultRejectsCrossGroupUuid()
+
+    /**
+     * REQ-DASH-015: simulate failure between SET and CLEAR — rollback
+     * MUST fire so the previous default survives.
+     *
+     * @return void
+     */
+    public function testSetGroupDefaultIsTransactional(): void
+    {
+        $this->groupManager->method('isAdmin')
+            ->with('admin')
+            ->willReturn(true);
+
+        $this->db->expects($this->once())->method('beginTransaction');
+        $this->db->expects($this->never())->method('commit');
+        $this->db->expects($this->once())->method('rollBack');
+
+        $this->dashboardMapper->expects($this->once())
+            ->method('setGroupDefaultUuid')
+            ->willReturn(1);
+        $this->dashboardMapper->expects($this->once())
+            ->method('clearGroupDefaults')
+            ->willThrowException(new RuntimeException('DB down'));
+
+        $this->expectException(RuntimeException::class);
+
+        $this->service->setGroupDefault(
+            actorUserId: 'admin',
+            groupId: 'marketing',
+            uuid: 'uuid-b'
+        );
+    }//end testSetGroupDefaultIsTransactional()
+
+    /**
+     * Non-admin caller: HTTP 403 surface mapped via service exception.
+     * No DB writes MUST be attempted.
+     *
+     * @return void
+     */
+    public function testSetGroupDefaultRejectsNonAdmin(): void
+    {
+        $this->groupManager->method('isAdmin')
+            ->with('alice')
+            ->willReturn(false);
+
+        $this->db->expects($this->never())->method('beginTransaction');
+        $this->db->expects($this->never())->method('commit');
+        $this->db->expects($this->never())->method('rollBack');
+
+        $this->dashboardMapper->expects($this->never())
+            ->method('setGroupDefaultUuid');
+        $this->dashboardMapper->expects($this->never())
+            ->method('clearGroupDefaults');
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage(
+            DashboardService::ERR_FORBIDDEN_NOT_ADMIN
+        );
+
+        $this->service->setGroupDefault(
+            actorUserId: 'alice',
+            groupId: 'marketing',
+            uuid: 'uuid-b'
+        );
+    }//end testSetGroupDefaultRejectsNonAdmin()
+
+    /**
+     * REQ-DASH-016: createGroupShared MUST set isDefault=0 on the new
+     * row, regardless of factory state — this is the defense-in-depth
+     * against payload smuggling.
+     *
+     * @return void
+     */
+    public function testCreateGroupSharedAlwaysStartsNonDefault(): void
+    {
+        $this->groupManager->method('isAdmin')->willReturn(true);
+
+        $entity = new Dashboard();
+        // Pretend the factory accidentally created the row with
+        // isDefault=1 — the service must overwrite it.
+        $entity->setIsDefault(1);
+
+        $this->dashboardFactory->method('create')->willReturn($entity);
+        $this->dashboardMapper->method('insert')->willReturnArgument(0);
+
+        $result = $this->service->createGroupShared(
+            actorUserId: 'admin',
+            groupId: 'marketing',
+            name: 'Sneaky'
+        );
+
+        $this->assertSame(0, $result->getIsDefault());
+    }//end testCreateGroupSharedAlwaysStartsNonDefault()
+
+    /**
+     * REQ-DASH-017: updateGroupShared MUST drop the isDefault key from
+     * the patch before applying it. The PUT endpoint can never flip
+     * the flag — only POST .../default can.
+     *
+     * @return void
+     */
+    public function testUpdateGroupSharedIgnoresIsDefaultInPatch(): void
+    {
+        $this->groupManager->method('isAdmin')->willReturn(true);
+
+        $entity = new Dashboard();
+        $entity->setUuid('uuid-a');
+        $entity->setType(Dashboard::TYPE_GROUP_SHARED);
+        $entity->setGroupId('marketing');
+        $entity->setIsDefault(1);
+        $entity->setName('Original');
+
+        $this->dashboardMapper->method('findByUuid')->willReturn($entity);
+        $this->dashboardMapper->method('update')->willReturnArgument(0);
+
+        $result = $this->service->updateGroupShared(
+            actorUserId: 'admin',
+            groupId: 'marketing',
+            uuid: 'uuid-a',
+            patch: ['name' => 'Renamed', 'isDefault' => 0]
+        );
+
+        $this->assertSame('Renamed', $result->getName());
+        $this->assertSame(
+            1,
+            $result->getIsDefault(),
+            'PUT must not flip the default off'
+        );
+    }//end testUpdateGroupSharedIgnoresIsDefaultInPatch()
+
+    /**
+     * Mirror of the previous test on the opposite direction — PUT with
+     * isDefault=1 on a non-default row leaves the flag at 0.
+     *
+     * @return void
+     */
+    public function testUpdateGroupSharedCannotFlipDefaultOn(): void
+    {
+        $this->groupManager->method('isAdmin')->willReturn(true);
+
+        $entity = new Dashboard();
+        $entity->setUuid('uuid-b');
+        $entity->setType(Dashboard::TYPE_GROUP_SHARED);
+        $entity->setGroupId('marketing');
+        $entity->setIsDefault(0);
+        $entity->setName('Original');
+
+        $this->dashboardMapper->method('findByUuid')->willReturn($entity);
+        $this->dashboardMapper->method('update')->willReturnArgument(0);
+
+        $result = $this->service->updateGroupShared(
+            actorUserId: 'admin',
+            groupId: 'marketing',
+            uuid: 'uuid-b',
+            patch: ['name' => 'Renamed', 'isDefault' => 1]
+        );
+
+        $this->assertSame('Renamed', $result->getName());
+        $this->assertSame(
+            0,
+            $result->getIsDefault(),
+            'PUT must not flip the default on'
+        );
+    }//end testUpdateGroupSharedCannotFlipDefaultOn()
+}//end class

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -39,6 +39,13 @@ if (file_exists(__DIR__ . '/../../../lib/base.php')) {
     $ocpLoader = new \Composer\Autoload\ClassLoader();
     $ocpLoader->addPsr4('OCP\\', __DIR__ . '/../vendor/nextcloud/ocp/OCP/');
     $ocpLoader->register();
+
+    // The OCP IDBConnection / IQueryBuilder stubs reference Doctrine
+    // DBAL classes that are not in our composer.json (Nextcloud
+    // provides them at runtime). Load minimal placeholder classes so
+    // PHPUnit's automatic mock generator can introspect IDBConnection
+    // for the REQ-DASH-015 tests.
+    require_once __DIR__ . '/Stubs/DoctrineStubs.php';
 }
 
 // Register Test\ namespace for NC test classes.


### PR DESCRIPTION
## Summary

Implements REQ-DASH-015..017 from spec change `default-dashboard-flag`: a single canonical default per `group_shared` dashboard group, flipped via a dedicated transactional endpoint, with create/update paths hardened against `isDefault` mutation.

- New endpoint `POST /api/dashboards/group/{groupId}/default` (admin-only, body `{"uuid": "..."}`).
- `DashboardService::setGroupDefault()` runs the SET-target + CLEAR-others writes inside a single `IDBConnection::beginTransaction()` / `commit()` / `rollBack()` block. Cross-group uuids return 404 with the existing default preserved.
- `createGroupShared()` always inserts with `isDefault = 0`; `updateGroupShared()` strips `isDefault` from the patch — the only mutation path for the flag is the dedicated endpoint.
- Reuses the existing `isDefault SMALLINT` column from the `admin-templates` change — no schema migration required.

## Spec sources

- Spec proposal + tasks + delta: PR #42 (`feature/replica-spec-proposals`, `openspec/changes/default-dashboard-flag/`).
- Builds on PR #47 (`multi-scope-dashboards`, already merged to `development`).

## Transactional invariant

The service writes in this order: `setGroupDefaultUuid` first → if 0 rows affected, throw `DoesNotExistException` and roll back so the previous default in any other group is untouched. Only when the target write succeeds does `clearGroupDefaults` run, then `commit()`. Concurrent admin clicks on different uuids in the same group can only end with a single `isDefault = 1` row.

## Test plan

- [x] `composer phpcs` passes (clean).
- [x] `composer phpmd` passes (clean — fixed `MissingImport` for `InvalidArgumentException`).
- [x] `composer test:all` — 183 tests / 480 assertions pass (was 169 before; +14 new tests).
- [x] `composer check:strict` reports `ALL CHECKS PASSED`.
- [ ] Hydra reviewer + security reviewer (added `ready-for-code-review` label only per `feedback_hydra-reset-sequential.md`).

## Notes

- Tests use a small `tests/Stubs/DoctrineStubs.php` to allow PHPUnit to mock `IDBConnection` outside the Docker container — no-op inside the container, where the real Doctrine classes are loaded by `lib/base.php`.
- Pre-existing Psalm error in `UserAttributeResolver` and PHPStan error in `ImageMimeValidator` are unrelated to this change and predate `development` HEAD; not touched per the strict "modify only files needed for this implementation" rule.
- Frontend tasks (5.x), Playwright tests (7.x), OpenAPI/Postman regeneration (8.3), and i18n keys (8.4) from `tasks.md` are deferred — backend contract is complete and unblocks them as a follow-up.