### PR TITLE
feat(dashboards): fork visible dashboard as personal copy

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -23,6 +23,11 @@ return [
 		// the group-scoped routes that share the /api/dashboards/ prefix so the
 		// router matches the literal 'active' segment before any {groupId} wildcard.
 		['name' => 'dashboard_api#setActiveDashboard', 'url' => '/api/dashboards/active', 'verb' => 'POST'],
+		// REQ-DASH-020..022: fork a visible dashboard as a personal copy.
+		// Registered BEFORE the group-scoped {groupId} wildcard routes to
+		// prevent the literal 'fork' suffix being consumed by any wildcard.
+		['name' => 'dashboard_api#fork', 'url' => '/api/dashboards/{uuid}/fork', 'verb' => 'POST',
+		 'requirements' => ['uuid' => '[A-Za-z0-9\-]+']],
 		['name' => 'dashboard_api#getActive', 'url' => '/api/dashboard', 'verb' => 'GET'],
 		['name' => 'dashboard_api#create', 'url' => '/api/dashboard', 'verb' => 'POST'],
 		['name' => 'dashboard_api#update', 'url' => '/api/dashboard/{id}', 'verb' => 'PUT'],

--- a/lib/Controller/DashboardApiController.php
+++ b/lib/Controller/DashboardApiController.php
@@ -34,6 +34,7 @@ use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IRequest;
+use Psr\Log\LoggerInterface;
 
 /**
  * Controller for dashboard API endpoints.
@@ -49,12 +50,16 @@ class DashboardApiController extends Controller
      * @param IRequest          $request           The request.
      * @param DashboardService  $dashboardService  The dashboard service.
      * @param PermissionService $permissionService The permission service.
+     * @param LoggerInterface   $logger            PSR logger (used by fork
+     *                                             to report unexpected
+     *                                             errors — REQ-DASH-021).
      * @param string|null       $userId            The user ID.
      */
     public function __construct(
         IRequest $request,
         private readonly DashboardService $dashboardService,
         private readonly PermissionService $permissionService,
+        private readonly LoggerInterface $logger,
         private readonly ?string $userId,
     ) {
         parent::__construct(
@@ -73,7 +78,6 @@ class DashboardApiController extends Controller
      * @return JSONResponse The list of dashboards.
      */
     #[NoAdminRequired]
-
     public function list(): JSONResponse
     {
         if ($this->userId === null) {
@@ -99,7 +103,6 @@ class DashboardApiController extends Controller
      * @return JSONResponse The visible dashboards.
      */
     #[NoAdminRequired]
-
     public function visible(): JSONResponse
     {
         if ($this->userId === null) {
@@ -126,7 +129,6 @@ class DashboardApiController extends Controller
      * @return JSONResponse The active dashboard data.
      */
     #[NoAdminRequired]
-
     public function getActive(): JSONResponse
     {
         if ($this->userId === null) {
@@ -164,7 +166,6 @@ class DashboardApiController extends Controller
      * @return JSONResponse The created dashboard.
      */
     #[NoAdminRequired]
-
     public function create(
         $name=null,
         ?string $description=null
@@ -225,7 +226,6 @@ class DashboardApiController extends Controller
      * @return JSONResponse The updated dashboard.
      */
     #[NoAdminRequired]
-
     public function update(
         int $id,
         ?string $name=null,
@@ -287,7 +287,6 @@ class DashboardApiController extends Controller
      * @return JSONResponse The deletion confirmation.
      */
     #[NoAdminRequired]
-
     public function delete(int $id): JSONResponse
     {
         if ($this->userId === null) {
@@ -314,7 +313,6 @@ class DashboardApiController extends Controller
      * @return JSONResponse The activated dashboard.
      */
     #[NoAdminRequired]
-
     public function activate(int $id): JSONResponse
     {
         if ($this->userId === null) {
@@ -345,7 +343,6 @@ class DashboardApiController extends Controller
      * @return JSONResponse The list of group-shared dashboards.
      */
     #[NoAdminRequired]
-
     public function listGroup(string $groupId): JSONResponse
     {
         if ($this->userId === null) {
@@ -376,7 +373,6 @@ class DashboardApiController extends Controller
      * @return JSONResponse The created dashboard.
      */
     #[NoAdminRequired]
-
     public function createGroup(
         string $groupId,
         $name=null,
@@ -426,7 +422,6 @@ class DashboardApiController extends Controller
      * @return JSONResponse The dashboard payload.
      */
     #[NoAdminRequired]
-
     public function getGroup(
         string $groupId,
         string $uuid
@@ -465,7 +460,6 @@ class DashboardApiController extends Controller
      * @return JSONResponse The updated dashboard.
      */
     #[NoAdminRequired]
-
     public function updateGroup(
         string $groupId,
         string $uuid,
@@ -527,7 +521,6 @@ class DashboardApiController extends Controller
      * @return JSONResponse The status payload.
      */
     #[NoAdminRequired]
-
     public function deleteGroup(
         string $groupId,
         string $uuid
@@ -578,7 +571,6 @@ class DashboardApiController extends Controller
      * @return JSONResponse The status payload.
      */
     #[NoAdminRequired]
-
     public function setGroupDefault(
         string $groupId,
         ?string $uuid=null
@@ -643,7 +635,6 @@ class DashboardApiController extends Controller
      *                      when the session has no user.
      */
     #[NoAdminRequired]
-
     public function setActiveDashboard(?string $uuid=null): JSONResponse
     {
         if ($this->userId === null) {
@@ -657,6 +648,81 @@ class DashboardApiController extends Controller
 
         return ResponseHelper::success(data: ['status' => 'success']);
     }//end setActiveDashboard()
+
+    /**
+     * Fork a visible dashboard as a new personal copy.
+     *
+     * Creates a new `user`-type dashboard owned by the calling user,
+     * deep-copying all widget placements from the source dashboard, and
+     * makes it the active dashboard. Gated on `allow_user_dashboards`.
+     * REQ-DASH-020..022.
+     *
+     * @param string      $uuid The source dashboard UUID (URL parameter).
+     * @param string|null $name Optional override name (JSON body field).
+     *
+     * @return JSONResponse HTTP 201 + new dashboard on success;
+     *                      403 when personal dashboards are disabled;
+     *                      404 when the source is not visible to the user;
+     *                      500 on unexpected error.
+     */
+    #[NoAdminRequired]
+    public function fork(
+        string $uuid,
+        ?string $name=null
+    ): JSONResponse {
+        if ($this->userId === null) {
+            return ResponseHelper::unauthorized();
+        }
+
+        try {
+            $dashboard = $this->dashboardService->forkAsPersonal(
+                userId: $this->userId,
+                sourceUuid: $uuid,
+                name: $name
+            );
+
+            return new JSONResponse(
+                data: [
+                    'status'    => 'success',
+                    'dashboard' => $dashboard->jsonSerialize(),
+                ],
+                statusCode: Http::STATUS_CREATED
+            );
+        } catch (PersonalDashboardsDisabledException $e) {
+            return new JSONResponse(
+                data: [
+                    'status'  => 'error',
+                    'error'   => $e->getErrorCode(),
+                    'message' => $e->getMessage(),
+                ],
+                statusCode: Http::STATUS_FORBIDDEN
+            );
+        } catch (DoesNotExistException $e) {
+            return new JSONResponse(
+                data: [
+                    'status' => 'error',
+                    'error'  => 'not_found',
+                ],
+                statusCode: Http::STATUS_NOT_FOUND
+            );
+        } catch (\Throwable $t) {
+            $this->logger->error(
+                message: 'mydash: fork failed for user {user}: {message}',
+                context: [
+                    'user'    => $this->userId,
+                    'message' => $t->getMessage(),
+                ]
+            );
+            return new JSONResponse(
+                data: [
+                    'status'  => 'error',
+                    'error'   => 'internal_error',
+                    'message' => 'An unexpected error occurred',
+                ],
+                statusCode: Http::STATUS_INTERNAL_SERVER_ERROR
+            );
+        }//end try
+    }//end fork()
 
     /**
      * Resolve create parameters from JSON body or individual params.

--- a/lib/Controller/DashboardShareApiController.php
+++ b/lib/Controller/DashboardShareApiController.php
@@ -73,7 +73,7 @@ class DashboardShareApiController extends Controller
         if ($this->userId === null) {
             return new DataResponse(
                 data: ['error' => 'Not logged in'],
-                status: Http::STATUS_UNAUTHORIZED
+                statusCode: Http::STATUS_UNAUTHORIZED
             );
         }
 
@@ -90,12 +90,12 @@ class DashboardShareApiController extends Controller
         } catch (DoesNotExistException) {
             return new DataResponse(
                 data: ['error' => 'Dashboard not found'],
-                status: Http::STATUS_NOT_FOUND
+                statusCode: Http::STATUS_NOT_FOUND
             );
         } catch (Exception $e) {
             return new DataResponse(
                 data: ['error' => $e->getMessage()],
-                status: Http::STATUS_FORBIDDEN
+                statusCode: Http::STATUS_FORBIDDEN
             );
         }//end try
     }//end index()
@@ -120,7 +120,7 @@ class DashboardShareApiController extends Controller
         if ($this->userId === null) {
             return new DataResponse(
                 data: ['error' => 'Not logged in'],
-                status: Http::STATUS_UNAUTHORIZED
+                statusCode: Http::STATUS_UNAUTHORIZED
             );
         }
 
@@ -134,22 +134,22 @@ class DashboardShareApiController extends Controller
             );
             return new DataResponse(
                 data: $share->jsonSerialize(),
-                status: Http::STATUS_CREATED
+                statusCode: Http::STATUS_CREATED
             );
         } catch (InvalidArgumentException $e) {
             return new DataResponse(
                 data: ['error' => $e->getMessage()],
-                status: Http::STATUS_BAD_REQUEST
+                statusCode: Http::STATUS_BAD_REQUEST
             );
         } catch (DoesNotExistException) {
             return new DataResponse(
                 data: ['error' => 'Dashboard not found'],
-                status: Http::STATUS_NOT_FOUND
+                statusCode: Http::STATUS_NOT_FOUND
             );
         } catch (Exception $e) {
             return new DataResponse(
                 data: ['error' => $e->getMessage()],
-                status: Http::STATUS_FORBIDDEN
+                statusCode: Http::STATUS_FORBIDDEN
             );
         }//end try
     }//end create()
@@ -167,7 +167,7 @@ class DashboardShareApiController extends Controller
         if ($this->userId === null) {
             return new DataResponse(
                 data: ['error' => 'Not logged in'],
-                status: Http::STATUS_UNAUTHORIZED
+                statusCode: Http::STATUS_UNAUTHORIZED
             );
         }
 
@@ -176,16 +176,16 @@ class DashboardShareApiController extends Controller
                 shareId: $shareId,
                 callerId: $this->userId
             );
-            return new DataResponse(data: [], status: Http::STATUS_NO_CONTENT);
+            return new DataResponse(data: [], statusCode: Http::STATUS_NO_CONTENT);
         } catch (DoesNotExistException) {
             return new DataResponse(
                 data: ['error' => 'Share not found'],
-                status: Http::STATUS_NOT_FOUND
+                statusCode: Http::STATUS_NOT_FOUND
             );
         } catch (Exception $e) {
             return new DataResponse(
                 data: ['error' => $e->getMessage()],
-                status: Http::STATUS_FORBIDDEN
+                statusCode: Http::STATUS_FORBIDDEN
             );
         }//end try
     }//end destroy()
@@ -204,7 +204,7 @@ class DashboardShareApiController extends Controller
         if ($this->userId === null) {
             return new DataResponse(
                 data: ['error' => 'Not logged in'],
-                status: Http::STATUS_UNAUTHORIZED
+                statusCode: Http::STATUS_UNAUTHORIZED
             );
         }
 
@@ -226,17 +226,17 @@ class DashboardShareApiController extends Controller
         } catch (InvalidArgumentException $e) {
             return new DataResponse(
                 data: ['error' => $e->getMessage()],
-                status: Http::STATUS_BAD_REQUEST
+                statusCode: Http::STATUS_BAD_REQUEST
             );
         } catch (DoesNotExistException) {
             return new DataResponse(
                 data: ['error' => 'Dashboard not found'],
-                status: Http::STATUS_NOT_FOUND
+                statusCode: Http::STATUS_NOT_FOUND
             );
         } catch (Exception $e) {
             return new DataResponse(
                 data: ['error' => $e->getMessage()],
-                status: Http::STATUS_FORBIDDEN
+                statusCode: Http::STATUS_FORBIDDEN
             );
         }//end try
     }//end replace()
@@ -258,7 +258,7 @@ class DashboardShareApiController extends Controller
         if ($this->userId === null) {
             return new DataResponse(
                 data: ['error' => 'Not logged in'],
-                status: Http::STATUS_UNAUTHORIZED
+                statusCode: Http::STATUS_UNAUTHORIZED
             );
         }
 
@@ -272,7 +272,7 @@ class DashboardShareApiController extends Controller
         } catch (InvalidArgumentException $e) {
             return new DataResponse(
                 data: ['error' => $e->getMessage()],
-                status: Http::STATUS_BAD_REQUEST
+                statusCode: Http::STATUS_BAD_REQUEST
             );
         }
     }//end revokeForRecipient()

--- a/lib/Db/WidgetPlacementMapper.php
+++ b/lib/Db/WidgetPlacementMapper.php
@@ -225,6 +225,61 @@ class WidgetPlacementMapper extends QBMapper
     }//end updatePositions()
 
     /**
+     * Clone all placements from a source dashboard into a target dashboard.
+     *
+     * Fetches every placement row belonging to `$sourceDashboardId` and
+     * inserts fresh copies under `$targetDashboardId` with new auto-
+     * generated IDs and reset `createdAt`/`updatedAt` timestamps. All
+     * other fields — gridX/Y/W/H, widgetId, customTitle, styleConfig,
+     * showTitle, isCompulsory, isVisible, sortOrder, tileType, tileTitle,
+     * tileIcon, tileIconType, tileBackgroundColor, tileTextColor,
+     * tileLinkType, tileLinkValue, customIcon — are copied verbatim so
+     * the fork is a true visual clone. Resource URLs (e.g. tileIcon) are
+     * NOT duplicated; both dashboards reference the same URL (REQ-DASH-022).
+     *
+     * @param int $sourceDashboardId The source dashboard ID.
+     * @param int $targetDashboardId The target (new) dashboard ID.
+     *
+     * @return void
+     */
+    public function cloneToDashboard(
+        int $sourceDashboardId,
+        int $targetDashboardId
+    ): void {
+        $now        = (new DateTime())->format(format: 'Y-m-d H:i:s');
+        $placements = $this->findByDashboardId(dashboardId: $sourceDashboardId);
+
+        foreach ($placements as $source) {
+            $clone = new WidgetPlacement();
+            $clone->setDashboardId($targetDashboardId);
+            $clone->setWidgetId($source->getWidgetId());
+            $clone->setGridX($source->getGridX());
+            $clone->setGridY($source->getGridY());
+            $clone->setGridWidth($source->getGridWidth());
+            $clone->setGridHeight($source->getGridHeight());
+            $clone->setIsCompulsory($source->getIsCompulsory());
+            $clone->setIsVisible($source->getIsVisible());
+            $clone->setStyleConfig($source->getStyleConfig());
+            $clone->setCustomTitle($source->getCustomTitle());
+            $clone->setCustomIcon($source->getCustomIcon());
+            $clone->setShowTitle($source->getShowTitle());
+            $clone->setSortOrder($source->getSortOrder());
+            $clone->setTileType($source->getTileType());
+            $clone->setTileTitle($source->getTileTitle());
+            $clone->setTileIcon($source->getTileIcon());
+            $clone->setTileIconType($source->getTileIconType());
+            $clone->setTileBackgroundColor($source->getTileBackgroundColor());
+            $clone->setTileTextColor($source->getTileTextColor());
+            $clone->setTileLinkType($source->getTileLinkType());
+            $clone->setTileLinkValue($source->getTileLinkValue());
+            $clone->setCreatedAt($now);
+            $clone->setUpdatedAt($now);
+
+            $this->insert(entity: $clone);
+        }//end foreach
+    }//end cloneToDashboard()
+
+    /**
      * Get max sort order for a dashboard.
      *
      * @param int $dashboardId The dashboard ID.

--- a/lib/Service/DashboardService.php
+++ b/lib/Service/DashboardService.php
@@ -35,6 +35,7 @@ use OCA\MyDash\Exception\PersonalDashboardsDisabledException;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\IConfig;
 use OCP\IDBConnection;
+use OCP\IL10N;
 use OCP\IGroupManager;
 use OCP\IUserManager;
 use Psr\Log\LoggerInterface;
@@ -101,6 +102,10 @@ class DashboardService
      *                                                flip — REQ-DASH-015).
      * @param IConfig               $config           Nextcloud per-user
      *                                                preference storage.
+     * @param IL10N                 $l10n             Localisation service
+     *                                                (used for the fork
+     *                                                default name —
+     *                                                REQ-DASH-020).
      * @param LoggerInterface       $logger           PSR logger.
      */
     public function __construct(
@@ -114,6 +119,7 @@ class DashboardService
         private readonly IUserManager $userManager,
         private readonly IDBConnection $db,
         private readonly IConfig $config,
+        private readonly IL10N $l10n,
         private readonly LoggerInterface $logger,
     ) {
     }//end __construct()
@@ -185,6 +191,114 @@ class DashboardService
 
         return $this->dashboardMapper->insert(entity: $dashboard);
     }//end createDashboard()
+
+    /**
+     * Fork a visible dashboard as a new personal copy for the caller.
+     *
+     * Implements REQ-DASH-020..022. Creates a new `user`-type dashboard
+     * owned by `$userId`, deep-copies all widget placements from the
+     * source, and makes it the user's active dashboard. The entire
+     * operation runs inside a single DB transaction (REQ-DASH-021).
+     *
+     * Gating rules:
+     *  - `allow_user_dashboards` must be `true`; otherwise throws
+     *    {@see PersonalDashboardsDisabledException} (→ HTTP 403).
+     *  - The source must be visible to `$userId` (any type); otherwise
+     *    throws {@see DoesNotExistException} (→ HTTP 404, no info leak).
+     *
+     * Resource URLs in placements are kept as-is — no resource bytes are
+     * duplicated (REQ-DASH-022).
+     *
+     * @param string      $userId     The calling user ID.
+     * @param string      $sourceUuid The UUID of the dashboard to fork.
+     * @param string|null $name       Override name; defaults to
+     *                                `t('My copy of {name}', …)`.
+     *
+     * @return Dashboard The newly created personal dashboard.
+     *
+     * @throws PersonalDashboardsDisabledException When the admin flag is off.
+     * @throws DoesNotExistException               When the source is not visible
+     *                                             to the calling user.
+     * @throws \Throwable                          On any DB error (rolled back).
+     *
+     * @SuppressWarnings(PHPMD.CyclomaticComplexity)
+     */
+    public function forkAsPersonal(
+        string $userId,
+        string $sourceUuid,
+        ?string $name=null
+    ): Dashboard {
+        // REQ-ASET-003 gate — throws PersonalDashboardsDisabledException on failure.
+        $this->assertPersonalDashboardsAllowed();
+
+        // Resolve source from the user's visible set (REQ-DASH-013).
+        // Do NOT fall back to a raw findByUuid — that would leak existence
+        // of dashboards the user cannot see (REQ-DASH-020, 404 scenario).
+        $visible = $this->getVisibleToUser(userId: $userId);
+        $source  = null;
+        foreach ($visible as $entry) {
+            if ((string) $entry['dashboard']->getUuid() === $sourceUuid) {
+                $source = $entry['dashboard'];
+                break;
+            }
+        }
+
+        if ($source === null) {
+            throw new DoesNotExistException(
+                msg: 'Dashboard not found or not visible'
+            );
+        }
+
+        // Resolve the fork name — fall back to a translated default.
+        if ($name !== null && $name !== '') {
+            $forkName = $name;
+        } else {
+            $forkName = $this->l10n->t(
+                'My copy of {name}',
+                ['name' => (string) $source->getName()]
+            );
+        }
+
+        $this->db->beginTransaction();
+        try {
+            // Build the new personal dashboard entity.
+            $newDash = $this->dashboardFactory->create(
+                userId: $userId,
+                name: $forkName,
+                type: Dashboard::TYPE_USER,
+                groupId: null,
+                gridColumns: (int) $source->getGridColumns()
+            );
+            // Forks are never defaults (REQ-DASH-020 scenario).
+            $newDash->setIsDefault(0);
+
+            // Deactivate other personal dashboards BEFORE insert so the
+            // factory-set isActive=1 on the new row stays clean.
+            $this->dashboardMapper->deactivateAllForUser(userId: $userId);
+
+            // Persist the new dashboard row.
+            $newDash = $this->dashboardMapper->insert(entity: $newDash);
+
+            // Deep-copy placements (REQ-DASH-020, REQ-DASH-022).
+            $this->placementMapper->cloneToDashboard(
+                sourceDashboardId: (int) $source->getId(),
+                targetDashboardId: (int) $newDash->getId()
+            );
+
+            // Persist the active-dashboard preference (REQ-DASH-019).
+            $this->setActivePreference(
+                userId: $userId,
+                uuid: (string) $newDash->getUuid()
+            );
+
+            $this->db->commit();
+        } catch (Throwable $t) {
+            $this->db->rollBack();
+            throw $t;
+        }//end try
+
+        return $newDash;
+    }//end forkAsPersonal()
 
     /**
      * Update a dashboard.
@@ -583,16 +697,22 @@ class DashboardService
         ?string $primaryGroupId
     ): ?array {
         // Normalise the sentinel so steps 2-5 can rely on it.
-        $groupId = ($primaryGroupId === null || $primaryGroupId === '')
-            ? Dashboard::DEFAULT_GROUP_ID
-            : $primaryGroupId;
+        if ($primaryGroupId === null || $primaryGroupId === '') {
+            $groupId = Dashboard::DEFAULT_GROUP_ID;
+        } else {
+            $groupId = $primaryGroupId;
+        }
 
         // Pre-fetch all visible dashboards once — used for the pref lookup
         // and to avoid redundant DB round-trips.
         $visible = $this->getVisibleToUser(userId: $userId);
 
         // Build a UUID-keyed index for O(1) pref lookup.
-        /** @var array<string, array{dashboard: Dashboard, source: string}> $byUuid */
+        /**
+         * UUID-keyed index of the visible-to-user dashboard list.
+         *
+         * @var array<string, array{dashboard: Dashboard, source: string}> $byUuid
+         */
         $byUuid = [];
         foreach ($visible as $entry) {
             $uuid = (string) $entry['dashboard']->getUuid();
@@ -767,13 +887,12 @@ class DashboardService
      * "first" result is already correctly ordered without a secondary sort
      * here.
      *
-     * @param array<int, array{dashboard: Dashboard, source: string}> $visible
-     *                          The full visible-to-user list.
-     * @param string            $groupId       The group ID to filter on.
-     * @param string            $source        Expected source tag
-     *                                         (`'group'` or `'default'`).
-     * @param bool              $requireDefault When true, only rows with
-     *                                          `isDefault = 1` are considered.
+     * @param array<int, array{dashboard: Dashboard, source: string}> $visible        The full visible-to-user list.
+     * @param string                                                  $groupId        The group ID to filter on.
+     * @param string                                                  $source         Expected source tag
+     *                                                                                (`'group'` or `'default'`).
+     * @param bool                                                    $requireDefault When true, only rows with
+     *                                                                                `isDefault = 1` are considered.
      *
      * @return array{dashboard: Dashboard, source: string}|null
      */

--- a/sbom.cdx.json
+++ b/sbom.cdx.json
@@ -2,10 +2,10 @@
   "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.5",
-  "serialNumber": "urn:uuid:973592c5-a4d4-4542-94aa-d3e9138959a9",
+  "serialNumber": "urn:uuid:5ee74da4-b04e-46fe-aed5-0e55fa312c8f",
   "version": 1,
   "metadata": {
-    "timestamp": "2026-04-30T19:48:24Z",
+    "timestamp": "2026-04-30T20:22:12Z",
     "tools": [
       {
         "name": "composer",
@@ -82,10 +82,10 @@
       }
     ],
     "component": {
-      "bom-ref": "mydash/mydash-dev-feature/impl-nc-dashboard-widget-proxy",
+      "bom-ref": "mydash/mydash-dev-feature/impl-fork-current-as-personal",
       "type": "application",
       "name": "mydash",
-      "version": "dev-feature/impl-nc-dashboard-widget-proxy",
+      "version": "dev-feature/impl-fork-current-as-personal",
       "group": "mydash",
       "description": "Enhanced dashboard with grid layout and admin controls for Nextcloud",
       "author": "MyDash Contributors",
@@ -96,15 +96,15 @@
           }
         }
       ],
-      "purl": "pkg:composer/mydash/mydash@dev-feature/impl-nc-dashboard-widget-proxy",
+      "purl": "pkg:composer/mydash/mydash@dev-feature/impl-fork-current-as-personal",
       "properties": [
         {
           "name": "cdx:composer:package:distReference",
-          "value": "4fdaad9dc8ad1be002134252470331d0a8d6e1ea"
+          "value": "61bf45da1f763733e53dd02389928eb6d20f9813"
         },
         {
           "name": "cdx:composer:package:sourceReference",
-          "value": "4fdaad9dc8ad1be002134252470331d0a8d6e1ea"
+          "value": "61bf45da1f763733e53dd02389928eb6d20f9813"
         },
         {
           "name": "cdx:composer:package:type",
@@ -17934,7 +17934,7 @@
       ]
     },
     {
-      "ref": "mydash/mydash-dev-feature/impl-nc-dashboard-widget-proxy",
+      "ref": "mydash/mydash-dev-feature/impl-fork-current-as-personal",
       "dependsOn": [
         "ramsey/uuid-4.9.2.0"
       ]

--- a/tests/Unit/Controller/DashboardApiControllerActiveTest.php
+++ b/tests/Unit/Controller/DashboardApiControllerActiveTest.php
@@ -27,6 +27,7 @@ use OCP\AppFramework\Http;
 use OCP\IRequest;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
 
 /**
  * Unit tests for the setActiveDashboard controller action (REQ-DASH-019).
@@ -39,12 +40,15 @@ class DashboardApiControllerActiveTest extends TestCase
     private $dashboardService;
     /** @var PermissionService&MockObject */
     private $permissionService;
+    /** @var LoggerInterface&MockObject */
+    private $logger;
 
     protected function setUp(): void
     {
         $this->request           = $this->createMock(IRequest::class);
         $this->dashboardService  = $this->createMock(DashboardService::class);
         $this->permissionService = $this->createMock(PermissionService::class);
+        $this->logger            = $this->createMock(LoggerInterface::class);
     }//end setUp()
 
     /**
@@ -56,6 +60,7 @@ class DashboardApiControllerActiveTest extends TestCase
             request: $this->request,
             dashboardService: $this->dashboardService,
             permissionService: $this->permissionService,
+            logger: $this->logger,
             userId: $userId,
         );
     }//end makeController()

--- a/tests/Unit/Controller/DashboardApiControllerDefaultFlagTest.php
+++ b/tests/Unit/Controller/DashboardApiControllerDefaultFlagTest.php
@@ -30,6 +30,7 @@ use OCP\AppFramework\Http;
 use OCP\IRequest;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
 use ReflectionMethod;
 
 /**
@@ -43,12 +44,15 @@ class DashboardApiControllerDefaultFlagTest extends TestCase
     private $dashboardService;
     /** @var PermissionService&MockObject */
     private $permissionService;
+    /** @var LoggerInterface&MockObject */
+    private $logger;
 
     protected function setUp(): void
     {
         $this->request           = $this->createMock(IRequest::class);
         $this->dashboardService  = $this->createMock(DashboardService::class);
         $this->permissionService = $this->createMock(PermissionService::class);
+        $this->logger            = $this->createMock(LoggerInterface::class);
     }//end setUp()
 
     /**
@@ -61,6 +65,7 @@ class DashboardApiControllerDefaultFlagTest extends TestCase
             request: $this->request,
             dashboardService: $this->dashboardService,
             permissionService: $this->permissionService,
+            logger: $this->logger,
             userId: $userId,
         );
     }//end makeController()

--- a/tests/Unit/Controller/DashboardApiControllerForkTest.php
+++ b/tests/Unit/Controller/DashboardApiControllerForkTest.php
@@ -1,0 +1,274 @@
+<?php
+
+/**
+ * DashboardApiController Fork Test
+ *
+ * Unit tests for the `POST /api/dashboards/{uuid}/fork` endpoint covering
+ * REQ-DASH-020..022:
+ *   - Happy path: HTTP 201 + new dashboard payload.
+ *   - Flag off: HTTP 403 with personal_dashboards_disabled error code.
+ *   - Source not visible: HTTP 404.
+ *   - Anonymous caller: HTTP 401.
+ *
+ * @category  Test
+ * @package   OCA\MyDash\Tests\Unit\Controller
+ * @author    Conduction b.v. <info@conduction.nl>
+ * @copyright 2026 Conduction b.v.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-FileCopyrightText: 2026 MyDash Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Controller;
+
+use OCA\MyDash\Controller\DashboardApiController;
+use OCA\MyDash\Db\Dashboard;
+use OCA\MyDash\Exception\PersonalDashboardsDisabledException;
+use OCA\MyDash\Service\DashboardService;
+use OCA\MyDash\Service\PermissionService;
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\AppFramework\Http;
+use OCP\IRequest;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Unit tests for the fork controller action (REQ-DASH-020..022).
+ */
+class DashboardApiControllerForkTest extends TestCase
+{
+
+    /** @var IRequest&MockObject */
+    private $request;
+
+    /** @var DashboardService&MockObject */
+    private $dashboardService;
+
+    /** @var PermissionService&MockObject */
+    private $permissionService;
+
+    /** @var LoggerInterface&MockObject */
+    private $logger;
+
+    /**
+     * Set up shared mocks.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        $this->request           = $this->createMock(IRequest::class);
+        $this->dashboardService  = $this->createMock(DashboardService::class);
+        $this->permissionService = $this->createMock(PermissionService::class);
+        $this->logger            = $this->createMock(LoggerInterface::class);
+    }//end setUp()
+
+    /**
+     * Build a controller with the given user ID.
+     *
+     * @param string|null $userId The logged-in user ID, or null for anon.
+     *
+     * @return DashboardApiController
+     */
+    private function makeController(?string $userId): DashboardApiController
+    {
+        return new DashboardApiController(
+            request: $this->request,
+            dashboardService: $this->dashboardService,
+            permissionService: $this->permissionService,
+            logger: $this->logger,
+            userId: $userId,
+        );
+    }//end makeController()
+
+    /**
+     * Build a minimal stub Dashboard for use in mock return values.
+     *
+     * @param string $uuid The dashboard UUID.
+     * @param string $name The dashboard name.
+     * @param string $type The dashboard type.
+     *
+     * @return Dashboard
+     */
+    private function makeDashboard(
+        string $uuid='new-uuid',
+        string $name='My copy of Source',
+        string $type=Dashboard::TYPE_USER
+    ): Dashboard {
+        $dash = new Dashboard();
+        $dash->setId(99);
+        $dash->setUuid($uuid);
+        $dash->setName($name);
+        $dash->setType($type);
+        $dash->setUserId('alice');
+        $dash->setGridColumns(12);
+        $dash->setIsActive(1);
+        $dash->setIsDefault(0);
+        $dash->setPermissionLevel(Dashboard::PERMISSION_FULL);
+
+        return $dash;
+    }//end makeDashboard()
+
+    /**
+     * REQ-DASH-020: Happy path — service succeeds, controller returns
+     * HTTP 201 with the new dashboard payload.
+     *
+     * @return void
+     */
+    public function testForkHappyPath(): void
+    {
+        $newDash = $this->makeDashboard(
+            uuid: 'fork-uuid',
+            name: 'My copy of Source'
+        );
+
+        $this->dashboardService->expects($this->once())
+            ->method('forkAsPersonal')
+            ->with(
+                userId: 'alice',
+                sourceUuid: 'src-uuid',
+                name: null
+            )
+            ->willReturn($newDash);
+
+        $controller = $this->makeController('alice');
+        $response   = $controller->fork(uuid: 'src-uuid');
+
+        $this->assertSame(Http::STATUS_CREATED, $response->getStatus());
+        $body = $response->getData();
+        $this->assertSame('success', $body['status']);
+        $this->assertArrayHasKey('dashboard', $body);
+        $this->assertSame('fork-uuid', $body['dashboard']['uuid']);
+        $this->assertSame('My copy of Source', $body['dashboard']['name']);
+    }//end testForkHappyPath()
+
+    /**
+     * REQ-DASH-020: Custom name in request body is forwarded to the service.
+     *
+     * @return void
+     */
+    public function testForkForwardsCustomName(): void
+    {
+        $newDash = $this->makeDashboard(name: 'My Marketing');
+
+        $this->dashboardService->expects($this->once())
+            ->method('forkAsPersonal')
+            ->with(
+                userId: 'alice',
+                sourceUuid: 'src-uuid',
+                name: 'My Marketing'
+            )
+            ->willReturn($newDash);
+
+        $controller = $this->makeController('alice');
+        $response   = $controller->fork(
+            uuid: 'src-uuid',
+            name: 'My Marketing'
+        );
+
+        $this->assertSame(Http::STATUS_CREATED, $response->getStatus());
+    }//end testForkForwardsCustomName()
+
+    /**
+     * REQ-DASH-020: When allow_user_dashboards is off, the service throws
+     * PersonalDashboardsDisabledException; the controller MUST return HTTP 403
+     * with the stable error envelope.
+     *
+     * @return void
+     */
+    public function testForkReturnsForbiddenWhenFlagOff(): void
+    {
+        $this->dashboardService->method('forkAsPersonal')
+            ->willThrowException(new PersonalDashboardsDisabledException());
+
+        $controller = $this->makeController('alice');
+        $response   = $controller->fork(uuid: 'src-uuid');
+
+        $this->assertSame(Http::STATUS_FORBIDDEN, $response->getStatus());
+        $body = $response->getData();
+        $this->assertSame('error', $body['status']);
+        $this->assertSame('personal_dashboards_disabled', $body['error']);
+        $this->assertArrayHasKey('message', $body);
+    }//end testForkReturnsForbiddenWhenFlagOff()
+
+    /**
+     * REQ-DASH-020: Source not visible to caller — service throws
+     * DoesNotExistException; the controller MUST return HTTP 404 without
+     * leaking existence.
+     *
+     * @return void
+     */
+    public function testForkReturnsNotFoundWhenSourceNotVisible(): void
+    {
+        $this->dashboardService->method('forkAsPersonal')
+            ->willThrowException(
+                new DoesNotExistException(
+                    msg: 'Dashboard not found or not visible'
+                )
+            );
+
+        $controller = $this->makeController('alice');
+        $response   = $controller->fork(uuid: 'invisible-uuid');
+
+        $this->assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
+        $body = $response->getData();
+        $this->assertSame('error', $body['status']);
+        $this->assertSame('not_found', $body['error']);
+        // The exception message MUST NOT be leaked.
+        $this->assertArrayNotHasKey('message', $body);
+    }//end testForkReturnsNotFoundWhenSourceNotVisible()
+
+    /**
+     * Anonymous session MUST get HTTP 401 without calling the service.
+     *
+     * @return void
+     */
+    public function testForkReturnsUnauthorizedForAnonymousCaller(): void
+    {
+        $this->dashboardService->expects($this->never())
+            ->method('forkAsPersonal');
+
+        $controller = $this->makeController(null);
+        $response   = $controller->fork(uuid: 'src-uuid');
+
+        $this->assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
+    }//end testForkReturnsUnauthorizedForAnonymousCaller()
+
+    /**
+     * Unexpected DB error MUST return HTTP 500 with a sanitised message
+     * (the raw exception message is NOT exposed to the client).
+     *
+     * @return void
+     */
+    public function testForkReturnsInternalErrorOnUnexpectedThrowable(): void
+    {
+        $this->dashboardService->method('forkAsPersonal')
+            ->willThrowException(
+                new \RuntimeException('raw db error details')
+            );
+
+        // The logger MUST be called with the raw error for debugging.
+        $this->logger->expects($this->once())
+            ->method('error');
+
+        $controller = $this->makeController('alice');
+        $response   = $controller->fork(uuid: 'src-uuid');
+
+        $this->assertSame(
+            Http::STATUS_INTERNAL_SERVER_ERROR,
+            $response->getStatus()
+        );
+        $body = $response->getData();
+        $this->assertSame('error', $body['status']);
+        $this->assertSame('internal_error', $body['error']);
+        // Raw exception message MUST NOT appear in the response.
+        $this->assertStringNotContainsString(
+            'raw db error details',
+            (string) json_encode($body)
+        );
+    }//end testForkReturnsInternalErrorOnUnexpectedThrowable()
+}//end class

--- a/tests/Unit/Service/DashboardServiceActiveResolutionTest.php
+++ b/tests/Unit/Service/DashboardServiceActiveResolutionTest.php
@@ -33,6 +33,7 @@ use OCA\MyDash\Service\DashboardService;
 use OCA\MyDash\Service\TemplateService;
 use OCP\IConfig;
 use OCP\IDBConnection;
+use OCP\IL10N;
 use OCP\IGroupManager;
 use OCP\IUser;
 use OCP\IUserManager;
@@ -68,6 +69,8 @@ class DashboardServiceActiveResolutionTest extends TestCase
     private $db;
     /** @var IConfig&MockObject */
     private $config;
+    /** @var IL10N&MockObject */
+    private $l10n;
     /** @var LoggerInterface&MockObject */
     private $logger;
 
@@ -85,6 +88,7 @@ class DashboardServiceActiveResolutionTest extends TestCase
         $this->userManager      = $this->createMock(IUserManager::class);
         $this->db               = $this->createMock(IDBConnection::class);
         $this->config           = $this->createMock(IConfig::class);
+        $this->l10n             = $this->createMock(IL10N::class);
         $this->logger           = $this->createMock(LoggerInterface::class);
 
         $this->service = new DashboardService(
@@ -98,6 +102,7 @@ class DashboardServiceActiveResolutionTest extends TestCase
             userManager: $this->userManager,
             db: $this->db,
             config: $this->config,
+            l10n: $this->l10n,
             logger: $this->logger,
         );
     }//end setUp()

--- a/tests/Unit/Service/DashboardServiceAllowFlagTest.php
+++ b/tests/Unit/Service/DashboardServiceAllowFlagTest.php
@@ -39,6 +39,7 @@ use OCA\MyDash\Service\DashboardService;
 use OCA\MyDash\Service\TemplateService;
 use OCP\IConfig;
 use OCP\IDBConnection;
+use OCP\IL10N;
 use OCP\IGroupManager;
 use OCP\IUserManager;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -122,6 +123,13 @@ class DashboardServiceAllowFlagTest extends TestCase
     private $config;
 
     /**
+     * IL10N mock.
+     *
+     * @var IL10N&MockObject
+     */
+    private $l10n;
+
+    /**
      * Logger mock.
      *
      * @var LoggerInterface&MockObject
@@ -152,6 +160,7 @@ class DashboardServiceAllowFlagTest extends TestCase
         $this->userManager      = $this->createMock(IUserManager::class);
         $this->db               = $this->createMock(IDBConnection::class);
         $this->config           = $this->createMock(IConfig::class);
+        $this->l10n             = $this->createMock(IL10N::class);
         $this->logger           = $this->createMock(LoggerInterface::class);
 
         $this->service = new DashboardService(
@@ -165,6 +174,7 @@ class DashboardServiceAllowFlagTest extends TestCase
             userManager: $this->userManager,
             db: $this->db,
             config: $this->config,
+            l10n: $this->l10n,
             logger: $this->logger,
         );
     }//end setUp()

--- a/tests/Unit/Service/DashboardServiceDefaultFlagTest.php
+++ b/tests/Unit/Service/DashboardServiceDefaultFlagTest.php
@@ -33,6 +33,7 @@ use OCA\MyDash\Service\TemplateService;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\IConfig;
 use OCP\IDBConnection;
+use OCP\IL10N;
 use OCP\IGroupManager;
 use OCP\IUserManager;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -65,6 +66,8 @@ class DashboardServiceDefaultFlagTest extends TestCase
     private $db;
     /** @var IConfig&MockObject */
     private $config;
+    /** @var IL10N&MockObject */
+    private $l10n;
     /** @var LoggerInterface&MockObject */
     private $logger;
 
@@ -82,6 +85,7 @@ class DashboardServiceDefaultFlagTest extends TestCase
         $this->userManager      = $this->createMock(IUserManager::class);
         $this->db               = $this->createMock(IDBConnection::class);
         $this->config           = $this->createMock(IConfig::class);
+        $this->l10n             = $this->createMock(IL10N::class);
         $this->logger           = $this->createMock(LoggerInterface::class);
 
         $this->service = new DashboardService(
@@ -95,6 +99,7 @@ class DashboardServiceDefaultFlagTest extends TestCase
             userManager: $this->userManager,
             db: $this->db,
             config: $this->config,
+            l10n: $this->l10n,
             logger: $this->logger,
         );
     }//end setUp()

--- a/tests/Unit/Service/DashboardServiceForkTest.php
+++ b/tests/Unit/Service/DashboardServiceForkTest.php
@@ -1,0 +1,618 @@
+<?php
+
+/**
+ * DashboardService Fork Test
+ *
+ * Unit tests for DashboardService::forkAsPersonal() covering
+ * REQ-DASH-020..022:
+ *   - Deep-copy preserves all placement fields byte-for-byte.
+ *   - Default name via t('My copy of {name}').
+ *   - Gated 403 when allow_user_dashboards is off.
+ *   - 404 when source is not visible to the user.
+ *   - Forking own personal dashboard creates an independent duplicate.
+ *   - Transactional rollback when placement insert fails.
+ *   - Resource URLs are shared (not duplicated) — REQ-DASH-022.
+ *
+ * @category  Test
+ * @package   OCA\MyDash\Tests\Unit\Service
+ * @author    Conduction b.v. <info@conduction.nl>
+ * @copyright 2026 Conduction b.v.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-FileCopyrightText: 2026 MyDash Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Service;
+
+use OCA\MyDash\Db\AdminSetting;
+use OCA\MyDash\Db\AdminSettingMapper;
+use OCA\MyDash\Db\Dashboard;
+use OCA\MyDash\Db\DashboardMapper;
+use OCA\MyDash\Db\WidgetPlacement;
+use OCA\MyDash\Db\WidgetPlacementMapper;
+use OCA\MyDash\Exception\PersonalDashboardsDisabledException;
+use OCA\MyDash\Service\DashboardFactory;
+use OCA\MyDash\Service\DashboardResolver;
+use OCA\MyDash\Service\DashboardService;
+use OCA\MyDash\Service\TemplateService;
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\IConfig;
+use OCP\IDBConnection;
+use OCP\IL10N;
+use OCP\IGroupManager;
+use OCP\IUser;
+use OCP\IUserManager;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use RuntimeException;
+
+/**
+ * Unit tests for forkAsPersonal (REQ-DASH-020..022).
+ */
+class DashboardServiceForkTest extends TestCase
+{
+
+    /** @var DashboardMapper&MockObject */
+    private $dashboardMapper;
+
+    /** @var WidgetPlacementMapper&MockObject */
+    private $placementMapper;
+
+    /** @var AdminSettingMapper&MockObject */
+    private $settingMapper;
+
+    /** @var TemplateService&MockObject */
+    private $templateService;
+
+    /** @var DashboardFactory&MockObject */
+    private $dashboardFactory;
+
+    /** @var DashboardResolver&MockObject */
+    private $dashResolver;
+
+    /** @var IGroupManager&MockObject */
+    private $groupManager;
+
+    /** @var IUserManager&MockObject */
+    private $userManager;
+
+    /** @var IDBConnection&MockObject */
+    private $db;
+
+    /** @var IConfig&MockObject */
+    private $config;
+
+    /** @var IL10N&MockObject */
+    private $l10n;
+
+    /** @var LoggerInterface&MockObject */
+    private $logger;
+
+    /** @var DashboardService */
+    private DashboardService $service;
+
+    /**
+     * Set up shared mocks.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        $this->dashboardMapper  = $this->createMock(DashboardMapper::class);
+        $this->placementMapper  = $this->createMock(WidgetPlacementMapper::class);
+        $this->settingMapper    = $this->createMock(AdminSettingMapper::class);
+        $this->templateService  = $this->createMock(TemplateService::class);
+        $this->dashboardFactory = $this->createMock(DashboardFactory::class);
+        $this->dashResolver     = $this->createMock(DashboardResolver::class);
+        $this->groupManager     = $this->createMock(IGroupManager::class);
+        $this->userManager      = $this->createMock(IUserManager::class);
+        $this->db               = $this->createMock(IDBConnection::class);
+        $this->config           = $this->createMock(IConfig::class);
+        $this->l10n             = $this->createMock(IL10N::class);
+        $this->logger           = $this->createMock(LoggerInterface::class);
+
+        $this->service = new DashboardService(
+            dashboardMapper: $this->dashboardMapper,
+            placementMapper: $this->placementMapper,
+            settingMapper: $this->settingMapper,
+            templateService: $this->templateService,
+            dashboardFactory: $this->dashboardFactory,
+            dashResolver: $this->dashResolver,
+            groupManager: $this->groupManager,
+            userManager: $this->userManager,
+            db: $this->db,
+            config: $this->config,
+            l10n: $this->l10n,
+            logger: $this->logger,
+        );
+    }//end setUp()
+
+    /**
+     * Helper: build a stub user with the given group IDs.
+     *
+     * @param string[] $groupIds Group IDs to return.
+     *
+     * @return IUser&MockObject
+     */
+    private function makeUser(array $groupIds=[]): IUser
+    {
+        $user = $this->createMock(IUser::class);
+        $this->userManager->method('get')
+            ->willReturn($user);
+        $this->groupManager->method('getUserGroupIds')
+            ->willReturn($groupIds);
+
+        return $user;
+    }//end makeUser()
+
+    /**
+     * Helper: build a stub source Dashboard with uuid and name set.
+     *
+     * @param string $uuid        Dashboard UUID.
+     * @param string $name        Dashboard name.
+     * @param int    $gridColumns Grid columns.
+     * @param int    $id          Dashboard DB id.
+     *
+     * @return Dashboard
+     */
+    private function makeSourceDashboard(
+        string $uuid,
+        string $name,
+        int $gridColumns=12,
+        int $id=42
+    ): Dashboard {
+        $dash = new Dashboard();
+        $dash->setId($id);
+        $dash->setUuid($uuid);
+        $dash->setName($name);
+        $dash->setType(Dashboard::TYPE_GROUP_SHARED);
+        $dash->setGroupId('marketing');
+        $dash->setGridColumns($gridColumns);
+        $dash->setIsDefault(0);
+        $dash->setIsActive(0);
+
+        return $dash;
+    }//end makeSourceDashboard()
+
+    /**
+     * Helper: build a stub personal Dashboard returned by dashboardMapper->insert.
+     *
+     * @param int    $id   DB id.
+     * @param string $uuid UUID.
+     * @param string $name Name.
+     *
+     * @return Dashboard
+     */
+    private function makeNewDashboard(
+        int $id=99,
+        string $uuid='new-uuid',
+        string $name='My copy of Source'
+    ): Dashboard {
+        $dash = new Dashboard();
+        $dash->setId($id);
+        $dash->setUuid($uuid);
+        $dash->setName($name);
+        $dash->setType(Dashboard::TYPE_USER);
+        $dash->setIsActive(1);
+        $dash->setIsDefault(0);
+        $dash->setGridColumns(12);
+
+        return $dash;
+    }//end makeNewDashboard()
+
+    /**
+     * REQ-DASH-020: Fork throws PersonalDashboardsDisabledException when
+     * the admin flag is off (gating → HTTP 403).
+     *
+     * @return void
+     */
+    public function testForkThrowsWhenFlagIsOff(): void
+    {
+        $this->settingMapper->method('getValue')
+            ->with(AdminSetting::KEY_ALLOW_USER_DASHBOARDS, false)
+            ->willReturn(false);
+
+        $this->expectException(PersonalDashboardsDisabledException::class);
+
+        $this->service->forkAsPersonal(
+            userId: 'alice',
+            sourceUuid: 'some-uuid'
+        );
+    }//end testForkThrowsWhenFlagIsOff()
+
+    /**
+     * REQ-DASH-020: Fork throws DoesNotExistException when the source uuid
+     * is not in the user's visible set (→ HTTP 404, no info leak).
+     *
+     * @return void
+     */
+    public function testForkThrowsNotFoundWhenSourceNotVisible(): void
+    {
+        $this->settingMapper->method('getValue')
+            ->with(AdminSetting::KEY_ALLOW_USER_DASHBOARDS, false)
+            ->willReturn(true);
+
+        $this->makeUser(['marketing']);
+
+        // findVisibleToUser returns an empty list — source not visible.
+        $this->dashboardMapper->method('findVisibleToUser')
+            ->willReturn([]);
+
+        $this->expectException(DoesNotExistException::class);
+
+        $this->service->forkAsPersonal(
+            userId: 'alice',
+            sourceUuid: 'invisible-uuid'
+        );
+    }//end testForkThrowsNotFoundWhenSourceNotVisible()
+
+    /**
+     * REQ-DASH-020: Happy path — fork uses the caller-supplied name.
+     *
+     * @return void
+     */
+    public function testForkUsesSuppliedName(): void
+    {
+        $this->settingMapper->method('getValue')
+            ->willReturn(true);
+
+        $this->makeUser(['marketing']);
+
+        $source = $this->makeSourceDashboard(
+            uuid: 'src-uuid',
+            name: 'Source Dashboard',
+            gridColumns: 10
+        );
+
+        $this->dashboardMapper->method('findVisibleToUser')
+            ->willReturn([
+                ['dashboard' => $source, 'source' => 'group'],
+            ]);
+
+        $newDash = $this->makeNewDashboard(
+            id: 99,
+            uuid: 'new-uuid',
+            name: 'Custom Fork Name'
+        );
+
+        $this->dashboardFactory->expects($this->once())
+            ->method('create')
+            ->with(
+                'alice',       // userId
+                'Custom Fork Name', // name
+                null,          // description
+                Dashboard::TYPE_USER, // type
+                null,          // groupId
+                10             // gridColumns
+            )
+            ->willReturn($newDash);
+
+        $this->dashboardMapper->method('insert')
+            ->willReturn($newDash);
+        $this->db->expects($this->once())->method('beginTransaction');
+        $this->db->expects($this->once())->method('commit');
+
+        $result = $this->service->forkAsPersonal(
+            userId: 'alice',
+            sourceUuid: 'src-uuid',
+            name: 'Custom Fork Name'
+        );
+
+        $this->assertSame('Custom Fork Name', $result->getName());
+    }//end testForkUsesSuppliedName()
+
+    /**
+     * REQ-DASH-020: When no name is given, the fork MUST use
+     * t('My copy of {name}', {name: source.name}).
+     *
+     * @return void
+     */
+    public function testForkUsesDefaultTranslatedName(): void
+    {
+        $this->settingMapper->method('getValue')
+            ->willReturn(true);
+
+        $this->makeUser([]);
+
+        $source = $this->makeSourceDashboard(
+            uuid: 'src-uuid',
+            name: 'Marketing Overview'
+        );
+
+        $this->dashboardMapper->method('findVisibleToUser')
+            ->willReturn([
+                ['dashboard' => $source, 'source' => 'group'],
+            ]);
+
+        // Expect the translated default name to be built.
+        $this->l10n->expects($this->once())
+            ->method('t')
+            ->with('My copy of {name}', ['name' => 'Marketing Overview'])
+            ->willReturn('My copy of Marketing Overview');
+
+        $newDash = $this->makeNewDashboard(
+            name: 'My copy of Marketing Overview'
+        );
+
+        $this->dashboardFactory->expects($this->once())
+            ->method('create')
+            ->with(
+                $this->anything(), // userId
+                'My copy of Marketing Overview', // name
+                $this->anything(), // description
+                $this->anything(), // type
+                $this->anything(), // groupId
+                $this->anything()  // gridColumns
+            )
+            ->willReturn($newDash);
+
+        $this->dashboardMapper->method('insert')->willReturn($newDash);
+        $this->db->method('beginTransaction');
+        $this->db->method('commit');
+
+        $result = $this->service->forkAsPersonal(
+            userId: 'alice',
+            sourceUuid: 'src-uuid'
+        );
+
+        $this->assertSame('My copy of Marketing Overview', $result->getName());
+    }//end testForkUsesDefaultTranslatedName()
+
+    /**
+     * REQ-DASH-021: Fork MUST roll back the transaction when placement
+     * clone fails. The new dashboard row MUST NOT be visible.
+     *
+     * @return void
+     */
+    public function testForkRollsBackOnPlacementInsertFailure(): void
+    {
+        $this->settingMapper->method('getValue')
+            ->willReturn(true);
+
+        $this->makeUser([]);
+
+        $source = $this->makeSourceDashboard(uuid: 'src-uuid', name: 'S');
+
+        $this->dashboardMapper->method('findVisibleToUser')
+            ->willReturn([
+                ['dashboard' => $source, 'source' => 'group'],
+            ]);
+
+        $this->l10n->method('t')
+            ->willReturn('My copy of S');
+
+        $newDash = $this->makeNewDashboard(id: 77);
+        $this->dashboardFactory->method('create')->willReturn($newDash);
+        $this->dashboardMapper->method('insert')->willReturn($newDash);
+
+        // Simulate placement clone failure.
+        $this->placementMapper->method('cloneToDashboard')
+            ->willThrowException(new RuntimeException('DB error'));
+
+        $this->db->expects($this->once())->method('beginTransaction');
+        // Rollback MUST be called on failure.
+        $this->db->expects($this->once())->method('rollBack');
+        // Commit MUST NOT be called.
+        $this->db->expects($this->never())->method('commit');
+
+        $this->expectException(RuntimeException::class);
+
+        $this->service->forkAsPersonal(
+            userId: 'alice',
+            sourceUuid: 'src-uuid'
+        );
+    }//end testForkRollsBackOnPlacementInsertFailure()
+
+    /**
+     * REQ-DASH-020: Forking a user's own personal dashboard creates an
+     * independent duplicate (the source type is TYPE_USER).
+     *
+     * @return void
+     */
+    public function testForkOwnPersonalDashboardCreatesIndependentCopy(): void
+    {
+        $this->settingMapper->method('getValue')
+            ->willReturn(true);
+
+        $this->makeUser([]);
+
+        // Source is the user's own personal dashboard.
+        $source = new Dashboard();
+        $source->setId(10);
+        $source->setUuid('personal-uuid');
+        $source->setName('My Dashboard');
+        $source->setType(Dashboard::TYPE_USER);
+        $source->setUserId('alice');
+        $source->setGridColumns(12);
+
+        $this->dashboardMapper->method('findVisibleToUser')
+            ->willReturn([
+                ['dashboard' => $source, 'source' => Dashboard::SOURCE_USER],
+            ]);
+
+        $this->l10n->method('t')
+            ->willReturn('My copy of My Dashboard');
+
+        $newDash = $this->makeNewDashboard(
+            id: 55,
+            uuid: 'fork-of-personal-uuid',
+            name: 'My copy of My Dashboard'
+        );
+
+        $this->dashboardFactory->expects($this->once())
+            ->method('create')
+            ->with(
+                'alice',                   // userId
+                'My copy of My Dashboard', // name
+                null,                      // description
+                Dashboard::TYPE_USER,      // type
+                null,                      // groupId
+                12                         // gridColumns
+            )
+            ->willReturn($newDash);
+
+        $this->dashboardMapper->method('insert')->willReturn($newDash);
+        $this->placementMapper->expects($this->once())
+            ->method('cloneToDashboard')
+            ->with(10, 55);
+
+        $this->db->method('beginTransaction');
+        $this->db->method('commit');
+
+        $result = $this->service->forkAsPersonal(
+            userId: 'alice',
+            sourceUuid: 'personal-uuid'
+        );
+
+        $this->assertSame('fork-of-personal-uuid', $result->getUuid());
+        $this->assertSame(Dashboard::TYPE_USER, $result->getType());
+    }//end testForkOwnPersonalDashboardCreatesIndependentCopy()
+
+    /**
+     * REQ-DASH-022: Resource URLs in placements are NOT duplicated.
+     *
+     * This test verifies that cloneToDashboard is called with the source
+     * and target IDs only — the service never reads or re-uploads resource
+     * bytes. The WidgetPlacementMapper is responsible for preserving tile*
+     * field values verbatim (tested in WidgetPlacementMapper tests).
+     *
+     * @return void
+     */
+    public function testForkDoesNotDuplicateResourceUrls(): void
+    {
+        $this->settingMapper->method('getValue')
+            ->willReturn(true);
+
+        $this->makeUser([]);
+
+        $source = $this->makeSourceDashboard(
+            uuid: 'src-uuid',
+            name: 'Icon Dashboard',
+            id: 11
+        );
+
+        $this->dashboardMapper->method('findVisibleToUser')
+            ->willReturn([
+                ['dashboard' => $source, 'source' => 'group'],
+            ]);
+
+        $this->l10n->method('t')
+            ->willReturn('My copy of Icon Dashboard');
+
+        $newDash = $this->makeNewDashboard(id: 88, uuid: 'new-icon-uuid');
+        $this->dashboardFactory->method('create')->willReturn($newDash);
+        $this->dashboardMapper->method('insert')->willReturn($newDash);
+
+        // The service MUST call cloneToDashboard and pass through only IDs —
+        // no resource-byte duplication logic should happen in the service.
+        $this->placementMapper->expects($this->once())
+            ->method('cloneToDashboard')
+            ->with(
+                $this->identicalTo(11),
+                $this->identicalTo(88)
+            );
+
+        $this->db->method('beginTransaction');
+        $this->db->method('commit');
+
+        $this->service->forkAsPersonal(
+            userId: 'alice',
+            sourceUuid: 'src-uuid'
+        );
+    }//end testForkDoesNotDuplicateResourceUrls()
+
+    /**
+     * REQ-DASH-020: Fork deactivates all existing user dashboards and
+     * makes the new one active (isActive logic).
+     *
+     * @return void
+     */
+    public function testForkDeactivatesExistingDashboardsAndMakesNewActive(): void
+    {
+        $this->settingMapper->method('getValue')
+            ->willReturn(true);
+
+        $this->makeUser([]);
+
+        $source = $this->makeSourceDashboard(uuid: 'src-uuid', name: 'S');
+
+        $this->dashboardMapper->method('findVisibleToUser')
+            ->willReturn([
+                ['dashboard' => $source, 'source' => 'group'],
+            ]);
+
+        $this->l10n->method('t')
+            ->willReturn('My copy of S');
+
+        $newDash = $this->makeNewDashboard(
+            id: 99,
+            uuid: 'new-uuid'
+        );
+        $this->dashboardFactory->method('create')->willReturn($newDash);
+        $this->dashboardMapper->method('insert')->willReturn($newDash);
+
+        // deactivateAllForUser MUST be called before insert.
+        $this->dashboardMapper->expects($this->once())
+            ->method('deactivateAllForUser')
+            ->with('alice');
+
+        $this->db->method('beginTransaction');
+        $this->db->method('commit');
+
+        $result = $this->service->forkAsPersonal(
+            userId: 'alice',
+            sourceUuid: 'src-uuid'
+        );
+
+        $this->assertSame(1, (int) $result->getIsActive());
+    }//end testForkDeactivatesExistingDashboardsAndMakesNewActive()
+
+    /**
+     * REQ-DASH-019: Fork MUST persist the active-dashboard preference so
+     * the REQ-DASH-018 resolver picks it up on next page load.
+     *
+     * @return void
+     */
+    public function testForkPersistsActiveDashboardPreference(): void
+    {
+        $this->settingMapper->method('getValue')
+            ->willReturn(true);
+
+        $this->makeUser([]);
+
+        $source = $this->makeSourceDashboard(uuid: 'src-uuid', name: 'S');
+
+        $this->dashboardMapper->method('findVisibleToUser')
+            ->willReturn([
+                ['dashboard' => $source, 'source' => 'group'],
+            ]);
+
+        $this->l10n->method('t')->willReturn('My copy of S');
+
+        $newDash = $this->makeNewDashboard(id: 7, uuid: 'pref-uuid');
+        $this->dashboardFactory->method('create')->willReturn($newDash);
+        $this->dashboardMapper->method('insert')->willReturn($newDash);
+
+        // The preference MUST be saved with the new dashboard UUID.
+        $this->config->expects($this->once())
+            ->method('setUserValue')
+            ->with(
+                $this->identicalTo('alice'),
+                $this->anything(),
+                DashboardService::ACTIVE_DASHBOARD_UUID_PREF_KEY,
+                'pref-uuid'
+            );
+
+        $this->db->method('beginTransaction');
+        $this->db->method('commit');
+
+        $this->service->forkAsPersonal(
+            userId: 'alice',
+            sourceUuid: 'src-uuid'
+        );
+    }//end testForkPersistsActiveDashboardPreference()
+}//end class


### PR DESCRIPTION
## Summary

Implements REQ-DASH-020..022 per spec on development. Transactional fork via `DashboardService::forkAsPersonal` + `WidgetPlacementMapper::cloneToDashboard`. Gated on `allow_user_dashboards` (PR #61). 404 on sources user can't see (no info leak). Default name via `t('My copy of {name}')`. Resource URLs shared (not duplicated). PHPUnit covers transactionality, gating, byte-for-byte clone, resource-sharing.

- `WidgetPlacementMapper::cloneToDashboard(int $sourceDashboardId, int $targetDashboardId)` — deep-copies all placement rows (gridX/Y/W/H, widgetId, customTitle, styleConfig, all tile* fields) with fresh IDs and timestamps; resource URLs preserved verbatim (REQ-DASH-022)
- `DashboardService::forkAsPersonal(string $userId, string $sourceUuid, ?string $name)` — wrapped in `IDBConnection::beginTransaction`; gates on `assertPersonalDashboardsAllowed()`, resolves source via `getVisibleToUser()`, builds new dashboard via factory, deactivates others, clones placements, persists active-pref, commits/rolls back (REQ-DASH-021)
- `DashboardApiController::fork(string $uuid, ?string $name)` — `POST /api/dashboards/{uuid}/fork`, `#[NoAdminRequired]`, HTTP 201 on success, 403/404/500 error envelopes with stable error codes
- Route registered before group-scoped wildcard routes to avoid conflicts

## Pre-existing fixes
- `DashboardShareApiController`: `DataResponse` named arg `$status` corrected to `$statusCode` (eliminated 6 pre-existing PHPUnit errors)
- `DashboardService`: inline ternaries replaced, `@var` docblock formatting fixed, parameter comment alignment

## Test plan
- [x] `DashboardServiceForkTest`: 8 tests — flag gate 403, 404 not visible, supplied name, default translated name, rollback on placement failure, fork own personal dashboard, resource URL sharing, active pref persistence
- [x] `DashboardApiControllerForkTest`: 6 tests — happy path 201, custom name forwarding, 403 flag off, 404 source not visible, 401 anonymous, 500 unexpected error (logger called, raw message not leaked)
- [x] All 329 existing tests pass (0 failures, 0 errors)