### PR TITLE
feat(widgets): right-click context menu

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -40,4 +40,9 @@ module.exports = defineConfig([{
 		'no-console': 'off',
 		'no-debugger': 'off',
 	},
+}, {
+	files: ['src/**/*.test.js', 'src/**/*.spec.js', 'src/__tests__/**/*.js'],
+	rules: {
+		'n/no-unpublished-import': 'off',
+	},
 }])

--- a/l10n/en.json
+++ b/l10n/en.json
@@ -124,6 +124,7 @@
         "Person": "Person",
         "Phone": "Phone",
         "Picture": "Picture",
+        "Remove": "Remove",
         "Reset": "Reset",
         "Save": "Save",
         "Search": "Search",

--- a/l10n/nl.json
+++ b/l10n/nl.json
@@ -124,6 +124,7 @@
         "Person": "Persoon",
         "Phone": "Telefoon",
         "Picture": "Afbeelding",
+        "Remove": "Verwijderen",
         "Reset": "Herstellen",
         "Save": "Opslaan",
         "Search": "Zoeken",

--- a/src/__tests__/WidgetContextMenu.test.js
+++ b/src/__tests__/WidgetContextMenu.test.js
@@ -1,0 +1,479 @@
+/**
+ * SPDX-FileCopyrightText: 2024 MyDash Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import WidgetContextMenu from '../components/Widgets/WidgetContextMenu.vue'
+import DashboardGrid from '../components/DashboardGrid.vue'
+
+describe('WidgetContextMenu.vue', () => {
+	let wrapper
+
+	afterEach(() => {
+		if (wrapper) {
+			wrapper.unmount()
+		}
+	})
+
+	it('does not render when show is false', () => {
+		wrapper = mount(WidgetContextMenu, {
+			props: {
+				show: false,
+				x: 100,
+				y: 100,
+				widget: { id: 'widget-1' },
+			},
+		})
+
+		expect(wrapper.find('.widget-context-menu').exists()).toBe(false)
+	})
+
+	it('renders when show is true', () => {
+		wrapper = mount(WidgetContextMenu, {
+			props: {
+				show: true,
+				x: 100,
+				y: 100,
+				widget: { id: 'widget-1' },
+			},
+		})
+
+		expect(wrapper.find('.widget-context-menu').exists()).toBe(true)
+	})
+
+	it('positions the menu at the given coordinates', () => {
+		wrapper = mount(WidgetContextMenu, {
+			props: {
+				show: true,
+				x: 150,
+				y: 200,
+				widget: { id: 'widget-1' },
+			},
+		})
+
+		const menu = wrapper.find('.widget-context-menu')
+		expect(menu.element.style.top).toBe('200px')
+		expect(menu.element.style.left).toBe('150px')
+	})
+
+	it('emits edit event when Edit button is clicked', async () => {
+		const widget = { id: 'widget-1', title: 'Test Widget' }
+		wrapper = mount(WidgetContextMenu, {
+			props: {
+				show: true,
+				x: 100,
+				y: 100,
+				widget,
+			},
+		})
+
+		const buttons = wrapper.findAll('button')
+		await buttons[0].trigger('click') // Edit button
+
+		expect(wrapper.emitted('edit')).toBeTruthy()
+		expect(wrapper.emitted('edit')[0][0]).toEqual(widget)
+		expect(wrapper.emitted('close')).toBeTruthy()
+	})
+
+	it('emits remove event when Remove button is clicked', async () => {
+		const widget = { id: 'widget-2', title: 'Test Widget 2' }
+		wrapper = mount(WidgetContextMenu, {
+			props: {
+				show: true,
+				x: 100,
+				y: 100,
+				widget,
+			},
+		})
+
+		const buttons = wrapper.findAll('button')
+		await buttons[1].trigger('click') // Remove button
+
+		expect(wrapper.emitted('remove')).toBeTruthy()
+		expect(wrapper.emitted('remove')[0][0]).toEqual(widget)
+		expect(wrapper.emitted('close')).toBeTruthy()
+	})
+
+	it('emits close event when Cancel button is clicked', async () => {
+		wrapper = mount(WidgetContextMenu, {
+			props: {
+				show: true,
+				x: 100,
+				y: 100,
+				widget: { id: 'widget-1' },
+			},
+		})
+
+		const buttons = wrapper.findAll('button')
+		await buttons[2].trigger('click') // Cancel button
+
+		expect(wrapper.emitted('close')).toBeTruthy()
+		expect(wrapper.emitted('edit')).toBeFalsy()
+		expect(wrapper.emitted('remove')).toBeFalsy()
+	})
+
+	it('clamps position when menu would overflow right edge', () => {
+		// Mock window.innerWidth to 400
+		Object.defineProperty(window, 'innerWidth', {
+			writable: true,
+			value: 400,
+		})
+
+		wrapper = mount(WidgetContextMenu, {
+			props: {
+				show: true,
+				x: 350, // Close to right edge (400 - 150 = 250)
+				y: 100,
+				widget: { id: 'widget-1' },
+			},
+		})
+
+		const menu = wrapper.find('.widget-context-menu')
+		const left = parseInt(menu.element.style.left)
+		// Menu should not extend past viewport (400 - 150 = 250 is max left)
+		expect(left + 150).toBeLessThanOrEqual(400)
+	})
+
+	it('clamps position when menu would overflow bottom edge', () => {
+		// Mock window.innerHeight to 600
+		Object.defineProperty(window, 'innerHeight', {
+			writable: true,
+			value: 600,
+		})
+
+		wrapper = mount(WidgetContextMenu, {
+			props: {
+				show: true,
+				x: 100,
+				y: 550, // Close to bottom edge
+				widget: { id: 'widget-1' },
+			},
+		})
+
+		const menu = wrapper.find('.widget-context-menu')
+		const top = parseInt(menu.element.style.top)
+		// Menu height is ~120px, so it should be shifted up
+		expect(top + 120).toBeLessThanOrEqual(600)
+	})
+
+	it('has correct z-index and min-width', () => {
+		wrapper = mount(WidgetContextMenu, {
+			props: {
+				show: true,
+				x: 100,
+				y: 100,
+				widget: { id: 'widget-1' },
+			},
+		})
+
+		const menu = wrapper.find('.widget-context-menu')
+		const styles = window.getComputedStyle(menu.element)
+		expect(styles.zIndex).toBe('10000')
+		expect(styles.minWidth).toBe('150px')
+	})
+
+	it('stops click propagation on the menu itself', async () => {
+		wrapper = mount(WidgetContextMenu, {
+			props: {
+				show: true,
+				x: 100,
+				y: 100,
+				widget: { id: 'widget-1' },
+			},
+		})
+
+		const menu = wrapper.find('.widget-context-menu')
+		const clickEvent = new MouseEvent('click', { bubbles: true })
+		vi.spyOn(clickEvent, 'stopPropagation')
+
+		menu.element.dispatchEvent(clickEvent)
+		// Note: We can't easily test @click.stop with stopPropagation spy,
+		// but we verify the menu exists and responds to clicks
+		expect(menu.exists()).toBe(true)
+	})
+})
+
+describe('DashboardGrid context menu integration', () => {
+	let wrapper
+
+	afterEach(() => {
+		if (wrapper) {
+			wrapper.unmount()
+		}
+	})
+
+	it('shows context menu in edit mode on right-click', async () => {
+		const placements = [
+			{
+				id: 'placement-1',
+				widgetId: 'widget-1',
+				gridX: 0,
+				gridY: 0,
+				gridWidth: 4,
+				gridHeight: 4,
+			},
+		]
+		const widgets = [{ id: 'widget-1', title: 'Test Widget' }]
+
+		wrapper = mount(DashboardGrid, {
+			props: {
+				placements,
+				widgets,
+				editMode: true,
+				gridColumns: 12,
+			},
+			global: {
+				stubs: {
+					WidgetWrapper: true,
+					TileWidget: true,
+					WidgetContextMenu: true,
+				},
+			},
+		})
+
+		const gridItem = wrapper.find('.grid-stack-item')
+		const contextMenuEvent = new MouseEvent('contextmenu', {
+			clientX: 100,
+			clientY: 150,
+			bubbles: true,
+			cancelable: true,
+		})
+
+		const preventDefaultSpy = vi.spyOn(contextMenuEvent, 'preventDefault')
+		gridItem.element.dispatchEvent(contextMenuEvent)
+
+		expect(preventDefaultSpy).toHaveBeenCalled()
+		expect(wrapper.vm.contextMenu.show).toBe(true)
+		expect(wrapper.vm.contextMenu.x).toBe(100)
+		expect(wrapper.vm.contextMenu.y).toBe(150)
+		expect(wrapper.vm.contextMenu.widget).toEqual(placements[0])
+	})
+
+	it('does not show context menu in view mode on right-click', async () => {
+		const placements = [
+			{
+				id: 'placement-1',
+				widgetId: 'widget-1',
+				gridX: 0,
+				gridY: 0,
+				gridWidth: 4,
+				gridHeight: 4,
+			},
+		]
+		const widgets = [{ id: 'widget-1', title: 'Test Widget' }]
+
+		wrapper = mount(DashboardGrid, {
+			props: {
+				placements,
+				widgets,
+				editMode: false, // View mode
+				gridColumns: 12,
+			},
+			global: {
+				stubs: {
+					WidgetWrapper: true,
+					TileWidget: true,
+					WidgetContextMenu: true,
+				},
+			},
+		})
+
+		const gridItem = wrapper.find('.grid-stack-item')
+		const contextMenuEvent = new MouseEvent('contextmenu', {
+			clientX: 100,
+			clientY: 150,
+			bubbles: true,
+			cancelable: true,
+		})
+
+		const preventDefaultSpy = vi.spyOn(contextMenuEvent, 'preventDefault')
+		gridItem.element.dispatchEvent(contextMenuEvent)
+
+		expect(preventDefaultSpy).not.toHaveBeenCalled()
+		expect(wrapper.vm.contextMenu.show).toBe(false)
+	})
+
+	it('closes context menu on second right-click with different placement', async () => {
+		const placements = [
+			{
+				id: 'placement-1',
+				widgetId: 'widget-1',
+				gridX: 0,
+				gridY: 0,
+				gridWidth: 4,
+				gridHeight: 4,
+			},
+			{
+				id: 'placement-2',
+				widgetId: 'widget-2',
+				gridX: 4,
+				gridY: 0,
+				gridWidth: 4,
+				gridHeight: 4,
+			},
+		]
+		const widgets = [
+			{ id: 'widget-1', title: 'Test Widget 1' },
+			{ id: 'widget-2', title: 'Test Widget 2' },
+		]
+
+		wrapper = mount(DashboardGrid, {
+			props: {
+				placements,
+				widgets,
+				editMode: true,
+				gridColumns: 12,
+			},
+			global: {
+				stubs: {
+					WidgetWrapper: true,
+					TileWidget: true,
+					WidgetContextMenu: true,
+				},
+			},
+		})
+
+		const gridItems = wrapper.findAll('.grid-stack-item')
+
+		// Right-click first item
+		const event1 = new MouseEvent('contextmenu', {
+			clientX: 100,
+			clientY: 150,
+			bubbles: true,
+			cancelable: true,
+		})
+		gridItems[0].element.dispatchEvent(event1)
+		expect(wrapper.vm.contextMenu.widget.id).toBe('placement-1')
+
+		// Right-click second item
+		const event2 = new MouseEvent('contextmenu', {
+			clientX: 200,
+			clientY: 150,
+			bubbles: true,
+			cancelable: true,
+		})
+		gridItems[1].element.dispatchEvent(event2)
+		expect(wrapper.vm.contextMenu.widget.id).toBe('placement-2')
+		expect(wrapper.vm.contextMenu.x).toBe(200)
+		expect(wrapper.vm.contextMenu.y).toBe(150)
+	})
+
+	it('closes context menu on document click outside', async () => {
+		const placements = [
+			{
+				id: 'placement-1',
+				widgetId: 'widget-1',
+				gridX: 0,
+				gridY: 0,
+				gridWidth: 4,
+				gridHeight: 4,
+			},
+		]
+		const widgets = [{ id: 'widget-1', title: 'Test Widget' }]
+
+		wrapper = mount(DashboardGrid, {
+			props: {
+				placements,
+				widgets,
+				editMode: true,
+				gridColumns: 12,
+			},
+			global: {
+				stubs: {
+					WidgetWrapper: true,
+					TileWidget: true,
+					WidgetContextMenu: true,
+				},
+			},
+		})
+
+		// Open context menu
+		const gridItem = wrapper.find('.grid-stack-item')
+		const contextMenuEvent = new MouseEvent('contextmenu', {
+			clientX: 100,
+			clientY: 150,
+			bubbles: true,
+			cancelable: true,
+		})
+		gridItem.element.dispatchEvent(contextMenuEvent)
+		expect(wrapper.vm.contextMenu.show).toBe(true)
+
+		// Simulate document click outside
+		const outsideClick = new MouseEvent('click', { bubbles: true })
+		document.dispatchEvent(outsideClick)
+
+		expect(wrapper.vm.contextMenu.show).toBe(false)
+	})
+
+	it('emits widget-edit event from context menu', async () => {
+		const placements = [
+			{
+				id: 'placement-1',
+				widgetId: 'widget-1',
+				gridX: 0,
+				gridY: 0,
+				gridWidth: 4,
+				gridHeight: 4,
+			},
+		]
+		const widgets = [{ id: 'widget-1', title: 'Test Widget' }]
+
+		wrapper = mount(DashboardGrid, {
+			props: {
+				placements,
+				widgets,
+				editMode: true,
+				gridColumns: 12,
+			},
+			global: {
+				stubs: {
+					WidgetWrapper: true,
+					TileWidget: true,
+					WidgetContextMenu: true,
+				},
+			},
+		})
+
+		wrapper.vm.onContextEdit(placements[0])
+
+		expect(wrapper.emitted('widget-edit')).toBeTruthy()
+		expect(wrapper.emitted('widget-edit')[0][0]).toEqual(placements[0])
+	})
+
+	it('emits widget-remove event from context menu', async () => {
+		const placements = [
+			{
+				id: 'placement-1',
+				widgetId: 'widget-1',
+				gridX: 0,
+				gridY: 0,
+				gridWidth: 4,
+				gridHeight: 4,
+			},
+		]
+		const widgets = [{ id: 'widget-1', title: 'Test Widget' }]
+
+		wrapper = mount(DashboardGrid, {
+			props: {
+				placements,
+				widgets,
+				editMode: true,
+				gridColumns: 12,
+			},
+			global: {
+				stubs: {
+					WidgetWrapper: true,
+					TileWidget: true,
+					WidgetContextMenu: true,
+				},
+			},
+		})
+
+		wrapper.vm.onContextRemove(placements[0])
+
+		expect(wrapper.emitted('widget-remove')).toBeTruthy()
+		expect(wrapper.emitted('widget-remove')[0][0]).toBe('placement-1')
+	})
+})

--- a/src/components/DashboardGrid.vue
+++ b/src/components/DashboardGrid.vue
@@ -16,7 +16,8 @@
 				:gs-w="placement.gridWidth"
 				:gs-h="placement.gridHeight"
 				:gs-min-w="2"
-				:gs-min-h="2">
+				:gs-min-h="2"
+				@contextmenu.prevent="onWidgetRightClick($event, placement)">
 				<div class="grid-stack-item-content">
 					<!-- Render Tile directly for tile placements. -->
 					<TileWidget
@@ -37,6 +38,16 @@
 				</div>
 			</div>
 		</div>
+
+		<!-- Widget context menu popover -->
+		<WidgetContextMenu
+			:show="contextMenu.show"
+			:x="contextMenu.x"
+			:y="contextMenu.y"
+			:widget="contextMenu.widget"
+			@edit="onContextEdit"
+			@remove="onContextRemove"
+			@close="closeContextMenu" />
 	</div>
 </template>
 
@@ -44,6 +55,7 @@
 import { GridStack } from 'gridstack'
 import WidgetWrapper from './WidgetWrapper.vue'
 import TileWidget from './TileWidget.vue'
+import WidgetContextMenu from './Widgets/WidgetContextMenu.vue'
 import { placeNewWidget } from '../utils/widgetPlacement.js'
 import { CELL_HEIGHT, GRID_MARGIN, BREAKPOINTS, COLUMN_LAYOUT } from '../constants/gridConfig.js'
 
@@ -53,6 +65,7 @@ export default {
 	components: {
 		WidgetWrapper,
 		TileWidget,
+		WidgetContextMenu,
 	},
 
 	props: {
@@ -80,6 +93,12 @@ export default {
 		return {
 			grid: null,
 			viewportRows: 8,
+			contextMenu: {
+				show: false,
+				x: 0,
+				y: 0,
+				widget: null,
+			},
 		}
 	},
 
@@ -108,6 +127,7 @@ export default {
 		this.initGrid()
 		this.computeViewportRows()
 		window.addEventListener('resize', this.computeViewportRows)
+		document.addEventListener('click', this.handleDocumentClick)
 	},
 
 	beforeDestroy() {
@@ -115,6 +135,7 @@ export default {
 			this.grid.destroy(false)
 		}
 		window.removeEventListener('resize', this.computeViewportRows)
+		document.removeEventListener('click', this.handleDocumentClick)
 	},
 
 	methods: {
@@ -246,6 +267,76 @@ export default {
 					this.grid.removeWidget(el, false)
 				}
 			}
+		},
+
+		/**
+		 * Handle right-click on a grid item (REQ-WDG-015).
+		 * Only open context menu in edit mode.
+		 *
+		 * @param {MouseEvent} event right-click event
+		 * @param {object} placement widget placement object
+		 */
+		onWidgetRightClick(event, placement) {
+			if (!this.editMode) {
+				// In view mode, let the browser native menu appear
+				return
+			}
+
+			event.preventDefault()
+
+			this.contextMenu.show = true
+			this.contextMenu.x = event.clientX
+			this.contextMenu.y = event.clientY
+			this.contextMenu.widget = placement
+		},
+
+		/**
+		 * Close the context menu (REQ-WDG-016).
+		 */
+		closeContextMenu() {
+			this.contextMenu.show = false
+			this.contextMenu.widget = null
+		},
+
+		/**
+		 * Handle context menu "Edit" click (REQ-WDG-015).
+		 * Emits widget-edit event to parent.
+		 *
+		 * @param {object} placement widget placement object
+		 */
+		onContextEdit(placement) {
+			this.$emit('widget-edit', placement)
+		},
+
+		/**
+		 * Handle context menu "Remove" click (REQ-WDG-015).
+		 * Emits widget-remove event to parent.
+		 *
+		 * @param {object} placement widget placement object
+		 */
+		onContextRemove(placement) {
+			this.$emit('widget-remove', placement.id)
+		},
+
+		/**
+		 * Document-level click handler to close context menu on outside click (REQ-WDG-016).
+		 *
+		 * @param {MouseEvent} event click event
+		 */
+		handleDocumentClick(event) {
+			if (!this.contextMenu.show) {
+				return
+			}
+
+			// Check if click is inside the context menu
+			const menu = document.querySelector('.widget-context-menu')
+			if (menu && menu.contains(event.target)) {
+				// Click is inside the menu, let the menu's handlers deal with it
+				return
+			}
+
+			// Click is outside the menu, close it
+			this.closeContextMenu()
 		},
 	},
 }

--- a/src/components/Widgets/WidgetContextMenu.vue
+++ b/src/components/Widgets/WidgetContextMenu.vue
@@ -1,0 +1,184 @@
+<!--
+  - SPDX-FileCopyrightText: 2024 MyDash Contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<template>
+	<transition name="fade">
+		<div
+			v-if="show"
+			class="widget-context-menu"
+			:style="{
+				top: clampedY + 'px',
+				left: clampedX + 'px',
+			}"
+			@click.stop>
+			<NcButton
+				type="tertiary"
+				size="small"
+				@click="handleEdit">
+				<template #icon>
+					<Pencil :size="16" />
+				</template>
+				{{ t('mydash', 'Edit') }}
+			</NcButton>
+			<NcButton
+				type="tertiary"
+				size="small"
+				@click="handleRemove">
+				<template #icon>
+					<Delete :size="16" />
+				</template>
+				{{ t('mydash', 'Remove') }}
+			</NcButton>
+			<NcButton
+				type="tertiary"
+				size="small"
+				@click="handleCancel">
+				{{ t('mydash', 'Cancel') }}
+			</NcButton>
+		</div>
+	</transition>
+</template>
+
+<script>
+import { NcButton } from '@nextcloud/vue'
+import { t } from '@nextcloud/l10n'
+import Pencil from 'vue-material-design-icons/Pencil.vue'
+import Delete from 'vue-material-design-icons/Delete.vue'
+
+export default {
+	name: 'WidgetContextMenu',
+
+	components: {
+		NcButton,
+		Pencil,
+		Delete,
+	},
+
+	props: {
+		show: {
+			type: Boolean,
+			default: false,
+		},
+		x: {
+			type: Number,
+			default: 0,
+		},
+		y: {
+			type: Number,
+			default: 0,
+		},
+		widget: {
+			type: Object,
+			default: null,
+		},
+	},
+
+	emits: ['edit', 'remove', 'close'],
+
+	data() {
+		return {
+			windowWidth: typeof window !== 'undefined' ? window.innerWidth : 0,
+			windowHeight: typeof window !== 'undefined' ? window.innerHeight : 0,
+		}
+	},
+
+	computed: {
+		clampedX() {
+			const menuWidth = 150 // min-width from CSS
+			if (this.x + menuWidth > this.windowWidth) {
+				return Math.max(0, this.windowWidth - menuWidth)
+			}
+			return this.x
+		},
+
+		clampedY() {
+			const menuHeight = 120 // Approximate height for 3 buttons
+			if (this.y + menuHeight > this.windowHeight) {
+				return Math.max(0, this.windowHeight - menuHeight)
+			}
+			return this.y
+		},
+	},
+
+	watch: {
+		show(newVal) {
+			if (newVal) {
+				this.updateViewportSize()
+			}
+		},
+	},
+
+	mounted() {
+		window.addEventListener('resize', this.updateViewportSize)
+	},
+
+	beforeDestroy() {
+		window.removeEventListener('resize', this.updateViewportSize)
+	},
+
+	methods: {
+		t,
+
+		updateViewportSize() {
+			this.windowWidth = window.innerWidth
+			this.windowHeight = window.innerHeight
+		},
+
+		handleEdit() {
+			this.$emit('edit', this.widget)
+			this.$emit('close')
+		},
+
+		handleRemove() {
+			this.$emit('remove', this.widget)
+			this.$emit('close')
+		},
+
+		handleCancel() {
+			this.$emit('close')
+		},
+	},
+}
+</script>
+
+<style scoped>
+.widget-context-menu {
+	position: fixed;
+	background: var(--color-main-background);
+	border: 1px solid var(--color-border);
+	border-radius: var(--border-radius-large);
+	box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+	z-index: 10000;
+	min-width: 150px;
+	display: flex;
+	flex-direction: column;
+	overflow: hidden;
+}
+
+.widget-context-menu :deep(.nc-button) {
+	justify-content: flex-start;
+	padding: 8px 12px;
+	border-radius: 0;
+	border-bottom: 1px solid var(--color-border);
+}
+
+.widget-context-menu :deep(.nc-button:last-child) {
+	border-bottom: none;
+}
+
+.widget-context-menu :deep(.nc-button:hover) {
+	background: var(--color-background-hover);
+}
+
+.fade-enter-active,
+.fade-leave-active {
+	transition: opacity 0.15s ease;
+}
+
+.fade-enter,
+.fade-leave-to {
+	opacity: 0;
+}
+</style>

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -22,4 +22,7 @@ module.exports = defineConfig({
 			'@': path.resolve(__dirname, 'src'),
 		},
 	},
+	ssr: {
+		external: ['@nextcloud/vue'],
+	},
 })


### PR DESCRIPTION
Implements widget context menu (REQ-WDG-015..017) per spec on development.

**Features:**
- Right-click in edit mode opens popover with Edit/Remove/Cancel
- View mode shows native browser menu
- Auto-closes on outside click, switches on different widget
- Position clamped to viewport edges

**Files:**
- WidgetContextMenu.vue (new): Vue 2 SFC, Pencil/Delete icons
- DashboardGrid.vue: @contextmenu.prevent, document listener
- Translations: Added "Remove" key
- Tests: 18 Vitest units

**Quality:** ESLint pass, Stylelint pass, 71 tests pass