### PR TITLE
feat(grid): widget collision placement helper

### DIFF
--- a/sbom.cdx.json
+++ b/sbom.cdx.json
@@ -2,10 +2,10 @@
   "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.5",
-  "serialNumber": "urn:uuid:5a8d01e9-189d-41a2-9dcf-903890262473",
+  "serialNumber": "urn:uuid:056c0c17-fe7c-44de-b020-57c82df72cba",
   "version": 1,
   "metadata": {
-    "timestamp": "2026-04-30T18:24:08Z",
+    "timestamp": "2026-04-30T18:45:21Z",
     "tools": [
       {
         "name": "composer",
@@ -82,10 +82,10 @@
       }
     ],
     "component": {
-      "bom-ref": "mydash/mydash-dev-feature/impl-image-widget",
+      "bom-ref": "mydash/mydash-dev-feature/impl-widget-collision-placement",
       "type": "application",
       "name": "mydash",
-      "version": "dev-feature/impl-image-widget",
+      "version": "dev-feature/impl-widget-collision-placement",
       "group": "mydash",
       "description": "Enhanced dashboard with grid layout and admin controls for Nextcloud",
       "author": "MyDash Contributors",
@@ -96,15 +96,15 @@
           }
         }
       ],
-      "purl": "pkg:composer/mydash/mydash@dev-feature/impl-image-widget",
+      "purl": "pkg:composer/mydash/mydash@dev-feature/impl-widget-collision-placement",
       "properties": [
         {
           "name": "cdx:composer:package:distReference",
-          "value": "193f08b27ed00723f29fc6f99321f4040bb84b29"
+          "value": "5fcf2fd73fb70a70661083f4a5fad10008c06396"
         },
         {
           "name": "cdx:composer:package:sourceReference",
-          "value": "193f08b27ed00723f29fc6f99321f4040bb84b29"
+          "value": "5fcf2fd73fb70a70661083f4a5fad10008c06396"
         },
         {
           "name": "cdx:composer:package:type",
@@ -17934,7 +17934,7 @@
       ]
     },
     {
-      "ref": "mydash/mydash-dev-feature/impl-image-widget",
+      "ref": "mydash/mydash-dev-feature/impl-widget-collision-placement",
       "dependsOn": [
         "ramsey/uuid-4.9.2.0"
       ]

--- a/src/__tests__/ImageWidget.test.js
+++ b/src/__tests__/ImageWidget.test.js
@@ -3,8 +3,10 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+/* eslint-disable n/no-unpublished-import */
 import { describe, it, expect, beforeAll, vi } from 'vitest'
 import { mount } from '@vue/test-utils'
+/* eslint-enable n/no-unpublished-import */
 
 import ImageWidget from '../components/Widgets/Renderers/ImageWidget.vue'
 import ImageForm from '../components/Widgets/Forms/ImageForm.vue'

--- a/src/__tests__/widgetPlacement.test.js
+++ b/src/__tests__/widgetPlacement.test.js
@@ -1,0 +1,200 @@
+/**
+ * SPDX-FileCopyrightText: 2024 MyDash Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+/* eslint-disable n/no-unpublished-import */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+/* eslint-enable n/no-unpublished-import */
+import { placeNewWidget } from '../utils/widgetPlacement.js'
+
+describe('widgetPlacement', () => {
+	let mockGridInstance
+	let layout
+
+	beforeEach(() => {
+		layout = []
+
+		// Mock GridStack instance
+		mockGridInstance = {
+			addWidget: vi.fn(),
+			update: vi.fn(),
+			removeWidget: vi.fn(),
+			engine: {
+				nodes: [],
+			},
+		}
+
+		// Mock DOM methods
+		vi.spyOn(document, 'createElement').mockReturnValue({
+			setAttribute: vi.fn(),
+		})
+	})
+
+	describe('auto-position into empty space', () => {
+		it('should use GridStack auto-position when slot is within viewport', () => {
+			const spec = { w: 4, h: 4 }
+
+			// Mock GridStack to return a slot at y=0 (within viewport)
+			const mockEl = { setAttribute: vi.fn() }
+			document.createElement = vi.fn().mockReturnValue(mockEl)
+
+			const mockNode = { el: mockEl, x: 6, y: 0 }
+			mockGridInstance.addWidget = vi.fn((el) => {
+				mockGridInstance.engine.nodes.push(mockNode)
+			})
+
+			const result = placeNewWidget(spec, layout, mockGridInstance, 8)
+
+			expect(result).toEqual({
+				x: 6,
+				y: 0,
+				w: 4,
+				h: 4,
+			})
+			expect(mockGridInstance.removeWidget).toHaveBeenCalled()
+		})
+	})
+
+	describe('push-down fallback when grid is full at top', () => {
+		it('should compute overlapping widgets correctly', () => {
+			// Existing widgets occupying [0..12] × [0..4]
+			layout = [
+				{ id: 1, gridX: 0, gridY: 0, gridWidth: 6, gridHeight: 4 },
+				{ id: 2, gridX: 6, gridY: 0, gridWidth: 6, gridHeight: 4 },
+			]
+
+			const spec = { w: 4, h: 4 }
+
+			// Mock GridStack to fail auto-position
+			mockGridInstance.addWidget = vi.fn().mockImplementation(() => {
+				throw new Error('no space')
+			})
+
+			vi.spyOn(document, 'querySelector').mockReturnValue({})
+
+			const result = placeNewWidget(spec, layout, mockGridInstance, 8)
+
+			// New widget should be at top-left
+			expect(result).toEqual({
+				x: 0,
+				y: 0,
+				w: 4,
+				h: 4,
+			})
+		})
+	})
+
+	describe('non-overlapping widgets unchanged', () => {
+		it('should not move widgets that do not overlap new widget', () => {
+			layout = [
+				{ id: 1, gridX: 0, gridY: 0, gridWidth: 6, gridHeight: 4 },
+				{ id: 2, gridX: 6, gridY: 5, gridWidth: 6, gridHeight: 4 }, // Below the new widget
+			]
+
+			const spec = { w: 4, h: 4 }
+			mockGridInstance.addWidget = vi.fn().mockImplementation(() => {
+				throw new Error('no space')
+			})
+
+			vi.spyOn(document, 'querySelector').mockReturnValue({})
+
+			const result = placeNewWidget(spec, layout, mockGridInstance, 8)
+
+			expect(result).toEqual({
+				x: 0,
+				y: 0,
+				w: 4,
+				h: 4,
+			})
+
+			// Only one call to update (for the overlapping widget)
+			expect(mockGridInstance.update).toHaveBeenCalledTimes(1)
+		})
+	})
+
+	describe('default size on omitted dimensions', () => {
+		it('should use default w=4, h=4 when caller omits w and h', () => {
+			const spec = { type: 'text' }
+
+			mockGridInstance.addWidget = vi.fn().mockImplementation(() => {
+				throw new Error('no space')
+			})
+
+			const result = placeNewWidget(spec, layout, mockGridInstance, 8)
+
+			expect(result.w).toBe(4)
+			expect(result.h).toBe(4)
+		})
+
+		it('should use spec.w when provided, default h=4', () => {
+			const spec = { w: 6 }
+
+			mockGridInstance.addWidget = vi.fn().mockImplementation(() => {
+				throw new Error('no space')
+			})
+
+			const result = placeNewWidget(spec, layout, mockGridInstance, 8)
+
+			expect(result.w).toBe(6)
+			expect(result.h).toBe(4)
+		})
+
+		it('should use spec.h when provided, default w=4', () => {
+			const spec = { h: 3 }
+
+			mockGridInstance.addWidget = vi.fn().mockImplementation(() => {
+				throw new Error('no space')
+			})
+
+			const result = placeNewWidget(spec, layout, mockGridInstance, 8)
+
+			expect(result.w).toBe(4)
+			expect(result.h).toBe(3)
+		})
+	})
+
+	describe('viewport row boundary detection', () => {
+		it('should use fallback when auto-position slot is below viewport', () => {
+			const spec = { w: 4, h: 4 }
+
+			const mockEl = { setAttribute: vi.fn() }
+			document.createElement = vi.fn().mockReturnValue(mockEl)
+
+			const mockNode = { el: mockEl, x: 0, y: 10 } // Below viewport (8 rows)
+			mockGridInstance.addWidget = vi.fn((el) => {
+				mockGridInstance.engine.nodes.push(mockNode)
+			})
+
+			const result = placeNewWidget(spec, layout, mockGridInstance, 8)
+
+			// Should fall back to top-left instead of using slot at y=10
+			expect(result).toEqual({
+				x: 0,
+				y: 0,
+				w: 4,
+				h: 4,
+			})
+		})
+	})
+
+	describe('pushed widgets only change gridY', () => {
+		it('should identify overlapping widgets and push them', () => {
+			layout = [
+				{ id: 1, gridX: 0, gridY: 0, gridWidth: 4, gridHeight: 2 },
+			]
+
+			const spec = { w: 6, h: 3 }
+			mockGridInstance.addWidget = vi.fn().mockImplementation(() => {
+				throw new Error('no space')
+			})
+
+			vi.spyOn(document, 'querySelector').mockReturnValue({})
+
+			placeNewWidget(spec, layout, mockGridInstance, 8)
+
+			// Should be called once for the overlapping widget
+			expect(mockGridInstance.update).toHaveBeenCalledTimes(1)
+		})
+	})
+})

--- a/src/components/DashboardGrid.vue
+++ b/src/components/DashboardGrid.vue
@@ -44,6 +44,7 @@
 import { GridStack } from 'gridstack'
 import WidgetWrapper from './WidgetWrapper.vue'
 import TileWidget from './TileWidget.vue'
+import { placeNewWidget } from '../utils/widgetPlacement.js'
 
 export default {
 	name: 'DashboardGrid',
@@ -77,6 +78,7 @@ export default {
 	data() {
 		return {
 			grid: null,
+			viewportRows: 8,
 		}
 	},
 
@@ -103,15 +105,43 @@ export default {
 
 	mounted() {
 		this.initGrid()
+		this.computeViewportRows()
+		window.addEventListener('resize', this.computeViewportRows)
 	},
 
 	beforeDestroy() {
 		if (this.grid) {
 			this.grid.destroy(false)
 		}
+		window.removeEventListener('resize', this.computeViewportRows)
 	},
 
 	methods: {
+		/**
+		 * Place a new widget using the collision placement algorithm (REQ-GRID-006, REQ-GRID-014).
+		 * Returns the placement position {x, y, w, h} for the new widget.
+		 * Caller MUST persist this position via the standard updatePlacements API.
+		 *
+		 * @param {object} spec widget spec with optional {w, h} dimensions
+		 * @return {object} placement position {x, y, w, h}
+		 */
+		placeWidget(spec) {
+			return placeNewWidget(spec, this.placements, this.grid, this.viewportRows)
+		},
+
+		/**
+		 * Compute viewport rows from the grid container height.
+		 * Called on mount and resize events.
+		 */
+		computeViewportRows() {
+			if (!this.$refs.gridContainer) return
+			const containerHeight = this.$refs.gridContainer.offsetHeight
+			const cellHeight = 80 // Must match the cellHeight in initGrid
+			const margin = 12 // Must match the margin in initGrid
+			const rowHeight = cellHeight + margin
+			this.viewportRows = Math.ceil(containerHeight / rowHeight)
+		},
+
 		getPlacementKey(placement) {
 			// Generate a key that changes when placement properties update.
 			// Include updatedAt or stringify relevant properties to force re-render.

--- a/src/utils/widgetPlacement.js
+++ b/src/utils/widgetPlacement.js
@@ -1,0 +1,143 @@
+/**
+ * SPDX-FileCopyrightText: 2024 MyDash Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+/**
+ * Widget placement helper implementing REQ-GRID-006 (modified) + REQ-GRID-014.
+ *
+ * This module provides the single placement authority for all "add widget" code paths.
+ * All inline grid.addWidget(...) calls outside this file are forbidden per REQ-GRID-014.
+ *
+ * Algorithm:
+ * 1. Try GridStack auto-position: call grid.addWidget({autoPosition: true, ...spec})
+ *    - If it finds an empty slot within the visible viewport (y < viewportRows), use it
+ * 2. Fallback: place at top-left (0, 0) and push overlapping widgets down by newH rows
+ *    - For every existing widget whose rect overlaps [0..newW] × [0..newH],
+ *      set its gridY = newH (just below the new widget)
+ *    - Non-overlapping widgets are NOT moved
+ *
+ * Rationale: Top-left + push-down matches first-run user expectations ("new things at the top")
+ * while preserving all existing widgets and keeping the new one visible (never below fold).
+ */
+
+const DEFAULT_W = 4
+const DEFAULT_H = 4
+
+/**
+ * Detects if two axis-aligned rectangles overlap.
+ * Rectangle A: [aX..aX+aW] × [aY..aY+aH]
+ * Rectangle B: [bX..bX+bW] × [bY..bY+bH]
+ *
+ * @param {number} aX rect A x-start
+ * @param {number} aY rect A y-start
+ * @param {number} aW rect A width
+ * @param {number} aH rect A height
+ * @param {number} bX rect B x-start
+ * @param {number} bY rect B y-start
+ * @param {number} bW rect B width
+ * @param {number} bH rect B height
+ * @return {boolean} true if rectangles overlap
+ */
+function rectsOverlap(aX, aY, aW, aH, bX, bY, bW, bH) {
+	return !(aX + aW <= bX || bX + bW <= aX || aY + aH <= bY || bY + bH <= aY)
+}
+
+/**
+ * Place a new widget on the dashboard using GridStack auto-position + fallback push-down.
+ *
+ * @param {object} spec widget spec with optional {w, h} dimensions
+ * @param {number} spec.w widget width in grid columns (default: 4)
+ * @param {number} spec.h widget height in grid rows (default: 4)
+ * @param {Array} layout current layout array (placement objects with gridX, gridY, gridWidth, gridHeight)
+ * @param {object} gridInstance GridStack instance (with addWidget and update methods)
+ * @param {number} viewportRows visible grid rows (used to detect "below fold" auto-position)
+ *
+ * @return {object} placement position {x, y, w, h} for the new widget
+ *   Note: the caller MUST persist this position AND any pushed-down widgets via the standard API.
+ */
+export function placeNewWidget(spec, layout, gridInstance, viewportRows = 8) {
+	const newW = spec.w ?? DEFAULT_W
+	const newH = spec.h ?? DEFAULT_H
+
+	// Step 1: Try GridStack auto-position
+	if (gridInstance && gridInstance.addWidget) {
+		try {
+			const tempEl = document.createElement('div')
+			tempEl.setAttribute('gs-w', String(newW))
+			tempEl.setAttribute('gs-h', String(newH))
+
+			gridInstance.addWidget(tempEl, {
+				x: 0,
+				y: 0,
+				w: newW,
+				h: newH,
+				autoPosition: true,
+			})
+
+			// Check if the placement is within the viewport
+			const engineNode = gridInstance.engine.nodes.find(n => n.el === tempEl)
+			if (engineNode && engineNode.y < viewportRows) {
+				// Success: GridStack found a slot within the visible region
+				const result = {
+					x: engineNode.x,
+					y: engineNode.y,
+					w: newW,
+					h: newH,
+				}
+
+				// Clean up the temp element
+				gridInstance.removeWidget(tempEl, false)
+				return result
+			}
+
+			// Auto-position placed below viewport; fall through to step 2
+			gridInstance.removeWidget(tempEl, false)
+		} catch (error) {
+			// Grid instance not ready or error occurred; fall through to step 2
+			console.warn('[widgetPlacement] GridStack auto-position failed, using fallback:', error)
+		}
+	}
+
+	// Step 2: Fallback - place at top-left and push overlapping widgets down
+	const newPlacements = []
+
+	// Identify overlapping widgets and prepare push-down updates
+	for (const widget of layout) {
+		const {
+			gridX: wX,
+			gridY: wY,
+			gridWidth: wW,
+			gridHeight: wH,
+		} = widget
+
+		// Check if this widget overlaps the new widget's footprint [0..newW] × [0..newH]
+		if (rectsOverlap(0, 0, newW, newH, wX, wY, wW, wH)) {
+			// Push this widget down to y = newH
+			newPlacements.push({
+				id: widget.id,
+				gridY: newH,
+			})
+		}
+	}
+
+	// Apply push-down updates to the grid instance
+	for (const update of newPlacements) {
+		const widget = layout.find(w => w.id === update.id)
+		if (widget && gridInstance && gridInstance.update) {
+			const el = document.querySelector(`[gs-id="${update.id}"]`)
+			if (el) {
+				gridInstance.update(el, {
+					y: update.gridY,
+				})
+			}
+		}
+	}
+
+	return {
+		x: 0,
+		y: 0,
+		w: newW,
+		h: newH,
+	}
+}

--- a/src/views/Views.vue
+++ b/src/views/Views.vue
@@ -41,6 +41,7 @@
 		<div class="mydash-container" :class="{ 'mydash-edit-mode': isEditMode }">
 			<DashboardGrid
 				v-if="activeDashboard"
+				ref="dashboardGrid"
 				:placements="widgetPlacements"
 				:widgets="availableWidgets"
 				:edit-mode="isEditMode"
@@ -211,7 +212,21 @@ export default {
 			this.isPickerOpen = false
 		},
 		async addWidget(widgetId) {
-			await this.addWidgetToDashboard(widgetId)
+			// Use the widget placement helper to compute position
+			const gridComponent = this.$refs.dashboardGrid
+			let position = null
+
+			if (gridComponent && gridComponent.placeWidget) {
+				// Get widget spec (default size if not specified)
+				const widget = this.availableWidgets.find(w => w.id === widgetId)
+				const spec = {
+					w: widget?.defaultWidth ?? 4,
+					h: widget?.defaultHeight ?? 4,
+				}
+				position = gridComponent.placeWidget(spec)
+			}
+
+			await this.addWidgetToDashboard(widgetId, position)
 		},
 		async removeWidget(placementId) {
 			await this.removeWidgetFromDashboard(placementId)
@@ -276,8 +291,18 @@ export default {
 					console.log('[Views] Tile updated successfully')
 				} else {
 					console.log('[Views] Creating new tile for dashboard')
+					// Use the widget placement helper to compute position
+					const gridComponent = this.$refs.dashboardGrid
+					let position = null
+
+					if (gridComponent && gridComponent.placeWidget) {
+						// Tiles have default size 2×2
+						const spec = { w: 2, h: 2 }
+						position = gridComponent.placeWidget(spec)
+					}
+
 					// Create new tile using the store action (like widgets).
-					await this.addTileToDashboard(tileData)
+					await this.addTileToDashboard(tileData, position)
 					console.log('[Views] Tile added successfully')
 				}
 				this.closeTileEditor()


### PR DESCRIPTION
Implements REQ-GRID-006 (modified) + REQ-GRID-014 per spec on development branch.

**Changes:**
- New src/utils/widgetPlacement.js with placeNewWidget(spec, layout, grid, viewportRows) helper
- Step 1: GridStack auto-position into empty space (if slot within viewport)  
- Step 2 fallback: place at top-left (0,0) + push overlapping widgets down by newH rows
- Non-overlapping widgets unchanged; default size 4x4 when omitted
- DashboardGrid.vue exposes placeWidget() method; computes viewportRows on mount/resize
- Views.vue calls placeWidget() before addWidgetToDashboard() for position
- Single source of truth enforced: grep confirms grid.addWidget only in widgetPlacement.js

**Tests (Vitest):** All 60 tests pass - covers auto-position, push-down fallback, default sizing, non-overlap preservation, viewport detection

**Quality gates:** ESLint pass | Stylelint pass | Vitest pass

Spec: openspec/changes/widget-collision-placement/