### PR TITLE
ci(sbom): open PR for SBOM updates instead of pushing direct to protected branches

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main, development]
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   sbom:
     runs-on: ubuntu-latest
@@ -79,7 +83,18 @@ jobs:
       - name: npm audit
         run: npm audit --audit-level=critical
 
-      - name: Commit SBOM
+      # Protected branches (main, development, beta) reject direct pushes per
+      # the org ruleset, so route SBOM updates through a PR instead. On any
+      # other branch (feature/**, bugfix/**, hotfix/**) commit + push direct
+      # since they aren't protected. Skip entirely on pull_request events —
+      # the SBOM is already validated by the steps above; merging the PR will
+      # re-trigger this workflow on the target branch.
+      - name: Commit SBOM (unprotected branches)
+        if: |
+          github.event_name == 'push' &&
+          github.ref_name != 'main' &&
+          github.ref_name != 'development' &&
+          github.ref_name != 'beta'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -90,6 +105,26 @@ jobs:
             git commit -m "chore: update SBOM"
             git push
           fi
+
+      - name: Open PR with SBOM update (protected branches)
+        if: |
+          github.event_name == 'push' &&
+          (github.ref_name == 'main' || github.ref_name == 'development' || github.ref_name == 'beta')
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "chore: update SBOM"
+          title: "chore: update SBOM (auto-generated)"
+          body: |
+            Auto-generated SBOM regeneration after a push to `${{ github.ref_name }}`.
+
+            Source run: [${{ github.workflow }} #${{ github.run_number }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}).
+
+            Merge to keep `sbom.cdx.json` in sync with the locked dependency tree on `${{ github.ref_name }}`.
+          branch: chore/sbom-update-${{ github.ref_name }}
+          base: ${{ github.ref_name }}
+          add-paths: sbom.cdx.json
+          delete-branch: true
 
       - name: Upload SBOM artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary

Unblocks the third red check on PR #72 (release: development → beta): \`SBOM Generation & Validation\`.

The current \`Commit SBOM\` step does \`git push\` unconditionally on every push trigger. On main / development / beta the org ruleset rejects that push and the workflow fails with:

\`\`\`
remote: error: GH013: Repository rule violations found for refs/heads/development.
error: failed to push some refs to 'https://github.com/ConductionNL/mydash'
##[error]Process completed with exit code 1.
\`\`\`

(Source: PR #72's failing run, job \`SBOM Generation & Validation\` in run \`25190361610\`.)

## What changed

Split the post-build step by event/branch type:

| Trigger | Step | Behaviour |
|---|---|---|
| \`push\` to \`feature/**\`, \`bugfix/**\`, \`hotfix/**\` | Commit SBOM (unprotected branches) | Direct commit + push — same as today |
| \`push\` to \`main\` / \`development\` / \`beta\` | Open PR with SBOM update (protected branches) | \`peter-evans/create-pull-request@v6\` opens or updates \`chore/sbom-update-<branch>\` with the regenerated \`sbom.cdx.json\`. A reviewer merges normally; the ruleset's review requirement is honoured. |
| \`pull_request\` | Both steps skipped | The SBOM is already validated by the scan steps above; merging the PR re-triggers this workflow on the target branch. |

Also adds an explicit job-level \`permissions:\` block (\`contents: write\`, \`pull-requests: write\`) so the bot has the perms it needs without relying on the repo's default permission setting.

## Test plan

- [x] YAML validated locally
- [ ] Once merged, the next push to \`development\` triggers the workflow and either:
  - reports "No SBOM changes to commit" (when sbom is already in sync), or
  - opens \`chore/sbom-update-development\` with the regenerated \`sbom.cdx.json\`
- [ ] Confirm PR #72's \`SBOM Generation & Validation\` check goes green on its next run