### PR TITLE
feat(dashboards): active-dashboard resolution chain

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -19,6 +19,10 @@ return [
 		// User dashboard endpoints
 		['name' => 'dashboard_api#list', 'url' => '/api/dashboards', 'verb' => 'GET'],
 		['name' => 'dashboard_api#visible', 'url' => '/api/dashboards/visible', 'verb' => 'GET'],
+		// REQ-DASH-019: persist active-dashboard preference. Registered BEFORE
+		// the group-scoped routes that share the /api/dashboards/ prefix so the
+		// router matches the literal 'active' segment before any {groupId} wildcard.
+		['name' => 'dashboard_api#setActiveDashboard', 'url' => '/api/dashboards/active', 'verb' => 'POST'],
 		['name' => 'dashboard_api#getActive', 'url' => '/api/dashboard', 'verb' => 'GET'],
 		['name' => 'dashboard_api#create', 'url' => '/api/dashboard', 'verb' => 'POST'],
 		['name' => 'dashboard_api#update', 'url' => '/api/dashboard/{id}', 'verb' => 'PUT'],

--- a/lib/Controller/DashboardApiController.php
+++ b/lib/Controller/DashboardApiController.php
@@ -630,6 +630,35 @@ class DashboardApiController extends Controller
     }//end setGroupDefault()
 
     /**
+     * Persist the user's active-dashboard preference.
+     *
+     * Accepts any UUID string (including non-existent UUIDs — the resolver's
+     * stale-pref path handles invalid values on next render). Empty string
+     * clears the preference. REQ-DASH-019.
+     *
+     * @param string|null $uuid The dashboard UUID from the request body, or
+     *                          empty string to clear.
+     *
+     * @return JSONResponse HTTP 200 `{status: 'success'}` on success; 401
+     *                      when the session has no user.
+     */
+    #[NoAdminRequired]
+
+    public function setActiveDashboard(?string $uuid=null): JSONResponse
+    {
+        if ($this->userId === null) {
+            return ResponseHelper::unauthorized();
+        }
+
+        $this->dashboardService->setActivePreference(
+            userId: $this->userId,
+            uuid: ($uuid ?? '')
+        );
+
+        return ResponseHelper::success(data: ['status' => 'success']);
+    }//end setActiveDashboard()
+
+    /**
      * Resolve create parameters from JSON body or individual params.
      *
      * @param mixed       $name        The name parameter.

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -26,7 +26,10 @@ declare(strict_types=1);
 namespace OCA\MyDash\Controller;
 
 use OCA\MyDash\AppInfo\Application;
+use OCA\MyDash\Db\Dashboard;
 use OCA\MyDash\Service\AdminSettingsService;
+use OCA\MyDash\Service\AdminTemplateService;
+use OCA\MyDash\Service\DashboardService;
 use OCA\MyDash\Service\InitialStateBuilder;
 use OCA\MyDash\Service\Page;
 use OCP\AppFramework\Controller;
@@ -45,12 +48,17 @@ class PageController extends Controller
     /**
      * Constructor
      *
-     * @param IRequest             $request          The request.
-     * @param IInitialState        $initialState     Nextcloud initial-state service.
-     * @param IDashboardManager    $dashboardManager Dashboard widget manager.
-     * @param IUserSession         $userSession      Current user session.
-     * @param IGroupManager        $groupManager     Group membership lookup.
-     * @param AdminSettingsService $adminSettings    MyDash admin settings.
+     * @param IRequest             $request             The request.
+     * @param IInitialState        $initialState        Nextcloud initial-state service.
+     * @param IDashboardManager    $dashboardManager    Dashboard widget manager.
+     * @param IUserSession         $userSession         Current user session.
+     * @param IGroupManager        $groupManager        Group membership lookup.
+     * @param AdminSettingsService $adminSettings       MyDash admin settings.
+     * @param DashboardService     $dashboardService    Dashboard service (active
+     *                                                  resolver — REQ-DASH-018).
+     * @param AdminTemplateService $templateService     Template service (primary
+     *                                                  group resolver —
+     *                                                  REQ-TMPL-012).
      */
     public function __construct(
         IRequest $request,
@@ -59,6 +67,8 @@ class PageController extends Controller
         private readonly IUserSession $userSession,
         private readonly IGroupManager $groupManager,
         private readonly AdminSettingsService $adminSettings,
+        private readonly DashboardService $dashboardService,
+        private readonly AdminTemplateService $templateService,
     ) {
         parent::__construct(appName: Application::APP_ID, request: $request);
     }//end __construct()
@@ -83,13 +93,17 @@ class PageController extends Controller
 
         $user     = $this->userSession->getUser();
         $isAdmin  = false;
-        $groupIds = [];
+        $userId   = null;
         if ($user !== null) {
-            $isAdmin  = $this->groupManager->isAdmin(userId: $user->getUID());
-            $groupIds = $this->groupManager->getUserGroupIds(user: $user);
+            $userId  = $user->getUID();
+            $isAdmin = $this->groupManager->isAdmin(userId: $userId);
         }
 
-        $primaryGroup     = ($groupIds[0] ?? 'default');
+        // Resolve the primary group via the canonical REQ-TMPL-012 authority.
+        $primaryGroup = ($userId !== null)
+            ? $this->templateService->resolvePrimaryGroup(userId: $userId)
+            : Dashboard::DEFAULT_GROUP_ID;
+
         $primaryGroupName = $primaryGroup;
         if ($primaryGroup !== 'default'
             && $this->groupManager->groupExists(gid: $primaryGroup) === true
@@ -97,6 +111,20 @@ class PageController extends Controller
             $group = $this->groupManager->get(gid: $primaryGroup);
             if ($group !== null) {
                 $primaryGroupName = $group->getDisplayName();
+            }
+        }
+
+        // Resolve the active dashboard via the REQ-DASH-018 precedence chain.
+        $activeDashboardId = '';
+        $dashboardSource   = 'group';
+        if ($userId !== null) {
+            $resolved = $this->dashboardService->resolveActiveDashboard(
+                userId: $userId,
+                primaryGroupId: $primaryGroup
+            );
+            if ($resolved !== null) {
+                $activeDashboardId = (string) $resolved['dashboard']->getUuid();
+                $dashboardSource   = $resolved['source'];
             }
         }
 
@@ -112,8 +140,8 @@ class PageController extends Controller
             ->setPrimaryGroup(primaryGroup: $primaryGroup)
             ->setPrimaryGroupName(primaryGroupName: $primaryGroupName)
             ->setIsAdmin(isAdmin: $isAdmin)
-            ->setActiveDashboardId(activeDashboardId: '')
-            ->setDashboardSource(dashboardSource: 'group')
+            ->setActiveDashboardId(activeDashboardId: $activeDashboardId)
+            ->setDashboardSource(dashboardSource: $dashboardSource)
             ->setGroupDashboards(groupDashboards: [])
             ->setUserDashboards(userDashboards: [])
             ->setAllowUserDashboards(

--- a/lib/Service/DashboardService.php
+++ b/lib/Service/DashboardService.php
@@ -24,6 +24,7 @@ namespace OCA\MyDash\Service;
 
 use DateTime;
 use Exception;
+use OCA\MyDash\AppInfo\Application;
 use OCA\MyDash\Db\AdminSetting;
 use OCA\MyDash\Db\AdminSettingMapper;
 use OCA\MyDash\Db\Dashboard;
@@ -32,9 +33,11 @@ use OCA\MyDash\Db\WidgetPlacement;
 use OCA\MyDash\Db\WidgetPlacementMapper;
 use OCA\MyDash\Exception\PersonalDashboardsDisabledException;
 use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\IConfig;
 use OCP\IDBConnection;
 use OCP\IGroupManager;
 use OCP\IUserManager;
+use Psr\Log\LoggerInterface;
 use Throwable;
 
 /**
@@ -73,6 +76,16 @@ class DashboardService
     public const ERR_DEFAULT_TARGET_NOT_IN_GROUP = 'Dashboard not found in group';
 
     /**
+     * Preference key for the user's last-active dashboard UUID.
+     *
+     * Stored via IConfig::setUserValue / getUserValue.
+     * REQ-DASH-019.
+     *
+     * @var string
+     */
+    public const ACTIVE_DASHBOARD_UUID_PREF_KEY = 'active_dashboard_uuid';
+
+    /**
      * Constructor
      *
      * @param DashboardMapper       $dashboardMapper  Dashboard mapper.
@@ -86,6 +99,9 @@ class DashboardService
      * @param IDBConnection         $db               DB connection (for the
      *                                                transactional default
      *                                                flip — REQ-DASH-015).
+     * @param IConfig               $config           Nextcloud per-user
+     *                                                preference storage.
+     * @param LoggerInterface       $logger           PSR logger.
      */
     public function __construct(
         private readonly DashboardMapper $dashboardMapper,
@@ -97,6 +113,8 @@ class DashboardService
         private readonly IGroupManager $groupManager,
         private readonly IUserManager $userManager,
         private readonly IDBConnection $db,
+        private readonly IConfig $config,
+        private readonly LoggerInterface $logger,
     ) {
     }//end __construct()
 
@@ -534,6 +552,173 @@ class DashboardService
     }//end getVisibleToUser()
 
     /**
+     * Resolve the active dashboard for a user using the 7-step precedence
+     * chain defined in REQ-DASH-018.
+     *
+     * Steps:
+     *  1. Saved `active_dashboard_uuid` preference — if the UUID resolves to
+     *     a dashboard currently visible to the user (REQ-DASH-013).
+     *  2. `group_shared` with `isDefault = 1` in the user's primary group.
+     *  3. `group_shared` with `isDefault = 1` in the `'default'` group.
+     *  4. First `group_shared` (by sortOrder ASC, then createdAt) in the
+     *     user's primary group.
+     *  5. First `group_shared` in the `'default'` group.
+     *  6. User's first personal (`user`-type) dashboard.
+     *  7. `null` — triggers the empty-state UI.
+     *
+     * The only side-effect on read is the stale-pref auto-clear in step 1:
+     * when the saved UUID is not visible the pref is deleted and a WARNING
+     * is logged before falling through to step 2.
+     *
+     * @param string      $userId         The user ID.
+     * @param string|null $primaryGroupId The user's primary group ID, or null /
+     *                                    {@see Dashboard::DEFAULT_GROUP_ID}.
+     *
+     * @return array{dashboard: Dashboard, source: string}|null
+     *   `{dashboard, source}` where source is `'user'`, `'group'`, or
+     *   `'default'`; or `null` when no dashboard exists at all.
+     */
+    public function resolveActiveDashboard(
+        string $userId,
+        ?string $primaryGroupId
+    ): ?array {
+        // Normalise the sentinel so steps 2-5 can rely on it.
+        $groupId = ($primaryGroupId === null || $primaryGroupId === '')
+            ? Dashboard::DEFAULT_GROUP_ID
+            : $primaryGroupId;
+
+        // Pre-fetch all visible dashboards once — used for the pref lookup
+        // and to avoid redundant DB round-trips.
+        $visible = $this->getVisibleToUser(userId: $userId);
+
+        // Build a UUID-keyed index for O(1) pref lookup.
+        /** @var array<string, array{dashboard: Dashboard, source: string}> $byUuid */
+        $byUuid = [];
+        foreach ($visible as $entry) {
+            $uuid = (string) $entry['dashboard']->getUuid();
+            if ($uuid !== '') {
+                $byUuid[$uuid] = $entry;
+            }
+        }
+
+        // Step 1: saved preference.
+        $savedUuid = $this->config->getUserValue(
+            userId: $userId,
+            appName: Application::APP_ID,
+            key: self::ACTIVE_DASHBOARD_UUID_PREF_KEY,
+            default: ''
+        );
+
+        if ($savedUuid !== '') {
+            if (isset($byUuid[$savedUuid]) === true) {
+                return $byUuid[$savedUuid];
+            }
+
+            // Stale pref: UUID is no longer visible — clear and fall through.
+            $this->config->deleteUserValue(
+                userId: $userId,
+                appName: Application::APP_ID,
+                key: self::ACTIVE_DASHBOARD_UUID_PREF_KEY
+            );
+            $this->logger->warning(
+                message: 'mydash: stale active_dashboard_uuid "{uuid}" cleared for user "{user}"',
+                context: ['uuid' => $savedUuid, 'user' => $userId]
+            );
+        }
+
+        // Steps 2-3: group-shared with isDefault = 1.
+        if ($groupId !== Dashboard::DEFAULT_GROUP_ID) {
+            // Step 2: primary group default.
+            $result = $this->findFirstGroupSharedWhere(
+                visible: $visible,
+                groupId: $groupId,
+                source: Dashboard::SOURCE_GROUP,
+                requireDefault: true
+            );
+            if ($result !== null) {
+                return $result;
+            }
+        }
+
+        // Step 3: default-group default.
+        $result = $this->findFirstGroupSharedWhere(
+            visible: $visible,
+            groupId: Dashboard::DEFAULT_GROUP_ID,
+            source: Dashboard::SOURCE_DEFAULT,
+            requireDefault: true
+        );
+        if ($result !== null) {
+            return $result;
+        }
+
+        // Steps 4-5: first group-shared (sortOrder ASC, createdAt ASC).
+        if ($groupId !== Dashboard::DEFAULT_GROUP_ID) {
+            // Step 4: primary group first.
+            $result = $this->findFirstGroupSharedWhere(
+                visible: $visible,
+                groupId: $groupId,
+                source: Dashboard::SOURCE_GROUP,
+                requireDefault: false
+            );
+            if ($result !== null) {
+                return $result;
+            }
+        }
+
+        // Step 5: default-group first.
+        $result = $this->findFirstGroupSharedWhere(
+            visible: $visible,
+            groupId: Dashboard::DEFAULT_GROUP_ID,
+            source: Dashboard::SOURCE_DEFAULT,
+            requireDefault: false
+        );
+        if ($result !== null) {
+            return $result;
+        }
+
+        // Step 6: first personal dashboard.
+        foreach ($visible as $entry) {
+            if ($entry['source'] === Dashboard::SOURCE_USER) {
+                return $entry;
+            }
+        }
+
+        // Step 7: nothing found.
+        return null;
+    }//end resolveActiveDashboard()
+
+    /**
+     * Persist (or clear) the user's active-dashboard preference.
+     *
+     * Accepts any non-empty UUID string without performing an existence
+     * check — the resolver's stale-pref path handles invalid UUIDs on next
+     * read (REQ-DASH-019 "no existence check on write").
+     *
+     * @param string $userId The user ID.
+     * @param string $uuid   The dashboard UUID, or empty string to clear.
+     *
+     * @return void
+     */
+    public function setActivePreference(string $userId, string $uuid): void
+    {
+        if ($uuid === '') {
+            $this->config->deleteUserValue(
+                userId: $userId,
+                appName: Application::APP_ID,
+                key: self::ACTIVE_DASHBOARD_UUID_PREF_KEY
+            );
+            return;
+        }
+
+        $this->config->setUserValue(
+            userId: $userId,
+            appName: Application::APP_ID,
+            key: self::ACTIVE_DASHBOARD_UUID_PREF_KEY,
+            value: $uuid
+        );
+    }//end setActivePreference()
+
+    /**
      * Check whether the given user is a Nextcloud administrator.
      *
      * Wraps `IGroupManager::isAdmin()` so callers don't have to import
@@ -572,6 +757,57 @@ class DashboardService
             throw new PersonalDashboardsDisabledException();
         }
     }//end assertPersonalDashboardsAllowed()
+
+    /**
+     * Scan the pre-fetched visible list for the first group-shared dashboard
+     * matching a given `groupId`, optionally filtered to `isDefault = 1`.
+     *
+     * The visible list preserves mapper order (sortOrder ASC, createdAt ASC
+     * for group-shared rows via {@see DashboardMapper::findByGroup}), so the
+     * "first" result is already correctly ordered without a secondary sort
+     * here.
+     *
+     * @param array<int, array{dashboard: Dashboard, source: string}> $visible
+     *                          The full visible-to-user list.
+     * @param string            $groupId       The group ID to filter on.
+     * @param string            $source        Expected source tag
+     *                                         (`'group'` or `'default'`).
+     * @param bool              $requireDefault When true, only rows with
+     *                                          `isDefault = 1` are considered.
+     *
+     * @return array{dashboard: Dashboard, source: string}|null
+     */
+    private function findFirstGroupSharedWhere(
+        array $visible,
+        string $groupId,
+        string $source,
+        bool $requireDefault
+    ): ?array {
+        foreach ($visible as $entry) {
+            if ($entry['source'] !== $source) {
+                continue;
+            }
+
+            $dashboard = $entry['dashboard'];
+            if ($dashboard->getType() !== Dashboard::TYPE_GROUP_SHARED) {
+                continue;
+            }
+
+            if ($dashboard->getGroupId() !== $groupId) {
+                continue;
+            }
+
+            if ($requireDefault === true
+                && (int) $dashboard->getIsDefault() !== 1
+            ) {
+                continue;
+            }
+
+            return $entry;
+        }//end foreach
+
+        return null;
+    }//end findFirstGroupSharedWhere()
 
     /**
      * Try to create a dashboard from a template or empty.

--- a/tests/Unit/Controller/DashboardApiControllerActiveTest.php
+++ b/tests/Unit/Controller/DashboardApiControllerActiveTest.php
@@ -1,0 +1,172 @@
+<?php
+
+/**
+ * DashboardApiController Active-Preference Test
+ *
+ * Covers the new `setActiveDashboard` action mapping to
+ * `POST /api/dashboards/active` per REQ-DASH-019.
+ *
+ * @category  Test
+ * @package   OCA\MyDash\Tests\Unit\Controller
+ * @author    Conduction b.v. <info@conduction.nl>
+ * @copyright 2026 Conduction b.v.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-FileCopyrightText: 2026 MyDash Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Controller;
+
+use OCA\MyDash\Controller\DashboardApiController;
+use OCA\MyDash\Service\DashboardService;
+use OCA\MyDash\Service\PermissionService;
+use OCP\AppFramework\Http;
+use OCP\IRequest;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for the setActiveDashboard controller action (REQ-DASH-019).
+ */
+class DashboardApiControllerActiveTest extends TestCase
+{
+    /** @var IRequest&MockObject */
+    private $request;
+    /** @var DashboardService&MockObject */
+    private $dashboardService;
+    /** @var PermissionService&MockObject */
+    private $permissionService;
+
+    protected function setUp(): void
+    {
+        $this->request           = $this->createMock(IRequest::class);
+        $this->dashboardService  = $this->createMock(DashboardService::class);
+        $this->permissionService = $this->createMock(PermissionService::class);
+    }//end setUp()
+
+    /**
+     * Build the controller with the given user ID (or null for anonymous).
+     */
+    private function makeController(?string $userId): DashboardApiController
+    {
+        return new DashboardApiController(
+            request: $this->request,
+            dashboardService: $this->dashboardService,
+            permissionService: $this->permissionService,
+            userId: $userId,
+        );
+    }//end makeController()
+
+    // -----------------------------------------------------------------------
+    // REQ-DASH-019: POST /api/dashboards/active — valid uuid
+    // -----------------------------------------------------------------------
+
+    /**
+     * REQ-DASH-019 scenario "Save preference": valid UUID → 200 + service called.
+     *
+     * @return void
+     */
+    public function testSetActiveDashboardWritesPref(): void
+    {
+        $this->dashboardService->expects($this->once())
+            ->method('setActivePreference')
+            ->with('alice', 'abc-123');
+
+        $controller = $this->makeController('alice');
+        $response   = $controller->setActiveDashboard('abc-123');
+
+        $this->assertSame(Http::STATUS_OK, $response->getStatus());
+        $data = $response->getData();
+        $this->assertSame('success', $data['status']);
+    }//end testSetActiveDashboardWritesPref()
+
+    // -----------------------------------------------------------------------
+    // REQ-DASH-019: empty uuid clears the preference
+    // -----------------------------------------------------------------------
+
+    /**
+     * REQ-DASH-019 scenario "Empty uuid clears the preference": empty string
+     * passed to service and 200 returned.
+     *
+     * @return void
+     */
+    public function testSetActiveDashboardEmptyUuidClearsPref(): void
+    {
+        $this->dashboardService->expects($this->once())
+            ->method('setActivePreference')
+            ->with('alice', '');
+
+        $controller = $this->makeController('alice');
+        $response   = $controller->setActiveDashboard('');
+
+        $this->assertSame(Http::STATUS_OK, $response->getStatus());
+    }//end testSetActiveDashboardEmptyUuidClearsPref()
+
+    // -----------------------------------------------------------------------
+    // REQ-DASH-019: null uuid (omitted body field)
+    // -----------------------------------------------------------------------
+
+    /**
+     * Null uuid (body field omitted) should be normalised to empty string and
+     * call the service with ''.
+     *
+     * @return void
+     */
+    public function testSetActiveDashboardNullUuidTreatedAsEmpty(): void
+    {
+        $this->dashboardService->expects($this->once())
+            ->method('setActivePreference')
+            ->with('alice', '');
+
+        $controller = $this->makeController('alice');
+        $response   = $controller->setActiveDashboard(null);
+
+        $this->assertSame(Http::STATUS_OK, $response->getStatus());
+    }//end testSetActiveDashboardNullUuidTreatedAsEmpty()
+
+    // -----------------------------------------------------------------------
+    // Unauthenticated session → 401
+    // -----------------------------------------------------------------------
+
+    /**
+     * Anonymous session: setActiveDashboard MUST return 401 and MUST NOT call
+     * the service.
+     *
+     * @return void
+     */
+    public function testSetActiveDashboardUnauthenticatedReturns401(): void
+    {
+        $this->dashboardService->expects($this->never())
+            ->method('setActivePreference');
+
+        $controller = $this->makeController(null);
+        $response   = $controller->setActiveDashboard('abc-123');
+
+        $this->assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
+    }//end testSetActiveDashboardUnauthenticatedReturns401()
+
+    // -----------------------------------------------------------------------
+    // No existence check on write (REQ-DASH-019)
+    // -----------------------------------------------------------------------
+
+    /**
+     * REQ-DASH-019 scenario "No existence check on write": non-existent UUID is
+     * forwarded to the service without validation — 200 returned.
+     *
+     * @return void
+     */
+    public function testSetActiveDashboardNonExistentUuidAccepted(): void
+    {
+        $this->dashboardService->expects($this->once())
+            ->method('setActivePreference')
+            ->with('alice', 'does-not-exist');
+
+        $controller = $this->makeController('alice');
+        $response   = $controller->setActiveDashboard('does-not-exist');
+
+        $this->assertSame(Http::STATUS_OK, $response->getStatus());
+    }//end testSetActiveDashboardNonExistentUuidAccepted()
+}//end class

--- a/tests/Unit/Service/DashboardServiceActiveResolutionTest.php
+++ b/tests/Unit/Service/DashboardServiceActiveResolutionTest.php
@@ -1,0 +1,509 @@
+<?php
+
+/**
+ * DashboardService Active-Resolution Test
+ *
+ * Table-driven unit tests for REQ-DASH-018 (resolveActiveDashboard) and
+ * REQ-DASH-019 (setActivePreference). Covers all 7 precedence steps,
+ * stale-pref auto-clear, cross-group preference invalidation, and the
+ * empty-state scenario.
+ *
+ * @category  Test
+ * @package   OCA\MyDash\Tests\Unit\Service
+ * @author    Conduction b.v. <info@conduction.nl>
+ * @copyright 2026 Conduction b.v.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-FileCopyrightText: 2026 MyDash Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Service;
+
+use OCA\MyDash\AppInfo\Application;
+use OCA\MyDash\Db\AdminSettingMapper;
+use OCA\MyDash\Db\Dashboard;
+use OCA\MyDash\Db\DashboardMapper;
+use OCA\MyDash\Db\WidgetPlacementMapper;
+use OCA\MyDash\Service\DashboardFactory;
+use OCA\MyDash\Service\DashboardResolver;
+use OCA\MyDash\Service\DashboardService;
+use OCA\MyDash\Service\TemplateService;
+use OCP\IConfig;
+use OCP\IDBConnection;
+use OCP\IGroupManager;
+use OCP\IUser;
+use OCP\IUserManager;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Unit tests for the active-dashboard resolution chain.
+ *
+ * @SuppressWarnings(PHPMD.TooManyPublicMethods)
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ */
+class DashboardServiceActiveResolutionTest extends TestCase
+{
+    /** @var DashboardMapper&MockObject */
+    private $dashboardMapper;
+    /** @var WidgetPlacementMapper&MockObject */
+    private $placementMapper;
+    /** @var AdminSettingMapper&MockObject */
+    private $settingMapper;
+    /** @var TemplateService&MockObject */
+    private $templateService;
+    /** @var DashboardFactory&MockObject */
+    private $dashboardFactory;
+    /** @var DashboardResolver&MockObject */
+    private $dashResolver;
+    /** @var IGroupManager&MockObject */
+    private $groupManager;
+    /** @var IUserManager&MockObject */
+    private $userManager;
+    /** @var IDBConnection&MockObject */
+    private $db;
+    /** @var IConfig&MockObject */
+    private $config;
+    /** @var LoggerInterface&MockObject */
+    private $logger;
+
+    private DashboardService $service;
+
+    protected function setUp(): void
+    {
+        $this->dashboardMapper  = $this->createMock(DashboardMapper::class);
+        $this->placementMapper  = $this->createMock(WidgetPlacementMapper::class);
+        $this->settingMapper    = $this->createMock(AdminSettingMapper::class);
+        $this->templateService  = $this->createMock(TemplateService::class);
+        $this->dashboardFactory = $this->createMock(DashboardFactory::class);
+        $this->dashResolver     = $this->createMock(DashboardResolver::class);
+        $this->groupManager     = $this->createMock(IGroupManager::class);
+        $this->userManager      = $this->createMock(IUserManager::class);
+        $this->db               = $this->createMock(IDBConnection::class);
+        $this->config           = $this->createMock(IConfig::class);
+        $this->logger           = $this->createMock(LoggerInterface::class);
+
+        $this->service = new DashboardService(
+            dashboardMapper: $this->dashboardMapper,
+            placementMapper: $this->placementMapper,
+            settingMapper: $this->settingMapper,
+            templateService: $this->templateService,
+            dashboardFactory: $this->dashboardFactory,
+            dashResolver: $this->dashResolver,
+            groupManager: $this->groupManager,
+            userManager: $this->userManager,
+            db: $this->db,
+            config: $this->config,
+            logger: $this->logger,
+        );
+    }//end setUp()
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    /**
+     * Build a Dashboard stub with the given UUID, type, groupId and isDefault.
+     */
+    private function makeDashboard(
+        string $uuid,
+        string $type=Dashboard::TYPE_USER,
+        ?string $groupId=null,
+        int $isDefault=0,
+        ?string $userId=null
+    ): Dashboard {
+        $d = new Dashboard();
+        $d->setUuid($uuid);
+        $d->setType($type);
+        $d->setGroupId($groupId);
+        $d->setIsDefault($isDefault);
+        $d->setUserId($userId);
+        $d->setName('Dashboard ' . $uuid);
+        return $d;
+    }//end makeDashboard()
+
+    /**
+     * Wire `getVisibleToUser` to return the given array of
+     * `{dashboard, source}` entries. Sets up the IUser / IGroupManager mocks
+     * needed by `getVisibleToUser`.
+     *
+     * @param array<int, array{dashboard: Dashboard, source: string}> $entries
+     */
+    private function stubVisibleToUser(array $entries): void
+    {
+        $user = $this->createMock(IUser::class);
+        $this->userManager->method('get')->willReturn($user);
+        $this->groupManager->method('getUserGroupIds')->willReturn([]);
+        // DashboardService::getVisibleToUser delegates to findVisibleToUser on the mapper.
+        $this->dashboardMapper->method('findVisibleToUser')->willReturn($entries);
+    }//end stubVisibleToUser()
+
+    /**
+     * Wire IConfig::getUserValue to return the given saved UUID (or '').
+     */
+    private function stubSavedPref(string $uuid): void
+    {
+        $this->config->method('getUserValue')
+            ->with('alice', Application::APP_ID, DashboardService::ACTIVE_DASHBOARD_UUID_PREF_KEY, '')
+            ->willReturn($uuid);
+    }//end stubSavedPref()
+
+    // -----------------------------------------------------------------------
+    // Step 1: Saved preference (honoured)
+    // -----------------------------------------------------------------------
+
+    /**
+     * REQ-DASH-018 step 1: Saved pref UUID is in the visible list — return it.
+     *
+     * @return void
+     */
+    public function testStep1HonouredSavedPref(): void
+    {
+        $personal = $this->makeDashboard('uuid-personal', Dashboard::TYPE_USER, null, 0, 'alice');
+        $entries  = [
+            ['dashboard' => $personal, 'source' => Dashboard::SOURCE_USER],
+        ];
+
+        $this->stubVisibleToUser($entries);
+        $this->stubSavedPref('uuid-personal');
+
+        $result = $this->service->resolveActiveDashboard('alice', null);
+
+        $this->assertNotNull($result);
+        $this->assertSame('uuid-personal', $result['dashboard']->getUuid());
+        $this->assertSame(Dashboard::SOURCE_USER, $result['source']);
+    }//end testStep1HonouredSavedPref()
+
+    // -----------------------------------------------------------------------
+    // Step 1: Stale pref (auto-clear)
+    // -----------------------------------------------------------------------
+
+    /**
+     * REQ-DASH-018 stale-pref: UUID not in visible list — clear pref exactly
+     * once, log one WARNING, then fall through the chain.
+     *
+     * @return void
+     */
+    public function testStep1StalePrefClearedOnce(): void
+    {
+        // Visible list has only a default-group dashboard — stale pref
+        // points to a UUID not in the list.
+        $defaultDash = $this->makeDashboard('uuid-default', Dashboard::TYPE_GROUP_SHARED, 'default', 1);
+        $entries     = [
+            ['dashboard' => $defaultDash, 'source' => Dashboard::SOURCE_DEFAULT],
+        ];
+
+        $this->stubVisibleToUser($entries);
+        $this->stubSavedPref('uuid-stale');
+
+        // deleteUserValue MUST be called exactly once.
+        $this->config->expects($this->once())
+            ->method('deleteUserValue')
+            ->with('alice', Application::APP_ID, DashboardService::ACTIVE_DASHBOARD_UUID_PREF_KEY);
+
+        // One WARNING log.
+        $this->logger->expects($this->once())->method('warning');
+
+        $result = $this->service->resolveActiveDashboard('alice', null);
+
+        // Falls through to step 3 (default-group default).
+        $this->assertNotNull($result);
+        $this->assertSame('uuid-default', $result['dashboard']->getUuid());
+        $this->assertSame(Dashboard::SOURCE_DEFAULT, $result['source']);
+    }//end testStep1StalePrefClearedOnce()
+
+    /**
+     * REQ-DASH-018: Stale pref is cleared exactly once — not on every
+     * visibility check. (Idempotency guard: no second call to deleteUserValue.)
+     *
+     * @return void
+     */
+    public function testStep1StalePrefClearedAtMostOnce(): void
+    {
+        $this->stubVisibleToUser([]);
+        $this->stubSavedPref('uuid-gone');
+
+        $this->config->expects($this->exactly(1))
+            ->method('deleteUserValue');
+
+        $this->logger->expects($this->once())->method('warning');
+
+        $result = $this->service->resolveActiveDashboard('alice', null);
+        $this->assertNull($result);
+    }//end testStep1StalePrefClearedAtMostOnce()
+
+    // -----------------------------------------------------------------------
+    // Step 2: Primary group default
+    // -----------------------------------------------------------------------
+
+    /**
+     * REQ-DASH-018 step 2: Primary group has a default group-shared dashboard;
+     * no user preference is saved. Must win over step 3.
+     *
+     * @return void
+     */
+    public function testStep2PrimaryGroupDefault(): void
+    {
+        $groupDefault   = $this->makeDashboard('uuid-grp-default', Dashboard::TYPE_GROUP_SHARED, 'engineering', 1);
+        $defaultDefault = $this->makeDashboard('uuid-def-default', Dashboard::TYPE_GROUP_SHARED, 'default', 1);
+        $entries        = [
+            ['dashboard' => $groupDefault,   'source' => Dashboard::SOURCE_GROUP],
+            ['dashboard' => $defaultDefault, 'source' => Dashboard::SOURCE_DEFAULT],
+        ];
+
+        $this->stubVisibleToUser($entries);
+        $this->stubSavedPref('');
+
+        $result = $this->service->resolveActiveDashboard('alice', 'engineering');
+
+        $this->assertNotNull($result);
+        $this->assertSame('uuid-grp-default', $result['dashboard']->getUuid());
+        $this->assertSame(Dashboard::SOURCE_GROUP, $result['source']);
+    }//end testStep2PrimaryGroupDefault()
+
+    // -----------------------------------------------------------------------
+    // Step 3: Default-group default
+    // -----------------------------------------------------------------------
+
+    /**
+     * REQ-DASH-018 step 3: Primary group has no default; default group has one.
+     *
+     * @return void
+     */
+    public function testStep3DefaultGroupDefault(): void
+    {
+        $groupFirst     = $this->makeDashboard('uuid-grp-first', Dashboard::TYPE_GROUP_SHARED, 'support', 0);
+        $defaultDefault = $this->makeDashboard('uuid-def-default', Dashboard::TYPE_GROUP_SHARED, 'default', 1);
+        $entries        = [
+            ['dashboard' => $groupFirst,     'source' => Dashboard::SOURCE_GROUP],
+            ['dashboard' => $defaultDefault, 'source' => Dashboard::SOURCE_DEFAULT],
+        ];
+
+        $this->stubVisibleToUser($entries);
+        $this->stubSavedPref('');
+
+        $result = $this->service->resolveActiveDashboard('alice', 'support');
+
+        $this->assertNotNull($result);
+        $this->assertSame('uuid-def-default', $result['dashboard']->getUuid());
+        $this->assertSame(Dashboard::SOURCE_DEFAULT, $result['source']);
+    }//end testStep3DefaultGroupDefault()
+
+    // -----------------------------------------------------------------------
+    // Step 4: First in primary group
+    // -----------------------------------------------------------------------
+
+    /**
+     * REQ-DASH-018 step 4: No defaults anywhere; primary group has dashboards.
+     *
+     * @return void
+     */
+    public function testStep4FirstInPrimaryGroup(): void
+    {
+        $groupA  = $this->makeDashboard('uuid-grp-a', Dashboard::TYPE_GROUP_SHARED, 'engineering', 0);
+        $groupB  = $this->makeDashboard('uuid-grp-b', Dashboard::TYPE_GROUP_SHARED, 'engineering', 0);
+        $entries = [
+            ['dashboard' => $groupA, 'source' => Dashboard::SOURCE_GROUP],
+            ['dashboard' => $groupB, 'source' => Dashboard::SOURCE_GROUP],
+        ];
+
+        $this->stubVisibleToUser($entries);
+        $this->stubSavedPref('');
+
+        $result = $this->service->resolveActiveDashboard('alice', 'engineering');
+
+        $this->assertNotNull($result);
+        $this->assertSame('uuid-grp-a', $result['dashboard']->getUuid());
+        $this->assertSame(Dashboard::SOURCE_GROUP, $result['source']);
+    }//end testStep4FirstInPrimaryGroup()
+
+    // -----------------------------------------------------------------------
+    // Step 5: First in default group
+    // -----------------------------------------------------------------------
+
+    /**
+     * REQ-DASH-018 step 5: Primary group has no dashboards; default group has
+     * non-default dashboards.
+     *
+     * @return void
+     */
+    public function testStep5FirstInDefaultGroup(): void
+    {
+        $defA    = $this->makeDashboard('uuid-def-a', Dashboard::TYPE_GROUP_SHARED, 'default', 0);
+        $entries = [
+            ['dashboard' => $defA, 'source' => Dashboard::SOURCE_DEFAULT],
+        ];
+
+        $this->stubVisibleToUser($entries);
+        $this->stubSavedPref('');
+
+        // primaryGroupId = 'support' but no dashboards for that group.
+        $result = $this->service->resolveActiveDashboard('alice', 'support');
+
+        $this->assertNotNull($result);
+        $this->assertSame('uuid-def-a', $result['dashboard']->getUuid());
+        $this->assertSame(Dashboard::SOURCE_DEFAULT, $result['source']);
+    }//end testStep5FirstInDefaultGroup()
+
+    // -----------------------------------------------------------------------
+    // Step 6: First personal dashboard
+    // -----------------------------------------------------------------------
+
+    /**
+     * REQ-DASH-018 step 6: No group dashboards at all; user has a personal one.
+     *
+     * @return void
+     */
+    public function testStep6FirstPersonalDashboard(): void
+    {
+        $personal = $this->makeDashboard('uuid-personal', Dashboard::TYPE_USER, null, 0, 'alice');
+        $entries  = [
+            ['dashboard' => $personal, 'source' => Dashboard::SOURCE_USER],
+        ];
+
+        $this->stubVisibleToUser($entries);
+        $this->stubSavedPref('');
+
+        $result = $this->service->resolveActiveDashboard('alice', null);
+
+        $this->assertNotNull($result);
+        $this->assertSame('uuid-personal', $result['dashboard']->getUuid());
+        $this->assertSame(Dashboard::SOURCE_USER, $result['source']);
+    }//end testStep6FirstPersonalDashboard()
+
+    // -----------------------------------------------------------------------
+    // Step 7: Empty state
+    // -----------------------------------------------------------------------
+
+    /**
+     * REQ-DASH-018 step 7: No dashboards of any kind — resolver returns null.
+     *
+     * @return void
+     */
+    public function testStep7EmptyStateReturnsNull(): void
+    {
+        $this->stubVisibleToUser([]);
+        $this->stubSavedPref('');
+
+        $result = $this->service->resolveActiveDashboard('alice', null);
+
+        $this->assertNull($result);
+    }//end testStep7EmptyStateReturnsNull()
+
+    // -----------------------------------------------------------------------
+    // Cross-group preference invalidation
+    // -----------------------------------------------------------------------
+
+    /**
+     * REQ-DASH-018: Alice's preference points to a dashboard in a group she no
+     * longer belongs to — that dashboard is absent from `getVisibleToUser`,
+     * so the pref must be cleared and the chain continues.
+     *
+     * @return void
+     */
+    public function testCrossGroupPrefInvalidated(): void
+    {
+        // alice's pref points to 'uuid-old-group' which is NOT in the visible list.
+        $fallback = $this->makeDashboard('uuid-def-default', Dashboard::TYPE_GROUP_SHARED, 'default', 1);
+        $entries  = [
+            ['dashboard' => $fallback, 'source' => Dashboard::SOURCE_DEFAULT],
+        ];
+
+        $this->stubVisibleToUser($entries);
+        $this->stubSavedPref('uuid-old-group');
+
+        $this->config->expects($this->once())
+            ->method('deleteUserValue')
+            ->with('alice', Application::APP_ID, DashboardService::ACTIVE_DASHBOARD_UUID_PREF_KEY);
+
+        $this->logger->expects($this->once())->method('warning');
+
+        $result = $this->service->resolveActiveDashboard('alice', null);
+
+        // Should fall through to the default-group default.
+        $this->assertNotNull($result);
+        $this->assertSame('uuid-def-default', $result['dashboard']->getUuid());
+    }//end testCrossGroupPrefInvalidated()
+
+    // -----------------------------------------------------------------------
+    // No primary group (null / 'default' sentinel)
+    // -----------------------------------------------------------------------
+
+    /**
+     * REQ-DASH-018: When primaryGroupId is null the resolver treats it as
+     * 'default' and only steps 3, 5, 6, 7 are eligible (steps 2 and 4 skip).
+     *
+     * @return void
+     */
+    public function testNullPrimaryGroupSkipsGroupSteps(): void
+    {
+        $defaultDefault = $this->makeDashboard('uuid-def-default', Dashboard::TYPE_GROUP_SHARED, 'default', 1);
+        $entries        = [
+            ['dashboard' => $defaultDefault, 'source' => Dashboard::SOURCE_DEFAULT],
+        ];
+
+        $this->stubVisibleToUser($entries);
+        $this->stubSavedPref('');
+
+        // primaryGroupId = null → treated as 'default', so only step 3 applies.
+        $result = $this->service->resolveActiveDashboard('alice', null);
+
+        $this->assertNotNull($result);
+        $this->assertSame('uuid-def-default', $result['dashboard']->getUuid());
+        $this->assertSame(Dashboard::SOURCE_DEFAULT, $result['source']);
+    }//end testNullPrimaryGroupSkipsGroupSteps()
+
+    // -----------------------------------------------------------------------
+    // REQ-DASH-019: setActivePreference
+    // -----------------------------------------------------------------------
+
+    /**
+     * REQ-DASH-019: setActivePreference writes the UUID to IConfig.
+     *
+     * @return void
+     */
+    public function testSetActivePreferenceWritesUuid(): void
+    {
+        $this->config->expects($this->once())
+            ->method('setUserValue')
+            ->with('alice', Application::APP_ID, DashboardService::ACTIVE_DASHBOARD_UUID_PREF_KEY, 'abc-123');
+
+        $this->service->setActivePreference('alice', 'abc-123');
+    }//end testSetActivePreferenceWritesUuid()
+
+    /**
+     * REQ-DASH-019 scenario "empty uuid clears the preference": empty string
+     * MUST call deleteUserValue, not setUserValue.
+     *
+     * @return void
+     */
+    public function testSetActivePreferenceEmptyStringClears(): void
+    {
+        $this->config->expects($this->never())->method('setUserValue');
+        $this->config->expects($this->once())
+            ->method('deleteUserValue')
+            ->with('alice', Application::APP_ID, DashboardService::ACTIVE_DASHBOARD_UUID_PREF_KEY);
+
+        $this->service->setActivePreference('alice', '');
+    }//end testSetActivePreferenceEmptyStringClears()
+
+    /**
+     * REQ-DASH-019 scenario "no existence check on write": non-existent UUID is
+     * accepted without error — setUserValue called with whatever was passed.
+     *
+     * @return void
+     */
+    public function testSetActivePreferenceAcceptsNonExistentUuid(): void
+    {
+        $this->config->expects($this->once())
+            ->method('setUserValue')
+            ->with('alice', Application::APP_ID, DashboardService::ACTIVE_DASHBOARD_UUID_PREF_KEY, 'does-not-exist');
+
+        // No exception thrown.
+        $this->service->setActivePreference('alice', 'does-not-exist');
+    }//end testSetActivePreferenceAcceptsNonExistentUuid()
+}//end class

--- a/tests/Unit/Service/DashboardServiceAllowFlagTest.php
+++ b/tests/Unit/Service/DashboardServiceAllowFlagTest.php
@@ -37,11 +37,13 @@ use OCA\MyDash\Service\DashboardFactory;
 use OCA\MyDash\Service\DashboardResolver;
 use OCA\MyDash\Service\DashboardService;
 use OCA\MyDash\Service\TemplateService;
+use OCP\IConfig;
 use OCP\IDBConnection;
 use OCP\IGroupManager;
 use OCP\IUserManager;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
 
 /**
  * Unit tests for the allow-user-dashboards runtime gate (REQ-ASET-003).
@@ -113,6 +115,20 @@ class DashboardServiceAllowFlagTest extends TestCase
     private $db;
 
     /**
+     * IConfig mock.
+     *
+     * @var IConfig&MockObject
+     */
+    private $config;
+
+    /**
+     * Logger mock.
+     *
+     * @var LoggerInterface&MockObject
+     */
+    private $logger;
+
+    /**
      * Service under test.
      *
      * @var DashboardService
@@ -126,15 +142,17 @@ class DashboardServiceAllowFlagTest extends TestCase
      */
     protected function setUp(): void
     {
-        $this->dashboardMapper  = $this->createMock(className: DashboardMapper::class);
-        $this->placementMapper  = $this->createMock(className: WidgetPlacementMapper::class);
-        $this->settingMapper    = $this->createMock(className: AdminSettingMapper::class);
-        $this->templateService  = $this->createMock(className: TemplateService::class);
-        $this->dashboardFactory = $this->createMock(className: DashboardFactory::class);
-        $this->dashResolver     = $this->createMock(className: DashboardResolver::class);
-        $this->groupManager     = $this->createMock(className: IGroupManager::class);
-        $this->userManager      = $this->createMock(className: IUserManager::class);
-        $this->db               = $this->createMock(className: IDBConnection::class);
+        $this->dashboardMapper  = $this->createMock(DashboardMapper::class);
+        $this->placementMapper  = $this->createMock(WidgetPlacementMapper::class);
+        $this->settingMapper    = $this->createMock(AdminSettingMapper::class);
+        $this->templateService  = $this->createMock(TemplateService::class);
+        $this->dashboardFactory = $this->createMock(DashboardFactory::class);
+        $this->dashResolver     = $this->createMock(DashboardResolver::class);
+        $this->groupManager     = $this->createMock(IGroupManager::class);
+        $this->userManager      = $this->createMock(IUserManager::class);
+        $this->db               = $this->createMock(IDBConnection::class);
+        $this->config           = $this->createMock(IConfig::class);
+        $this->logger           = $this->createMock(LoggerInterface::class);
 
         $this->service = new DashboardService(
             dashboardMapper: $this->dashboardMapper,
@@ -146,6 +164,8 @@ class DashboardServiceAllowFlagTest extends TestCase
             groupManager: $this->groupManager,
             userManager: $this->userManager,
             db: $this->db,
+            config: $this->config,
+            logger: $this->logger,
         );
     }//end setUp()
 
@@ -343,8 +363,9 @@ class DashboardServiceAllowFlagTest extends TestCase
         $this->placementMapper->expects($this->never())->method('update');
         $this->placementMapper->expects($this->never())->method('delete');
 
-        // Simulate flag=false (throws — but still no writes before the throw).
-        $this->settingMapper->method('getValue')->willReturn(false);
+        // Consecutive calls: first returns false (expect throw), then true (no throw).
+        $this->settingMapper->method('getValue')
+            ->willReturnOnConsecutiveCalls(false, true);
 
         try {
             $this->service->assertPersonalDashboardsAllowed();
@@ -352,8 +373,7 @@ class DashboardServiceAllowFlagTest extends TestCase
             // Expected — no writes should have occurred.
         }
 
-        // Simulate flag=true (no throw — still no writes).
-        $this->settingMapper->method('getValue')->willReturn(true);
+        // Second call: flag=true (no throw — still no writes).
         $this->service->assertPersonalDashboardsAllowed();
     }//end testTogglingFlagDoesNotMutateData()
 }//end class

--- a/tests/Unit/Service/DashboardServiceDefaultFlagTest.php
+++ b/tests/Unit/Service/DashboardServiceDefaultFlagTest.php
@@ -31,11 +31,13 @@ use OCA\MyDash\Service\DashboardResolver;
 use OCA\MyDash\Service\DashboardService;
 use OCA\MyDash\Service\TemplateService;
 use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\IConfig;
 use OCP\IDBConnection;
 use OCP\IGroupManager;
 use OCP\IUserManager;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
 use RuntimeException;
 
 /**
@@ -61,6 +63,10 @@ class DashboardServiceDefaultFlagTest extends TestCase
     private $userManager;
     /** @var IDBConnection&MockObject */
     private $db;
+    /** @var IConfig&MockObject */
+    private $config;
+    /** @var LoggerInterface&MockObject */
+    private $logger;
 
     private DashboardService $service;
 
@@ -75,6 +81,8 @@ class DashboardServiceDefaultFlagTest extends TestCase
         $this->groupManager     = $this->createMock(IGroupManager::class);
         $this->userManager      = $this->createMock(IUserManager::class);
         $this->db               = $this->createMock(IDBConnection::class);
+        $this->config           = $this->createMock(IConfig::class);
+        $this->logger           = $this->createMock(LoggerInterface::class);
 
         $this->service = new DashboardService(
             dashboardMapper: $this->dashboardMapper,
@@ -86,6 +94,8 @@ class DashboardServiceDefaultFlagTest extends TestCase
             groupManager: $this->groupManager,
             userManager: $this->userManager,
             db: $this->db,
+            config: $this->config,
+            logger: $this->logger,
         );
     }//end setUp()
 


### PR DESCRIPTION
Implements REQ-DASH-018..019 per spec on development. 7-step precedence resolver in DashboardService with stale-pref auto-clear. New POST /api/dashboards/active write endpoint. PageController refactored to use resolver + push resolved dashboard via InitialStateBuilder. PHPUnit covers all 7 steps + stale-pref + empty-state.