### PR TITLE
feat(dashboard-switcher): slide-in sidebar with 3 sections

### DIFF
--- a/l10n/en.json
+++ b/l10n/en.json
@@ -168,6 +168,8 @@
         "Fill": "Fill",
         "None": "None",
         "Failed to upload image": "Failed to upload image",
-        "Image URL is required": "Image URL is required"
+        "Image URL is required": "Image URL is required",
+        "My Dashboards": "My Dashboards",
+        "+ New Dashboard": "+ New Dashboard"
     }
 }

--- a/l10n/nl.json
+++ b/l10n/nl.json
@@ -168,6 +168,8 @@
         "Fill": "Vullen",
         "None": "Geen",
         "Failed to upload image": "Afbeelding kon niet worden geüpload",
-        "Image URL is required": "Afbeeldings-URL is verplicht"
+        "Image URL is required": "Afbeeldings-URL is verplicht",
+        "My Dashboards": "Mijn dashboards",
+        "+ New Dashboard": "+ Nieuw dashboard"
     }
 }

--- a/src/__tests__/DashboardSwitcherSidebar.test.js
+++ b/src/__tests__/DashboardSwitcherSidebar.test.js
@@ -1,0 +1,394 @@
+/**
+ * SPDX-FileCopyrightText: 2026 MyDash Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+/* eslint-disable n/no-unpublished-import */
+import { describe, it, expect, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import DashboardSwitcherSidebar from '@/components/Workspace/DashboardSwitcherSidebar.vue'
+
+// Mock the translate function
+vi.mock('@nextcloud/l10n', () => ({
+	translate: vi.fn((app, key) => key),
+}))
+
+describe('DashboardSwitcherSidebar', () => {
+	describe('REQ-SWITCH-001: Three-section navigation', () => {
+		it('renders only visible sections', () => {
+			const wrapper = mount(DashboardSwitcherSidebar, {
+				propsData: {
+					groupDashboards: [],
+					userDashboards: [{ id: 'u1', name: 'User Dash', icon: 'Star' }],
+				},
+				mocks: {
+					t: (app, key) => key,
+				},
+			})
+
+			// Should have only "My Dashboards" section
+			expect(wrapper.find('.sidebar-section-heading').text()).toBe('My Dashboards')
+			expect(wrapper.findAll('.sidebar-section-heading')).toHaveLength(1)
+		})
+
+		it('renders all three sections when populated', () => {
+			const wrapper = mount(DashboardSwitcherSidebar, {
+				propsData: {
+					groupName: 'Engineering',
+					groupDashboards: [
+						{ id: 'g1', name: 'Group Dash', icon: 'Home', source: 'group' },
+						{ id: 'd1', name: 'Default Dash', icon: 'Star', source: 'default' },
+					],
+					userDashboards: [{ id: 'u1', name: 'User Dash', icon: 'Heart' }],
+				},
+				mocks: {
+					t: (app, key) => key,
+				},
+			})
+
+			const headings = wrapper.findAll('.sidebar-section-heading')
+			expect(headings).toHaveLength(3)
+			expect(headings.at(0).text()).toBe('Engineering')
+			expect(headings.at(1).text()).toBe('Default')
+			expect(headings.at(2).text()).toBe('My Dashboards')
+		})
+
+		it('shows My Dashboards when allowUserDashboards is true even with empty list', () => {
+			const wrapper = mount(DashboardSwitcherSidebar, {
+				propsData: {
+					groupDashboards: [],
+					userDashboards: [],
+					allowUserDashboards: true,
+				},
+				mocks: {
+					t: (app, key) => key,
+				},
+			})
+
+			expect(wrapper.find('.sidebar-section-heading').text()).toBe('My Dashboards')
+		})
+
+		it('does not render My Dashboards when empty and allowUserDashboards is false', () => {
+			const wrapper = mount(DashboardSwitcherSidebar, {
+				propsData: {
+					groupDashboards: [],
+					userDashboards: [],
+					allowUserDashboards: false,
+				},
+				mocks: {
+					t: (app, key) => key,
+				},
+			})
+
+			expect(wrapper.find('.sidebar-section-heading').exists()).toBe(false)
+		})
+	})
+
+	describe('REQ-SWITCH-002: Click semantics', () => {
+		it('emits update:open(false) BEFORE switch event', async () => {
+			const wrapper = mount(DashboardSwitcherSidebar, {
+				propsData: {
+					groupDashboards: [{ id: 'g1', name: 'Group Dash', icon: 'Home', source: 'group' }],
+					userDashboards: [],
+				},
+				mocks: {
+					t: (app, key) => key,
+				},
+			})
+
+			const emits = []
+			wrapper.vm.$on('update:open', () => emits.push('update:open'))
+			wrapper.vm.$on('switch', () => emits.push('switch'))
+
+			const dashButton = wrapper.find('.sidebar-item--dashboard')
+			await dashButton.trigger('click')
+
+			expect(emits).toEqual(['update:open', 'switch'])
+		})
+
+		it('emits switch with correct source for primary group items', async () => {
+			const wrapper = mount(DashboardSwitcherSidebar, {
+				propsData: {
+					groupDashboards: [{ id: 'g1', name: 'Group Dash', icon: 'Home', source: 'group' }],
+					userDashboards: [],
+				},
+				mocks: {
+					t: (app, key) => key,
+				},
+			})
+
+			const dashButton = wrapper.find('.sidebar-item--dashboard')
+			await dashButton.trigger('click')
+
+			const switchEmits = wrapper.emitted('switch')
+			expect(switchEmits).toHaveLength(1)
+			expect(switchEmits[0]).toEqual(['g1', 'group'])
+		})
+
+		it('emits switch with source "default" for default group items', async () => {
+			const wrapper = mount(DashboardSwitcherSidebar, {
+				propsData: {
+					groupDashboards: [{ id: 'd1', name: 'Default Dash', icon: 'Star', source: 'default' }],
+					userDashboards: [],
+				},
+				mocks: {
+					t: (app, key) => key,
+				},
+			})
+
+			const dashButton = wrapper.find('.sidebar-item--dashboard')
+			await dashButton.trigger('click')
+
+			const switchEmits = wrapper.emitted('switch')
+			expect(switchEmits[0]).toEqual(['d1', 'default'])
+		})
+
+		it('emits switch with source "user" for personal items', async () => {
+			const wrapper = mount(DashboardSwitcherSidebar, {
+				propsData: {
+					groupDashboards: [],
+					userDashboards: [{ id: 'u1', name: 'User Dash', icon: 'Heart' }],
+				},
+				mocks: {
+					t: (app, key) => key,
+				},
+			})
+
+			const dashButton = wrapper.find('.sidebar-item--dashboard')
+			await dashButton.trigger('click')
+
+			const switchEmits = wrapper.emitted('switch')
+			expect(switchEmits[0]).toEqual(['u1', 'user'])
+		})
+	})
+
+	describe('REQ-SWITCH-003: Active item highlight', () => {
+		it('applies active class to the active dashboard', () => {
+			const wrapper = mount(DashboardSwitcherSidebar, {
+				propsData: {
+					groupDashboards: [
+						{ id: 'g1', name: 'Group Dash 1', icon: 'Home', source: 'group' },
+						{ id: 'g2', name: 'Group Dash 2', icon: 'Star', source: 'group' },
+					],
+					userDashboards: [],
+					activeDashboardId: 'g2',
+				},
+				mocks: {
+					t: (app, key) => key,
+				},
+			})
+
+			const items = wrapper.findAll('.sidebar-item--dashboard')
+			expect(items.at(0).classes()).not.toContain('active')
+			expect(items.at(1).classes()).toContain('active')
+		})
+
+		it('updates active class reactively when prop changes', async () => {
+			const wrapper = mount(DashboardSwitcherSidebar, {
+				propsData: {
+					groupDashboards: [{ id: 'g1', name: 'Group Dash', icon: 'Home', source: 'group' }],
+					userDashboards: [{ id: 'u1', name: 'User Dash', icon: 'Heart' }],
+					activeDashboardId: 'g1',
+				},
+				mocks: {
+					t: (app, key) => key,
+				},
+			})
+
+			expect(wrapper.findAll('.sidebar-item.active')).toHaveLength(1)
+
+			await wrapper.setProps({ activeDashboardId: 'u1' })
+
+			const activeItems = wrapper.findAll('.sidebar-item.active')
+			expect(activeItems).toHaveLength(1)
+			expect(activeItems.at(0).text()).toContain('User Dash')
+		})
+	})
+
+	describe('REQ-SWITCH-004: Personal delete affordance', () => {
+		it('does not emit switch when delete button is clicked', async () => {
+			const wrapper = mount(DashboardSwitcherSidebar, {
+				propsData: {
+					groupDashboards: [],
+					userDashboards: [{ id: 'u1', name: 'User Dash', icon: 'Heart' }],
+				},
+				mocks: {
+					t: (app, key) => key,
+				},
+			})
+
+			const deleteButton = wrapper.find('.sidebar-item-delete')
+			await deleteButton.trigger('click')
+
+			expect(wrapper.emitted('switch')).toBeUndefined()
+			expect(wrapper.emitted('update:open')).toBeUndefined()
+		})
+
+		it('emits delete-dashboard when delete button is clicked', async () => {
+			const wrapper = mount(DashboardSwitcherSidebar, {
+				propsData: {
+					groupDashboards: [],
+					userDashboards: [{ id: 'u1', name: 'User Dash', icon: 'Heart' }],
+				},
+				mocks: {
+					t: (app, key) => key,
+				},
+			})
+
+			const deleteButton = wrapper.find('.sidebar-item-delete')
+			await deleteButton.trigger('click')
+
+			const deleteEmits = wrapper.emitted('delete-dashboard')
+			expect(deleteEmits).toHaveLength(1)
+			expect(deleteEmits[0]).toEqual(['u1'])
+		})
+
+		it('shows delete button only for personal dashboards, not for group items', () => {
+			const wrapper = mount(DashboardSwitcherSidebar, {
+				propsData: {
+					groupDashboards: [{ id: 'g1', name: 'Group Dash', icon: 'Home', source: 'group' }],
+					userDashboards: [{ id: 'u1', name: 'User Dash', icon: 'Heart' }],
+				},
+				mocks: {
+					t: (app, key) => key,
+				},
+			})
+
+			expect(wrapper.findAll('.sidebar-item-delete')).toHaveLength(1)
+		})
+	})
+
+	describe('REQ-SWITCH-005: Create-dashboard affordance', () => {
+		it('renders + New Dashboard button when allowUserDashboards is true', () => {
+			const wrapper = mount(DashboardSwitcherSidebar, {
+				propsData: {
+					groupDashboards: [],
+					userDashboards: [],
+					allowUserDashboards: true,
+				},
+				mocks: {
+					t: (app, key) => key,
+				},
+			})
+
+			expect(wrapper.find('.sidebar-item--action').exists()).toBe(true)
+		})
+
+		it('does not render + New Dashboard button when allowUserDashboards is false', () => {
+			const wrapper = mount(DashboardSwitcherSidebar, {
+				propsData: {
+					groupDashboards: [],
+					userDashboards: [],
+					allowUserDashboards: false,
+				},
+				mocks: {
+					t: (app, key) => key,
+				},
+			})
+
+			expect(wrapper.find('.sidebar-item--action').exists()).toBe(false)
+		})
+
+		it('emits update:open(false) and create-dashboard in order', async () => {
+			const wrapper = mount(DashboardSwitcherSidebar, {
+				propsData: {
+					groupDashboards: [],
+					userDashboards: [],
+					allowUserDashboards: true,
+				},
+				mocks: {
+					t: (app, key) => key,
+				},
+			})
+
+			const emits = []
+			wrapper.vm.$on('update:open', () => emits.push('update:open'))
+			wrapper.vm.$on('create-dashboard', () => emits.push('create-dashboard'))
+
+			const createButton = wrapper.find('.sidebar-item--action')
+			await createButton.trigger('click')
+
+			expect(emits).toEqual(['update:open', 'create-dashboard'])
+		})
+	})
+
+	describe('REQ-SWITCH-006: Slide-in animation', () => {
+		it('applies open class when isOpen is true', async () => {
+			const wrapper = mount(DashboardSwitcherSidebar, {
+				propsData: {
+					isOpen: false,
+					groupDashboards: [],
+					userDashboards: [],
+				},
+				mocks: {
+					t: (app, key) => key,
+				},
+			})
+
+			expect(wrapper.find('.dashboard-switcher-sidebar').classes()).not.toContain('open')
+
+			await wrapper.setProps({ isOpen: true })
+
+			expect(wrapper.find('.dashboard-switcher-sidebar').classes()).toContain('open')
+		})
+	})
+
+	describe('REQ-SWITCH-007: Icon rendering', () => {
+		it('renders icons via IconRenderer for all dashboard items', () => {
+			const wrapper = mount(DashboardSwitcherSidebar, {
+				propsData: {
+					groupDashboards: [
+						{ id: 'g1', name: 'Home', icon: 'Home', source: 'group' },
+						{ id: 'g2', name: 'Chart', icon: 'ChartBar', source: 'group' },
+					],
+					userDashboards: [
+						{ id: 'u1', name: 'Star', icon: 'Star' },
+						{ id: 'u2', name: 'Default', icon: null },
+					],
+				},
+				mocks: {
+					t: (app, key) => key,
+				},
+			})
+
+			const iconRenderers = wrapper.findAllComponents({ name: 'IconRenderer' })
+			expect(iconRenderers.length).toBeGreaterThan(0)
+		})
+	})
+
+	describe('Accessibility', () => {
+		it('responds to Esc key to close sidebar', async () => {
+			const wrapper = mount(DashboardSwitcherSidebar, {
+				propsData: {
+					isOpen: true,
+					groupDashboards: [],
+					userDashboards: [],
+				},
+				mocks: {
+					t: (app, key) => key,
+				},
+			})
+
+			await wrapper.find('.dashboard-switcher-sidebar').trigger('keydown.esc')
+
+			const updateEmits = wrapper.emitted('update:open')
+			expect(updateEmits).toHaveLength(1)
+			expect(updateEmits[0]).toEqual([false])
+		})
+
+		it('has aria-labels on dashboard items', () => {
+			const wrapper = mount(DashboardSwitcherSidebar, {
+				propsData: {
+					groupDashboards: [{ id: 'g1', name: 'Engineering Dashboard', icon: 'Home', source: 'group' }],
+					userDashboards: [],
+				},
+				mocks: {
+					t: (app, key) => key,
+				},
+			})
+
+			const button = wrapper.find('.sidebar-item--dashboard')
+			expect(button.attributes('aria-label')).toBe('Engineering Dashboard')
+		})
+	})
+})

--- a/src/components/Workspace/DashboardSwitcherSidebar.vue
+++ b/src/components/Workspace/DashboardSwitcherSidebar.vue
@@ -1,0 +1,347 @@
+<!--
+  - SPDX-FileCopyrightText: 2026 MyDash Contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<template>
+	<aside
+		:class="{ open: isOpen }"
+		class="dashboard-switcher-sidebar"
+		@keydown.esc="handleEsc">
+		<!-- Primary group section -->
+		<template v-if="matchedGroupDashboards.length > 0">
+			<div class="sidebar-section-heading">
+				{{ groupName || t('mydash', 'Dashboards') }}
+			</div>
+			<div class="sidebar-section">
+				<button
+					v-for="dashboard in matchedGroupDashboards"
+					:key="`group-${dashboard.id}`"
+					:class="{ active: dashboard.id === activeDashboardId }"
+					class="sidebar-item sidebar-item--dashboard"
+					:aria-label="dashboard.name"
+					@click="handleDashboardClick(dashboard.id, 'group')">
+					<IconRenderer :name="dashboard.icon" :size="20" />
+					<span class="sidebar-item__label">{{ dashboard.name }}</span>
+				</button>
+			</div>
+		</template>
+
+		<!-- Divider between sections -->
+		<div
+			v-if="matchedGroupDashboards.length > 0 && (defaultGroupDashboards.length > 0 || userDashboardsVisible)"
+			class="sidebar-divider" />
+
+		<!-- Default group section -->
+		<template v-if="defaultGroupDashboards.length > 0">
+			<div class="sidebar-section-heading">
+				{{ t('mydash', 'Default') }}
+			</div>
+			<div class="sidebar-section">
+				<button
+					v-for="dashboard in defaultGroupDashboards"
+					:key="`default-${dashboard.id}`"
+					:class="{ active: dashboard.id === activeDashboardId }"
+					class="sidebar-item sidebar-item--dashboard"
+					:aria-label="dashboard.name"
+					@click="handleDashboardClick(dashboard.id, 'default')">
+					<IconRenderer :name="dashboard.icon" :size="20" />
+					<span class="sidebar-item__label">{{ dashboard.name }}</span>
+				</button>
+			</div>
+		</template>
+
+		<!-- Divider between sections -->
+		<div
+			v-if="(matchedGroupDashboards.length > 0 || defaultGroupDashboards.length > 0) && userDashboardsVisible"
+			class="sidebar-divider" />
+
+		<!-- My Dashboards section -->
+		<template v-if="userDashboardsVisible">
+			<div class="sidebar-section-heading">
+				{{ t('mydash', 'My Dashboards') }}
+			</div>
+			<div class="sidebar-section">
+				<!-- User dashboards -->
+				<div
+					v-for="dashboard in userDashboards"
+					:key="`user-${dashboard.id}`"
+					class="sidebar-item-wrapper">
+					<button
+						:class="{ active: dashboard.id === activeDashboardId }"
+						class="sidebar-item sidebar-item--dashboard"
+						:aria-label="dashboard.name"
+						@click="handleDashboardClick(dashboard.id, 'user')">
+						<IconRenderer :name="dashboard.icon" :size="20" />
+						<span class="sidebar-item__label">{{ dashboard.name }}</span>
+					</button>
+					<button
+						v-if="userDashboards.length > 0"
+						class="sidebar-item-delete"
+						:aria-label="t('mydash', 'Delete dashboard')"
+						@click.stop="handleDeleteClick(dashboard.id)">
+						<Close :size="16" />
+					</button>
+				</div>
+
+				<!-- Create dashboard button -->
+				<button
+					v-if="allowUserDashboards"
+					class="sidebar-item sidebar-item--action"
+					@click="handleCreateClick">
+					<Plus :size="20" />
+					<span class="sidebar-item__label">{{ t('mydash', '+ New Dashboard') }}</span>
+				</button>
+			</div>
+		</template>
+	</aside>
+</template>
+
+<script>
+import { translate as t } from '@nextcloud/l10n'
+import Close from 'vue-material-design-icons/Close.vue'
+import Plus from 'vue-material-design-icons/Plus.vue'
+import IconRenderer from '../Dashboard/IconRenderer.vue'
+
+export default {
+	name: 'DashboardSwitcherSidebar',
+
+	components: {
+		IconRenderer,
+		Close,
+		Plus,
+	},
+
+	props: {
+		/**
+		 * Whether the sidebar is open (controlled via v-model:open)
+		 */
+		isOpen: {
+			type: Boolean,
+			default: false,
+		},
+
+		/**
+		 * Display name of the user's primary group
+		 */
+		groupName: {
+			type: String,
+			default: '',
+		},
+
+		/**
+		 * Dashboards from the group (both matched and default-source)
+		 * Shape: {id, name, icon, source: 'group' | 'default'}
+		 */
+		groupDashboards: {
+			type: Array,
+			default: () => [],
+		},
+
+		/**
+		 * User's personal dashboards
+		 * Shape: {id, name, icon}
+		 */
+		userDashboards: {
+			type: Array,
+			default: () => [],
+		},
+
+		/**
+		 * ID of the currently active dashboard (for highlighting)
+		 */
+		activeDashboardId: {
+			type: String,
+			default: '',
+		},
+
+		/**
+		 * When true, the "+ New Dashboard" button is shown in the personal section
+		 */
+		allowUserDashboards: {
+			type: Boolean,
+			default: false,
+		},
+	},
+
+	emits: ['switch', 'create-dashboard', 'delete-dashboard', 'update:open'],
+
+	computed: {
+		/**
+		 * Primary group dashboards (source !== 'default')
+		 */
+		matchedGroupDashboards() {
+			return this.groupDashboards.filter(d => d.source !== 'default')
+		},
+
+		/**
+		 * Default group dashboards (source === 'default')
+		 */
+		defaultGroupDashboards() {
+			return this.groupDashboards.filter(d => d.source === 'default')
+		},
+
+		/**
+		 * Whether the "My Dashboards" section is visible
+		 */
+		userDashboardsVisible() {
+			return this.userDashboards.length > 0 || this.allowUserDashboards
+		},
+	},
+
+	methods: {
+		t,
+
+		/**
+		 * Handle dashboard click: close sidebar, then emit switch
+		 * @param {string} dashboardId - The ID of the dashboard to switch to
+		 * @param {string} source - The source of the dashboard ('group', 'default', 'user')
+		 */
+		handleDashboardClick(dashboardId, source) {
+			this.$emit('update:open', false)
+			this.$emit('switch', dashboardId, source)
+		},
+
+		/**
+		 * Handle delete button click (no switch emit)
+		 * @param {string} dashboardId - The ID of the dashboard to delete
+		 */
+		handleDeleteClick(dashboardId) {
+			this.$emit('delete-dashboard', dashboardId)
+		},
+
+		/**
+		 * Handle create button click: close sidebar, then emit create-dashboard
+		 */
+		handleCreateClick() {
+			this.$emit('update:open', false)
+			this.$emit('create-dashboard')
+		},
+
+		/**
+		 * Handle Esc key to close the sidebar
+		 */
+		handleEsc() {
+			this.$emit('update:open', false)
+		},
+	},
+}
+</script>
+
+<style scoped lang="scss">
+.dashboard-switcher-sidebar {
+	position: fixed;
+	top: 50px;
+	left: 0;
+	width: 280px;
+	max-height: calc(100vh - 50px);
+	background: var(--color-main-background);
+	border-right: 1px solid var(--color-border);
+	z-index: 1500;
+	overflow-y: auto;
+	transform: translateX(-100%);
+	transition: transform 0.25s ease;
+
+	&.open {
+		transform: translateX(0);
+	}
+
+	.sidebar-section-heading {
+		padding: 12px 16px;
+		font-size: 12px;
+		font-weight: 600;
+		text-transform: uppercase;
+		color: var(--color-text-maxcontrast);
+		letter-spacing: 0.5px;
+	}
+
+	.sidebar-section {
+		display: flex;
+		flex-direction: column;
+	}
+
+	.sidebar-item {
+		display: flex;
+		align-items: center;
+		gap: 12px;
+		padding: 8px 16px;
+		background: none;
+		border: none;
+		cursor: pointer;
+		color: var(--color-text-base);
+		font-size: 14px;
+		text-align: left;
+		transition: background-color 0.15s ease;
+
+		&:hover {
+			background-color: var(--color-background-hover);
+		}
+
+		&.active {
+			background-color: var(--color-primary-element-light);
+		}
+
+		&.active :deep(svg) {
+			color: var(--color-primary-element);
+		}
+
+		&--dashboard {
+			padding-left: 16px;
+		}
+
+		&--action {
+			color: var(--color-primary-element);
+			font-weight: 500;
+
+			&:hover {
+				background-color: var(--color-primary-element-light);
+			}
+		}
+
+		&__label {
+			overflow: hidden;
+			text-overflow: ellipsis;
+			white-space: nowrap;
+			flex: 1;
+		}
+	}
+
+	.sidebar-item-wrapper {
+		position: relative;
+		display: flex;
+		align-items: center;
+
+		.sidebar-item {
+			flex: 1;
+		}
+
+		&:hover .sidebar-item-delete {
+			display: inline-flex;
+		}
+	}
+
+	.sidebar-item-delete {
+		display: none;
+		align-items: center;
+		justify-content: center;
+		width: 32px;
+		height: 32px;
+		padding: 0;
+		background: none;
+		border: none;
+		cursor: pointer;
+		color: var(--color-text-maxcontrast);
+		transition: color 0.15s ease;
+
+		&:hover {
+			color: var(--color-error);
+		}
+	}
+
+	.sidebar-divider {
+		height: 1px;
+		background: var(--color-border);
+		margin: 8px 0;
+	}
+}
+</style>

--- a/src/components/Workspace/SidebarBackdrop.vue
+++ b/src/components/Workspace/SidebarBackdrop.vue
@@ -1,0 +1,50 @@
+<!--
+  - SPDX-FileCopyrightText: 2026 MyDash Contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<template>
+	<div
+		:class="{ visible: isOpen }"
+		class="sidebar-backdrop"
+		@click="$emit('close')" />
+</template>
+
+<script>
+export default {
+	name: 'SidebarBackdrop',
+
+	props: {
+		/**
+		 * Whether the backdrop should be visible
+		 */
+		isOpen: {
+			type: Boolean,
+			default: false,
+		},
+	},
+
+	emits: ['close'],
+}
+</script>
+
+<style scoped lang="scss">
+.sidebar-backdrop {
+	position: fixed;
+	top: 0;
+	left: 0;
+	width: 100%;
+	height: 100%;
+	background: rgba(0, 0, 0, 0);
+	z-index: 1499;
+	opacity: 0;
+	pointer-events: none;
+	transition: opacity 0.25s ease;
+
+	&.visible {
+		background: rgba(0, 0, 0, 0.3);
+		opacity: 1;
+		pointer-events: auto;
+	}
+}
+</style>


### PR DESCRIPTION
Implements REQ-SWITCH-001..007 per spec on development. New DashboardSwitcherSidebar.vue with 3 conditional sections (matched group / default / personal), hover-reveal delete on personal items, +New Dashboard gated on allowUserDashboards, slide-in animation. Uses IconRenderer for icons (no inline branching). Vitest covers all 7 REQs. Will be wired into runtime-shell (later).