### PR TITLE
feat(widgets): unified Add/Edit widget modal

### DIFF
--- a/src/__tests__/AddWidgetModal.test.js
+++ b/src/__tests__/AddWidgetModal.test.js
@@ -1,0 +1,289 @@
+/**
+ * SPDX-FileCopyrightText: 2026 MyDash Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { describe, it, expect, beforeAll, afterEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import AddWidgetModal from '../components/Widgets/AddWidgetModal.vue'
+import { widgetRegistry } from '../constants/widgetRegistry.js'
+
+// Stub the Nextcloud `t` global.
+beforeAll(() => {
+	if (typeof globalThis.t !== 'function') {
+		globalThis.t = (_app, key) => key
+	}
+})
+
+// ---------------------------------------------------------------------------
+// Minimal form stubs.  The component :is binding resolves via the registry's
+// `form` component object.  Vue 2 Test Utils matches stubs by component name.
+// ---------------------------------------------------------------------------
+function makeFormStub(componentName, { errorsOnValidate = [] } = {}) {
+	return {
+		name: componentName,
+		props: {
+			editingWidget: { default: null },
+		},
+		template: `<div class="stub-form" data-form="${componentName}"></div>`,
+		methods: {
+			validate() {
+				return errorsOnValidate
+			},
+		},
+	}
+}
+
+// Build stubs keyed by each form component's `name` option (required by Vue 2 TU).
+function buildStubs(overrides = {}) {
+	const stubs = {}
+	for (const entry of Object.values(widgetRegistry)) {
+		const name = entry.form.name
+		stubs[name] = makeFormStub(name)
+	}
+	return { ...stubs, ...overrides }
+}
+
+// Mount helper for Vue 2 Test Utils (uses propsData, not props).
+function mountModal(propsData = {}, extra = {}) {
+	return mount(AddWidgetModal, {
+		propsData: {
+			show: true,
+			...propsData,
+		},
+		stubs: buildStubs(extra.stubs),
+		...extra,
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('AddWidgetModal', () => {
+	let wrapper
+
+	afterEach(() => {
+		if (wrapper) {
+			wrapper.destroy()
+			wrapper = null
+		}
+	})
+
+	// -------------------------------------------------------------------------
+	// 1. Open in create mode — type select visible, first sub-form rendered
+	// -------------------------------------------------------------------------
+	it('shows type selector in create mode (no preselectedType, no editingWidget)', () => {
+		wrapper = mountModal({ preselectedType: null, editingWidget: null })
+
+		const select = wrapper.find('select.add-widget-modal__select')
+		expect(select.exists()).toBe(true)
+
+		const options = select.findAll('option')
+		expect(options.length).toBe(Object.keys(widgetRegistry).length)
+
+		// The first registry type's sub-form stub should be rendered.
+		const firstType = Object.keys(widgetRegistry)[0]
+		const firstName = widgetRegistry[firstType].form.name
+		expect(wrapper.find(`[data-form="${firstName}"]`).exists()).toBe(true)
+	})
+
+	// -------------------------------------------------------------------------
+	// 2. Open with preselectedType — type select hidden
+	// -------------------------------------------------------------------------
+	it('hides type selector when preselectedType is set', () => {
+		wrapper = mountModal({ preselectedType: 'text', editingWidget: null })
+
+		const select = wrapper.find('select.add-widget-modal__select')
+		expect(select.exists()).toBe(false)
+	})
+
+	// -------------------------------------------------------------------------
+	// 3. Open in edit mode — title 'Edit Widget', type hidden, action 'Save'
+	// -------------------------------------------------------------------------
+	it('renders edit mode correctly', () => {
+		const editingWidget = {
+			type: 'image',
+			content: { url: '/img/x.png', alt: 'X', fit: 'cover', link: '' },
+		}
+		wrapper = mountModal({ editingWidget })
+
+		const title = wrapper.find('.add-widget-modal__title')
+		expect(title.text()).toBe('Edit Widget')
+
+		// Type selector hidden.
+		expect(wrapper.find('select.add-widget-modal__select').exists()).toBe(false)
+
+		// Primary button reads 'Save'.
+		const allBtns = wrapper.findAll('.add-widget-modal__btn')
+		const primaryBtn = allBtns.at(allBtns.length - 1)
+		expect(primaryBtn.text()).toBe('Save')
+	})
+
+	// -------------------------------------------------------------------------
+	// 4. Type switch resets form (no cross-type field leakage)
+	// -------------------------------------------------------------------------
+	it('resets formSnapshot on type switch so no cross-type leakage occurs', async () => {
+		wrapper = mountModal({ preselectedType: null, editingWidget: null })
+
+		const types = Object.keys(widgetRegistry)
+		expect(types.length).toBeGreaterThan(1)
+
+		// Switch to the second type.
+		await wrapper.vm.$nextTick()
+		wrapper.vm.activeType = types[1]
+		wrapper.vm.onTypeChange()
+		await wrapper.vm.$nextTick()
+
+		// formSnapshot should hold the defaults of the second type.
+		const secondDefaults = widgetRegistry[types[1]].defaults
+		for (const [key, val] of Object.entries(secondDefaults)) {
+			expect(wrapper.vm.formSnapshot[key]).toBe(val)
+		}
+
+		// Keys only present in the first type must NOT leak into formSnapshot.
+		const firstDefaults = widgetRegistry[types[0]].defaults
+		const firstOnlyKeys = Object.keys(firstDefaults).filter(
+			k => !Object.prototype.hasOwnProperty.call(secondDefaults, k),
+		)
+		for (const key of firstOnlyKeys) {
+			expect(Object.prototype.hasOwnProperty.call(wrapper.vm.formSnapshot, key)).toBe(false)
+		}
+	})
+
+	// -------------------------------------------------------------------------
+	// 5. Submit emits only the selected type's fields
+	// -------------------------------------------------------------------------
+	it('emits submit with only the relevant type fields (no cross-type leakage)', async () => {
+		wrapper = mountModal({ preselectedType: 'text' })
+
+		// Mark the modal as valid so submit goes through.
+		wrapper.vm.formErrors = []
+
+		// Simulate content update that includes a spurious 'url' key from image type.
+		wrapper.vm.onContentUpdate({ text: 'Hello', fontSize: '16px', url: '/leak.png' })
+		await wrapper.vm.$nextTick()
+
+		await wrapper.find('.add-widget-modal__btn--primary').trigger('click')
+
+		const emitted = wrapper.emitted('submit')
+		expect(emitted).toBeTruthy()
+		const payload = emitted[0][0]
+
+		expect(payload.type).toBe('text')
+		// Must include text fields.
+		expect(payload.content).toHaveProperty('text', 'Hello')
+		// Must NOT include image-only field.
+		expect(payload.content).not.toHaveProperty('url')
+	})
+
+	// -------------------------------------------------------------------------
+	// 6. Validation gating — submit disabled when validate() returns errors
+	// -------------------------------------------------------------------------
+	it('disables submit button when formErrors is non-empty', async () => {
+		wrapper = mountModal({ preselectedType: 'text' })
+
+		// Flush initModal's deferred revalidate() tick first.
+		await wrapper.vm.$nextTick()
+
+		// Directly set errors to simulate invalid form and wait for DOM update.
+		wrapper.vm.formErrors = ['Text is required']
+		await wrapper.vm.$nextTick()
+
+		const primaryBtn = wrapper.find('.add-widget-modal__btn--primary')
+		expect(primaryBtn.element.disabled).toBe(true)
+	})
+
+	it('enables submit button when formErrors is empty', async () => {
+		wrapper = mountModal({ preselectedType: 'text' })
+
+		// Clear errors to simulate valid form.
+		wrapper.vm.formErrors = []
+		await wrapper.vm.$nextTick()
+
+		const primaryBtn = wrapper.find('.add-widget-modal__btn--primary')
+		expect(primaryBtn.element.disabled).toBe(false)
+	})
+
+	it('calls sub-form validate() on submit and blocks when invalid', async () => {
+		const invalidStub = makeFormStub('TextDisplayForm', { errorsOnValidate: ['Required'] })
+		wrapper = mountModal(
+			{ preselectedType: 'text' },
+			{ stubs: buildStubs({ TextDisplayForm: invalidStub }) },
+		)
+
+		// Ensure formErrors starts empty so we can see the guard kick in.
+		wrapper.vm.formErrors = []
+
+		await wrapper.find('.add-widget-modal__btn--primary').trigger('click')
+
+		// revalidate() should have run and blocked the submit.
+		expect(wrapper.emitted('submit')).toBeFalsy()
+	})
+
+	// -------------------------------------------------------------------------
+	// 7. Backdrop click emits close (not submit)
+	// -------------------------------------------------------------------------
+	it('emits close (not submit) when backdrop is clicked', async () => {
+		wrapper = mountModal()
+
+		await wrapper.find('.add-widget-modal__backdrop').trigger('click')
+
+		expect(wrapper.emitted('close')).toBeTruthy()
+		expect(wrapper.emitted('submit')).toBeFalsy()
+	})
+
+	it('does NOT close when clicking the modal panel (not backdrop)', async () => {
+		wrapper = mountModal()
+
+		// Click on the modal container itself (not the backdrop @click.self target).
+		await wrapper.find('.add-widget-modal').trigger('click')
+
+		expect(wrapper.emitted('close')).toBeFalsy()
+	})
+
+	// -------------------------------------------------------------------------
+	// 8. Escape key emits close (not submit)
+	// -------------------------------------------------------------------------
+	it('emits close when Escape is pressed while modal is visible', async () => {
+		wrapper = mountModal({ show: true })
+
+		const event = new KeyboardEvent('keydown', { key: 'Escape', bubbles: true })
+		document.dispatchEvent(event)
+		await wrapper.vm.$nextTick()
+
+		expect(wrapper.emitted('close')).toBeTruthy()
+		expect(wrapper.emitted('submit')).toBeFalsy()
+	})
+
+	it('does NOT emit close on Escape when modal is hidden', async () => {
+		wrapper = mountModal({ show: false })
+
+		const event = new KeyboardEvent('keydown', { key: 'Escape', bubbles: true })
+		document.dispatchEvent(event)
+		await wrapper.vm.$nextTick()
+
+		expect(wrapper.emitted('close')).toBeFalsy()
+	})
+
+	// -------------------------------------------------------------------------
+	// 9. Reopening resets to defaults (not stale state)
+	// -------------------------------------------------------------------------
+	it('resets formSnapshot to type defaults when modal is reopened', async () => {
+		wrapper = mountModal({ show: true, preselectedType: 'text' })
+
+		// Simulate user entering data.
+		wrapper.vm.onContentUpdate({ text: 'Stale data', fontSize: '20px' })
+
+		// Close and reopen.
+		await wrapper.setProps({ show: false })
+		await wrapper.setProps({ show: true })
+		await wrapper.vm.$nextTick()
+
+		// formSnapshot should be reset to defaults for 'text' type.
+		const textDefaults = widgetRegistry.text.defaults
+		for (const [key, val] of Object.entries(textDefaults)) {
+			expect(wrapper.vm.formSnapshot[key]).toBe(val)
+		}
+	})
+})

--- a/src/components/Widgets/AddWidgetModal.vue
+++ b/src/components/Widgets/AddWidgetModal.vue
@@ -1,0 +1,448 @@
+<!--
+  - SPDX-FileCopyrightText: 2026 MyDash Contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<template>
+	<div
+		v-if="show"
+		class="add-widget-modal__backdrop"
+		role="presentation"
+		@click.self="handleBackdropClick">
+		<div
+			:id="modalId"
+			class="add-widget-modal"
+			role="dialog"
+			:aria-labelledby="titleId"
+			:aria-modal="true">
+			<!-- Header -->
+			<div class="add-widget-modal__header">
+				<h2 :id="titleId" class="add-widget-modal__title">
+					{{ editMode ? tt('Edit Widget') : tt('Add Widget') }}
+				</h2>
+				<button
+					class="add-widget-modal__close"
+					:aria-label="tt('Close')"
+					@click="handleClose">
+					&times;
+				</button>
+			</div>
+
+			<!-- Body -->
+			<div class="add-widget-modal__body">
+				<!-- Type selector — hidden in edit mode and when preselectedType is set -->
+				<div v-if="showTypeSelector" class="add-widget-modal__field">
+					<label :for="typeSelectorId" class="add-widget-modal__label">
+						{{ tt('Type') }}
+					</label>
+					<select
+						:id="typeSelectorId"
+						v-model="activeType"
+						class="add-widget-modal__select"
+						@change="onTypeChange">
+						<option
+							v-for="(entry, typeKey) in widgetRegistry"
+							:key="typeKey"
+							:value="typeKey">
+							{{ entry.label }}
+						</option>
+					</select>
+				</div>
+
+				<!-- Per-type sub-form -->
+				<component
+					:is="activeFormComponent"
+					v-if="activeFormComponent"
+					ref="activeFormRef"
+					:editing-widget="editMode ? editingWidget : null"
+					@update:content="onContentUpdate" />
+			</div>
+
+			<!-- Footer / action buttons -->
+			<div class="add-widget-modal__footer">
+				<button
+					class="add-widget-modal__btn add-widget-modal__btn--secondary"
+					@click="handleClose">
+					{{ tt('Cancel') }}
+				</button>
+				<button
+					class="add-widget-modal__btn add-widget-modal__btn--primary"
+					:disabled="!isValid"
+					:title="firstValidationError"
+					@click="handleSubmit">
+					{{ editMode ? tt('Save') : tt('Add') }}
+				</button>
+			</div>
+		</div>
+	</div>
+</template>
+
+<script>
+import { widgetRegistry } from '../../constants/widgetRegistry.js'
+import { resetForm, loadEditingWidget, assembleContent } from '../../utils/widgetForm.js'
+
+let uidCounter = 0
+
+export default {
+	name: 'AddWidgetModal',
+
+	props: {
+		/**
+		 * Controls modal visibility.
+		 */
+		show: {
+			type: Boolean,
+			default: false,
+		},
+
+		/**
+		 * System Nextcloud widgets list (passed to nc-widget form if needed).
+		 */
+		widgets: {
+			type: Array,
+			default: () => [],
+		},
+
+		/**
+		 * When set, the type selector is hidden and this type is pre-selected.
+		 */
+		preselectedType: {
+			type: String,
+			default: null,
+		},
+
+		/**
+		 * When set, the modal opens in edit mode pre-filled from this widget.
+		 */
+		editingWidget: {
+			type: Object,
+			default: null,
+		},
+	},
+
+	emits: ['close', 'submit'],
+
+	data() {
+		const uid = ++uidCounter
+		const firstType = Object.keys(widgetRegistry)[0] || 'text'
+		return {
+			uid,
+			widgetRegistry,
+			activeType: firstType,
+			// Reactive snapshot of the current form state (updated via onContentUpdate).
+			formSnapshot: {},
+			// Validation errors populated by revalidate() — kept reactive.
+			formErrors: [''],
+		}
+	},
+
+	computed: {
+		modalId() {
+			return `add-widget-modal-${this.uid}`
+		},
+
+		titleId() {
+			return `add-widget-modal-title-${this.uid}`
+		},
+
+		typeSelectorId() {
+			return `add-widget-modal-type-${this.uid}`
+		},
+
+		editMode() {
+			return Boolean(this.editingWidget)
+		},
+
+		showTypeSelector() {
+			return !this.preselectedType && !this.editMode
+		},
+
+		activeRegistryEntry() {
+			return widgetRegistry[this.activeType] || null
+		},
+
+		activeFormComponent() {
+			return this.activeRegistryEntry ? this.activeRegistryEntry.form : null
+		},
+
+		/**
+		 * Submit is allowed only when formErrors is empty.
+		 *
+		 * @return {boolean}
+		 */
+		isValid() {
+			return this.formErrors.length === 0
+		},
+
+		firstValidationError() {
+			return this.formErrors[0] || ''
+		},
+	},
+
+	watch: {
+		/**
+		 * React to show changes: reset form on open; restore editing state if needed.
+		 *
+		 * @param {boolean} newVal new visibility value
+		 * @param {boolean} oldVal previous visibility value
+		 */
+		show(newVal, oldVal) {
+			if (newVal && !oldVal) {
+				this.initModal()
+			}
+		},
+
+		/**
+		 * React to editingWidget changes when modal is already open.
+		 *
+		 * @param {object|null} newVal updated editing widget value
+		 */
+		editingWidget(newVal) {
+			if (this.show && newVal) {
+				this.initModal()
+			}
+		},
+	},
+
+	mounted() {
+		document.addEventListener('keydown', this.handleKeydown)
+		if (this.show) {
+			this.initModal()
+		}
+	},
+
+	beforeDestroy() {
+		document.removeEventListener('keydown', this.handleKeydown)
+	},
+
+	methods: {
+		tt(key) {
+			if (typeof t === 'function') {
+				return t('mydash', key)
+			}
+			return key
+		},
+
+		/**
+		 * Initialise modal state on open / re-open.
+		 * Chooses type, then resets or pre-fills form.
+		 */
+		initModal() {
+			if (this.editMode) {
+				this.activeType = this.editingWidget.type || Object.keys(widgetRegistry)[0]
+			} else if (this.preselectedType) {
+				this.activeType = this.preselectedType
+			} else {
+				this.activeType = Object.keys(widgetRegistry)[0] || 'text'
+			}
+
+			// Reset form snapshot.
+			this.formSnapshot = resetForm(this.activeType)
+
+			if (this.editMode) {
+				this.formSnapshot = loadEditingWidget(this.formSnapshot, this.editingWidget)
+			}
+
+			// Reset validation (start blocked until sub-form validates after mount).
+			this.formErrors = ['']
+
+			// After the sub-form mounts, do an initial validation pass.
+			this.$nextTick(() => {
+				this.revalidate()
+			})
+		},
+
+		/**
+		 * Called when the user changes the type selector.
+		 * Resets form state to prevent cross-type field leakage.
+		 */
+		onTypeChange() {
+			this.formSnapshot = resetForm(this.activeType)
+			this.formErrors = ['']
+			this.$nextTick(() => {
+				this.revalidate()
+			})
+		},
+
+		/**
+		 * Called by the sub-form whenever its content changes.
+		 * Updates the snapshot and triggers validation.
+		 *
+		 * @param {object} content updated content from sub-form
+		 */
+		onContentUpdate(content) {
+			this.formSnapshot = { type: this.activeType, ...content }
+			this.revalidate()
+		},
+
+		/**
+		 * Call validate() on the active sub-form ref and store results in
+		 * reactive `formErrors` so that `isValid` computed re-evaluates.
+		 */
+		revalidate() {
+			const subForm = this.$refs.activeFormRef
+			if (!subForm || typeof subForm.validate !== 'function') {
+				// No validate method — treat as valid.
+				this.formErrors = []
+				return
+			}
+			const errors = subForm.validate()
+			this.formErrors = Array.isArray(errors) ? errors : []
+		},
+
+		handleBackdropClick() {
+			this.handleClose()
+		},
+
+		/**
+		 * Global keydown listener for Escape while modal is visible.
+		 *
+		 * @param {KeyboardEvent} event the keyboard event
+		 */
+		handleKeydown(event) {
+			if (this.show && event.key === 'Escape') {
+				this.handleClose()
+			}
+		},
+
+		handleClose() {
+			this.$emit('close')
+		},
+
+		handleSubmit() {
+			// Re-validate before submitting as a safety guard.
+			this.revalidate()
+			if (!this.isValid) {
+				return
+			}
+
+			const payload = assembleContent(this.activeType, this.formSnapshot)
+			this.$emit('submit', payload)
+		},
+	},
+}
+</script>
+
+<style scoped>
+.add-widget-modal__backdrop {
+	position: fixed;
+	inset: 0;
+	background: rgba(0, 0, 0, 0.5);
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	z-index: 2000;
+}
+
+.add-widget-modal {
+	background: var(--color-main-background);
+	border-radius: var(--border-radius-large);
+	box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
+	width: min(480px, calc(100vw - 32px));
+	max-height: calc(100vh - 64px);
+	display: flex;
+	flex-direction: column;
+	overflow: hidden;
+}
+
+.add-widget-modal__header {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	padding: 20px 24px 16px;
+	border-bottom: 1px solid var(--color-border);
+	flex-shrink: 0;
+}
+
+.add-widget-modal__title {
+	font-size: 18px;
+	font-weight: 600;
+	margin: 0;
+}
+
+.add-widget-modal__close {
+	background: none;
+	border: none;
+	font-size: 24px;
+	cursor: pointer;
+	color: var(--color-text-maxcontrast);
+	padding: 0 4px;
+	line-height: 1;
+}
+
+.add-widget-modal__close:hover {
+	color: var(--color-main-text);
+}
+
+.add-widget-modal__body {
+	flex: 1;
+	overflow-y: auto;
+	padding: 20px 24px;
+	display: flex;
+	flex-direction: column;
+	gap: 16px;
+}
+
+.add-widget-modal__field {
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+}
+
+.add-widget-modal__label {
+	font-weight: bold;
+	font-size: 14px;
+}
+
+.add-widget-modal__select {
+	width: 100%;
+	padding: 8px;
+	border: 1px solid var(--color-border);
+	border-radius: var(--border-radius);
+	background: var(--color-main-background);
+	color: var(--color-main-text);
+}
+
+.add-widget-modal__footer {
+	display: flex;
+	justify-content: flex-end;
+	gap: 8px;
+	padding: 16px 24px 20px;
+	border-top: 1px solid var(--color-border);
+	flex-shrink: 0;
+}
+
+.add-widget-modal__btn {
+	padding: 8px 16px;
+	border-radius: var(--border-radius);
+	border: 1px solid transparent;
+	cursor: pointer;
+	font-size: 14px;
+	font-weight: 500;
+	transition: background var(--animation-quick) ease;
+}
+
+.add-widget-modal__btn:disabled {
+	opacity: 0.5;
+	cursor: not-allowed;
+}
+
+.add-widget-modal__btn--secondary {
+	background: var(--color-background-hover);
+	border-color: var(--color-border);
+	color: var(--color-main-text);
+}
+
+.add-widget-modal__btn--secondary:hover:not(:disabled) {
+	background: var(--color-border);
+}
+
+.add-widget-modal__btn--primary {
+	background: var(--color-primary-element);
+	color: var(--color-primary-element-text);
+}
+
+.add-widget-modal__btn--primary:hover:not(:disabled) {
+	background: var(--color-primary-element-hover);
+}
+</style>

--- a/src/utils/widgetForm.js
+++ b/src/utils/widgetForm.js
@@ -1,0 +1,74 @@
+/**
+ * SPDX-FileCopyrightText: 2026 MyDash Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { widgetRegistry } from '../constants/widgetRegistry.js'
+
+/**
+ * Return a fresh form state (defaults) for the given widget type.
+ * The returned object always contains a `type` field.
+ *
+ * @param {string} type the widget type discriminator (e.g. 'text')
+ * @return {object} a shallow-cloned defaults object with `type` set
+ */
+export function resetForm(type) {
+	const entry = widgetRegistry[type]
+	const defaults = entry ? { ...entry.defaults } : {}
+	return { type, ...defaults }
+}
+
+/**
+ * Deep-merge `editingWidget.content` into `form` for the given editing widget.
+ * Returns a new plain object — does NOT mutate `form` in place.
+ *
+ * @param {object} form the current form state
+ * @param {object} editingWidget the widget being edited (must have `.type` and `.content`)
+ * @return {object} merged form state
+ */
+export function loadEditingWidget(form, editingWidget) {
+	if (!editingWidget) {
+		return { ...form }
+	}
+
+	const type = editingWidget.type || form.type
+	const content = editingWidget.content || {}
+
+	// Start from registry defaults so we always have a complete shape, then
+	// overlay the editing widget's persisted content.
+	const entry = widgetRegistry[type]
+	const base = entry ? { ...entry.defaults } : {}
+
+	return {
+		type,
+		...base,
+		...content,
+	}
+}
+
+/**
+ * Assemble the submit payload from the form, keeping only the fields that
+ * belong to the selected type (strips cross-type leakage).
+ *
+ * @param {string} type the currently selected widget type
+ * @param {object} form the current raw form state
+ * @return {{type: string, content: object}} the clean submit payload
+ */
+export function assembleContent(type, form) {
+	const entry = widgetRegistry[type]
+	if (!entry) {
+		// Unknown type — return empty content rather than leaking everything.
+		return { type, content: {} }
+	}
+
+	// Only keep keys that appear in this type's defaults.
+	const allowedKeys = Object.keys(entry.defaults)
+	const content = {}
+	for (const key of allowedKeys) {
+		if (Object.prototype.hasOwnProperty.call(form, key)) {
+			content[key] = form[key]
+		}
+	}
+
+	return { type, content }
+}

--- a/src/views/Views.vue
+++ b/src/views/Views.vue
@@ -48,7 +48,7 @@
 				:grid-columns="activeDashboard.gridColumns"
 				@update:placements="updatePlacements"
 				@widget-remove="removeWidget"
-				@widget-edit="openStyleEditor"
+				@widget-edit="openWidgetEditModal"
 				@tile-edit="openTileEditorForEdit" />
 
 			<div v-else class="mydash-empty">
@@ -91,6 +91,14 @@
 			@update="updateWidgetStyle"
 			@delete="deleteWidget" />
 
+		<!-- Add / Edit widget modal (content-level) -->
+		<AddWidgetModal
+			:show="isWidgetModalOpen"
+			:widgets="availableWidgets"
+			:editing-widget="editingWidgetContent"
+			@close="closeWidgetModal"
+			@submit="handleWidgetModalSubmit" />
+
 		<!-- Tile editor modal -->
 		<TileEditor
 			:open="isTileEditorOpen"
@@ -117,6 +125,7 @@ import BookOpenVariantOutline from 'vue-material-design-icons/BookOpenVariantOut
 import DashboardGrid from '../components/DashboardGrid.vue'
 import WidgetPicker from '../components/WidgetPicker.vue'
 import WidgetStyleEditor from '../components/WidgetStyleEditor.vue'
+import AddWidgetModal from '../components/Widgets/AddWidgetModal.vue'
 import TileEditor from '../components/TileEditor.vue'
 import DashboardSwitcher from '../components/DashboardSwitcher.vue'
 
@@ -139,6 +148,7 @@ export default {
 		DashboardGrid,
 		WidgetPicker,
 		WidgetStyleEditor,
+		AddWidgetModal,
 		TileEditor,
 		DashboardSwitcher,
 	},
@@ -150,6 +160,9 @@ export default {
 			editingPlacement: null,
 			isTileEditorOpen: false,
 			editingTile: null,
+			// Add/edit widget modal state
+			isWidgetModalOpen: false,
+			editingWidgetContent: null,
 		}
 	},
 	computed: {
@@ -231,6 +244,49 @@ export default {
 		async removeWidget(placementId) {
 			await this.removeWidgetFromDashboard(placementId)
 		},
+		/**
+		 * Open AddWidgetModal in edit mode for a placement that carries
+		 * widget content (styleConfig.type is set).
+		 * Falls through to the style editor for placements without content types.
+		 *
+		 * @param {object} placement the placement object to edit
+		 */
+		openWidgetEditModal(placement) {
+			const contentType = placement.styleConfig?.type
+			if (contentType) {
+				this.editingWidgetContent = {
+					type: contentType,
+					content: placement.styleConfig?.content || {},
+					placementId: placement.id,
+				}
+				this.isWidgetModalOpen = true
+			} else {
+				// No content type — fall through to the style editor.
+				this.openStyleEditor(placement)
+			}
+		},
+
+		closeWidgetModal() {
+			this.isWidgetModalOpen = false
+			this.editingWidgetContent = null
+		},
+
+		async handleWidgetModalSubmit(payload) {
+			if (this.editingWidgetContent?.placementId) {
+				// Edit mode: persist content back into styleConfig.
+				const existing = this.widgetPlacements.find(p => p.id === this.editingWidgetContent.placementId)
+				const updates = {
+					styleConfig: {
+						...(existing?.styleConfig || {}),
+						type: payload.type,
+						content: payload.content,
+					},
+				}
+				await this.updateWidgetPlacement(this.editingWidgetContent.placementId, updates)
+			}
+			this.closeWidgetModal()
+		},
+
 		openStyleEditor(placement) {
 			this.editingPlacement = placement
 			this.isStyleEditorOpen = true


### PR DESCRIPTION
## Summary

- Implements REQ-WDG-010 (modified), REQ-WDG-012, REQ-WDG-013, REQ-WDG-014 per spec at \`openspec/changes/widget-add-edit-modal/\`
- New \`AddWidgetModal.vue\` handles both create and edit flows via dynamic \`<component :is>\` sub-form loading from \`widgetRegistry\`
- New \`src/utils/widgetForm.js\` provides \`resetForm\`, \`loadEditingWidget\`, \`assembleContent\` (strips cross-type field leakage on submit)
- Per-type \`validate(): string[]\` contract gates the submit button reactively; three close triggers (cancel, backdrop click, Esc key) — none submit
- Wired into \`Views.vue\`: \`widget-edit\` from DashboardGrid (inline button + context-menu) routes content-type placements to the new modal; style-only placements fall through to \`WidgetStyleEditor\`
- \`WidgetPicker.vue\` preserved as-is (Nextcloud widget discovery surface)
- 12 Vitest scenarios: create/edit mode, type-switch leakage, submit field filtering, validation gating, all three close triggers, reopen reset

## Test plan

- [ ] Run \`npm test\` — all 133 tests pass; only pre-existing \`WidgetContextMenu.test.js\` CSS import failure (unrelated)
- [ ] Run \`npm run lint\` — exits 0 (warnings are pre-existing)
- [ ] Run \`npm run stylelint\` — exits 0
- [ ] Open modal in create mode: type selector visible with all registry entries, correct sub-form renders
- [ ] Open with \`preselectedType\`: type selector hidden
- [ ] Open in edit mode: title "Edit Widget", type hidden, form pre-filled, button reads "Save"
- [ ] Switch type: previous type's fields do not appear in new type's form
- [ ] Click backdrop: modal closes, no submit emitted
- [ ] Press Escape: modal closes, no submit emitted
- [ ] Click Cancel: modal closes, no submit emitted
- [ ] Submit with invalid sub-form: button disabled, submit blocked
- [ ] Submit with valid sub-form: \`submit({type, content})\` emitted with only the type's fields