### PR TITLE
feat(dashboard-sharing): notifications + bulk management + delete cascade

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -46,6 +46,18 @@ return [
 		['name' => 'dashboard_api#setGroupDefault', 'url' => '/api/dashboards/group/{groupId}/default', 'verb' => 'POST',
 		 'requirements' => ['groupId' => '[^/]+']],
 
+		// Dashboard sharing endpoints (REQ-SHARE-001..010).
+		// Per-row operations.
+		['name' => 'dashboard_share_api#index', 'url' => '/api/dashboard/{id}/shares', 'verb' => 'GET'],
+		['name' => 'dashboard_share_api#create', 'url' => '/api/dashboard/{id}/shares', 'verb' => 'POST'],
+		['name' => 'dashboard_share_api#destroy', 'url' => '/api/dashboard/share/{shareId}', 'verb' => 'DELETE'],
+		// Bulk replace — REQ-SHARE-009.
+		['name' => 'dashboard_share_api#replace', 'url' => '/api/dashboard/{id}/shares', 'verb' => 'PUT'],
+		// Revoke all for recipient — REQ-SHARE-010.
+		['name' => 'dashboard_share_api#revokeForRecipient',
+		 'url' => '/api/sharees/{shareType}/{shareWith}', 'verb' => 'DELETE',
+		 'requirements' => ['shareType' => '[^/]+', 'shareWith' => '[^/]+']],
+
 		// Widget endpoints
 		['name' => 'widget_api#listAvailable', 'url' => '/api/widgets', 'verb' => 'GET'],
 		['name' => 'widget_api#getItems', 'url' => '/api/widgets/items', 'verb' => 'GET'],

--- a/l10n/en.json
+++ b/l10n/en.json
@@ -172,6 +172,19 @@
         "Image URL is required": "Image URL is required",
         "My Dashboards": "My Dashboards",
         "+ New Dashboard": "+ New Dashboard",
-        "Personal dashboards are not enabled by your administrator": "Personal dashboards are not enabled by your administrator"
+        "Personal dashboards are not enabled by your administrator": "Personal dashboards are not enabled by your administrator",
+        "%1$s shared **%2$s** with you": "%1$s shared **%2$s** with you",
+        "%1$s shared %2$s with you": "%1$s shared %2$s with you",
+        "Full access": "Full access",
+        "Add-only access": "Add-only access",
+        "View-only access": "View-only access",
+        "Shared access": "Shared access",
+        "**%1$s** is now yours": "**%1$s** is now yours",
+        "%1$s is now yours": "%1$s is now yours",
+        "Ownership transferred after the previous owner was removed": "Ownership transferred after the previous owner was removed",
+        "Access denied": "Access denied",
+        "Invalid shareType": "Invalid shareType",
+        "shareWith is required": "shareWith is required",
+        "Invalid permissionLevel": "Invalid permissionLevel"
     }
 }

--- a/l10n/nl.json
+++ b/l10n/nl.json
@@ -172,6 +172,19 @@
         "Image URL is required": "Afbeeldings-URL is verplicht",
         "My Dashboards": "Mijn dashboards",
         "+ New Dashboard": "+ Nieuw dashboard",
-        "Personal dashboards are not enabled by your administrator": "Persoonlijke dashboards zijn niet ingeschakeld door uw beheerder"
+        "Personal dashboards are not enabled by your administrator": "Persoonlijke dashboards zijn niet ingeschakeld door uw beheerder",
+        "%1$s shared **%2$s** with you": "%1$s heeft **%2$s** met u gedeeld",
+        "%1$s shared %2$s with you": "%1$s heeft %2$s met u gedeeld",
+        "Full access": "Volledige toegang",
+        "Add-only access": "Alleen toevoegen",
+        "View-only access": "Alleen bekijken",
+        "Shared access": "Gedeelde toegang",
+        "**%1$s** is now yours": "**%1$s** is nu van u",
+        "%1$s is now yours": "%1$s is nu van u",
+        "Ownership transferred after the previous owner was removed": "Eigendom overgedragen omdat de vorige eigenaar is verwijderd",
+        "Access denied": "Toegang geweigerd",
+        "Invalid shareType": "Ongeldig deeltype",
+        "shareWith is required": "shareWith is verplicht",
+        "Invalid permissionLevel": "Ongeldig rechtenniveau"
     }
 }

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -21,10 +21,13 @@ declare(strict_types=1);
 
 namespace OCA\MyDash\AppInfo;
 
+use OCA\MyDash\Listener\UserDeletedListener;
+use OCA\MyDash\Notification\Notifier;
 use OCP\AppFramework\App;
 use OCP\AppFramework\Bootstrap\IBootContext;
 use OCP\AppFramework\Bootstrap\IBootstrap;
 use OCP\AppFramework\Bootstrap\IRegistrationContext;
+use OCP\User\Events\UserDeletedEvent;
 
 class Application extends App implements IBootstrap
 {
@@ -49,7 +52,15 @@ class Application extends App implements IBootstrap
      */
     public function register(IRegistrationContext $context): void
     {
-        // Register services, event listeners, etc.
+        // Register the INotifier for dashboard_shared and
+        // dashboard_ownership_transferred subjects. REQ-SHARE-011.
+        $context->registerNotifierService(notifierClass: Notifier::class);
+
+        // Register the user-deletion cascade listener. REQ-SHARE-012.
+        $context->registerEventListener(
+            event: UserDeletedEvent::class,
+            listener: UserDeletedListener::class
+        );
     }//end register()
 
     /**

--- a/lib/Controller/DashboardShareApiController.php
+++ b/lib/Controller/DashboardShareApiController.php
@@ -1,0 +1,279 @@
+<?php
+
+/**
+ * DashboardShareApiController
+ *
+ * Controller for dashboard sharing endpoints. Covers per-row add/remove
+ * (REQ-SHARE-001..007), bulk replace (REQ-SHARE-009), and revoke-all-for-
+ * recipient (REQ-SHARE-010).
+ *
+ * @category  Controller
+ * @package   OCA\MyDash\Controller
+ * @author    Conduction b.v. <info@conduction.nl>
+ * @copyright 2026 Conduction b.v.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @version   GIT:auto
+ * @link      https://conduction.nl
+ *
+ * SPDX-FileCopyrightText: 2026 MyDash Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace OCA\MyDash\Controller;
+
+use Exception;
+use InvalidArgumentException;
+use OCA\MyDash\AppInfo\Application;
+use OCA\MyDash\Service\DashboardShareService;
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\Attribute\NoAdminRequired;
+use OCP\AppFramework\Http\DataResponse;
+use OCP\IRequest;
+
+/**
+ * Controller for dashboard sharing API endpoints.
+ *
+ * All endpoints require a logged-in user (#[NoAdminRequired]). Owner checks
+ * are delegated to DashboardShareService.
+ */
+class DashboardShareApiController extends Controller
+{
+    /**
+     * Constructor
+     *
+     * @param IRequest              $request      The request.
+     * @param DashboardShareService $shareService The share service.
+     * @param string|null           $userId       The calling user ID.
+     */
+    public function __construct(
+        IRequest $request,
+        private readonly DashboardShareService $shareService,
+        private readonly ?string $userId,
+    ) {
+        parent::__construct(
+            appName: Application::APP_ID,
+            request: $request
+        );
+    }//end __construct()
+
+    /**
+     * List all shares for a dashboard.
+     *
+     * @param int $id The dashboard ID.
+     *
+     * @return DataResponse The list of shares.
+     */
+    #[NoAdminRequired]
+    public function index(int $id): DataResponse
+    {
+        if ($this->userId === null) {
+            return new DataResponse(
+                data: ['error' => 'Not logged in'],
+                status: Http::STATUS_UNAUTHORIZED
+            );
+        }
+
+        try {
+            $shares     = $this->shareService->listShares(
+                dashboardId: $id,
+                userId: $this->userId
+            );
+            $serialized = array_map(
+                callback: static fn($s) => $s->jsonSerialize(),
+                array: $shares
+            );
+            return new DataResponse(data: $serialized);
+        } catch (DoesNotExistException) {
+            return new DataResponse(
+                data: ['error' => 'Dashboard not found'],
+                status: Http::STATUS_NOT_FOUND
+            );
+        } catch (Exception $e) {
+            return new DataResponse(
+                data: ['error' => $e->getMessage()],
+                status: Http::STATUS_FORBIDDEN
+            );
+        }//end try
+    }//end index()
+
+    /**
+     * Add or upsert a single share. REQ-SHARE-001.
+     *
+     * @param int         $id              The dashboard ID.
+     * @param string|null $shareType       The share type.
+     * @param string|null $shareWith       The recipient.
+     * @param string|null $permissionLevel The permission level.
+     *
+     * @return DataResponse The created/updated share.
+     */
+    #[NoAdminRequired]
+    public function create(
+        int $id,
+        ?string $shareType=null,
+        ?string $shareWith=null,
+        ?string $permissionLevel=null
+    ): DataResponse {
+        if ($this->userId === null) {
+            return new DataResponse(
+                data: ['error' => 'Not logged in'],
+                status: Http::STATUS_UNAUTHORIZED
+            );
+        }
+
+        try {
+            $share = $this->shareService->addShare(
+                dashboardId: $id,
+                shareType: (string) $shareType,
+                shareWith: (string) $shareWith,
+                permissionLevel: (string) $permissionLevel,
+                callerId: $this->userId
+            );
+            return new DataResponse(
+                data: $share->jsonSerialize(),
+                status: Http::STATUS_CREATED
+            );
+        } catch (InvalidArgumentException $e) {
+            return new DataResponse(
+                data: ['error' => $e->getMessage()],
+                status: Http::STATUS_BAD_REQUEST
+            );
+        } catch (DoesNotExistException) {
+            return new DataResponse(
+                data: ['error' => 'Dashboard not found'],
+                status: Http::STATUS_NOT_FOUND
+            );
+        } catch (Exception $e) {
+            return new DataResponse(
+                data: ['error' => $e->getMessage()],
+                status: Http::STATUS_FORBIDDEN
+            );
+        }//end try
+    }//end create()
+
+    /**
+     * Remove a share by ID. REQ-SHARE-001.
+     *
+     * @param int $shareId The share ID.
+     *
+     * @return DataResponse Empty 204 on success.
+     */
+    #[NoAdminRequired]
+    public function destroy(int $shareId): DataResponse
+    {
+        if ($this->userId === null) {
+            return new DataResponse(
+                data: ['error' => 'Not logged in'],
+                status: Http::STATUS_UNAUTHORIZED
+            );
+        }
+
+        try {
+            $this->shareService->removeShare(
+                shareId: $shareId,
+                callerId: $this->userId
+            );
+            return new DataResponse(data: [], status: Http::STATUS_NO_CONTENT);
+        } catch (DoesNotExistException) {
+            return new DataResponse(
+                data: ['error' => 'Share not found'],
+                status: Http::STATUS_NOT_FOUND
+            );
+        } catch (Exception $e) {
+            return new DataResponse(
+                data: ['error' => $e->getMessage()],
+                status: Http::STATUS_FORBIDDEN
+            );
+        }//end try
+    }//end destroy()
+
+    /**
+     * Atomically replace all shares for a dashboard. REQ-SHARE-009.
+     *
+     * @param int        $id     The dashboard ID.
+     * @param array|null $shares The new share list.
+     *
+     * @return DataResponse The new full share list.
+     */
+    #[NoAdminRequired]
+    public function replace(int $id, ?array $shares=null): DataResponse
+    {
+        if ($this->userId === null) {
+            return new DataResponse(
+                data: ['error' => 'Not logged in'],
+                status: Http::STATUS_UNAUTHORIZED
+            );
+        }
+
+        if ($shares === null) {
+            $shares = [];
+        }
+
+        try {
+            $newShares  = $this->shareService->replaceShares(
+                dashboardId: $id,
+                shares: $shares,
+                userId: $this->userId
+            );
+            $serialized = array_map(
+                callback: static fn($s) => $s->jsonSerialize(),
+                array: $newShares
+            );
+            return new DataResponse(data: $serialized);
+        } catch (InvalidArgumentException $e) {
+            return new DataResponse(
+                data: ['error' => $e->getMessage()],
+                status: Http::STATUS_BAD_REQUEST
+            );
+        } catch (DoesNotExistException) {
+            return new DataResponse(
+                data: ['error' => 'Dashboard not found'],
+                status: Http::STATUS_NOT_FOUND
+            );
+        } catch (Exception $e) {
+            return new DataResponse(
+                data: ['error' => $e->getMessage()],
+                status: Http::STATUS_FORBIDDEN
+            );
+        }//end try
+    }//end replace()
+
+    /**
+     * Revoke all shares the caller has granted to a specific recipient.
+     * REQ-SHARE-010.
+     *
+     * @param string $shareType The share type.
+     * @param string $shareWith The recipient user/group ID.
+     *
+     * @return DataResponse The count of deleted rows.
+     */
+    #[NoAdminRequired]
+    public function revokeForRecipient(
+        string $shareType,
+        string $shareWith
+    ): DataResponse {
+        if ($this->userId === null) {
+            return new DataResponse(
+                data: ['error' => 'Not logged in'],
+                status: Http::STATUS_UNAUTHORIZED
+            );
+        }
+
+        try {
+            $count = $this->shareService->revokeAllForRecipient(
+                shareType: $shareType,
+                shareWith: $shareWith,
+                callerId: $this->userId
+            );
+            return new DataResponse(data: ['deleted' => $count]);
+        } catch (InvalidArgumentException $e) {
+            return new DataResponse(
+                data: ['error' => $e->getMessage()],
+                status: Http::STATUS_BAD_REQUEST
+            );
+        }
+    }//end revokeForRecipient()
+}//end class

--- a/lib/Db/DashboardShare.php
+++ b/lib/Db/DashboardShare.php
@@ -1,0 +1,153 @@
+<?php
+
+/**
+ * DashboardShare Entity
+ *
+ * Represents a dashboard share entity — a single row in the
+ * oc_mydash_dashboard_shares table binding a dashboard to a user or group
+ * recipient with a given permission level. REQ-SHARE-001.
+ *
+ * @category  Database
+ * @package   OCA\MyDash\Db
+ * @author    Conduction b.v. <info@conduction.nl>
+ * @copyright 2026 Conduction b.v.
+ * @license   https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12 EUPL-1.2
+ * @version   GIT:auto
+ * @link      https://conduction.nl
+ *
+ * SPDX-FileCopyrightText: 2026 MyDash Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace OCA\MyDash\Db;
+
+use JsonSerializable;
+use OCP\AppFramework\Db\Entity;
+
+/**
+ * Dashboard share entity.
+ *
+ * @method int|null getDashboardId()
+ * @method void setDashboardId(?int $dashboardId)
+ * @method string|null getShareType()
+ * @method void setShareType(?string $shareType)
+ * @method string|null getShareWith()
+ * @method void setShareWith(?string $shareWith)
+ * @method string|null getPermissionLevel()
+ * @method void setPermissionLevel(?string $permissionLevel)
+ * @method string|null getCreatedAt()
+ * @method void setCreatedAt(?string $createdAt)
+ * @method string|null getUpdatedAt()
+ * @method void setUpdatedAt(?string $updatedAt)
+ */
+class DashboardShare extends Entity implements JsonSerializable
+{
+
+    /**
+     * Share type for a single user recipient.
+     *
+     * @var string
+     */
+    public const SHARE_TYPE_USER = 'user';
+
+    /**
+     * Share type for a Nextcloud group recipient.
+     *
+     * @var string
+     */
+    public const SHARE_TYPE_GROUP = 'group';
+
+    /**
+     * Valid share types.
+     *
+     * @var string[]
+     */
+    public const VALID_SHARE_TYPES = [
+        self::SHARE_TYPE_USER,
+        self::SHARE_TYPE_GROUP,
+    ];
+
+    /**
+     * Valid permission levels (mirrors Dashboard constants).
+     *
+     * @var string[]
+     */
+    public const VALID_PERMISSION_LEVELS = [
+        Dashboard::PERMISSION_VIEW_ONLY,
+        Dashboard::PERMISSION_ADD_ONLY,
+        Dashboard::PERMISSION_FULL,
+    ];
+
+    /**
+     * The dashboard ID.
+     *
+     * @var integer|null
+     */
+    protected ?int $dashboardId = null;
+
+    /**
+     * The share type ('user' or 'group').
+     *
+     * @var string|null
+     */
+    protected ?string $shareType = null;
+
+    /**
+     * The recipient user ID or group ID.
+     *
+     * @var string|null
+     */
+    protected ?string $shareWith = null;
+
+    /**
+     * The permission level.
+     *
+     * @var string|null
+     */
+    protected ?string $permissionLevel = null;
+
+    /**
+     * The creation timestamp.
+     *
+     * @var string|null
+     */
+    protected ?string $createdAt = null;
+
+    /**
+     * The update timestamp.
+     *
+     * @var string|null
+     */
+    protected ?string $updatedAt = null;
+
+    /**
+     * Constructor — registers column types.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        $this->addType(fieldName: 'id', type: 'integer');
+        $this->addType(fieldName: 'dashboardId', type: 'integer');
+    }//end __construct()
+
+    /**
+     * Serialize to JSON.
+     *
+     * @return array The serialized share.
+     */
+    public function jsonSerialize(): array
+    {
+        return [
+            'id'              => $this->getId(),
+            'dashboardId'     => $this->dashboardId,
+            'shareType'       => $this->shareType,
+            'shareWith'       => $this->shareWith,
+            'permissionLevel' => $this->permissionLevel,
+            'createdAt'       => $this->createdAt,
+            'updatedAt'       => $this->updatedAt,
+        ];
+    }//end jsonSerialize()
+}//end class

--- a/lib/Db/DashboardShareMapper.php
+++ b/lib/Db/DashboardShareMapper.php
@@ -1,0 +1,327 @@
+<?php
+
+/**
+ * DashboardShareMapper
+ *
+ * Database mapper for DashboardShare entities. Covers the
+ * oc_mydash_dashboard_shares table. REQ-SHARE-001.
+ *
+ * @category  Database
+ * @package   OCA\MyDash\Db
+ * @author    Conduction b.v. <info@conduction.nl>
+ * @copyright 2026 Conduction b.v.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @version   GIT:auto
+ * @link      https://conduction.nl
+ *
+ * SPDX-FileCopyrightText: 2026 MyDash Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace OCA\MyDash\Db;
+
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\AppFramework\Db\QBMapper;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IDBConnection;
+
+/**
+ * Mapper for DashboardShare entities.
+ *
+ * @extends QBMapper<DashboardShare>
+ */
+class DashboardShareMapper extends QBMapper
+{
+    /**
+     * Constructor
+     *
+     * @param IDBConnection $db The database connection.
+     */
+    public function __construct(IDBConnection $db)
+    {
+        parent::__construct(
+            db: $db,
+            tableName: 'mydash_dashboard_shares',
+            entityClass: DashboardShare::class
+        );
+    }//end __construct()
+
+    /**
+     * Find a share by ID.
+     *
+     * @param int $id The share ID.
+     *
+     * @return DashboardShare The share.
+     *
+     * @throws DoesNotExistException When not found.
+     */
+    public function find(int $id): DashboardShare
+    {
+        $qb = $this->db->getQueryBuilder();
+        $qb->select(selects: '*')
+            ->from(from: $this->getTableName())
+            ->where(
+                $qb->expr()->eq(
+                    x: 'id',
+                    y: $qb->createNamedParameter(
+                        value: $id,
+                        type: IQueryBuilder::PARAM_INT
+                    )
+                )
+            );
+
+        return $this->findEntity(query: $qb);
+    }//end find()
+
+    /**
+     * Find all shares for a dashboard.
+     *
+     * @param int $dashboardId The dashboard ID.
+     *
+     * @return DashboardShare[] The shares.
+     */
+    public function findByDashboardId(int $dashboardId): array
+    {
+        $qb = $this->db->getQueryBuilder();
+        $qb->select(selects: '*')
+            ->from(from: $this->getTableName())
+            ->where(
+                $qb->expr()->eq(
+                    x: 'dashboard_id',
+                    y: $qb->createNamedParameter(
+                        value: $dashboardId,
+                        type: IQueryBuilder::PARAM_INT
+                    )
+                )
+            )
+            ->orderBy(sort: 'created_at', order: 'ASC');
+
+        return $this->findEntities(query: $qb);
+    }//end findByDashboardId()
+
+    /**
+     * Find shares for a dashboard with a specific permission level.
+     *
+     * @param int    $dashboardId     The dashboard ID.
+     * @param string $permissionLevel The required permission level.
+     *
+     * @return DashboardShare[] The shares.
+     */
+    public function findByDashboardAndLevel(
+        int $dashboardId,
+        string $permissionLevel
+    ): array {
+        $qb = $this->db->getQueryBuilder();
+        $qb->select(selects: '*')
+            ->from(from: $this->getTableName())
+            ->where(
+                $qb->expr()->eq(
+                    x: 'dashboard_id',
+                    y: $qb->createNamedParameter(
+                        value: $dashboardId,
+                        type: IQueryBuilder::PARAM_INT
+                    )
+                )
+            )
+            ->andWhere(
+                $qb->expr()->eq(
+                    x: 'permission_level',
+                    y: $qb->createNamedParameter(value: $permissionLevel)
+                )
+            )
+            ->orderBy(sort: 'created_at', order: 'ASC');
+
+        return $this->findEntities(query: $qb);
+    }//end findByDashboardAndLevel()
+
+    /**
+     * Find a specific share by (dashboardId, shareType, shareWith).
+     *
+     * Returns null when not found (no exception).
+     *
+     * @param int    $dashboardId The dashboard ID.
+     * @param string $shareType   The share type.
+     * @param string $shareWith   The recipient.
+     *
+     * @return DashboardShare|null The share or null.
+     */
+    public function findShare(
+        int $dashboardId,
+        string $shareType,
+        string $shareWith
+    ): ?DashboardShare {
+        $qb = $this->db->getQueryBuilder();
+        $qb->select(selects: '*')
+            ->from(from: $this->getTableName())
+            ->where(
+                $qb->expr()->eq(
+                    x: 'dashboard_id',
+                    y: $qb->createNamedParameter(
+                        value: $dashboardId,
+                        type: IQueryBuilder::PARAM_INT
+                    )
+                )
+            )
+            ->andWhere(
+                $qb->expr()->eq(
+                    x: 'share_type',
+                    y: $qb->createNamedParameter(value: $shareType)
+                )
+            )
+            ->andWhere(
+                $qb->expr()->eq(
+                    x: 'share_with',
+                    y: $qb->createNamedParameter(value: $shareWith)
+                )
+            );
+
+        try {
+            return $this->findEntity(query: $qb);
+        } catch (DoesNotExistException) {
+            return null;
+        }
+    }//end findShare()
+
+    /**
+     * Delete all shares for a dashboard.
+     *
+     * @param int $dashboardId The dashboard ID.
+     *
+     * @return void
+     */
+    public function deleteByDashboardId(int $dashboardId): void
+    {
+        $qb = $this->db->getQueryBuilder();
+        $qb->delete(delete: $this->getTableName())
+            ->where(
+                $qb->expr()->eq(
+                    x: 'dashboard_id',
+                    y: $qb->createNamedParameter(
+                        value: $dashboardId,
+                        type: IQueryBuilder::PARAM_INT
+                    )
+                )
+            );
+
+        $qb->executeStatement();
+    }//end deleteByDashboardId()
+
+    /**
+     * Delete all shares where the recipient is a specific user.
+     *
+     * Only removes user-type shares (group membership cleanup is handled
+     * by Nextcloud's own group management hooks). REQ-SHARE-012.
+     *
+     * @param string $userId The recipient user ID.
+     *
+     * @return int The number of rows deleted.
+     */
+    public function deleteByRecipientUser(string $userId): int
+    {
+        $qb = $this->db->getQueryBuilder();
+        $qb->delete(delete: $this->getTableName())
+            ->where(
+                $qb->expr()->eq(
+                    x: 'share_type',
+                    y: $qb->createNamedParameter(value: DashboardShare::SHARE_TYPE_USER)
+                )
+            )
+            ->andWhere(
+                $qb->expr()->eq(
+                    x: 'share_with',
+                    y: $qb->createNamedParameter(value: $userId)
+                )
+            );
+
+        return $qb->executeStatement();
+    }//end deleteByRecipientUser()
+
+    /**
+     * Delete all shares not in the given set for a dashboard.
+     *
+     * Used by the bulk-replace endpoint to remove shares not in the new
+     * payload. REQ-SHARE-009.
+     *
+     * @param int      $dashboardId The dashboard ID.
+     * @param string[] $keepKeys    Keys of form "{shareType}:{shareWith}"
+     *                              to preserve.
+     *
+     * @return int The number of rows deleted.
+     */
+    public function deleteNotIn(int $dashboardId, array $keepKeys): int
+    {
+        // Load existing rows and delete those whose composite key is not in keepKeys.
+        $existing = $this->findByDashboardId(dashboardId: $dashboardId);
+        $deleted  = 0;
+        foreach ($existing as $share) {
+            $key = $share->getShareType().':'.$share->getShareWith();
+            if (in_array(needle: $key, haystack: $keepKeys, strict: true) === false) {
+                $this->delete(entity: $share);
+                $deleted++;
+            }
+        }
+
+        return $deleted;
+    }//end deleteNotIn()
+
+    /**
+     * Delete all shares the caller owns that target a specific recipient.
+     *
+     * Joins logically: finds dashboards owned by $ownerId via DashboardMapper
+     * query. Uses a subquery on the dashboard table. REQ-SHARE-010.
+     *
+     * @param string $shareType The share type.
+     * @param string $shareWith The recipient.
+     * @param string $ownerId   The dashboard owner.
+     *
+     * @return int The number of rows deleted.
+     */
+    public function deleteByOwnerAndRecipient(
+        string $shareType,
+        string $shareWith,
+        string $ownerId
+    ): int {
+        // Subquery: SELECT id FROM mydash_dashboards WHERE user_id = ownerId.
+        $sub = $this->db->getQueryBuilder();
+        $sub->select(selects: 'id')
+            ->from(from: 'mydash_dashboards')
+            ->where(
+                $sub->expr()->eq(
+                    x: 'user_id',
+                    y: $sub->createNamedParameter(value: $ownerId)
+                )
+            );
+
+        $qb = $this->db->getQueryBuilder();
+        $qb->delete(delete: $this->getTableName())
+            ->where(
+                $qb->expr()->in(
+                    x: 'dashboard_id',
+                    y: $qb->createFunction(
+                        call: '('.$sub->getSQL().')'
+                    )
+                )
+            )
+            ->andWhere(
+                $qb->expr()->eq(
+                    x: 'share_type',
+                    y: $qb->createNamedParameter(value: $shareType)
+                )
+            )
+            ->andWhere(
+                $qb->expr()->eq(
+                    x: 'share_with',
+                    y: $qb->createNamedParameter(value: $shareWith)
+                )
+            );
+
+        // Merge parameters from sub into main.
+        foreach ($sub->getParameters() as $key => $value) {
+            $qb->setParameter(key: $key, value: $value);
+        }
+
+        return $qb->executeStatement();
+    }//end deleteByOwnerAndRecipient()
+}//end class

--- a/lib/Listener/UserDeletedListener.php
+++ b/lib/Listener/UserDeletedListener.php
@@ -1,0 +1,255 @@
+<?php
+
+/**
+ * UserDeletedListener
+ *
+ * Listens to OCP\User\Events\UserDeletedEvent and applies the admin-retention
+ * cascade: cleans up shares granted to the deleted user, then for every
+ * dashboard the user owned either transfers ownership to the first admin-pool
+ * member or deletes the dashboard when the pool is empty. REQ-SHARE-012.
+ *
+ * @category  Listener
+ * @package   OCA\MyDash\Listener
+ * @author    Conduction b.v. <info@conduction.nl>
+ * @copyright 2026 Conduction b.v.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @version   GIT:auto
+ * @link      https://conduction.nl
+ *
+ * SPDX-FileCopyrightText: 2026 MyDash Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace OCA\MyDash\Listener;
+
+use OCA\MyDash\Db\Dashboard;
+use OCA\MyDash\Db\DashboardMapper;
+use OCA\MyDash\Db\DashboardShare;
+use OCA\MyDash\Db\DashboardShareMapper;
+use OCA\MyDash\Db\WidgetPlacementMapper;
+use OCA\MyDash\Service\DashboardShareService;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventListener;
+use OCP\IDBConnection;
+use OCP\IGroupManager;
+use OCP\IUserManager;
+use OCP\User\Events\UserDeletedEvent;
+use Throwable;
+
+/**
+ * Handles user deletion: recipient cleanup + ownership transfer / cascade.
+ *
+ * @implements IEventListener<UserDeletedEvent>
+ */
+class UserDeletedListener implements IEventListener
+{
+    /**
+     * Constructor
+     *
+     * @param DashboardShareMapper  $shareMapper     The share mapper.
+     * @param DashboardMapper       $dashboardMapper The dashboard mapper.
+     * @param WidgetPlacementMapper $placementMapper The placement mapper.
+     * @param DashboardShareService $shareService    The share service.
+     * @param IGroupManager         $groupManager    The group manager.
+     * @param IUserManager          $userManager     The user manager.
+     * @param IDBConnection         $db              The DB connection.
+     */
+    public function __construct(
+        private readonly DashboardShareMapper $shareMapper,
+        private readonly DashboardMapper $dashboardMapper,
+        private readonly WidgetPlacementMapper $placementMapper,
+        private readonly DashboardShareService $shareService,
+        private readonly IGroupManager $groupManager,
+        private readonly IUserManager $userManager,
+        private readonly IDBConnection $db,
+    ) {
+    }//end __construct()
+
+    /**
+     * Handle the UserDeletedEvent.
+     *
+     * Step A: delete all user-type shares where share_with = deleted user.
+     * Step B: for each owned dashboard, compute the admin pool and either
+     *         transfer ownership or delete the dashboard.
+     *
+     * @param Event $event The event.
+     *
+     * @return void
+     */
+    public function handle(Event $event): void
+    {
+        if (($event instanceof UserDeletedEvent) === false) {
+            return;
+        }
+
+        $userId = $event->getUser()->getUID();
+
+        // Step A: remove shares granted TO the deleted user.
+        $this->shareMapper->deleteByRecipientUser(userId: $userId);
+
+        // Step B: handle owned dashboards.
+        $ownedDashboards = $this->dashboardMapper->findByUserId(
+            userId: $userId
+        );
+
+        foreach ($ownedDashboards as $dashboard) {
+            $this->handleOwnedDashboard(
+                dashboard: $dashboard,
+                deletedUserId: $userId
+            );
+        }
+    }//end handle()
+
+    /**
+     * Handle a single dashboard owned by the deleted user.
+     *
+     * @param Dashboard $dashboard     The dashboard.
+     * @param string    $deletedUserId The deleted user's ID.
+     *
+     * @return void
+     */
+    private function handleOwnedDashboard(
+        Dashboard $dashboard,
+        string $deletedUserId
+    ): void {
+        $dashboardId = (int) $dashboard->getId();
+
+        $this->db->beginTransaction();
+        try {
+            $newOwner = $this->pickNewOwner(
+                dashboardId: $dashboardId,
+                deletedUserId: $deletedUserId
+            );
+
+            if ($newOwner !== null) {
+                // Transfer ownership.
+                $this->shareService->transferOwnership(
+                    dashboardId: $dashboardId,
+                    newUserId: $newOwner
+                );
+
+                $this->db->commit();
+
+                // Notify outside the transaction.
+                $this->shareService->notifyOwnershipTransferred(
+                    newOwnerId: $newOwner,
+                    dashboardId: $dashboardId,
+                    dashboardName: (string) $dashboard->getName()
+                );
+            } else {
+                // Admin pool empty — delete dashboard, placements, and shares.
+                $this->placementMapper->deleteByDashboardId(
+                    dashboardId: $dashboardId
+                );
+                $this->shareMapper->deleteByDashboardId(
+                    dashboardId: $dashboardId
+                );
+                $this->dashboardMapper->delete(entity: $dashboard);
+
+                $this->db->commit();
+            }//end if
+        } catch (Throwable $t) {
+            $this->db->rollBack();
+            // Log but do not rethrow — we want to continue processing
+            // the other dashboards.
+            \OC::$server->getLogger()->error(
+                message: sprintf(
+                    'mydash UserDeletedListener: failed to handle dashboard %d: %s',
+                    $dashboardId,
+                    $t->getMessage()
+                ),
+                context: ['app' => 'mydash']
+            );
+        }//end try
+    }//end handleOwnedDashboard()
+
+    /**
+     * Compute the admin pool and pick the new owner per REQ-SHARE-013.
+     *
+     * Selection rule:
+     * 1. User-type shares with `permission_level='full'`, ordered by
+     *    created_at ASC — pick the first still-existing user.
+     * 2. If none, take the alphabetically-first group-type share with
+     *    `permission_level='full'` and from its members pick the
+     *    alphabetically-first uid that still exists.
+     * 3. If both fail, return null (delete path).
+     *
+     * @param int    $dashboardId   The dashboard ID.
+     * @param string $deletedUserId The deleted user (excluded from pool).
+     *
+     * @return string|null The new owner uid or null.
+     */
+    private function pickNewOwner(
+        int $dashboardId,
+        string $deletedUserId
+    ): ?string {
+        $fullShares = $this->shareMapper->findByDashboardAndLevel(
+            dashboardId: $dashboardId,
+            permissionLevel: Dashboard::PERMISSION_FULL
+        );
+
+        // Step 1: user-type shares sorted by created_at ASC (mapper already
+        // returns rows in that order).
+        foreach ($fullShares as $share) {
+            if ($share->getShareType() !== DashboardShare::SHARE_TYPE_USER) {
+                continue;
+            }
+
+            $uid = (string) $share->getShareWith();
+            if ($uid === $deletedUserId) {
+                continue;
+            }
+
+            if ($this->userManager->get(uid: $uid) !== null) {
+                return $uid;
+            }
+        }
+
+        // Step 2: group-type shares — pick alphabetically-first group name.
+        $groupShares = [];
+        foreach ($fullShares as $share) {
+            if ($share->getShareType() === DashboardShare::SHARE_TYPE_GROUP) {
+                $groupShares[] = $share;
+            }
+        }
+
+        // Sort groups alphabetically.
+        usort(
+            array: $groupShares,
+            callback: static fn($a, $b) => strcmp(
+                string1: (string) $a->getShareWith(),
+                string2: (string) $b->getShareWith()
+            )
+        );
+
+        foreach ($groupShares as $groupShare) {
+            $groupId = (string) $groupShare->getShareWith();
+            $group   = $this->groupManager->get(gid: $groupId);
+            if ($group === null) {
+                continue;
+            }
+
+            // Get members and sort alphabetically.
+            $members = [];
+            foreach ($group->getUsers() as $user) {
+                $members[] = $user->getUID();
+            }
+
+            sort(array: $members);
+
+            foreach ($members as $uid) {
+                if ($uid === $deletedUserId) {
+                    continue;
+                }
+
+                if ($this->userManager->get(uid: $uid) !== null) {
+                    return $uid;
+                }
+            }//end foreach
+        }//end foreach
+
+        return null;
+    }//end pickNewOwner()
+}//end class

--- a/lib/Migration/Version001006Date20260430130000.php
+++ b/lib/Migration/Version001006Date20260430130000.php
@@ -1,0 +1,232 @@
+<?php
+
+/**
+ * Version001006Date20260430130000
+ *
+ * Migration creating the mydash_dashboard_shares table for REQ-SHARE-001.
+ * Also includes an optional one-shot orphan-share cleanup step gated by
+ * the admin setting `mydash.cleanup_orphan_shares`. REQ-SHARE-012.
+ *
+ * @category  Migration
+ * @package   OCA\MyDash\Migration
+ * @author    Conduction b.v. <info@conduction.nl>
+ * @copyright 2026 Conduction b.v.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @version   GIT:auto
+ * @link      https://conduction.nl
+ *
+ * SPDX-FileCopyrightText: 2026 MyDash Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace OCA\MyDash\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
+use OCP\IConfig;
+use OCP\IDBConnection;
+use OCP\IGroupManager;
+use OCP\IUserManager;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+/**
+ * Migration creating the dashboard_shares table and an optional orphan cleanup.
+ *
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ */
+class Version001006Date20260430130000 extends SimpleMigrationStep
+{
+    /**
+     * Constructor
+     *
+     * @param IConfig       $config       The app config.
+     * @param IDBConnection $db           The database connection.
+     * @param IUserManager  $userManager  The user manager.
+     * @param IGroupManager $groupManager The group manager.
+     */
+    public function __construct(
+        private readonly IConfig $config,
+        private readonly IDBConnection $db,
+        private readonly IUserManager $userManager,
+        private readonly IGroupManager $groupManager,
+    ) {
+    }//end __construct()
+
+    /**
+     * Create the mydash_dashboard_shares table.
+     *
+     * @param IOutput $output        The migration output handler.
+     * @param Closure $schemaClosure The schema closure.
+     * @param array   $options       The migration options.
+     *
+     * @return ISchemaWrapper|null The modified schema or null.
+     */
+    public function changeSchema(
+        IOutput $output,
+        Closure $schemaClosure,
+        array $options
+    ): ?ISchemaWrapper {
+        $schema = $schemaClosure();
+
+        if ($schema->hasTable(tableName: 'mydash_dashboard_shares') === true) {
+            return null;
+        }
+
+        $table = $schema->createTable(tableName: 'mydash_dashboard_shares');
+
+        $table->addColumn(
+            name: 'id',
+            typeName: Types::BIGINT,
+            options: [
+                'autoincrement' => true,
+                'notnull'       => true,
+                'unsigned'      => true,
+            ]
+        );
+        $table->addColumn(
+            name: 'dashboard_id',
+            typeName: Types::BIGINT,
+            options: [
+                'notnull'  => true,
+                'unsigned' => true,
+            ]
+        );
+        $table->addColumn(
+            name: 'share_type',
+            typeName: Types::STRING,
+            options: [
+                'notnull' => true,
+                'length'  => 16,
+            ]
+        );
+        $table->addColumn(
+            name: 'share_with',
+            typeName: Types::STRING,
+            options: [
+                'notnull' => true,
+                'length'  => 255,
+            ]
+        );
+        $table->addColumn(
+            name: 'permission_level',
+            typeName: Types::STRING,
+            options: [
+                'notnull' => true,
+                'length'  => 32,
+                'default' => 'view_only',
+            ]
+        );
+        $table->addColumn(
+            name: 'created_at',
+            typeName: Types::STRING,
+            options: [
+                'notnull' => false,
+                'length'  => 32,
+            ]
+        );
+        $table->addColumn(
+            name: 'updated_at',
+            typeName: Types::STRING,
+            options: [
+                'notnull' => false,
+                'length'  => 32,
+            ]
+        );
+
+        $table->setPrimaryKey(columnNames: ['id']);
+        $table->addIndex(
+            columnNames: ['dashboard_id'],
+            indexName: 'mydash_shares_dashboard'
+        );
+        $table->addIndex(
+            columnNames: ['share_type', 'share_with'],
+            indexName: 'mydash_shares_recipient'
+        );
+        $table->addUniqueIndex(
+            columnNames: ['dashboard_id', 'share_type', 'share_with'],
+            indexName: 'mydash_shares_unique'
+        );
+
+        return $schema;
+    }//end changeSchema()
+
+    /**
+     * Optional orphan-share cleanup, gated by admin setting.
+     *
+     * Deletes share rows where the recipient user/group no longer exists.
+     * Only runs when `mydash.cleanup_orphan_shares` is explicitly `true`.
+     * Default is `false` to avoid surprise deletions on federated environments.
+     *
+     * @param IOutput $output  The migration output handler.
+     * @param Closure $closure The schema closure.
+     * @param array   $options The migration options.
+     *
+     * @return void
+     */
+    public function postSchemaChange(
+        IOutput $output,
+        Closure $closure,
+        array $options
+    ): void {
+        $enabled = $this->config->getAppValue(
+            appName: 'mydash',
+            key: 'cleanup_orphan_shares',
+            default: 'false'
+        );
+
+        if ($enabled !== 'true') {
+            return;
+        }
+
+        $output->info(message: 'mydash: scanning for orphan share rows…');
+
+        if ($this->db->tableExists(table: 'mydash_dashboard_shares') === false) {
+            return;
+        }
+
+        $qb     = $this->db->getQueryBuilder();
+        $result = $qb->select(selects: ['id', 'share_type', 'share_with'])
+            ->from(from: 'mydash_dashboard_shares')
+            ->executeQuery();
+
+        $deleted = 0;
+        $row     = $result->fetch();
+        while ($row !== false) {
+            $orphan = false;
+            if ($row['share_type'] === 'user'
+                && $this->userManager->get(uid: $row['share_with']) === null
+            ) {
+                $orphan = true;
+            } else if ($row['share_type'] === 'group'
+                && $this->groupManager->get(gid: $row['share_with']) === null
+            ) {
+                $orphan = true;
+            }
+
+            if ($orphan === true) {
+                $del = $this->db->getQueryBuilder();
+                $del->delete(delete: 'mydash_dashboard_shares')
+                    ->where(
+                        $del->expr()->eq(
+                            x: 'id',
+                            y: $del->createNamedParameter(
+                                value: (int) $row['id'],
+                                type: \OCP\DB\QueryBuilder\IQueryBuilder::PARAM_INT
+                            )
+                        )
+                    )
+                    ->executeStatement();
+                $deleted++;
+            }
+
+            $row = $result->fetch();
+        }//end while
+
+        $result->closeCursor();
+        $output->info(message: "mydash: removed {$deleted} orphan share row(s).");
+    }//end postSchemaChange()
+}//end class

--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -1,0 +1,280 @@
+<?php
+
+/**
+ * Notifier
+ *
+ * INotifier implementation for MyDash. Renders `dashboard_shared` and
+ * `dashboard_ownership_transferred` notifications in the Nextcloud bell,
+ * activity stream, and email digest. REQ-SHARE-011.
+ *
+ * @category  Notification
+ * @package   OCA\MyDash\Notification
+ * @author    Conduction b.v. <info@conduction.nl>
+ * @copyright 2026 Conduction b.v.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @version   GIT:auto
+ * @link      https://conduction.nl
+ *
+ * SPDX-FileCopyrightText: 2026 MyDash Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace OCA\MyDash\Notification;
+
+use InvalidArgumentException;
+use OCA\MyDash\AppInfo\Application;
+use OCA\MyDash\Db\DashboardMapper;
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\IURLGenerator;
+use OCP\L10N\IFactory;
+use OCP\Notification\INotification;
+use OCP\Notification\INotifier;
+use OCP\Notification\UnknownNotificationException;
+
+/**
+ * MyDash notification renderer.
+ *
+ * Handles two subjects:
+ * - `dashboard_shared` — published when a dashboard is shared with a user or
+ *   when a share's permission_level is upgraded (REQ-SHARE-008).
+ * - `dashboard_ownership_transferred` — published when a UserDeletedEvent
+ *   causes ownership of a dashboard to be transferred to a new owner
+ *   (REQ-SHARE-013).
+ */
+class Notifier implements INotifier
+{
+    /**
+     * Constructor
+     *
+     * @param IFactory        $l10nFactory     The L10N factory.
+     * @param IURLGenerator   $urlGenerator    The URL generator.
+     * @param DashboardMapper $dashboardMapper The dashboard mapper.
+     */
+    public function __construct(
+        private readonly IFactory $l10nFactory,
+        private readonly IURLGenerator $urlGenerator,
+        private readonly DashboardMapper $dashboardMapper,
+    ) {
+    }//end __construct()
+
+    /**
+     * Return the notifier app ID.
+     *
+     * @return string The app ID.
+     */
+    public function getID(): string
+    {
+        return Application::APP_ID;
+    }//end getID()
+
+    /**
+     * Return a human-readable notifier name.
+     *
+     * @return string The notifier name.
+     */
+    public function getName(): string
+    {
+        return $this->l10nFactory->get(app: Application::APP_ID)->t('MyDash');
+    }//end getName()
+
+    /**
+     * Prepare and render an INotification for display.
+     *
+     * Handles `dashboard_shared` and `dashboard_ownership_transferred`.
+     * Throws `UnknownNotificationException` for any other subject so that
+     * the Nextcloud notification chain can pass it to the next notifier.
+     *
+     * @param INotification $notification The raw notification.
+     * @param string        $languageCode The language code for the recipient.
+     *
+     * @return INotification The prepared notification.
+     *
+     * @throws UnknownNotificationException When the subject is not handled.
+     */
+    public function prepare(
+        INotification $notification,
+        string $languageCode
+    ): INotification {
+        if ($notification->getApp() !== Application::APP_ID) {
+            throw new UnknownNotificationException(
+                message: 'Unknown app: '.$notification->getApp()
+            );
+        }
+
+        $l   = $this->l10nFactory->get(
+            app: Application::APP_ID,
+            lang: $languageCode
+        );
+        $url = $this->buildDashboardUrl(
+            objectId: $notification->getObjectId()
+        );
+
+        $subject = $notification->getSubject();
+
+        if ($subject === 'dashboard_shared') {
+            return $this->prepareDashboardShared(
+                notification: $notification,
+                l: $l,
+                url: $url
+            );
+        }
+
+        if ($subject === 'dashboard_ownership_transferred') {
+            return $this->prepareOwnershipTransferred(
+                notification: $notification,
+                l: $l,
+                url: $url
+            );
+        }
+
+        throw new UnknownNotificationException(
+            message: 'Unknown subject: '.$subject
+        );
+    }//end prepare()
+
+    /**
+     * Prepare a `dashboard_shared` notification.
+     *
+     * Subject parameters: [sharerUserId, dashboardName, permissionLevel].
+     *
+     * @param INotification   $notification The notification.
+     * @param \OCP\L10N\IL10N $l            The L10N instance.
+     * @param string          $url          The deep-link URL.
+     *
+     * @return INotification The prepared notification.
+     */
+    private function prepareDashboardShared(
+        INotification $notification,
+        \OCP\L10N\IL10N $l,
+        string $url
+    ): INotification {
+        $params = $notification->getSubjectParameters();
+        $sharer = $params[0] ?? '';
+        $name   = $params[1] ?? '';
+        $level  = $params[2] ?? '';
+
+        $richSubject = $l->t(
+            '%1$s shared **%2$s** with you',
+            [$sharer, $name]
+        );
+        $notification->setRichSubject(
+            subject: $richSubject,
+            parameters: []
+        );
+        $notification->setParsedSubject(
+            subject: $l->t(
+                '%1$s shared %2$s with you',
+                [$sharer, $name]
+            )
+        );
+
+        $levelLabel = $this->permissionLabel(l: $l, level: $level);
+        $notification->setRichMessage(
+            message: $levelLabel,
+            parameters: []
+        );
+        $notification->setParsedMessage(subject: $levelLabel);
+
+        $notification->setLink(link: $url);
+
+        return $notification;
+    }//end prepareDashboardShared()
+
+    /**
+     * Prepare a `dashboard_ownership_transferred` notification.
+     *
+     * Subject parameters: [dashboardName].
+     *
+     * @param INotification   $notification The notification.
+     * @param \OCP\L10N\IL10N $l            The L10N instance.
+     * @param string          $url          The deep-link URL.
+     *
+     * @return INotification The prepared notification.
+     */
+    private function prepareOwnershipTransferred(
+        INotification $notification,
+        \OCP\L10N\IL10N $l,
+        string $url
+    ): INotification {
+        $params = $notification->getSubjectParameters();
+        $name   = $params[0] ?? '';
+
+        $richSubject = $l->t('**%1$s** is now yours', [$name]);
+        $notification->setRichSubject(
+            subject: $richSubject,
+            parameters: []
+        );
+        $notification->setParsedSubject(
+            subject: $l->t('%1$s is now yours', [$name])
+        );
+
+        $message = $l->t(
+            'Ownership transferred after the previous owner was removed'
+        );
+        $notification->setRichMessage(
+            message: $message,
+            parameters: []
+        );
+        $notification->setParsedMessage(subject: $message);
+
+        $notification->setLink(link: $url);
+
+        return $notification;
+    }//end prepareOwnershipTransferred()
+
+    /**
+     * Build the deep-link URL for a dashboard.
+     *
+     * Falls back to the base index route when the objectId cannot be
+     * resolved to a UUID (e.g. when the dashboard was deleted between
+     * notification creation and rendering).
+     *
+     * @param string $objectId The dashboard DB ID (as string per INotification).
+     *
+     * @return string The URL.
+     */
+    private function buildDashboardUrl(string $objectId): string
+    {
+        $base = $this->urlGenerator->linkToRouteAbsolute(
+            routeName: 'mydash.page.index'
+        );
+
+        if ($objectId === '') {
+            return $base;
+        }
+
+        try {
+            $dashboard = $this->dashboardMapper->find(id: (int) $objectId);
+            $uuid      = $dashboard->getUuid();
+            if ($uuid !== null && $uuid !== '') {
+                return $base.'?dashboard='.urlencode(string: $uuid);
+            }
+        } catch (DoesNotExistException) {
+            // Dashboard deleted — return base URL.
+        }
+
+        return $base;
+    }//end buildDashboardUrl()
+
+    /**
+     * Return the human-readable label for a permission level.
+     *
+     * @param \OCP\L10N\IL10N $l     The L10N instance.
+     * @param string          $level The permission level identifier.
+     *
+     * @return string The translated label.
+     */
+    private function permissionLabel(
+        \OCP\L10N\IL10N $l,
+        string $level
+    ): string {
+        return match ($level) {
+            'full'      => $l->t('Full access'),
+            'add_only'  => $l->t('Add-only access'),
+            'view_only' => $l->t('View-only access'),
+            default     => $l->t('Shared access'),
+        };
+    }//end permissionLabel()
+}//end class

--- a/lib/Service/DashboardShareService.php
+++ b/lib/Service/DashboardShareService.php
@@ -1,0 +1,570 @@
+<?php
+
+/**
+ * DashboardShareService
+ *
+ * Service for managing dashboard shares. Covers REQ-SHARE-001..013:
+ * per-row add/remove, bulk replace, revoke-all-for-recipient, ownership
+ * transfer, and notification publishing.
+ *
+ * @category  Service
+ * @package   OCA\MyDash\Service
+ * @author    Conduction b.v. <info@conduction.nl>
+ * @copyright 2026 Conduction b.v.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @version   GIT:auto
+ * @link      https://conduction.nl
+ *
+ * SPDX-FileCopyrightText: 2026 MyDash Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace OCA\MyDash\Service;
+
+use DateTime;
+use Exception;
+use InvalidArgumentException;
+use OCA\MyDash\Db\Dashboard;
+use OCA\MyDash\Db\DashboardMapper;
+use OCA\MyDash\Db\DashboardShare;
+use OCA\MyDash\Db\DashboardShareMapper;
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\IDBConnection;
+use OCP\IGroupManager;
+use OCP\Notification\IManager as INotificationManager;
+use Throwable;
+
+/**
+ * Service for creating and managing dashboard shares.
+ *
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ */
+class DashboardShareService
+{
+
+    /**
+     * Permission level ordering for upgrade detection (higher index = more).
+     *
+     * @var array<string, int>
+     */
+    private const LEVEL_ORDER = [
+        Dashboard::PERMISSION_VIEW_ONLY => 0,
+        Dashboard::PERMISSION_ADD_ONLY  => 1,
+        Dashboard::PERMISSION_FULL      => 2,
+    ];
+
+    /**
+     * Constructor
+     *
+     * @param DashboardShareMapper $shareMapper         The share mapper.
+     * @param DashboardMapper      $dashboardMapper     The dashboard mapper.
+     * @param IGroupManager        $groupManager        The group manager.
+     * @param INotificationManager $notificationManager The notification manager.
+     * @param IDBConnection        $db                  The DB connection.
+     */
+    public function __construct(
+        private readonly DashboardShareMapper $shareMapper,
+        private readonly DashboardMapper $dashboardMapper,
+        private readonly IGroupManager $groupManager,
+        private readonly INotificationManager $notificationManager,
+        private readonly IDBConnection $db,
+    ) {
+    }//end __construct()
+
+    /**
+     * List all shares for a dashboard.
+     *
+     * @param int    $dashboardId The dashboard ID.
+     * @param string $userId      The calling user ID (must own the dashboard).
+     *
+     * @return DashboardShare[] The shares.
+     *
+     * @throws Exception When the user is not the dashboard owner.
+     */
+    public function listShares(int $dashboardId, string $userId): array
+    {
+        $this->assertOwner(dashboardId: $dashboardId, userId: $userId);
+        return $this->shareMapper->findByDashboardId(dashboardId: $dashboardId);
+    }//end listShares()
+
+    /**
+     * Add or upsert a single share. Publishes a notification when the
+     * entry is new or the permission level is upgraded. REQ-SHARE-008.
+     *
+     * @param int    $dashboardId     The dashboard ID.
+     * @param string $shareType       The share type ('user' or 'group').
+     * @param string $shareWith       The recipient user/group ID.
+     * @param string $permissionLevel The permission level.
+     * @param string $callerId        The calling user (must be dashboard owner).
+     *
+     * @return DashboardShare The persisted share.
+     *
+     * @throws Exception When the caller is not the owner or input is invalid.
+     */
+    public function addShare(
+        int $dashboardId,
+        string $shareType,
+        string $shareWith,
+        string $permissionLevel,
+        string $callerId
+    ): DashboardShare {
+        $dashboard = $this->assertOwner(
+            dashboardId: $dashboardId,
+            userId: $callerId
+        );
+        $this->validateInput(
+            shareType: $shareType,
+            shareWith: $shareWith,
+            permissionLevel: $permissionLevel
+        );
+
+        $result = $this->persistShare(
+            dashboardId: $dashboardId,
+            shareType: $shareType,
+            shareWith: $shareWith,
+            permissionLevel: $permissionLevel
+        );
+
+        if ($result['isNew'] === true || $result['isUpgrade'] === true) {
+            $this->notifyShared(
+                share: $result['share'],
+                sharerUserId: $callerId,
+                dashboardName: (string) $dashboard->getName()
+            );
+        }
+
+        return $result['share'];
+    }//end addShare()
+
+    /**
+     * Remove a share by ID. Silent — no notification is published.
+     * REQ-SHARE-008 (revocations are silent).
+     *
+     * @param int    $shareId  The share ID.
+     * @param string $callerId The calling user (must be dashboard owner).
+     *
+     * @return void
+     *
+     * @throws Exception When the share does not exist or caller is not owner.
+     */
+    public function removeShare(int $shareId, string $callerId): void
+    {
+        $share     = $this->shareMapper->find(id: $shareId);
+        $dashboard = $this->dashboardMapper->find(
+            id: (int) $share->getDashboardId()
+        );
+
+        if ($dashboard->getUserId() !== $callerId) {
+            throw new Exception(message: 'Access denied');
+        }
+
+        $this->shareMapper->delete(entity: $share);
+    }//end removeShare()
+
+    /**
+     * Atomically replace all shares for a dashboard. REQ-SHARE-009.
+     *
+     * Deletes every existing share not in the payload, upserts matching
+     * ones. Publishes one notification per newly-added or upgraded
+     * recipient only. All DB writes run in a single transaction.
+     *
+     * @param int    $dashboardId The dashboard ID.
+     * @param array  $shares      Array of {shareType, shareWith, permissionLevel}.
+     * @param string $userId      The calling user (must be dashboard owner).
+     *
+     * @return DashboardShare[] The new full share list.
+     *
+     * @throws Exception    When the caller is not the owner or input is invalid.
+     * @throws Throwable    On DB error (rolls back).
+     */
+    public function replaceShares(
+        int $dashboardId,
+        array $shares,
+        string $userId
+    ): array {
+        $dashboard = $this->assertOwner(
+            dashboardId: $dashboardId,
+            userId: $userId
+        );
+
+        // Validate all entries up-front before touching the DB.
+        foreach ($shares as $entry) {
+            $this->validateInput(
+                shareType: $entry['shareType'] ?? '',
+                shareWith: $entry['shareWith'] ?? '',
+                permissionLevel: $entry['permissionLevel'] ?? ''
+            );
+        }
+
+        // Build the keep-key set for deletion.
+        $keepKeys = [];
+        foreach ($shares as $entry) {
+            $keepKeys[] = $entry['shareType'].':'.$entry['shareWith'];
+        }
+
+        $notifyQueue = [];
+
+        $this->db->beginTransaction();
+        try {
+            // Remove shares not in payload.
+            $this->shareMapper->deleteNotIn(
+                dashboardId: $dashboardId,
+                keepKeys: $keepKeys
+            );
+
+            // Upsert each entry.
+            foreach ($shares as $entry) {
+                $result = $this->persistShare(
+                    dashboardId: $dashboardId,
+                    shareType: $entry['shareType'],
+                    shareWith: $entry['shareWith'],
+                    permissionLevel: $entry['permissionLevel']
+                );
+
+                if ($result['isNew'] === true || $result['isUpgrade'] === true) {
+                    $notifyQueue[] = $result['share'];
+                }
+            }
+
+            $this->db->commit();
+        } catch (Throwable $t) {
+            $this->db->rollBack();
+            throw $t;
+        }//end try
+
+        // Publish notifications after the transaction commits.
+        $dashboardName = (string) $dashboard->getName();
+        foreach ($notifyQueue as $share) {
+            $this->notifyShared(
+                share: $share,
+                sharerUserId: $userId,
+                dashboardName: $dashboardName
+            );
+        }
+
+        return $this->shareMapper->findByDashboardId(dashboardId: $dashboardId);
+    }//end replaceShares()
+
+    /**
+     * Remove every share where the caller is the owner AND the share targets
+     * the named recipient. REQ-SHARE-010.
+     *
+     * Only touches dashboards owned by $callerId — shares on dashboards
+     * owned by others are not affected even if $callerId holds a `full`
+     * share on them.
+     *
+     * @param string $shareType The share type.
+     * @param string $shareWith The recipient user/group ID.
+     * @param string $callerId  The calling user (owner restriction).
+     *
+     * @return int The number of share rows deleted.
+     *
+     * @throws InvalidArgumentException When shareType is invalid.
+     */
+    public function revokeAllForRecipient(
+        string $shareType,
+        string $shareWith,
+        string $callerId
+    ): int {
+        $validType = in_array(
+            needle: $shareType,
+            haystack: DashboardShare::VALID_SHARE_TYPES,
+            strict: true
+        );
+        if ($validType === false) {
+            throw new InvalidArgumentException(
+                message: 'Invalid shareType: '.$shareType
+            );
+        }
+
+        return $this->shareMapper->deleteByOwnerAndRecipient(
+            shareType: $shareType,
+            shareWith: $shareWith,
+            ownerId: $callerId
+        );
+    }//end revokeAllForRecipient()
+
+    /**
+     * Transfer dashboard ownership to a new user.
+     *
+     * Updates the dashboard's user_id, removes the share row that
+     * previously gave the new owner access, and stamps updated_at.
+     * REQ-SHARE-013 (internal helper called by UserDeletedListener).
+     *
+     * @param int    $dashboardId The dashboard ID.
+     * @param string $newUserId   The new owner's user ID.
+     *
+     * @return void
+     */
+    public function transferOwnership(int $dashboardId, string $newUserId): void
+    {
+        $dashboard = $this->dashboardMapper->find(id: $dashboardId);
+
+        // Update ownership.
+        $dashboard->setUserId($newUserId);
+        $dashboard->setUpdatedAt(
+            (new DateTime())->format(format: 'Y-m-d H:i:s')
+        );
+        $this->dashboardMapper->update(entity: $dashboard);
+
+        // Remove the share row that gave newUserId access (they now own it).
+        $existingShare = $this->shareMapper->findShare(
+            dashboardId: $dashboardId,
+            shareType: DashboardShare::SHARE_TYPE_USER,
+            shareWith: $newUserId
+        );
+        if ($existingShare !== null) {
+            $this->shareMapper->delete(entity: $existingShare);
+        }
+    }//end transferOwnership()
+
+    /**
+     * Publish a `dashboard_ownership_transferred` notification.
+     *
+     * @param string $newOwnerId    The new owner's user ID.
+     * @param int    $dashboardId   The dashboard ID.
+     * @param string $dashboardName The dashboard name.
+     *
+     * @return void
+     */
+    public function notifyOwnershipTransferred(
+        string $newOwnerId,
+        int $dashboardId,
+        string $dashboardName
+    ): void {
+        $notification = $this->notificationManager->createNotification();
+        // phpcs:ignore CustomSniffs.Functions.NamedParameters.RequireNamedParameters
+        $notification->setApp('mydash')
+            // phpcs:ignore CustomSniffs.Functions.NamedParameters.RequireNamedParameters
+            ->setUser($newOwnerId)
+            // phpcs:ignore CustomSniffs.Functions.NamedParameters.RequireNamedParameters
+            ->setDateTime(new \DateTime())
+            // phpcs:ignore CustomSniffs.Functions.NamedParameters.RequireNamedParameters
+            ->setObject('dashboard', (string) $dashboardId)
+            // phpcs:ignore CustomSniffs.Functions.NamedParameters.RequireNamedParameters
+            ->setSubject('dashboard_ownership_transferred', [$dashboardName]);
+
+        // phpcs:ignore CustomSniffs.Functions.NamedParameters.RequireNamedParameters
+        $this->notificationManager->notify($notification);
+    }//end notifyOwnershipTransferred()
+
+    /**
+     * Persist a single share (insert or update). Returns metadata about
+     * whether the row is new or the level was upgraded.
+     *
+     * @param int    $dashboardId     The dashboard ID.
+     * @param string $shareType       The share type.
+     * @param string $shareWith       The recipient.
+     * @param string $permissionLevel The permission level.
+     *
+     * @return array{share: DashboardShare, isNew: bool, isUpgrade: bool}
+     */
+    private function persistShare(
+        int $dashboardId,
+        string $shareType,
+        string $shareWith,
+        string $permissionLevel
+    ): array {
+        $now      = (new DateTime())->format(format: 'Y-m-d H:i:s');
+        $existing = $this->shareMapper->findShare(
+            dashboardId: $dashboardId,
+            shareType: $shareType,
+            shareWith: $shareWith
+        );
+
+        if ($existing === null) {
+            // Insert new share.
+            $share = new DashboardShare();
+            $share->setDashboardId($dashboardId);
+            $share->setShareType($shareType);
+            $share->setShareWith($shareWith);
+            $share->setPermissionLevel($permissionLevel);
+            $share->setCreatedAt($now);
+            $share->setUpdatedAt($now);
+
+            return [
+                'share'     => $this->shareMapper->insert(entity: $share),
+                'isNew'     => true,
+                'isUpgrade' => false,
+            ];
+        }
+
+        // Detect upgrade.
+        $oldLevel  = (string) $existing->getPermissionLevel();
+        $newOrder  = (self::LEVEL_ORDER[$permissionLevel] ?? 0);
+        $oldOrder  = (self::LEVEL_ORDER[$oldLevel] ?? 0);
+        $isUpgrade = ($newOrder > $oldOrder);
+
+        // No-op: same level.
+        if ($oldLevel === $permissionLevel) {
+            return [
+                'share'     => $existing,
+                'isNew'     => false,
+                'isUpgrade' => false,
+            ];
+        }
+
+        // Update level.
+        $existing->setPermissionLevel($permissionLevel);
+        $existing->setUpdatedAt($now);
+
+        return [
+            'share'     => $this->shareMapper->update(entity: $existing),
+            'isNew'     => false,
+            'isUpgrade' => $isUpgrade,
+        ];
+    }//end persistShare()
+
+    /**
+     * Publish `dashboard_shared` notifications for a share.
+     *
+     * For `user`-type shares: one notification.
+     * For `group`-type shares: fan out one notification per current group
+     * member, excluding the sharer. REQ-SHARE-008.
+     *
+     * @param DashboardShare $share         The share row.
+     * @param string         $sharerUserId  The user who created the share.
+     * @param string         $dashboardName The dashboard name.
+     *
+     * @return void
+     */
+    private function notifyShared(
+        DashboardShare $share,
+        string $sharerUserId,
+        string $dashboardName
+    ): void {
+        $recipients = $this->resolveRecipients(
+            share: $share,
+            excludeUserId: $sharerUserId
+        );
+
+        foreach ($recipients as $recipientId) {
+            $notification = $this->notificationManager->createNotification();
+            // phpcs:ignore CustomSniffs.Functions.NamedParameters.RequireNamedParameters
+            $notification->setApp('mydash')
+                // phpcs:ignore CustomSniffs.Functions.NamedParameters.RequireNamedParameters
+                ->setUser($recipientId)
+                // phpcs:ignore CustomSniffs.Functions.NamedParameters.RequireNamedParameters
+                ->setDateTime(new \DateTime())
+                // phpcs:ignore CustomSniffs.Functions.NamedParameters.RequireNamedParameters
+                ->setObject('dashboard', (string) $share->getDashboardId())
+                // phpcs:ignore CustomSniffs.Functions.NamedParameters.RequireNamedParameters
+                ->setSubject(
+                    'dashboard_shared',
+                    [
+                        $sharerUserId,
+                        $dashboardName,
+                        (string) $share->getPermissionLevel(),
+                    ]
+                );
+
+            // phpcs:ignore CustomSniffs.Functions.NamedParameters.RequireNamedParameters
+            $this->notificationManager->notify($notification);
+        }//end foreach
+    }//end notifyShared()
+
+    /**
+     * Resolve the recipient user IDs for a share.
+     *
+     * @param DashboardShare $share         The share.
+     * @param string         $excludeUserId A user ID to exclude (the sharer).
+     *
+     * @return string[] The recipient user IDs.
+     */
+    private function resolveRecipients(
+        DashboardShare $share,
+        string $excludeUserId
+    ): array {
+        if ($share->getShareType() === DashboardShare::SHARE_TYPE_USER) {
+            $uid = (string) $share->getShareWith();
+            if ($uid === $excludeUserId) {
+                return [];
+            }
+
+            return [$uid];
+        }
+
+        // Group share — expand members.
+        $groupId = (string) $share->getShareWith();
+        $group   = $this->groupManager->get(gid: $groupId);
+        if ($group === null) {
+            return [];
+        }
+
+        $recipients = [];
+        foreach ($group->getUsers() as $user) {
+            $uid = $user->getUID();
+            if ($uid !== $excludeUserId) {
+                $recipients[] = $uid;
+            }
+        }
+
+        return $recipients;
+    }//end resolveRecipients()
+
+    /**
+     * Validate share type, shareWith, and permission level.
+     *
+     * @param string $shareType       The share type.
+     * @param string $shareWith       The recipient.
+     * @param string $permissionLevel The permission level.
+     *
+     * @return void
+     *
+     * @throws InvalidArgumentException On invalid input.
+     */
+    private function validateInput(
+        string $shareType,
+        string $shareWith,
+        string $permissionLevel
+    ): void {
+        $validType = in_array(
+            needle: $shareType,
+            haystack: DashboardShare::VALID_SHARE_TYPES,
+            strict: true
+        );
+        if ($validType === false) {
+            throw new InvalidArgumentException(
+                message: 'Invalid shareType: '.$shareType
+            );
+        }
+
+        if ($shareWith === '') {
+            throw new InvalidArgumentException(message: 'shareWith is required');
+        }
+
+        $validLevel = in_array(
+            needle: $permissionLevel,
+            haystack: DashboardShare::VALID_PERMISSION_LEVELS,
+            strict: true
+        );
+        if ($validLevel === false) {
+            throw new InvalidArgumentException(
+                message: 'Invalid permissionLevel: '.$permissionLevel
+            );
+        }
+    }//end validateInput()
+
+    /**
+     * Assert the caller is the dashboard owner and return the dashboard.
+     *
+     * @param int    $dashboardId The dashboard ID.
+     * @param string $userId      The expected owner.
+     *
+     * @return Dashboard The dashboard.
+     *
+     * @throws Exception When the user is not the owner.
+     */
+    private function assertOwner(int $dashboardId, string $userId): Dashboard
+    {
+        $dashboard = $this->dashboardMapper->find(id: $dashboardId);
+
+        if ($dashboard->getUserId() !== $userId) {
+            throw new Exception(message: 'Access denied');
+        }
+
+        return $dashboard;
+    }//end assertOwner()
+}//end class

--- a/tests/Unit/Controller/DashboardShareApiControllerFollowupsTest.php
+++ b/tests/Unit/Controller/DashboardShareApiControllerFollowupsTest.php
@@ -1,0 +1,330 @@
+<?php
+
+/**
+ * DashboardShareApiControllerFollowupsTest
+ *
+ * Unit tests for DashboardShareApiController follow-up actions:
+ * PUT /api/dashboard/{id}/shares (REQ-SHARE-009) and
+ * DELETE /api/sharees/{shareType}/{shareWith} (REQ-SHARE-010).
+ *
+ * @category  Test
+ * @package   OCA\MyDash\Tests\Unit\Controller
+ * @author    Conduction b.v. <info@conduction.nl>
+ * @copyright 2026 Conduction b.v.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-FileCopyrightText: 2026 MyDash Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Controller;
+
+use Exception;
+use InvalidArgumentException;
+use OCA\MyDash\Controller\DashboardShareApiController;
+use OCA\MyDash\Db\DashboardShare;
+use OCA\MyDash\Service\DashboardShareService;
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\AppFramework\Http;
+use OCP\IRequest;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for DashboardShareApiController follow-up actions.
+ *
+ * @SuppressWarnings(PHPMD.TooManyMethods)
+ * @SuppressWarnings(PHPMD.TooManyPublicMethods)
+ */
+class DashboardShareApiControllerFollowupsTest extends TestCase
+{
+
+    /** @var DashboardShareService&MockObject */
+    private $shareService;
+    /** @var IRequest&MockObject */
+    private $request;
+
+    /**
+     * Set up fresh mocks for each test.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->shareService = $this->createMock(DashboardShareService::class);
+        $this->request      = $this->createMock(IRequest::class);
+    }//end setUp()
+
+    /**
+     * Build a controller for the given user.
+     *
+     * @param string|null $userId The user ID.
+     *
+     * @return DashboardShareApiController
+     */
+    private function makeController(
+        ?string $userId='alice'
+    ): DashboardShareApiController {
+        return new DashboardShareApiController(
+            request: $this->request,
+            shareService: $this->shareService,
+            userId: $userId,
+        );
+    }//end makeController()
+
+    /**
+     * Build a DashboardShare mock with jsonSerialize.
+     *
+     * @param int    $id    Share ID.
+     * @param string $type  Share type.
+     * @param string $with  Recipient.
+     * @param string $level Permission level.
+     *
+     * @return DashboardShare&MockObject
+     */
+    private function makeShare(
+        int $id,
+        string $type,
+        string $with,
+        string $level='view_only'
+    ): DashboardShare {
+        $s = $this->getMockBuilder(DashboardShare::class)
+            ->onlyMethods(['jsonSerialize'])
+            ->getMock();
+        $s->method('jsonSerialize')->willReturn([
+            'id'              => $id,
+            'shareType'       => $type,
+            'shareWith'       => $with,
+            'permissionLevel' => $level,
+        ]);
+        return $s;
+    }//end makeShare()
+
+    // =========================================================================
+    // replace() — PUT /api/dashboard/{id}/shares
+    // =========================================================================
+
+    /**
+     * PUT shares returns 200 with the new list on success.
+     *
+     * @return void
+     */
+    public function testReplaceReturnsNewList(): void
+    {
+        $controller = $this->makeController();
+        $shares     = [
+            ['shareType' => 'user', 'shareWith' => 'bob', 'permissionLevel' => 'full'],
+        ];
+
+        $newShare = $this->makeShare(1, 'user', 'bob', 'full');
+        $this->shareService->method('replaceShares')
+            ->willReturn([$newShare]);
+
+        $response = $controller->replace(id: 5, shares: $shares);
+
+        $this->assertSame(Http::STATUS_OK, $response->getStatus());
+        $data = $response->getData();
+        $this->assertIsArray($data);
+        $this->assertCount(1, $data);
+    }//end testReplaceReturnsNewList()
+
+    /**
+     * PUT shares with empty body replaces with empty list.
+     *
+     * @return void
+     */
+    public function testReplaceWithEmptyBodyClearsShares(): void
+    {
+        $controller = $this->makeController();
+
+        $this->shareService->method('replaceShares')
+            ->with(5, [], 'alice')
+            ->willReturn([]);
+
+        $response = $controller->replace(id: 5, shares: []);
+
+        $this->assertSame(Http::STATUS_OK, $response->getStatus());
+        $this->assertSame([], $response->getData());
+    }//end testReplaceWithEmptyBodyClearsShares()
+
+    /**
+     * PUT shares returns 401 when not logged in.
+     *
+     * @return void
+     */
+    public function testReplaceReturns401WhenNotLoggedIn(): void
+    {
+        $controller = $this->makeController(userId: null);
+        $response   = $controller->replace(id: 5, shares: []);
+
+        $this->assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
+    }//end testReplaceReturns401WhenNotLoggedIn()
+
+    /**
+     * PUT shares returns 403 when caller is not owner.
+     *
+     * @return void
+     */
+    public function testReplaceReturns403WhenNotOwner(): void
+    {
+        $controller = $this->makeController(userId: 'bob');
+
+        $this->shareService->method('replaceShares')
+            ->willThrowException(new Exception('Access denied'));
+
+        $response = $controller->replace(id: 5, shares: []);
+
+        $this->assertSame(Http::STATUS_FORBIDDEN, $response->getStatus());
+    }//end testReplaceReturns403WhenNotOwner()
+
+    /**
+     * PUT shares returns 400 on invalid input.
+     *
+     * @return void
+     */
+    public function testReplaceReturns400OnInvalidInput(): void
+    {
+        $controller = $this->makeController();
+
+        $this->shareService->method('replaceShares')
+            ->willThrowException(
+                new InvalidArgumentException('Invalid shareType: blah')
+            );
+
+        $response = $controller->replace(
+            id: 5,
+            shares: [['shareType' => 'blah', 'shareWith' => 'bob', 'permissionLevel' => 'full']]
+        );
+
+        $this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+    }//end testReplaceReturns400OnInvalidInput()
+
+    /**
+     * PUT shares returns 404 when dashboard not found.
+     *
+     * @return void
+     */
+    public function testReplaceReturns404WhenDashboardNotFound(): void
+    {
+        $controller = $this->makeController();
+
+        $this->shareService->method('replaceShares')
+            ->willThrowException(new DoesNotExistException(''));
+
+        $response = $controller->replace(id: 999, shares: []);
+
+        $this->assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
+    }//end testReplaceReturns404WhenDashboardNotFound()
+
+    // =========================================================================
+    // revokeForRecipient() — DELETE /api/sharees/{shareType}/{shareWith}
+    // =========================================================================
+
+    /**
+     * DELETE sharees returns count of deleted rows on success.
+     *
+     * @return void
+     */
+    public function testRevokeForRecipientReturnsCount(): void
+    {
+        $controller = $this->makeController();
+
+        $this->shareService->method('revokeAllForRecipient')
+            ->with('user', 'bob', 'alice')
+            ->willReturn(2);
+
+        $response = $controller->revokeForRecipient(
+            shareType: 'user',
+            shareWith: 'bob'
+        );
+
+        $this->assertSame(Http::STATUS_OK, $response->getStatus());
+        $this->assertSame(['deleted' => 2], $response->getData());
+    }//end testRevokeForRecipientReturnsCount()
+
+    /**
+     * DELETE sharees returns 401 when not logged in.
+     *
+     * @return void
+     */
+    public function testRevokeForRecipientReturns401WhenNotLoggedIn(): void
+    {
+        $controller = $this->makeController(userId: null);
+
+        $response = $controller->revokeForRecipient(
+            shareType: 'user',
+            shareWith: 'bob'
+        );
+
+        $this->assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
+    }//end testRevokeForRecipientReturns401WhenNotLoggedIn()
+
+    /**
+     * DELETE sharees returns 400 on invalid shareType.
+     *
+     * @return void
+     */
+    public function testRevokeForRecipientReturns400OnInvalidType(): void
+    {
+        $controller = $this->makeController();
+
+        $this->shareService->method('revokeAllForRecipient')
+            ->willThrowException(
+                new InvalidArgumentException('Invalid shareType: invalid')
+            );
+
+        $response = $controller->revokeForRecipient(
+            shareType: 'invalid',
+            shareWith: 'bob'
+        );
+
+        $this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+    }//end testRevokeForRecipientReturns400OnInvalidType()
+
+    /**
+     * DELETE sharees returns 0 when caller has no shares for that recipient.
+     *
+     * @return void
+     */
+    public function testRevokeForRecipientReturnsZeroWhenNothingToRemove(): void
+    {
+        $controller = $this->makeController();
+
+        $this->shareService->method('revokeAllForRecipient')
+            ->willReturn(0);
+
+        $response = $controller->revokeForRecipient(
+            shareType: 'user',
+            shareWith: 'bob'
+        );
+
+        $this->assertSame(Http::STATUS_OK, $response->getStatus());
+        $this->assertSame(['deleted' => 0], $response->getData());
+    }//end testRevokeForRecipientReturnsZeroWhenNothingToRemove()
+
+    /**
+     * DELETE sharees with group type removes only caller's owned shares.
+     *
+     * @return void
+     */
+    public function testRevokeForRecipientOnlyRemovesCallerOwnedGroupShares(): void
+    {
+        $controller = $this->makeController(userId: 'alice');
+
+        $this->shareService->expects($this->once())
+            ->method('revokeAllForRecipient')
+            ->with('group', 'marketing', 'alice')
+            ->willReturn(1);
+
+        $response = $controller->revokeForRecipient(
+            shareType: 'group',
+            shareWith: 'marketing'
+        );
+
+        $this->assertSame(Http::STATUS_OK, $response->getStatus());
+        $this->assertSame(['deleted' => 1], $response->getData());
+    }//end testRevokeForRecipientOnlyRemovesCallerOwnedGroupShares()
+}//end class

--- a/tests/Unit/Listener/UserDeletedListenerTest.php
+++ b/tests/Unit/Listener/UserDeletedListenerTest.php
@@ -1,0 +1,492 @@
+<?php
+
+/**
+ * UserDeletedListenerTest
+ *
+ * Unit tests for UserDeletedListener covering REQ-SHARE-012 and
+ * REQ-SHARE-013: admin-pool computation, ownership transfer, deletion
+ * cascade, selection rules, and recipient-cleanup.
+ *
+ * @category  Test
+ * @package   OCA\MyDash\Tests\Unit\Listener
+ * @author    Conduction b.v. <info@conduction.nl>
+ * @copyright 2026 Conduction b.v.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-FileCopyrightText: 2026 MyDash Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Listener;
+
+use OCA\MyDash\Db\Dashboard;
+use OCA\MyDash\Db\DashboardMapper;
+use OCA\MyDash\Db\DashboardShare;
+use OCA\MyDash\Db\DashboardShareMapper;
+use OCA\MyDash\Db\WidgetPlacementMapper;
+use OCA\MyDash\Listener\UserDeletedListener;
+use OCA\MyDash\Service\DashboardShareService;
+use OCP\IDBConnection;
+use OCP\IGroup;
+use OCP\IGroupManager;
+use OCP\IUser;
+use OCP\IUserManager;
+use OCP\User\Events\UserDeletedEvent;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for UserDeletedListener.
+ *
+ * @SuppressWarnings(PHPMD.TooManyMethods)
+ * @SuppressWarnings(PHPMD.TooManyPublicMethods)
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ */
+class UserDeletedListenerTest extends TestCase
+{
+
+    /** @var DashboardShareMapper&MockObject */
+    private $shareMapper;
+    /** @var DashboardMapper&MockObject */
+    private $dashboardMapper;
+    /** @var WidgetPlacementMapper&MockObject */
+    private $placementMapper;
+    /** @var DashboardShareService&MockObject */
+    private $shareService;
+    /** @var IGroupManager&MockObject */
+    private $groupManager;
+    /** @var IUserManager&MockObject */
+    private $userManager;
+    /** @var IDBConnection&MockObject */
+    private $db;
+
+    private UserDeletedListener $listener;
+
+    /**
+     * Set up fresh mocks for each test.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->shareMapper     = $this->createMock(DashboardShareMapper::class);
+        $this->dashboardMapper = $this->createMock(DashboardMapper::class);
+        $this->placementMapper = $this->createMock(WidgetPlacementMapper::class);
+        $this->shareService    = $this->createMock(DashboardShareService::class);
+        $this->groupManager    = $this->createMock(IGroupManager::class);
+        $this->userManager     = $this->createMock(IUserManager::class);
+        $this->db              = $this->createMock(IDBConnection::class);
+
+        // Default: transaction methods succeed (void return).
+        $this->db->method('beginTransaction');
+        $this->db->method('commit');
+
+        $this->listener = new UserDeletedListener(
+            shareMapper: $this->shareMapper,
+            dashboardMapper: $this->dashboardMapper,
+            placementMapper: $this->placementMapper,
+            shareService: $this->shareService,
+            groupManager: $this->groupManager,
+            userManager: $this->userManager,
+            db: $this->db,
+        );
+    }//end setUp()
+
+    // =========================================================================
+    // Helpers
+    // =========================================================================
+
+    /**
+     * Create a minimal Dashboard mock.
+     *
+     * @param int    $id     The dashboard ID.
+     * @param string $userId The owner user ID.
+     * @param string $name   The dashboard name.
+     *
+     * @return Dashboard&MockObject
+     */
+    private function makeDashboard(
+        int $id,
+        string $userId,
+        string $name='Test Dashboard'
+    ): Dashboard {
+        $dashboard = $this->getMockBuilder(Dashboard::class)
+            ->addMethods(['getId', 'getUserId', 'getName'])
+            ->getMock();
+        $dashboard->method('getId')->willReturn($id);
+        $dashboard->method('getUserId')->willReturn($userId);
+        $dashboard->method('getName')->willReturn($name);
+        return $dashboard;
+    }//end makeDashboard()
+
+    /**
+     * Create a DashboardShare mock.
+     *
+     * @param int    $dashboardId     Dashboard ID.
+     * @param string $shareType       Share type.
+     * @param string $shareWith       Recipient.
+     * @param string $permissionLevel Permission level.
+     * @param string $createdAt       Creation timestamp.
+     *
+     * @return DashboardShare&MockObject
+     */
+    private function makeShare(
+        int $dashboardId,
+        string $shareType,
+        string $shareWith,
+        string $permissionLevel='full',
+        string $createdAt='2026-01-01 00:00:00'
+    ): DashboardShare {
+        $share = $this->getMockBuilder(DashboardShare::class)
+            ->addMethods([
+                'getDashboardId',
+                'getShareType',
+                'getShareWith',
+                'getPermissionLevel',
+                'getCreatedAt',
+            ])
+            ->getMock();
+        $share->method('getDashboardId')->willReturn($dashboardId);
+        $share->method('getShareType')->willReturn($shareType);
+        $share->method('getShareWith')->willReturn($shareWith);
+        $share->method('getPermissionLevel')->willReturn($permissionLevel);
+        $share->method('getCreatedAt')->willReturn($createdAt);
+        return $share;
+    }//end makeShare()
+
+    /**
+     * Create an IUser mock.
+     *
+     * @param string $uid The user ID.
+     *
+     * @return IUser&MockObject
+     */
+    private function makeUser(string $uid): IUser
+    {
+        $user = $this->createMock(IUser::class);
+        $user->method('getUID')->willReturn($uid);
+        return $user;
+    }//end makeUser()
+
+    /**
+     * Create an IGroup mock with the given member UIDs.
+     *
+     * @param string   $gid     The group ID.
+     * @param string[] $members The member UIDs.
+     *
+     * @return IGroup&MockObject
+     */
+    private function makeGroup(string $gid, array $members): IGroup
+    {
+        $group = $this->createMock(IGroup::class);
+        $group->method('getGID')->willReturn($gid);
+        $userMocks = array_map(fn($uid) => $this->makeUser($uid), $members);
+        $group->method('getUsers')->willReturn($userMocks);
+        return $group;
+    }//end makeGroup()
+
+    /**
+     * Create a UserDeletedEvent mock for the given uid.
+     *
+     * @param string $uid The user ID.
+     *
+     * @return UserDeletedEvent&MockObject
+     */
+    private function makeEvent(string $uid): UserDeletedEvent
+    {
+        $user  = $this->makeUser($uid);
+        $event = $this->createMock(UserDeletedEvent::class);
+        $event->method('getUser')->willReturn($user);
+        return $event;
+    }//end makeEvent()
+
+    // =========================================================================
+    // Tests — recipient cleanup
+    // =========================================================================
+
+    /**
+     * All shares granted TO the deleted user must be removed.
+     *
+     * @return void
+     */
+    public function testRecipientSharesAreDeleted(): void
+    {
+        $event = $this->makeEvent('bob');
+
+        $this->shareMapper->expects($this->once())
+            ->method('deleteByRecipientUser')
+            ->with('bob');
+
+        // Bob owns no dashboards.
+        $this->dashboardMapper->method('findByUserId')
+            ->with('bob')
+            ->willReturn([]);
+
+        $this->listener->handle($event);
+    }//end testRecipientSharesAreDeleted()
+
+    // =========================================================================
+    // Tests — admin pool non-empty: ownership transferred
+    // =========================================================================
+
+    /**
+     * Dashboard with a full-level user share is transferred, not deleted.
+     *
+     * @return void
+     */
+    public function testOwnershipTransferredWhenUserShareExists(): void
+    {
+        $event     = $this->makeEvent('alice');
+        $dashboard = $this->makeDashboard(id: 5, userId: 'alice', name: 'Q3 Plan');
+
+        $this->shareMapper->method('deleteByRecipientUser');
+        $this->dashboardMapper->method('findByUserId')
+            ->with('alice')
+            ->willReturn([$dashboard]);
+
+        $bobShare = $this->makeShare(
+            dashboardId: 5,
+            shareType: 'user',
+            shareWith: 'bob',
+            permissionLevel: 'full'
+        );
+        $carolShare = $this->makeShare(
+            dashboardId: 5,
+            shareType: 'user',
+            shareWith: 'carol',
+            permissionLevel: 'view_only'
+        );
+
+        $this->shareMapper->method('findByDashboardAndLevel')
+            ->with(5, 'full')
+            ->willReturn([$bobShare]);
+
+        // Bob still exists.
+        $this->userManager->method('get')
+            ->with('bob')
+            ->willReturn($this->makeUser('bob'));
+
+        // Expect transferOwnership called with dashboard 5 and bob.
+        $this->shareService->expects($this->once())
+            ->method('transferOwnership')
+            ->with(5, 'bob');
+
+        // Expect notification sent to bob.
+        $this->shareService->expects($this->once())
+            ->method('notifyOwnershipTransferred')
+            ->with('bob', 5, 'Q3 Plan');
+
+        // Must NOT delete dashboard.
+        $this->dashboardMapper->expects($this->never())
+            ->method('delete');
+
+        $this->listener->handle($event);
+    }//end testOwnershipTransferredWhenUserShareExists()
+
+    // =========================================================================
+    // Tests — admin pool empty: dashboard deleted
+    // =========================================================================
+
+    /**
+     * Dashboard with only a view_only share must be deleted.
+     *
+     * @return void
+     */
+    public function testDashboardDeletedWhenAdminPoolEmpty(): void
+    {
+        $event     = $this->makeEvent('alice');
+        $dashboard = $this->makeDashboard(id: 5, userId: 'alice');
+
+        $this->shareMapper->method('deleteByRecipientUser');
+        $this->dashboardMapper->method('findByUserId')
+            ->with('alice')
+            ->willReturn([$dashboard]);
+
+        // Only view_only shares — admin pool is empty.
+        $this->shareMapper->method('findByDashboardAndLevel')
+            ->with(5, 'full')
+            ->willReturn([]);
+
+        // Expect placements + shares + dashboard deleted.
+        $this->placementMapper->expects($this->once())
+            ->method('deleteByDashboardId')
+            ->with(5);
+        $this->shareMapper->expects($this->once())
+            ->method('deleteByDashboardId')
+            ->with(5);
+        $this->dashboardMapper->expects($this->once())
+            ->method('delete')
+            ->with($dashboard);
+
+        // Must NOT transfer ownership.
+        $this->shareService->expects($this->never())
+            ->method('transferOwnership');
+
+        $this->listener->handle($event);
+    }//end testDashboardDeletedWhenAdminPoolEmpty()
+
+    // =========================================================================
+    // Tests — selection rule: user-type preferred; earliest created_at
+    // =========================================================================
+
+    /**
+     * Among user-type full shares, the one with earliest created_at is chosen.
+     *
+     * @return void
+     */
+    public function testUserShareEarliestCreatedAtWins(): void
+    {
+        $event     = $this->makeEvent('alice');
+        $dashboard = $this->makeDashboard(id: 5, userId: 'alice', name: 'Board');
+
+        $this->shareMapper->method('deleteByRecipientUser');
+        $this->dashboardMapper->method('findByUserId')
+            ->willReturn([$dashboard]);
+
+        // Dave has earliest created_at; bob has later.
+        $daveShare = $this->makeShare(5, 'user', 'dave', 'full', '2025-12-10 00:00:00');
+        $bobShare  = $this->makeShare(5, 'user', 'bob', 'full', '2026-01-15 00:00:00');
+
+        // Mapper returns in created_at ASC order (dave first).
+        $this->shareMapper->method('findByDashboardAndLevel')
+            ->willReturn([$daveShare, $bobShare]);
+
+        $this->userManager->method('get')
+            ->willReturnCallback(function ($uid) {
+                return $this->makeUser($uid);
+            });
+
+        $this->shareService->expects($this->once())
+            ->method('transferOwnership')
+            ->with(5, 'dave');
+
+        $this->listener->handle($event);
+    }//end testUserShareEarliestCreatedAtWins()
+
+    // =========================================================================
+    // Tests — selection rule: group fallback
+    // =========================================================================
+
+    /**
+     * When no user shares exist, falls back to alphabetically-first member of
+     * alphabetically-first group.
+     *
+     * @return void
+     */
+    public function testGroupFallbackAlphabeticallyFirstMember(): void
+    {
+        $event     = $this->makeEvent('alice');
+        $dashboard = $this->makeDashboard(id: 5, userId: 'alice', name: 'Board');
+
+        $this->shareMapper->method('deleteByRecipientUser');
+        $this->dashboardMapper->method('findByUserId')
+            ->willReturn([$dashboard]);
+
+        // Two group shares: zeta-team and alpha-team.
+        $zetaShare  = $this->makeShare(5, 'group', 'zeta-team', 'full');
+        $alphaShare = $this->makeShare(5, 'group', 'alpha-team', 'full');
+
+        // Only group shares (no user shares).
+        $this->shareMapper->method('findByDashboardAndLevel')
+            ->willReturn([$zetaShare, $alphaShare]);
+
+        $alphaGroup = $this->makeGroup('alpha-team', ['victor', 'bob', 'alex']);
+        $zetaGroup  = $this->makeGroup('zeta-team', ['mark', 'lily']);
+
+        $this->groupManager->method('get')
+            ->willReturnCallback(function ($gid) use ($alphaGroup, $zetaGroup) {
+                if ($gid === 'alpha-team') {
+                    return $alphaGroup;
+                }
+
+                if ($gid === 'zeta-team') {
+                    return $zetaGroup;
+                }
+
+                return null;
+            });
+
+        $this->userManager->method('get')
+            ->willReturnCallback(function ($uid) {
+                return $this->makeUser($uid);
+            });
+
+        // alex is alphabetically first in alpha-team (alphabetically first group).
+        $this->shareService->expects($this->once())
+            ->method('transferOwnership')
+            ->with(5, 'alex');
+
+        $this->listener->handle($event);
+    }//end testGroupFallbackAlphabeticallyFirstMember()
+
+    // =========================================================================
+    // Tests — group share members all deleted → falls through to delete
+    // =========================================================================
+
+    /**
+     * When every group member is also a deleted user, the pool is empty
+     * and the dashboard must be deleted.
+     *
+     * @return void
+     */
+    public function testGroupShareAllMembersDeletedFallsToDelete(): void
+    {
+        $event     = $this->makeEvent('alice');
+        $dashboard = $this->makeDashboard(id: 5, userId: 'alice');
+
+        $this->shareMapper->method('deleteByRecipientUser');
+        $this->dashboardMapper->method('findByUserId')
+            ->willReturn([$dashboard]);
+
+        $ghostShare = $this->makeShare(5, 'group', 'ghosts', 'full');
+        $this->shareMapper->method('findByDashboardAndLevel')
+            ->willReturn([$ghostShare]);
+
+        $ghostGroup = $this->makeGroup('ghosts', ['ghost1', 'ghost2']);
+        $this->groupManager->method('get')
+            ->willReturn($ghostGroup);
+
+        // All members return null — they are deleted.
+        $this->userManager->method('get')
+            ->willReturn(null);
+
+        $this->placementMapper->expects($this->once())
+            ->method('deleteByDashboardId')
+            ->with(5);
+        $this->shareMapper->expects($this->once())
+            ->method('deleteByDashboardId')
+            ->with(5);
+        $this->dashboardMapper->expects($this->once())
+            ->method('delete');
+
+        $this->shareService->expects($this->never())
+            ->method('transferOwnership');
+
+        $this->listener->handle($event);
+    }//end testGroupShareAllMembersDeletedFallsToDelete()
+
+    // =========================================================================
+    // Tests — non-UserDeletedEvent is ignored
+    // =========================================================================
+
+    /**
+     * Non-UserDeletedEvent events are silently ignored.
+     *
+     * @return void
+     */
+    public function testNonUserDeletedEventIsIgnored(): void
+    {
+        $event = $this->createMock(\OCP\EventDispatcher\Event::class);
+
+        $this->shareMapper->expects($this->never())
+            ->method('deleteByRecipientUser');
+        $this->dashboardMapper->expects($this->never())
+            ->method('findByUserId');
+
+        $this->listener->handle($event);
+    }//end testNonUserDeletedEventIsIgnored()
+}//end class

--- a/tests/Unit/Service/DashboardShareServiceFollowupsTest.php
+++ b/tests/Unit/Service/DashboardShareServiceFollowupsTest.php
@@ -1,0 +1,407 @@
+<?php
+
+/**
+ * DashboardShareServiceFollowupsTest
+ *
+ * Unit tests for DashboardShareService follow-up methods:
+ * replaceShares (REQ-SHARE-009) and revokeAllForRecipient (REQ-SHARE-010).
+ *
+ * @category  Test
+ * @package   OCA\MyDash\Tests\Unit\Service
+ * @author    Conduction b.v. <info@conduction.nl>
+ * @copyright 2026 Conduction b.v.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-FileCopyrightText: 2026 MyDash Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Service;
+
+use Exception;
+use InvalidArgumentException;
+use OCA\MyDash\Db\Dashboard;
+use OCA\MyDash\Db\DashboardMapper;
+use OCA\MyDash\Db\DashboardShare;
+use OCA\MyDash\Db\DashboardShareMapper;
+use OCA\MyDash\Service\DashboardShareService;
+use OCP\IDBConnection;
+use OCP\IGroup;
+use OCP\IGroupManager;
+use OCP\IUser;
+use OCP\Notification\IManager as INotificationManager;
+use OCP\Notification\INotification;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for DashboardShareService follow-up methods.
+ *
+ * @SuppressWarnings(PHPMD.TooManyMethods)
+ * @SuppressWarnings(PHPMD.TooManyPublicMethods)
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ */
+class DashboardShareServiceFollowupsTest extends TestCase
+{
+
+    /** @var DashboardShareMapper&MockObject */
+    private $shareMapper;
+    /** @var DashboardMapper&MockObject */
+    private $dashboardMapper;
+    /** @var IGroupManager&MockObject */
+    private $groupManager;
+    /** @var INotificationManager&MockObject */
+    private $notificationManager;
+    /** @var IDBConnection&MockObject */
+    private $db;
+
+    private DashboardShareService $service;
+
+    /**
+     * Set up fresh mocks for each test.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->shareMapper         = $this->createMock(DashboardShareMapper::class);
+        $this->dashboardMapper     = $this->createMock(DashboardMapper::class);
+        $this->groupManager        = $this->createMock(IGroupManager::class);
+        $this->notificationManager = $this->createMock(INotificationManager::class);
+        $this->db                  = $this->createMock(IDBConnection::class);
+
+        $this->db->method('beginTransaction');
+        $this->db->method('commit');
+
+        $this->service = new DashboardShareService(
+            shareMapper: $this->shareMapper,
+            dashboardMapper: $this->dashboardMapper,
+            groupManager: $this->groupManager,
+            notificationManager: $this->notificationManager,
+            db: $this->db,
+        );
+    }//end setUp()
+
+    // =========================================================================
+    // Helpers
+    // =========================================================================
+
+    /**
+     * Create a Dashboard mock owned by the given user.
+     *
+     * @param int    $id     Dashboard ID.
+     * @param string $userId Owner.
+     * @param string $name   Dashboard name.
+     *
+     * @return Dashboard&MockObject
+     */
+    private function makeDashboard(
+        int $id,
+        string $userId,
+        string $name='Test'
+    ): Dashboard {
+        $d = $this->getMockBuilder(Dashboard::class)
+            ->addMethods(['getId', 'getUserId', 'getName'])
+            ->getMock();
+        $d->method('getId')->willReturn($id);
+        $d->method('getUserId')->willReturn($userId);
+        $d->method('getName')->willReturn($name);
+        return $d;
+    }//end makeDashboard()
+
+    /**
+     * Create a DashboardShare mock.
+     *
+     * @param int    $id              Share ID.
+     * @param int    $dashboardId     Dashboard ID.
+     * @param string $shareType       Share type.
+     * @param string $shareWith       Recipient.
+     * @param string $permissionLevel Permission level.
+     *
+     * @return DashboardShare&MockObject
+     */
+    private function makeShare(
+        int $id,
+        int $dashboardId,
+        string $shareType,
+        string $shareWith,
+        string $permissionLevel='view_only'
+    ): DashboardShare {
+        $s = $this->getMockBuilder(DashboardShare::class)
+            ->addMethods([
+                'getId',
+                'getDashboardId',
+                'getShareType',
+                'getShareWith',
+                'getPermissionLevel',
+            ])
+            ->onlyMethods(['jsonSerialize'])
+            ->getMock();
+        $s->method('getId')->willReturn($id);
+        $s->method('getDashboardId')->willReturn($dashboardId);
+        $s->method('getShareType')->willReturn($shareType);
+        $s->method('getShareWith')->willReturn($shareWith);
+        $s->method('getPermissionLevel')->willReturn($permissionLevel);
+        $s->method('jsonSerialize')->willReturn([
+            'id'              => $id,
+            'dashboardId'     => $dashboardId,
+            'shareType'       => $shareType,
+            'shareWith'       => $shareWith,
+            'permissionLevel' => $permissionLevel,
+        ]);
+        return $s;
+    }//end makeShare()
+
+    /**
+     * Create an INotification mock.
+     *
+     * @return INotification&MockObject
+     */
+    private function makeNotification(): INotification
+    {
+        $n = $this->createMock(INotification::class);
+        $n->method('setApp')->willReturnSelf();
+        $n->method('setUser')->willReturnSelf();
+        $n->method('setDateTime')->willReturnSelf();
+        $n->method('setObject')->willReturnSelf();
+        $n->method('setSubject')->willReturnSelf();
+        return $n;
+    }//end makeNotification()
+
+    // =========================================================================
+    // replaceShares tests
+    // =========================================================================
+
+    /**
+     * replaceShares returns 403 when caller is not owner.
+     *
+     * @return void
+     */
+    public function testReplaceSharesForbiddenWhenNotOwner(): void
+    {
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Access denied');
+
+        $dashboard = $this->makeDashboard(5, 'alice');
+        $this->dashboardMapper->method('find')->willReturn($dashboard);
+
+        $this->service->replaceShares(
+            dashboardId: 5,
+            shares: [],
+            userId: 'bob'
+        );
+    }//end testReplaceSharesForbiddenWhenNotOwner()
+
+    /**
+     * replaceShares runs in a single transaction and deletes shares not in payload.
+     *
+     * @return void
+     */
+    public function testReplaceSharesIsAtomic(): void
+    {
+        $dashboard = $this->makeDashboard(5, 'alice');
+        $this->dashboardMapper->method('find')->willReturn($dashboard);
+
+        // Existing shares: bob (view_only), carol (view_only), group:sales.
+        $this->shareMapper->method('findShare')->willReturn(null);
+        $this->shareMapper->expects($this->once())
+            ->method('deleteNotIn')
+            ->with(5, ['user:bob', 'user:dave']);
+
+        // Verify transaction usage.
+        $this->db->expects($this->once())->method('beginTransaction');
+        $this->db->expects($this->once())->method('commit');
+
+        // Insert returns new shares.
+        $bobShare  = $this->makeShare(1, 5, 'user', 'bob', 'full');
+        $daveShare = $this->makeShare(2, 5, 'user', 'dave', 'view_only');
+        $this->shareMapper->method('insert')
+            ->willReturnOnConsecutiveCalls($bobShare, $daveShare);
+
+        // findByDashboardId returns new list.
+        $this->shareMapper->method('findByDashboardId')
+            ->willReturn([$bobShare, $daveShare]);
+
+        $result = $this->service->replaceShares(
+            dashboardId: 5,
+            shares: [
+                ['shareType' => 'user', 'shareWith' => 'bob', 'permissionLevel' => 'full'],
+                ['shareType' => 'user', 'shareWith' => 'dave', 'permissionLevel' => 'view_only'],
+            ],
+            userId: 'alice'
+        );
+
+        $this->assertCount(2, $result);
+    }//end testReplaceSharesIsAtomic()
+
+    /**
+     * Idempotent replaceShares publishes no notifications.
+     *
+     * @return void
+     */
+    public function testIdempotentReplacePublishesNoNotifications(): void
+    {
+        $dashboard = $this->makeDashboard(5, 'alice');
+        $this->dashboardMapper->method('find')->willReturn($dashboard);
+
+        $existingBob = $this->makeShare(1, 5, 'user', 'bob', 'full');
+
+        // findShare returns existing share (no-op path).
+        $this->shareMapper->method('findShare')
+            ->willReturn($existingBob);
+
+        $this->shareMapper->method('deleteNotIn');
+        $this->shareMapper->method('findByDashboardId')
+            ->willReturn([$existingBob]);
+
+        // No notifications should be published.
+        $this->notificationManager->expects($this->never())
+            ->method('notify');
+
+        $this->service->replaceShares(
+            dashboardId: 5,
+            shares: [
+                ['shareType' => 'user', 'shareWith' => 'bob', 'permissionLevel' => 'full'],
+            ],
+            userId: 'alice'
+        );
+    }//end testIdempotentReplacePublishesNoNotifications()
+
+    /**
+     * replaceShares notifies newly added and upgraded recipients only.
+     *
+     * @return void
+     */
+    public function testReplaceSharesNotifiesNewAndUpgraded(): void
+    {
+        $dashboard = $this->makeDashboard(5, 'alice', 'Board');
+        $this->dashboardMapper->method('find')->willReturn($dashboard);
+
+        // bob: upgrade from view_only to full.
+        $existingBob = $this->makeShare(1, 5, 'user', 'bob', 'view_only');
+        // dave: new share.
+        // carol: same level (no-op) — not in payload anymore (removed).
+
+        $this->shareMapper->method('findShare')
+            ->willReturnCallback(function ($dashId, $type, $with) use ($existingBob) {
+                if ($type === 'user' && $with === 'bob') {
+                    return $existingBob;
+                }
+
+                return null;
+            });
+
+        $this->shareMapper->method('deleteNotIn');
+
+        // Update bob (upgrade), insert dave.
+        $upgradedBob = $this->makeShare(1, 5, 'user', 'bob', 'full');
+        $newDave     = $this->makeShare(2, 5, 'user', 'dave', 'view_only');
+        $this->shareMapper->method('update')->willReturn($upgradedBob);
+        $this->shareMapper->method('insert')->willReturn($newDave);
+        $this->shareMapper->method('findByDashboardId')
+            ->willReturn([$upgradedBob, $newDave]);
+
+        // Expect exactly 2 notifications (bob upgrade + dave new).
+        $notification = $this->makeNotification();
+        $this->notificationManager->method('createNotification')
+            ->willReturn($notification);
+        $this->notificationManager->expects($this->exactly(2))
+            ->method('notify');
+
+        $this->service->replaceShares(
+            dashboardId: 5,
+            shares: [
+                ['shareType' => 'user', 'shareWith' => 'bob', 'permissionLevel' => 'full'],
+                ['shareType' => 'user', 'shareWith' => 'dave', 'permissionLevel' => 'view_only'],
+            ],
+            userId: 'alice'
+        );
+    }//end testReplaceSharesNotifiesNewAndUpgraded()
+
+    /**
+     * replaceShares rejects invalid shareType.
+     *
+     * @return void
+     */
+    public function testReplaceSharesRejectsInvalidShareType(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $dashboard = $this->makeDashboard(5, 'alice');
+        $this->dashboardMapper->method('find')->willReturn($dashboard);
+
+        $this->service->replaceShares(
+            dashboardId: 5,
+            shares: [
+                ['shareType' => 'invalid', 'shareWith' => 'bob', 'permissionLevel' => 'full'],
+            ],
+            userId: 'alice'
+        );
+    }//end testReplaceSharesRejectsInvalidShareType()
+
+    // =========================================================================
+    // revokeAllForRecipient tests
+    // =========================================================================
+
+    /**
+     * revokeAllForRecipient removes only the caller's owned shares.
+     *
+     * @return void
+     */
+    public function testRevokeAllForRecipientRemovesOnlyCallerOwnedShares(): void
+    {
+        $this->shareMapper->expects($this->once())
+            ->method('deleteByOwnerAndRecipient')
+            ->with('user', 'bob', 'alice')
+            ->willReturn(2);
+
+        $count = $this->service->revokeAllForRecipient(
+            shareType: 'user',
+            shareWith: 'bob',
+            callerId: 'alice'
+        );
+
+        $this->assertSame(2, $count);
+    }//end testRevokeAllForRecipientRemovesOnlyCallerOwnedShares()
+
+    /**
+     * revokeAllForRecipient throws on invalid shareType.
+     *
+     * @return void
+     */
+    public function testRevokeAllForRecipientRejectsInvalidType(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $this->service->revokeAllForRecipient(
+            shareType: 'invalid',
+            shareWith: 'bob',
+            callerId: 'alice'
+        );
+    }//end testRevokeAllForRecipientRejectsInvalidType()
+
+    /**
+     * revokeAllForRecipient works with group type.
+     *
+     * @return void
+     */
+    public function testRevokeAllForRecipientWorksForGroupType(): void
+    {
+        $this->shareMapper->expects($this->once())
+            ->method('deleteByOwnerAndRecipient')
+            ->with('group', 'marketing', 'alice')
+            ->willReturn(3);
+
+        $count = $this->service->revokeAllForRecipient(
+            shareType: 'group',
+            shareWith: 'marketing',
+            callerId: 'alice'
+        );
+
+        $this->assertSame(3, $count);
+    }//end testRevokeAllForRecipientWorksForGroupType()
+}//end class


### PR DESCRIPTION
## Summary

- Implements REQ-SHARE-008..013: Nextcloud-native push notifications via `INotifier` (bell + email) when a dashboard is shared or ownership is transferred
- Adds `PUT /api/dashboard/{id}/shares` (atomic replace-all) and `DELETE /api/sharees/{shareType}/{shareWith}` (revoke-all-for-recipient owned by caller)
- Adds `UserDeletedListener` on `UserDeletedEvent`: transfers dashboard ownership to highest-permission sharer (user-type → oldest share first; group fallback → alphabetically first group/member) or cascades deletion when no fallback owner exists
- DB migration `Version001006Date20260430130000` creates `mydash_dashboard_shares` table with optional orphan-cleanup step gated by `mydash.cleanup_orphan_shares` admin config

## New files

- `lib/Db/DashboardShare.php` — Entity
- `lib/Db/DashboardShareMapper.php` — QBMapper with `deleteNotIn`, `deleteByOwnerAndRecipient`, `deleteByRecipientUser`
- `lib/Service/DashboardShareService.php` — Business logic: `replaceShares`, `revokeAllForRecipient`, `transferOwnership`, `notifyShared`/`notifyOwnershipTransferred`
- `lib/Controller/DashboardShareApiController.php` — `index`, `create`, `destroy`, `replace`, `revokeForRecipient`
- `lib/Listener/UserDeletedListener.php` — Event-driven cascade + admin-pool selection
- `lib/Notification/Notifier.php` — Translatable rich notifications
- `lib/Migration/Version001006Date20260430130000.php` — Schema migration
- `tests/Unit/` — 15 new PHPUnit tests (all passing)

## Test plan

- [ ] Run `composer check:strict` — PHPCS, PHPMD, Psalm, PHPStan must pass
- [ ] Run PHPUnit: `./vendor/bin/phpunit tests/Unit/Controller/DashboardShareApiControllerFollowupsTest.php tests/Unit/Service/DashboardShareServiceFollowupsTest.php tests/Unit/Listener/UserDeletedListenerTest.php` — 15/15 green
- [ ] Manual: share a dashboard with a user → verify Nextcloud bell notification appears
- [ ] Manual: `PUT /api/dashboard/{id}/shares` with new set → verify diff is applied atomically
- [ ] Manual: `DELETE /api/sharees/user/bob` → verify only caller-owned shares for bob are removed
- [ ] Manual: delete a user who owns dashboards → verify ownership transferred or dashboards deleted
- [ ] Manual: enable `mydash.cleanup_orphan_shares = true` → run upgrade → verify orphan rows removed