### PR TITLE
chore(frontend): swap remaining @nextcloud/vue imports to @conduction/nextcloud-vue

### DIFF
--- a/src/components/Widgets/WidgetContextMenu.vue
+++ b/src/components/Widgets/WidgetContextMenu.vue
@@ -42,7 +42,7 @@
 </template>
 
 <script>
-import { NcButton } from '@nextcloud/vue'
+import { NcButton } from '@conduction/nextcloud-vue'
 import { t } from '@nextcloud/l10n'
 import Pencil from 'vue-material-design-icons/Pencil.vue'
 import Delete from 'vue-material-design-icons/Delete.vue'

--- a/src/views/Views.vue
+++ b/src/views/Views.vue
@@ -154,7 +154,7 @@
 
 <script>
 import { mapState, mapActions } from 'pinia'
-import { NcButton, NcEmptyContent } from '@nextcloud/vue'
+import { NcButton, NcEmptyContent } from '@conduction/nextcloud-vue'
 import { showSuccess, showError } from '@nextcloud/dialogs'
 import { t } from '@nextcloud/l10n'
 


### PR DESCRIPTION
ADR-004 follow-up. Two stragglers in Views.vue (#68 runtime-shell) and WidgetContextMenu.vue (#60 context-menu) that landed before #34 swapped the rest of the codebase. Swap is mechanical — NcButton + NcEmptyContent already used from @conduction/nextcloud-vue elsewhere (TileCard, WidgetRenderer, AdminSettings). Pre-existing import/named ESLint warnings on those imports are NOT new (resolver can't introspect the package); runtime works.