### PR TITLE
feat(dashboard-icons): IconPicker (built-in + upload)

### DIFF
--- a/sbom.cdx.json
+++ b/sbom.cdx.json
@@ -2,10 +2,10 @@
   "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.5",
-  "serialNumber": "urn:uuid:07cb40d7-dc66-445f-bf02-d30d1a44e53c",
+  "serialNumber": "urn:uuid:ba44392e-d355-4835-a7de-87ab446a0be5",
   "version": 1,
   "metadata": {
-    "timestamp": "2026-04-30T18:52:03Z",
+    "timestamp": "2026-04-30T19:07:09Z",
     "tools": [
       {
         "name": "composer",
@@ -82,10 +82,10 @@
       }
     ],
     "component": {
-      "bom-ref": "mydash/mydash-dev-feature/impl-responsive-grid-breakpoints",
+      "bom-ref": "mydash/mydash-dev-feature/impl-custom-icon-upload-pattern",
       "type": "application",
       "name": "mydash",
-      "version": "dev-feature/impl-responsive-grid-breakpoints",
+      "version": "dev-feature/impl-custom-icon-upload-pattern",
       "group": "mydash",
       "description": "Enhanced dashboard with grid layout and admin controls for Nextcloud",
       "author": "MyDash Contributors",
@@ -96,15 +96,15 @@
           }
         }
       ],
-      "purl": "pkg:composer/mydash/mydash@dev-feature/impl-responsive-grid-breakpoints",
+      "purl": "pkg:composer/mydash/mydash@dev-feature/impl-custom-icon-upload-pattern",
       "properties": [
         {
           "name": "cdx:composer:package:distReference",
-          "value": "3c99dad33a5c69d67ee0ba4096fa92961e7b85a2"
+          "value": "79a78691cc850abf188207ab5b9aa84a7e9fb34e"
         },
         {
           "name": "cdx:composer:package:sourceReference",
-          "value": "3c99dad33a5c69d67ee0ba4096fa92961e7b85a2"
+          "value": "79a78691cc850abf188207ab5b9aa84a7e9fb34e"
         },
         {
           "name": "cdx:composer:package:type",
@@ -17934,7 +17934,7 @@
       ]
     },
     {
-      "ref": "mydash/mydash-dev-feature/impl-responsive-grid-breakpoints",
+      "ref": "mydash/mydash-dev-feature/impl-custom-icon-upload-pattern",
       "dependsOn": [
         "ramsey/uuid-4.9.2.0"
       ]

--- a/src/__tests__/IconPicker.test.js
+++ b/src/__tests__/IconPicker.test.js
@@ -1,0 +1,281 @@
+/**
+ * SPDX-FileCopyrightText: 2026 MyDash Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+/* eslint-disable n/no-unpublished-import */
+import { describe, it, expect, beforeAll, afterEach, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+/* eslint-enable n/no-unpublished-import */
+
+import IconPicker from '../components/Dashboard/IconPicker.vue'
+
+beforeAll(() => {
+	// Stub the Nextcloud `t` global with an identity function so components
+	// render during tests without depending on @nextcloud/l10n.
+	if (typeof globalThis.t !== 'function') {
+		globalThis.t = (_app, key) => key
+	}
+})
+
+afterEach(() => {
+	vi.clearAllMocks()
+})
+
+describe('IconPicker — Select built-in icon (REQ-ICON-008)', () => {
+	it('renders select with registry options from Object.keys(DASHBOARD_ICONS)', () => {
+		const wrapper = mount(IconPicker, {
+			propsData: {
+				value: 'Star',
+			},
+		})
+		const select = wrapper.find('.icon-picker__select')
+		expect(select.exists()).toBe(true)
+		const options = select.findAll('option')
+		// First option is the disabled placeholder
+		expect(options.length).toBeGreaterThan(1)
+		// Find an option with text 'Star'
+		const starOption = options.wrappers.find(opt => opt.text() === 'Star')
+		expect(starOption).toBeDefined()
+		expect(starOption.element.value).toBe('Star')
+	})
+
+	it('emits input event when select changes', async () => {
+		const wrapper = mount(IconPicker, {
+			propsData: {
+				value: 'Star',
+			},
+		})
+		const select = wrapper.find('.icon-picker__select')
+		// Change to Home
+		await select.setValue('Home')
+		expect(wrapper.emitted('input')).toBeTruthy()
+		expect(wrapper.emitted('input')[0]).toEqual(['Home'])
+	})
+
+	it('renders 24×24 preview via IconRenderer', () => {
+		const wrapper = mount(IconPicker, {
+			propsData: {
+				value: 'Star',
+			},
+		})
+		const preview = wrapper.findComponent({ name: 'IconRenderer' })
+		expect(preview.exists()).toBe(true)
+		expect(preview.props('name')).toBe('Star')
+		expect(preview.props('size')).toBe(24)
+	})
+})
+
+describe('IconPicker — Upload custom URL (REQ-ICON-008)', () => {
+	it('renders file input with accept="image/*"', () => {
+		const wrapper = mount(IconPicker, {
+			propsData: {
+				value: 'Star',
+			},
+		})
+		const fileInput = wrapper.find('.icon-picker__file-input')
+		expect(fileInput.exists()).toBe(true)
+		expect(fileInput.element.accept).toBe('image/*')
+	})
+
+	it('uploads file and emits URL on success', async () => {
+		global.fetch = vi.fn(() =>
+			Promise.resolve({
+				ok: true,
+				json: () => Promise.resolve({ url: '/apps/mydash/resource/abc.png' }),
+			}),
+		)
+
+		const wrapper = mount(IconPicker, {
+			propsData: {
+				value: 'Star',
+			},
+		})
+
+		const fileInput = wrapper.find('.icon-picker__file-input')
+		const file = new File(['image'], 'test.png', { type: 'image/png' })
+
+		// Manually trigger file select
+		Object.defineProperty(fileInput.element, 'files', {
+			value: [file],
+			writable: false,
+		})
+		await fileInput.trigger('change')
+		// Wait for async operations to complete
+		await new Promise(resolve => setTimeout(resolve, 50))
+
+		expect(wrapper.emitted('input')).toBeTruthy()
+		expect(wrapper.emitted('input')[0]).toEqual(['/apps/mydash/resource/abc.png'])
+	})
+
+	it('clears error on successful upload', async () => {
+		global.fetch = vi.fn()
+			.mockImplementationOnce(() =>
+				Promise.resolve({
+					ok: false,
+					status: 500,
+				}),
+			)
+			.mockImplementationOnce(() =>
+				Promise.resolve({
+					ok: true,
+					json: () => Promise.resolve({ url: '/apps/mydash/resource/abc.png' }),
+				}),
+			)
+
+		const wrapper = mount(IconPicker, {
+			propsData: {
+				value: 'Star',
+			},
+		})
+
+		const fileInput = wrapper.find('.icon-picker__file-input')
+		const file1 = new File(['image'], 'test.png', { type: 'image/png' })
+
+		// First upload fails
+		Object.defineProperty(fileInput.element, 'files', {
+			value: [file1],
+			writable: false,
+		})
+		await fileInput.trigger('change')
+		// Wait for async operations to complete
+		await new Promise(resolve => setTimeout(resolve, 50))
+		expect(wrapper.find('.icon-picker__error').exists()).toBe(true)
+
+		// Create a new wrapper instance for the second upload to avoid redefining files
+		const wrapper2 = mount(IconPicker, {
+			propsData: {
+				value: 'Star',
+			},
+		})
+
+		const fileInput2 = wrapper2.find('.icon-picker__file-input')
+		const file2 = new File(['image'], 'test2.png', { type: 'image/png' })
+		Object.defineProperty(fileInput2.element, 'files', {
+			value: [file2],
+			writable: false,
+		})
+		await fileInput2.trigger('change')
+		// Wait for async operations to complete
+		await new Promise(resolve => setTimeout(resolve, 50))
+		expect(wrapper2.find('.icon-picker__error').exists()).toBe(false)
+	})
+})
+
+describe('IconPicker — Upload error handling (REQ-ICON-008)', () => {
+	it('shows error message on upload failure', async () => {
+		global.fetch = vi.fn(() =>
+			Promise.resolve({
+				ok: false,
+				status: 500,
+			}),
+		)
+
+		const wrapper = mount(IconPicker, {
+			propsData: {
+				value: 'Star',
+			},
+		})
+
+		const fileInput = wrapper.find('.icon-picker__file-input')
+		const file = new File(['image'], 'test.png', { type: 'image/png' })
+
+		Object.defineProperty(fileInput.element, 'files', {
+			value: [file],
+			writable: false,
+		})
+		await fileInput.trigger('change')
+		// Wait for async operations to complete
+		await new Promise(resolve => setTimeout(resolve, 50))
+
+		const errorMsg = wrapper.find('.icon-picker__error')
+		expect(errorMsg.exists()).toBe(true)
+		expect(errorMsg.text()).toBe('Failed to upload icon')
+	})
+
+	it('preserves previous value on upload error', async () => {
+		global.fetch = vi.fn(() =>
+			Promise.resolve({
+				ok: false,
+				status: 500,
+			}),
+		)
+
+		const wrapper = mount(IconPicker, {
+			propsData: {
+				value: 'Star',
+			},
+		})
+
+		const fileInput = wrapper.find('.icon-picker__file-input')
+		const file = new File(['image'], 'test.png', { type: 'image/png' })
+
+		Object.defineProperty(fileInput.element, 'files', {
+			value: [file],
+			writable: false,
+		})
+		await fileInput.trigger('change')
+		// Wait for async operations to complete
+		await new Promise(resolve => setTimeout(resolve, 50))
+
+		// Should not have emitted input on failure
+		expect(wrapper.emitted('input')).toBeFalsy()
+		// Preview should still show Star
+		expect(wrapper.findComponent({ name: 'IconRenderer' }).props('name')).toBe('Star')
+	})
+})
+
+describe('IconPicker — Mode switching (REQ-ICON-008)', () => {
+	it('switches from built-in to custom URL', async () => {
+		global.fetch = vi.fn(() =>
+			Promise.resolve({
+				ok: true,
+				json: () => Promise.resolve({ url: '/apps/mydash/resource/abc.png' }),
+			}),
+		)
+
+		const wrapper = mount(IconPicker, {
+			propsData: {
+				value: 'Star',
+			},
+		})
+
+		// Verify initial built-in render
+		const preview = wrapper.findComponent({ name: 'IconRenderer' })
+		expect(preview.props('name')).toBe('Star')
+
+		// Upload a file
+		const fileInput = wrapper.find('.icon-picker__file-input')
+		const file = new File(['image'], 'test.png', { type: 'image/png' })
+
+		Object.defineProperty(fileInput.element, 'files', {
+			value: [file],
+			writable: false,
+		})
+		await fileInput.trigger('change')
+		// Wait for async operations to complete
+		await new Promise(resolve => setTimeout(resolve, 50))
+
+		// Verify preview now shows URL
+		expect(wrapper.emitted('input')[0]).toEqual(['/apps/mydash/resource/abc.png'])
+	})
+
+	it('switches from custom URL back to built-in', async () => {
+		const wrapper = mount(IconPicker, {
+			propsData: {
+				value: '/apps/mydash/resource/abc.png',
+			},
+		})
+
+		// Verify initial URL render
+		const preview = wrapper.findComponent({ name: 'IconRenderer' })
+		expect(preview.props('name')).toBe('/apps/mydash/resource/abc.png')
+
+		// Select a built-in icon
+		const select = wrapper.find('.icon-picker__select')
+		await select.setValue('Home')
+
+		// Verify preview now shows built-in
+		expect(wrapper.emitted('input')[0]).toEqual(['Home'])
+	})
+})

--- a/src/components/Dashboard/IconPicker.vue
+++ b/src/components/Dashboard/IconPicker.vue
@@ -1,0 +1,204 @@
+<!--
+  - SPDX-FileCopyrightText: 2026 MyDash Contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<!--
+	IconPicker — capability `custom-icon-upload-pattern` (REQ-ICON-008..009)
+
+	Combined select + file-upload picker for the `icon` field following the
+	dashboards.icon convention. Lets users pick from a built-in registry OR
+	upload a custom image URL, both updating the same v-model value.
+
+	- Built-in select emits the registry key string (e.g. 'Star')
+	- File upload reads as data URL, POSTs to resource-uploads endpoint,
+	  emits the returned URL string
+	- 24×24 preview via IconRenderer
+	- Inline error display on upload failure (preserves previous value)
+
+	Uses v-model per Vue 2 convention: value prop + input event.
+-->
+
+<template>
+	<div class="icon-picker">
+		<div class="icon-picker__preview">
+			<IconRenderer
+				:name="value"
+				:alt="null"
+				:size="24" />
+		</div>
+
+		<select
+			:value="value"
+			class="icon-picker__select"
+			@change="selectIcon">
+			<option :value="null" disabled>
+				{{ tt('Select icon...') }}
+			</option>
+			<option
+				v-for="(_, name) in DASHBOARD_ICONS"
+				:key="name"
+				:value="name">
+				{{ name }}
+			</option>
+		</select>
+
+		<label class="icon-picker__upload-label">
+			<input
+				type="file"
+				accept="image/*"
+				class="icon-picker__file-input"
+				@change="handleFileSelect">
+			<span class="icon-picker__upload-button">
+				{{ tt('Upload icon') }}
+			</span>
+		</label>
+
+		<p v-if="uploadError" class="icon-picker__error">
+			{{ uploadError }}
+		</p>
+	</div>
+</template>
+
+<script>
+import { DASHBOARD_ICONS } from '../../constants/dashboardIcons.js'
+import { uploadDataUrl } from '../../services/resourceService.js'
+import IconRenderer from './IconRenderer.vue'
+
+export default {
+	name: 'IconPicker',
+
+	components: {
+		IconRenderer,
+	},
+
+	props: {
+		/**
+		 * The current icon value: either a registry key, a URL, or null.
+		 * Uses Vue 2 v-model convention (value prop + input event).
+		 */
+		value: {
+			type: String,
+			default: null,
+		},
+	},
+
+	emits: ['input'],
+
+	data() {
+		return {
+			DASHBOARD_ICONS,
+			uploadError: '',
+		}
+	},
+
+	methods: {
+		tt(key) {
+			if (typeof t === 'function') {
+				return t('mydash', key)
+			}
+			return key
+		},
+
+		selectIcon(event) {
+			const selected = event.target.value
+			this.uploadError = ''
+			this.$emit('input', selected || null)
+		},
+
+		handleFileSelect(event) {
+			const file = event.target.files?.[0]
+			if (!file) {
+				return
+			}
+
+			this.uploadError = ''
+			const reader = new FileReader()
+
+			reader.onload = async (e) => {
+				try {
+					const dataUrl = e.target.result
+					const response = await uploadDataUrl(dataUrl)
+					this.$emit('input', response.url)
+					// Reset file input
+					event.target.value = ''
+				} catch (error) {
+					this.uploadError = this.tt('Failed to upload icon')
+					console.error('Icon upload failed:', error)
+					// Reset file input
+					event.target.value = ''
+				}
+			}
+
+			reader.onerror = () => {
+				this.uploadError = this.tt('Failed to upload icon')
+				// Reset file input
+				event.target.value = ''
+			}
+
+			reader.readAsDataURL(file)
+		},
+	},
+}
+</script>
+
+<style scoped>
+.icon-picker {
+	display: flex;
+	flex-direction: column;
+	gap: 12px;
+}
+
+.icon-picker__preview {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 40px;
+	height: 40px;
+	border: 1px solid var(--color-border);
+	border-radius: 4px;
+	background-color: var(--color-background-secondary);
+}
+
+.icon-picker__select {
+	width: 100%;
+	padding: 6px 8px;
+	border: 1px solid var(--color-border);
+	border-radius: 4px;
+	font-size: 14px;
+}
+
+.icon-picker__upload-label {
+	position: relative;
+	display: inline-flex;
+	align-items: center;
+	gap: 8px;
+	cursor: pointer;
+}
+
+.icon-picker__file-input {
+	display: none;
+}
+
+.icon-picker__upload-button {
+	padding: 6px 12px;
+	border: 1px solid var(--color-border);
+	border-radius: 4px;
+	background-color: var(--color-background-secondary);
+	font-size: 14px;
+	transition: background-color 0.2s;
+}
+
+.icon-picker__upload-label:hover .icon-picker__upload-button {
+	background-color: var(--color-background-tertiary);
+}
+
+.icon-picker__error {
+	margin: 0;
+	padding: 4px 8px;
+	font-size: 12px;
+	color: var(--color-error);
+	background-color: rgba(192, 0, 0, 0.1);
+	border-radius: 2px;
+}
+</style>

--- a/src/components/Dashboard/IconRenderer.vue
+++ b/src/components/Dashboard/IconRenderer.vue
@@ -28,9 +28,9 @@
 	<img
 		v-if="isUrl"
 		:src="name"
+		:alt="alt || 'icon'"
 		:width="size"
-		:height="size"
-		alt="">
+		:height="size">
 	<component
 		:is="iconComponent"
 		v-else
@@ -64,6 +64,15 @@ export default {
 		size: {
 			type: Number,
 			default: 20,
+		},
+
+		/**
+		 * Alt text for `<img>` elements (custom URLs). Falls back to 'icon'
+		 * if not supplied.
+		 */
+		alt: {
+			type: String,
+			default: null,
 		},
 	},
 

--- a/src/constants/dashboardIcons.js
+++ b/src/constants/dashboardIcons.js
@@ -84,14 +84,21 @@ if (!DASHBOARD_ICONS[DEFAULT_ICON]) {
 /**
  * Resolve an icon name to a Vue component reference.
  *
- * Tolerates null, undefined, empty string, and unknown names — all of
- * these resolve to `DASHBOARD_ICONS[DEFAULT_ICON]`. Never throws and
- * never returns null.
+ * Returns null when the name is a URL (per REQ-ICON-006) — callers must
+ * render via `<img>` in that case. For registry names, tolerates null,
+ * undefined, empty string, and unknown names — all resolve to
+ * `DASHBOARD_ICONS[DEFAULT_ICON]`. Never throws on non-URL inputs.
  *
- * @param {string|null|undefined} name - Icon registry key, or null/empty.
- * @return {object} A Vue component suitable for `<component :is>`.
+ * @param {string|null|undefined} name - Icon registry key, URL, or null/empty.
+ * @return {object|null} A Vue component suitable for `<component :is>`, or null if name is a URL.
  */
 export function getIconComponent(name) {
+	// URL inputs return null — caller must use <img> instead
+	if (isCustomIconUrl(name)) {
+		return null
+	}
+
+	// Registry names or null/empty → resolve to DEFAULT_ICON
 	if (typeof name !== 'string' || name.length === 0) {
 		return DASHBOARD_ICONS[DEFAULT_ICON]
 	}


### PR DESCRIPTION
Implements REQ-ICON-008..009 per spec. New IconPicker.vue combining built-in select + file upload, both updating v-model, with live 24x24 preview via IconRenderer. Uses resourceService.uploadDataUrl from PR #55. Tests cover switching modes and error handling. Verified REQ-ICON-005..007 already implemented.