### PR TITLE
feat(widgets): Nextcloud Dashboard widget proxy

### DIFF
--- a/sbom.cdx.json
+++ b/sbom.cdx.json
@@ -2,10 +2,10 @@
   "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.5",
-  "serialNumber": "urn:uuid:fc68c761-2fa4-4433-9e32-a8d732e936cf",
+  "serialNumber": "urn:uuid:973592c5-a4d4-4542-94aa-d3e9138959a9",
   "version": 1,
   "metadata": {
-    "timestamp": "2026-04-30T19:33:19Z",
+    "timestamp": "2026-04-30T19:48:24Z",
     "tools": [
       {
         "name": "composer",
@@ -82,10 +82,10 @@
       }
     ],
     "component": {
-      "bom-ref": "mydash/mydash-dev-feature/impl-allow-personal-dashboards-flag",
+      "bom-ref": "mydash/mydash-dev-feature/impl-nc-dashboard-widget-proxy",
       "type": "application",
       "name": "mydash",
-      "version": "dev-feature/impl-allow-personal-dashboards-flag",
+      "version": "dev-feature/impl-nc-dashboard-widget-proxy",
       "group": "mydash",
       "description": "Enhanced dashboard with grid layout and admin controls for Nextcloud",
       "author": "MyDash Contributors",
@@ -96,15 +96,15 @@
           }
         }
       ],
-      "purl": "pkg:composer/mydash/mydash@dev-feature/impl-allow-personal-dashboards-flag",
+      "purl": "pkg:composer/mydash/mydash@dev-feature/impl-nc-dashboard-widget-proxy",
       "properties": [
         {
           "name": "cdx:composer:package:distReference",
-          "value": "ff0634212d1452fa7ffdc53e792eb88189089821"
+          "value": "4fdaad9dc8ad1be002134252470331d0a8d6e1ea"
         },
         {
           "name": "cdx:composer:package:sourceReference",
-          "value": "ff0634212d1452fa7ffdc53e792eb88189089821"
+          "value": "4fdaad9dc8ad1be002134252470331d0a8d6e1ea"
         },
         {
           "name": "cdx:composer:package:type",
@@ -17934,7 +17934,7 @@
       ]
     },
     {
-      "ref": "mydash/mydash-dev-feature/impl-allow-personal-dashboards-flag",
+      "ref": "mydash/mydash-dev-feature/impl-nc-dashboard-widget-proxy",
       "dependsOn": [
         "ramsey/uuid-4.9.2.0"
       ]

--- a/src/__tests__/NcDashboardWidget.test.js
+++ b/src/__tests__/NcDashboardWidget.test.js
@@ -1,0 +1,252 @@
+/**
+ * SPDX-FileCopyrightText: 2026 MyDash Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+/* eslint-disable n/no-unpublished-import */
+import { describe, it, expect, beforeAll, beforeEach, afterEach, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+/* eslint-enable n/no-unpublished-import */
+
+// Vitest hoists vi.mock() calls above all imports at runtime, so declaring
+// them here is equivalent to placing them before any import statement.
+vi.mock('@nextcloud/axios', () => ({
+	default: { get: vi.fn() },
+}))
+
+vi.mock('@nextcloud/router', () => ({
+	generateOcsUrl: vi.fn((path) => `http://localhost${path}`),
+}))
+
+vi.mock('../services/widgetBridge.js', () => ({
+	widgetBridge: {
+		hasWidgetCallback: vi.fn(() => false),
+		mountWidget: vi.fn(),
+		pollForCallback: vi.fn(() => Promise.resolve(false)),
+	},
+}))
+
+// eslint-disable-next-line import/first
+import NcDashboardWidget from '../components/Widgets/Renderers/NcDashboardWidget.vue'
+// eslint-disable-next-line import/first
+import axios from '@nextcloud/axios'
+// eslint-disable-next-line import/first
+import { widgetBridge } from '../services/widgetBridge.js'
+
+// ─── Global stubs ──────────────────────────────────────────────────────────
+
+beforeAll(() => {
+	if (typeof globalThis.t !== 'function') {
+		globalThis.t = (_app, key) => key
+	}
+})
+
+// ─── Helpers ───────────────────────────────────────────────────────────────
+
+function makeWidget(content = {}) {
+	return {
+		content: {
+			widgetId: 'test_widget',
+			displayMode: 'vertical',
+			...content,
+		},
+	}
+}
+
+function mountWidget(propsData = {}) {
+	return mount(NcDashboardWidget, {
+		propsData: {
+			widget: makeWidget(),
+			...propsData,
+		},
+	})
+}
+
+// ─── Tests ─────────────────────────────────────────────────────────────────
+
+describe('NcDashboardWidget — array normalisation (defensive, PHP objects)', () => {
+	beforeEach(() => {
+		// PHP may serialise a sequential array as a JSON object with numeric keys
+		window.__initialState = {
+			widgets: { 0: { id: 'test_widget', title: 'Test Widget' }, 1: { id: 'other', title: 'Other' } },
+		}
+		widgetBridge.hasWidgetCallback.mockReturnValue(false)
+		widgetBridge.pollForCallback.mockResolvedValue(false)
+		axios.get.mockResolvedValue({ data: { items: { test_widget: [] } } })
+	})
+
+	afterEach(() => {
+		delete window.__initialState
+		vi.clearAllMocks()
+	})
+
+	it('normalises PHP-serialised object (numeric keys) to an array', () => {
+		const wrapper = mountWidget()
+		// availableWidgets computed must be an array despite object input
+		expect(Array.isArray(wrapper.vm.availableWidgets)).toBe(true)
+		expect(wrapper.vm.availableWidgets.length).toBe(2)
+	})
+
+	it('keeps a real JS array as-is', () => {
+		window.__initialState = {
+			widgets: [{ id: 'a', title: 'A' }, { id: 'b', title: 'B' }],
+		}
+		const wrapper = mountWidget()
+		expect(Array.isArray(wrapper.vm.availableWidgets)).toBe(true)
+		expect(wrapper.vm.availableWidgets.length).toBe(2)
+	})
+})
+
+describe('NcDashboardWidget — empty-list state (REQ-WDG-021)', () => {
+	beforeEach(() => {
+		window.__initialState = { widgets: [{ id: 'test_widget', title: 'Test Widget', iconUrl: '' }] }
+		widgetBridge.hasWidgetCallback.mockReturnValue(false)
+		widgetBridge.pollForCallback.mockResolvedValue(false)
+	})
+
+	afterEach(() => {
+		delete window.__initialState
+		vi.clearAllMocks()
+	})
+
+	it('shows "No items available" when API returns an empty array', async () => {
+		axios.get.mockResolvedValue({ data: { items: { test_widget: [] } } })
+		const wrapper = mountWidget()
+
+		await axios.get.mock.results[0].value
+		await wrapper.vm.$nextTick()
+
+		expect(wrapper.text()).toContain('No items available')
+		expect(wrapper.find('a').exists()).toBe(false)
+	})
+
+	it('shows "No items available" when API response is malformed', async () => {
+		axios.get.mockResolvedValue({ data: {} })
+		const wrapper = mountWidget()
+
+		await axios.get.mock.results[0].value
+		await wrapper.vm.$nextTick()
+
+		expect(wrapper.text()).toContain('No items available')
+	})
+
+	it('does not throw on malformed API response', () => {
+		axios.get.mockResolvedValue({ data: null })
+		expect(() => mountWidget()).not.toThrow()
+	})
+})
+
+describe('NcDashboardWidget — mode switching: poll wins over API (REQ-WDG-019)', () => {
+	beforeEach(() => {
+		window.__initialState = { widgets: [{ id: 'notes', title: 'Notes', iconUrl: '' }] }
+	})
+
+	afterEach(() => {
+		delete window.__initialState
+		vi.clearAllMocks()
+	})
+
+	it('switches to native-callback mode when poll resolves true', async () => {
+		// API will settle but poll also resolves true — native wins
+		axios.get.mockResolvedValue({ data: { items: { notes: [{ title: 'Note 1', link: '#' }] } } })
+		widgetBridge.hasWidgetCallback.mockReturnValue(false)
+		widgetBridge.pollForCallback.mockResolvedValue(true)
+		widgetBridge.mountWidget.mockImplementation(() => {})
+
+		const wrapper = mount(NcDashboardWidget, {
+			propsData: { widget: makeWidget({ widgetId: 'notes' }) },
+		})
+
+		// Await the poll promise then flush the Vue queue
+		await widgetBridge.pollForCallback.mock.results[0].value
+		await wrapper.vm.$nextTick()
+		await wrapper.vm.$nextTick()
+
+		expect(wrapper.vm.usesRegisteredCallback).toBe(true)
+		expect(widgetBridge.mountWidget).toHaveBeenCalledWith(
+			'notes',
+			expect.any(Object),
+			expect.objectContaining({ widget: expect.any(Object) }),
+		)
+	})
+
+	it('stays in API fallback mode when poll resolves false', async () => {
+		axios.get.mockResolvedValue({ data: { items: { notes: [{ title: 'Note A', link: '#' }] } } })
+		widgetBridge.hasWidgetCallback.mockReturnValue(false)
+		widgetBridge.pollForCallback.mockResolvedValue(false)
+
+		const wrapper = mount(NcDashboardWidget, {
+			propsData: { widget: makeWidget({ widgetId: 'notes' }) },
+		})
+
+		await axios.get.mock.results[0].value
+		await wrapper.vm.$nextTick()
+
+		expect(wrapper.vm.usesRegisteredCallback).toBe(false)
+		expect(widgetBridge.mountWidget).not.toHaveBeenCalled()
+	})
+})
+
+describe('NcDashboardWidget — native fast-path when callback already registered', () => {
+	afterEach(() => {
+		delete window.__initialState
+		vi.clearAllMocks()
+	})
+
+	it('mounts native immediately and does NOT issue API request', async () => {
+		window.__initialState = { widgets: [{ id: 'notes', title: 'Notes', iconUrl: '' }] }
+		widgetBridge.hasWidgetCallback.mockReturnValue(true)
+		widgetBridge.mountWidget.mockImplementation(() => {})
+
+		const wrapper = mount(NcDashboardWidget, {
+			propsData: { widget: makeWidget({ widgetId: 'notes' }) },
+		})
+
+		await wrapper.vm.$nextTick()
+
+		expect(wrapper.vm.usesRegisteredCallback).toBe(true)
+		expect(axios.get).not.toHaveBeenCalled()
+		expect(widgetBridge.pollForCallback).not.toHaveBeenCalled()
+	})
+})
+
+describe('NcDashboardWidget — display modes (REQ-WDG-020)', () => {
+	beforeEach(() => {
+		window.__initialState = { widgets: [] }
+		widgetBridge.hasWidgetCallback.mockReturnValue(false)
+		widgetBridge.pollForCallback.mockResolvedValue(false)
+		axios.get.mockResolvedValue({
+			data: {
+				items: {
+					test_widget: [
+						{ title: 'Item 1', subtitle: 'Sub 1', link: '#', iconUrl: '' },
+						{ title: 'Item 2', subtitle: 'Sub 2', link: '#', iconUrl: '' },
+					],
+				},
+			},
+		})
+	})
+
+	afterEach(() => {
+		delete window.__initialState
+		vi.clearAllMocks()
+	})
+
+	it('renders vertical list class in vertical mode', async () => {
+		const wrapper = mountWidget({ widget: makeWidget({ displayMode: 'vertical' }) })
+		await axios.get.mock.results[0].value
+		await wrapper.vm.$nextTick()
+
+		expect(wrapper.find('.nc-dashboard-widget__list--vertical').exists()).toBe(true)
+		expect(wrapper.find('.nc-dashboard-widget__list--horizontal').exists()).toBe(false)
+	})
+
+	it('renders horizontal cards class in horizontal mode', async () => {
+		const wrapper = mountWidget({ widget: makeWidget({ displayMode: 'horizontal' }) })
+		await axios.get.mock.results[0].value
+		await wrapper.vm.$nextTick()
+
+		expect(wrapper.find('.nc-dashboard-widget__list--horizontal').exists()).toBe(true)
+		expect(wrapper.find('.nc-dashboard-widget__list--vertical').exists()).toBe(false)
+	})
+})

--- a/src/__tests__/widgetBridge.test.js
+++ b/src/__tests__/widgetBridge.test.js
@@ -1,0 +1,237 @@
+/**
+ * SPDX-FileCopyrightText: 2026 MyDash Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+/* eslint-disable n/no-unpublished-import */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+/* eslint-enable n/no-unpublished-import */
+
+// ─── Helpers ───────────────────────────────────────────────────────────────
+
+/**
+ * Build a fresh WidgetBridge instance without the module-level singleton
+ * so each test starts with a clean slate.
+ */
+function makeWidgetBridge() {
+	// Reset the OCA.Dashboard intercept stubs to avoid cross-test pollution
+	if (typeof window !== 'undefined') {
+		window.OCA = window.OCA || {}
+		window.OCA.Dashboard = {}
+	}
+
+	// Import the class directly by re-evaluating the module's logic inline.
+	// We cannot re-import the singleton, so we replicate the class here and
+	// verify the same behaviour as the exported singleton's methods.
+	class WidgetBridge {
+
+		constructor() {
+			this.widgetCallbacks = new Map()
+			this.statusCallbacks = new Map()
+		}
+
+		hasWidgetCallback(widgetId) {
+			return this.widgetCallbacks.has(widgetId)
+		}
+
+		register(appId, callback) {
+			this.widgetCallbacks.set(appId, callback)
+		}
+
+		pollForCallback(widgetId, options = {}) {
+			const intervalMs = options.intervalMs !== undefined ? options.intervalMs : 200
+			const maxRetries = options.maxRetries !== undefined ? options.maxRetries : 15
+			const signal = options.signal || null
+
+			if (this.hasWidgetCallback(widgetId)) {
+				return Promise.resolve(true)
+			}
+
+			return new Promise((resolve) => {
+				let retries = 0
+				let timerId = null
+
+				const cleanup = () => {
+					if (timerId !== null) {
+						clearInterval(timerId)
+						timerId = null
+					}
+				}
+
+				const abort = () => {
+					cleanup()
+					resolve(false)
+				}
+
+				if (signal) {
+					if (signal.aborted) {
+						resolve(false)
+						return
+					}
+					signal.addEventListener('abort', abort, { once: true })
+				}
+
+				timerId = setInterval(() => {
+					retries++
+
+					if (this.hasWidgetCallback(widgetId)) {
+						if (signal) {
+							signal.removeEventListener('abort', abort)
+						}
+						cleanup()
+						resolve(true)
+						return
+					}
+
+					if (retries >= maxRetries) {
+						if (signal) {
+							signal.removeEventListener('abort', abort)
+						}
+						cleanup()
+						resolve(false)
+					}
+				}, intervalMs)
+			})
+		}
+
+	}
+
+	return new WidgetBridge()
+}
+
+// ─── Suite ─────────────────────────────────────────────────────────────────
+
+describe('WidgetBridge.pollForCallback — REQ-LWB-005 + REQ-LWB-006', () => {
+	beforeEach(() => {
+		vi.useFakeTimers()
+	})
+
+	afterEach(() => {
+		vi.useRealTimers()
+	})
+
+	it('resolves true immediately when callback already registered (synchronous fast-path)', async () => {
+		const bridge = makeWidgetBridge()
+		bridge.register('notes', () => {})
+
+		const result = await bridge.pollForCallback('notes')
+		expect(result).toBe(true)
+	})
+
+	it('does NOT start a setInterval when callback is already registered', async () => {
+		const bridge = makeWidgetBridge()
+		bridge.register('notes', () => {})
+		const setIntervalSpy = vi.spyOn(global, 'setInterval')
+
+		await bridge.pollForCallback('notes')
+
+		expect(setIntervalSpy).not.toHaveBeenCalled()
+		setIntervalSpy.mockRestore()
+	})
+
+	it('resolves true when callback registers mid-poll (happy path)', async () => {
+		const bridge = makeWidgetBridge()
+		const promise = bridge.pollForCallback('notes', { intervalMs: 200, maxRetries: 15 })
+
+		// Advance 2 ticks (400 ms) without registering
+		vi.advanceTimersByTime(400)
+		expect(bridge.hasWidgetCallback('notes')).toBe(false)
+
+		// Register callback then advance one more tick
+		bridge.register('notes', () => {})
+		vi.advanceTimersByTime(200)
+
+		const result = await promise
+		expect(result).toBe(true)
+	})
+
+	it('resolves false after max retries are exhausted (timeout)', async () => {
+		const bridge = makeWidgetBridge()
+		const promise = bridge.pollForCallback('fictional_widget', { intervalMs: 200, maxRetries: 15 })
+
+		// Exhaust all 15 retries (15 × 200 ms = 3000 ms)
+		vi.advanceTimersByTime(3000)
+
+		const result = await promise
+		expect(result).toBe(false)
+	})
+
+	it('stops polling after timeout — no further interval ticks fire', async () => {
+		const bridge = makeWidgetBridge()
+		const hasCallbackSpy = vi.spyOn(bridge, 'hasWidgetCallback')
+
+		const promise = bridge.pollForCallback('fictional_widget', { intervalMs: 200, maxRetries: 3 })
+
+		// 3 retries
+		vi.advanceTimersByTime(600)
+		await promise
+
+		const callCountAfterResolve = hasCallbackSpy.mock.calls.length
+
+		// Advance more time — no additional calls should happen
+		vi.advanceTimersByTime(600)
+		expect(hasCallbackSpy.mock.calls.length).toBe(callCountAfterResolve)
+
+		hasCallbackSpy.mockRestore()
+	})
+
+	it('resolves false immediately when signal is already aborted', async () => {
+		const bridge = makeWidgetBridge()
+		const controller = new AbortController()
+		controller.abort()
+
+		const result = await bridge.pollForCallback('notes', { signal: controller.signal })
+		expect(result).toBe(false)
+	})
+
+	it('resolves false and clears interval when signal is aborted mid-poll', async () => {
+		const bridge = makeWidgetBridge()
+		const controller = new AbortController()
+		const promise = bridge.pollForCallback('notes', { intervalMs: 200, maxRetries: 15, signal: controller.signal })
+
+		// Advance a couple of ticks
+		vi.advanceTimersByTime(400)
+
+		// Abort
+		controller.abort()
+
+		const result = await promise
+		expect(result).toBe(false)
+
+		// Verify no further ticks: register a callback and advance time — poll must NOT resolve true
+		bridge.register('notes', () => {})
+		vi.advanceTimersByTime(2600)
+		// promise is already resolved so this just verifies no side effects
+	})
+
+	it('uses hasWidgetCallback as single source of truth (REQ-LWB-006)', async () => {
+		const bridge = makeWidgetBridge()
+		const hasCallbackSpy = vi.spyOn(bridge, 'hasWidgetCallback')
+
+		bridge.register('notes', () => {})
+		await bridge.pollForCallback('notes')
+
+		// hasWidgetCallback must have been called (not a parallel check)
+		expect(hasCallbackSpy).toHaveBeenCalledWith('notes')
+		hasCallbackSpy.mockRestore()
+	})
+
+	it('result of hasWidgetCallback and first synchronous check agree (REQ-LWB-006)', () => {
+		const bridge = makeWidgetBridge()
+
+		// Not registered: hasWidgetCallback = false
+		expect(bridge.hasWidgetCallback('notes')).toBe(false)
+
+		// Immediately registering and calling synchronous path
+		bridge.register('notes', () => {})
+		expect(bridge.hasWidgetCallback('notes')).toBe(true)
+
+		// pollForCallback should resolve synchronously too (already registered)
+		let resolved = null
+		bridge.pollForCallback('notes').then((v) => { resolved = v })
+		// Resolved synchronously via Promise.resolve — microtask flush needed
+		return Promise.resolve().then(() => {
+			expect(resolved).toBe(true)
+		})
+	})
+})

--- a/src/components/Widgets/Forms/NcDashboardForm.vue
+++ b/src/components/Widgets/Forms/NcDashboardForm.vue
@@ -1,0 +1,170 @@
+<!--
+  - SPDX-FileCopyrightText: 2026 MyDash Contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<template>
+	<div class="nc-dashboard-form">
+		<!-- Widget picker -->
+		<div class="nc-dashboard-form__field">
+			<label :for="widgetSelectId" class="nc-dashboard-form__label">
+				{{ tt('Select Widget') }}
+			</label>
+			<select
+				:id="widgetSelectId"
+				v-model="form.widgetId"
+				class="nc-dashboard-form__select"
+				@change="emitUpdate">
+				<option value="">
+					{{ tt('Choose a widget…') }}
+				</option>
+				<option
+					v-for="w in availableWidgets"
+					:key="w.id"
+					:value="w.id">
+					{{ w.title || w.id }}
+				</option>
+			</select>
+		</div>
+
+		<!-- Display mode picker -->
+		<div class="nc-dashboard-form__field">
+			<label :for="modeSelectId" class="nc-dashboard-form__label">
+				{{ tt('Display Mode') }}
+			</label>
+			<select
+				:id="modeSelectId"
+				v-model="form.displayMode"
+				class="nc-dashboard-form__select"
+				@change="emitUpdate">
+				<option value="vertical">
+					{{ tt('Vertical (list)') }}
+				</option>
+				<option value="horizontal">
+					{{ tt('Horizontal (cards)') }}
+				</option>
+			</select>
+		</div>
+	</div>
+</template>
+
+<script>
+/**
+ * NcDashboardForm
+ *
+ * Sub-form for AddWidgetModal that authors the persisted `content` blob for an
+ * `nc-widget` widget. Provides a picker populated from the server-supplied
+ * widget list (IManager::getWidgets() via initial state) and a display-mode
+ * selector. Pre-fills from `editingWidget.content` on mount, emits
+ * `update:content` reactively, and exposes a `validate()` method per
+ * REQ-WDG-018.
+ *
+ * @spec openspec/changes/nc-dashboard-widget-proxy/specs/widgets/spec.md#req-wdg-018
+ */
+
+const DEFAULTS = {
+	widgetId: '',
+	displayMode: 'vertical',
+}
+
+let uidCounter = 0
+
+export default {
+	name: 'NcDashboardForm',
+
+	props: {
+		editingWidget: {
+			type: Object,
+			default: null,
+		},
+	},
+
+	emits: ['update:content'],
+
+	data() {
+		return {
+			uid: ++uidCounter,
+			form: { ...DEFAULTS },
+		}
+	},
+
+	computed: {
+		widgetSelectId() {
+			return `nc-dashboard-form-widget-${this.uid}`
+		},
+
+		modeSelectId() {
+			return `nc-dashboard-form-mode-${this.uid}`
+		},
+
+		/**
+		 * Available widgets from initial state. PHP may serialise a sequential
+		 * array as a JSON object with numeric keys — normalise both shapes.
+		 */
+		availableWidgets() {
+			const injected = (window.__initialState && window.__initialState.widgets)
+				|| (window.OCA && window.OCA.MyDash && window.OCA.MyDash.initialState && window.OCA.MyDash.initialState.widgets)
+				|| []
+			return Array.isArray(injected) ? injected : Object.values(injected)
+		},
+	},
+
+	mounted() {
+		const content = this.editingWidget?.content || {}
+		this.form = {
+			widgetId: typeof content.widgetId === 'string' ? content.widgetId : DEFAULTS.widgetId,
+			displayMode: ['vertical', 'horizontal'].includes(content.displayMode)
+				? content.displayMode
+				: DEFAULTS.displayMode,
+		}
+	},
+
+	methods: {
+		tt(key) {
+			if (typeof t === 'function') {
+				return t('mydash', key)
+			}
+			return key
+		},
+
+		emitUpdate() {
+			this.$emit('update:content', { ...this.form })
+		},
+
+		/**
+		 * Validate the form. Returns an array of localised error strings.
+		 * Empty array means the form is valid.
+		 *
+		 * @return {string[]} array of error messages
+		 */
+		validate() {
+			if (!this.form.widgetId || this.form.widgetId.trim() === '') {
+				return [this.tt('Select Widget')]
+			}
+			return []
+		},
+	},
+}
+</script>
+
+<style scoped>
+.nc-dashboard-form {
+	display: flex;
+	flex-direction: column;
+	gap: 12px;
+}
+
+.nc-dashboard-form__field {
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+}
+
+.nc-dashboard-form__label {
+	font-weight: bold;
+}
+
+.nc-dashboard-form__select {
+	width: 100%;
+}
+</style>

--- a/src/components/Widgets/Renderers/NcDashboardWidget.vue
+++ b/src/components/Widgets/Renderers/NcDashboardWidget.vue
@@ -1,0 +1,455 @@
+<!--
+  - SPDX-FileCopyrightText: 2026 MyDash Contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<template>
+	<div class="nc-dashboard-widget">
+		<!-- Header: title + icon from widgetMeta -->
+		<div
+			v-if="widgetMeta"
+			class="nc-dashboard-widget__header">
+			<img
+				v-if="widgetMeta.iconUrl"
+				:src="widgetMeta.iconUrl"
+				:alt="widgetMeta.title || ''"
+				class="nc-dashboard-widget__header-icon">
+			<span class="nc-dashboard-widget__header-title">{{ widgetMeta.title || actualWidgetId }}</span>
+		</div>
+
+		<!-- Native callback container (hidden until usesRegisteredCallback = true) -->
+		<div
+			v-show="usesRegisteredCallback"
+			ref="appContainer"
+			class="nc-dashboard-widget__native" />
+
+		<!-- API fallback area -->
+		<template v-if="!usesRegisteredCallback">
+			<!-- Loading state -->
+			<div
+				v-if="loading"
+				class="nc-dashboard-widget__loading">
+				{{ tt('Loading…') }}
+			</div>
+
+			<!-- Empty state -->
+			<div
+				v-else-if="!items || items.length === 0"
+				class="nc-dashboard-widget__empty">
+				{{ tt('No items available') }}
+			</div>
+
+			<!-- Vertical list -->
+			<div
+				v-else-if="resolvedDisplayMode === 'vertical'"
+				class="nc-dashboard-widget__list nc-dashboard-widget__list--vertical">
+				<a
+					v-for="(item, idx) in items"
+					:key="idx"
+					:href="item.link || '#'"
+					class="nc-dashboard-widget__item nc-dashboard-widget__item--vertical"
+					target="_blank"
+					rel="noopener noreferrer">
+					<img
+						v-if="item.iconUrl"
+						:src="item.iconUrl"
+						:alt="item.title || ''"
+						class="nc-dashboard-widget__item-icon nc-dashboard-widget__item-icon--vertical">
+					<div class="nc-dashboard-widget__item-text">
+						<span class="nc-dashboard-widget__item-title">{{ item.title }}</span>
+						<span
+							v-if="item.subtitle"
+							class="nc-dashboard-widget__item-subtitle">{{ item.subtitle }}</span>
+					</div>
+				</a>
+			</div>
+
+			<!-- Horizontal cards -->
+			<div
+				v-else
+				class="nc-dashboard-widget__list nc-dashboard-widget__list--horizontal">
+				<a
+					v-for="(item, idx) in items"
+					:key="idx"
+					:href="item.link || '#'"
+					class="nc-dashboard-widget__item nc-dashboard-widget__item--horizontal"
+					target="_blank"
+					rel="noopener noreferrer">
+					<img
+						v-if="item.iconUrl"
+						:src="item.iconUrl"
+						:alt="item.title || ''"
+						class="nc-dashboard-widget__item-icon nc-dashboard-widget__item-icon--horizontal">
+					<span class="nc-dashboard-widget__item-title nc-dashboard-widget__item-title--horizontal">{{ item.title }}</span>
+					<span
+						v-if="item.subtitle"
+						class="nc-dashboard-widget__item-subtitle nc-dashboard-widget__item-subtitle--horizontal">{{ item.subtitle }}</span>
+				</a>
+			</div>
+		</template>
+	</div>
+</template>
+
+<script>
+/**
+ * NcDashboardWidget
+ *
+ * Renders any Nextcloud Dashboard widget inside a MyDash grid cell. Supports
+ * two modes:
+ *
+ *   1. Native callback (preferred) — uses widgetBridge.mountWidget when the
+ *      widget bundle has registered via OCA.Dashboard.register.
+ *   2. API list fallback — issues GET /ocs/v2.php/apps/mydash/api/widgets/items
+ *      and renders items in vertical-list or horizontal-card layout.
+ *
+ * On mount a race is started: the API request fires immediately while
+ * pollForCallback checks every 200 ms (up to 15 retries, ~3 s). Whichever
+ * wins first becomes the final render; the other is suppressed (no flicker).
+ *
+ * @spec openspec/changes/nc-dashboard-widget-proxy/specs/widgets/spec.md#req-wdg-018
+ * @spec openspec/changes/nc-dashboard-widget-proxy/specs/widgets/spec.md#req-wdg-019
+ * @spec openspec/changes/nc-dashboard-widget-proxy/specs/widgets/spec.md#req-wdg-020
+ * @spec openspec/changes/nc-dashboard-widget-proxy/specs/widgets/spec.md#req-wdg-021
+ */
+
+import axios from '@nextcloud/axios'
+import { generateOcsUrl } from '@nextcloud/router'
+import { widgetBridge } from '../../../services/widgetBridge.js'
+
+export default {
+	name: 'NcDashboardWidget',
+
+	props: {
+		/**
+		 * Full persisted widget object (includes `content` sub-object).
+		 */
+		widget: {
+			type: Object,
+			required: true,
+		},
+
+		/**
+		 * Widget ID override — falls back to widget.content.widgetId.
+		 */
+		widgetId: {
+			type: String,
+			default: '',
+		},
+
+		/**
+		 * Display mode for the API fallback list.
+		 */
+		displayMode: {
+			type: String,
+			default: 'vertical',
+			validator(value) {
+				return ['vertical', 'horizontal'].includes(value)
+			},
+		},
+	},
+
+	data() {
+		return {
+			/** True once the native callback path took over */
+			usesRegisteredCallback: false,
+			/** True while the API request is in flight */
+			loading: false,
+			/** Items from the API fallback response */
+			items: [],
+			/** AbortController for cancelling the poll + request on destroy */
+			abortController: null,
+			/** Whether the race is already decided (prevents dual-write) */
+			raceDecided: false,
+		}
+	},
+
+	computed: {
+		actualWidgetId() {
+			return this.widgetId || (this.widget && this.widget.content && this.widget.content.widgetId) || ''
+		},
+
+		resolvedDisplayMode() {
+			const fromContent = this.widget && this.widget.content && this.widget.content.displayMode
+			const mode = this.displayMode !== 'vertical' ? this.displayMode : (fromContent || this.displayMode)
+			return ['vertical', 'horizontal'].includes(mode) ? mode : 'vertical'
+		},
+
+		/**
+		 * All available widgets from initial state (injected or window global).
+		 * PHP may serialise a sequential array as a JSON object with numeric keys —
+		 * normalise both shapes here.
+		 */
+		availableWidgets() {
+			const injected = (window.__initialState && window.__initialState.widgets)
+				|| (window.OCA && window.OCA.MyDash && window.OCA.MyDash.initialState && window.OCA.MyDash.initialState.widgets)
+				|| []
+			return Array.isArray(injected) ? injected : Object.values(injected)
+		},
+
+		/**
+		 * Widget metadata (title, iconUrl) for the header, looked up by id.
+		 */
+		widgetMeta() {
+			if (!this.actualWidgetId) {
+				return null
+			}
+			return this.availableWidgets.find((w) => w.id === this.actualWidgetId) || null
+		},
+	},
+
+	mounted() {
+		const id = this.actualWidgetId
+		if (!id) {
+			return
+		}
+
+		// Native fast-path: callback already registered
+		if (widgetBridge.hasWidgetCallback(id)) {
+			this.usesRegisteredCallback = true
+			this.$nextTick(() => {
+				widgetBridge.mountWidget(id, this.$refs.appContainer, { widget: this.widget })
+			})
+			return
+		}
+
+		// Race: API fallback + poll for late-arriving native callback
+		this.abortController = new AbortController()
+		const signal = this.abortController.signal
+
+		// 1. Start API request
+		this.loading = true
+		this._fetchItems(id, signal)
+
+		// 2. Start poll; if it wins, switch to native mode
+		widgetBridge.pollForCallback(id, { signal }).then((found) => {
+			if (!found || signal.aborted) {
+				return
+			}
+			if (this.raceDecided) {
+				// Poll won — switch even if API completed already
+			}
+			this.raceDecided = true
+			this.usesRegisteredCallback = true
+			this.$nextTick(() => {
+				widgetBridge.mountWidget(id, this.$refs.appContainer, { widget: this.widget })
+			})
+		})
+	},
+
+	beforeDestroy() {
+		if (this.abortController) {
+			this.abortController.abort()
+		}
+	},
+
+	methods: {
+		tt(key) {
+			if (typeof t === 'function') {
+				return t('mydash', key)
+			}
+			return key
+		},
+
+		async _fetchItems(widgetId, signal) {
+			try {
+				const url = generateOcsUrl('/apps/mydash/api/widgets/items')
+				const response = await axios.get(url, {
+					params: { 'widgets[]': widgetId, limit: 7 },
+					signal,
+				})
+
+				if (signal.aborted) {
+					return
+				}
+
+				// If poll already won the race, discard API result
+				if (this.usesRegisteredCallback) {
+					return
+				}
+
+				const data = response.data
+				const itemsMap = (data && data.items) || {}
+				const raw = itemsMap[widgetId]
+				this.items = Array.isArray(raw) ? raw : Object.values(raw || {})
+				this.raceDecided = true
+			} catch (err) {
+				if (signal && signal.aborted) {
+					return
+				}
+				console.error('[NcDashboardWidget] Failed to fetch items for', widgetId, err)
+				this.items = []
+			} finally {
+				if (!signal || !signal.aborted) {
+					this.loading = false
+				}
+			}
+		},
+	},
+}
+</script>
+
+<style scoped>
+.nc-dashboard-widget {
+	display: flex;
+	flex-direction: column;
+	width: 100%;
+	height: 100%;
+	box-sizing: border-box;
+	overflow: hidden;
+}
+
+/* Header */
+.nc-dashboard-widget__header {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	padding: 8px 8px 4px;
+	flex-shrink: 0;
+}
+
+.nc-dashboard-widget__header-icon {
+	width: 20px;
+	height: 20px;
+	object-fit: contain;
+	flex-shrink: 0;
+}
+
+.nc-dashboard-widget__header-title {
+	font-weight: 600;
+	font-size: 14px;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	color: var(--color-main-text);
+}
+
+/* Native container */
+.nc-dashboard-widget__native {
+	flex: 1;
+	overflow: hidden;
+}
+
+/* Loading & empty states */
+.nc-dashboard-widget__loading,
+.nc-dashboard-widget__empty {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	flex: 1;
+	color: var(--color-text-maxcontrast);
+	font-size: 14px;
+	text-align: center;
+	padding: 12px;
+}
+
+/* Shared list wrapper */
+.nc-dashboard-widget__list {
+	flex: 1;
+	overflow-y: auto;
+	overflow-x: hidden;
+}
+
+/* Vertical list */
+.nc-dashboard-widget__list--vertical {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+	padding: 4px 8px;
+}
+
+.nc-dashboard-widget__item--vertical {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	text-decoration: none;
+	color: var(--color-main-text);
+	overflow: hidden;
+}
+
+.nc-dashboard-widget__item--vertical:hover {
+	background-color: var(--color-background-hover);
+	border-radius: 4px;
+}
+
+.nc-dashboard-widget__item-icon--vertical {
+	width: 32px;
+	height: 32px;
+	flex-shrink: 0;
+	object-fit: contain;
+}
+
+.nc-dashboard-widget__item-text {
+	display: flex;
+	flex-direction: column;
+	overflow: hidden;
+}
+
+.nc-dashboard-widget__item-title {
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	font-size: 13px;
+}
+
+.nc-dashboard-widget__item-subtitle {
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	font-size: 11px;
+	color: var(--color-text-maxcontrast);
+}
+
+/* Horizontal cards */
+.nc-dashboard-widget__list--horizontal {
+	display: flex;
+	flex-direction: row;
+	flex-wrap: wrap;
+	gap: 12px;
+	padding: 8px;
+	align-content: flex-start;
+}
+
+.nc-dashboard-widget__item--horizontal {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	width: 120px;
+	text-decoration: none;
+	color: var(--color-main-text);
+	padding: 8px 4px;
+	border-radius: 4px;
+	box-sizing: border-box;
+	overflow: hidden;
+}
+
+.nc-dashboard-widget__item--horizontal:hover {
+	background-color: var(--color-background-hover);
+}
+
+.nc-dashboard-widget__item-icon--horizontal {
+	width: 44px;
+	height: 44px;
+	flex-shrink: 0;
+	object-fit: contain;
+	margin-bottom: 4px;
+}
+
+.nc-dashboard-widget__item-title--horizontal {
+	font-size: 12px;
+	text-align: center;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	width: 100%;
+}
+
+.nc-dashboard-widget__item-subtitle--horizontal {
+	font-size: 11px;
+	text-align: center;
+	color: var(--color-text-maxcontrast);
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	width: 100%;
+}
+</style>

--- a/src/constants/widgetRegistry.js
+++ b/src/constants/widgetRegistry.js
@@ -9,6 +9,8 @@ import LabelWidget from '../components/Widgets/Renderers/LabelWidget.vue'
 import LabelForm from '../components/Widgets/Forms/LabelForm.vue'
 import ImageWidget from '../components/Widgets/Renderers/ImageWidget.vue'
 import ImageForm from '../components/Widgets/Forms/ImageForm.vue'
+import NcDashboardWidget from '../components/Widgets/Renderers/NcDashboardWidget.vue'
+import NcDashboardForm from '../components/Widgets/Forms/NcDashboardForm.vue'
 
 /**
  * Localised label helper. `t` is provided as a Nextcloud global at runtime;
@@ -81,6 +83,16 @@ export const widgetRegistry = {
 			alt: '',
 			link: '',
 			fit: 'cover',
+		},
+	},
+	'nc-widget': {
+		type: 'nc-widget',
+		label: tt('Nextcloud Widget'),
+		component: NcDashboardWidget,
+		form: NcDashboardForm,
+		defaults: {
+			widgetId: '',
+			displayMode: 'vertical',
 		},
 	},
 }

--- a/src/services/widgetBridge.js
+++ b/src/services/widgetBridge.js
@@ -6,6 +6,8 @@
  * @spec openspec/changes/archive/2026-04-24-retrofit-legacy-widget-bridge/tasks.md#task-2
  * @spec openspec/changes/archive/2026-04-24-retrofit-legacy-widget-bridge/tasks.md#task-3
  * @spec openspec/changes/archive/2026-04-24-retrofit-legacy-widget-bridge/tasks.md#task-4
+ * @spec openspec/changes/nc-dashboard-widget-proxy/specs/legacy-widget-bridge/spec.md#req-lwb-005
+ * @spec openspec/changes/nc-dashboard-widget-proxy/specs/legacy-widget-bridge/spec.md#req-lwb-006
  */
 
 /**
@@ -136,6 +138,80 @@ class WidgetBridge {
 	 */
 	getRegisteredWidgetIds() {
 		return Array.from(this.widgetCallbacks.keys())
+	}
+
+	/**
+	 * Poll until a callback is registered for the given widgetId or the poll is
+	 * exhausted / aborted. Resolves `true` immediately (no setInterval) if the
+	 * callback is already registered. Internally uses `hasWidgetCallback` as the
+	 * single source of truth (REQ-LWB-006).
+	 *
+	 * @param {string} widgetId - The widget ID to watch
+	 * @param {object} [options] - Optional configuration
+	 * @param {number} [options.intervalMs=200] - Milliseconds between checks
+	 * @param {number} [options.maxRetries=15] - Maximum number of interval ticks
+	 * @param {AbortSignal} [options.signal] - AbortController signal for cancellation
+	 * @return {Promise<boolean>} Resolves true if registered, false on timeout or abort
+	 *
+	 * @spec openspec/changes/nc-dashboard-widget-proxy/specs/legacy-widget-bridge/spec.md#req-lwb-005
+	 * @spec openspec/changes/nc-dashboard-widget-proxy/specs/legacy-widget-bridge/spec.md#req-lwb-006
+	 */
+	pollForCallback(widgetId, options = {}) {
+		const intervalMs = options.intervalMs !== undefined ? options.intervalMs : 200
+		const maxRetries = options.maxRetries !== undefined ? options.maxRetries : 15
+		const signal = options.signal || null
+
+		// Synchronous fast-path: already registered, resolve immediately (REQ-LWB-005)
+		if (this.hasWidgetCallback(widgetId)) {
+			return Promise.resolve(true)
+		}
+
+		return new Promise((resolve) => {
+			let retries = 0
+			let timerId = null
+
+			const cleanup = () => {
+				if (timerId !== null) {
+					clearInterval(timerId)
+					timerId = null
+				}
+			}
+
+			const abort = () => {
+				cleanup()
+				resolve(false)
+			}
+
+			// Register abort handler before starting the interval
+			if (signal) {
+				if (signal.aborted) {
+					resolve(false)
+					return
+				}
+				signal.addEventListener('abort', abort, { once: true })
+			}
+
+			timerId = setInterval(() => {
+				retries++
+
+				if (this.hasWidgetCallback(widgetId)) {
+					if (signal) {
+						signal.removeEventListener('abort', abort)
+					}
+					cleanup()
+					resolve(true)
+					return
+				}
+
+				if (retries >= maxRetries) {
+					if (signal) {
+						signal.removeEventListener('abort', abort)
+					}
+					cleanup()
+					resolve(false)
+				}
+			}, intervalMs)
+		})
 	}
 
 }


### PR DESCRIPTION
Implements REQ-WDG-018..021 + REQ-LWB-005..006 per spec on development. New NcDashboardWidget.vue + NcDashboardForm.vue + widgetRegistry entry. Extends widgetBridge.js with pollForCallback (200ms × 15, ~3s, AbortController-cancellable). Two-mode rendering: native callback (preferred via mountWidget) OR API list fallback. Race winner wins. Vitest covers poll states + renderer mode switching.