### PR TITLE
fix(factory): accept permissionLevel arg on DashboardFactory::create (fixes broken unit test)

### DIFF
--- a/lib/Service/DashboardFactory.php
+++ b/lib/Service/DashboardFactory.php
@@ -36,18 +36,27 @@ class DashboardFactory
      * mismatch — no row is persisted in that case (the caller never
      * receives an entity to insert).
      *
-     * @param string|null $userId      The user ID — must be non-null for
-     *                                 `TYPE_USER`, must be null for
-     *                                 `TYPE_GROUP_SHARED` /
-     *                                 `TYPE_ADMIN_TEMPLATE`.
-     * @param string      $name        The dashboard name.
-     * @param string|null $description The dashboard description.
-     * @param string      $type        The dashboard type
-     *                                 (default {@see Dashboard::TYPE_USER}).
-     * @param string|null $groupId     The group ID — required when
-     *                                 `type === TYPE_GROUP_SHARED`,
-     *                                 forbidden otherwise.
-     * @param int         $gridColumns The grid column count.
+     * @param string|null $userId          The user ID — must be non-null
+     *                                     for `TYPE_USER`, must be null for
+     *                                     `TYPE_GROUP_SHARED` /
+     *                                     `TYPE_ADMIN_TEMPLATE`.
+     * @param string      $name            The dashboard name.
+     * @param string|null $description     The dashboard description.
+     * @param string      $type            The dashboard type
+     *                                     (default {@see
+     *                                     Dashboard::TYPE_USER}).
+     * @param string|null $groupId         The group ID — required
+     *                                     when `type ===
+     *                                     TYPE_GROUP_SHARED`,
+     *                                     forbidden otherwise.
+     * @param int         $gridColumns     The grid column count.
+     * @param string      $permissionLevel The owner's permission level on
+     *                                     this dashboard. Defaults to
+     *                                     {@see Dashboard::PERMISSION_FULL};
+     *                                     callers may pass a more
+     *                                     restrictive level when forking
+     *                                     a shared dashboard or
+     *                                     creating a read-only template.
      *
      * @return Dashboard The created dashboard entity (not yet persisted).
      *
@@ -60,7 +69,8 @@ class DashboardFactory
         ?string $description=null,
         string $type=Dashboard::TYPE_USER,
         ?string $groupId=null,
-        int $gridColumns=12
+        int $gridColumns=12,
+        string $permissionLevel=Dashboard::PERMISSION_FULL
     ): Dashboard {
         $this->assertTypeGroupInvariant(type: $type, groupId: $groupId);
 
@@ -73,7 +83,7 @@ class DashboardFactory
         $dashboard->setUserId($userId);
         $dashboard->setGroupId($groupId);
         $dashboard->setGridColumns($gridColumns);
-        $dashboard->setPermissionLevel(Dashboard::PERMISSION_FULL);
+        $dashboard->setPermissionLevel($permissionLevel);
         // Group-shared dashboards are not "active" per-user — activation
         // is a personal-scope concept tied to the active-dashboard cookie.
         $isActive = 0;


### PR DESCRIPTION
## Summary

Repairs \`DashboardFactoryTest::testCreateRespectsExplicitPermissionLevel\`, which currently fails with:

\`\`\`
Error: Unknown named parameter \$permissionLevel
tests/Unit/Service/DashboardFactoryTest.php:116
\`\`\`

The test passes \`permissionLevel: Dashboard::PERMISSION_ADD_ONLY\` as a named argument, but the factory's signature stops at \`gridColumns\` and the body hard-codes \`setPermissionLevel(PERMISSION_FULL)\`. The test was written ahead of the parameter — adding the param closes the gap and gives share/fork flows a way to create restricted dashboards without immediately mutating-then-saving.

## What changed

\`lib/Service/DashboardFactory.php\` — append \`string \$permissionLevel = Dashboard::PERMISSION_FULL\` to \`create()\`, pass it to \`setPermissionLevel(\$permissionLevel)\`, document the new param in the docblock.

Default value is \`PERMISSION_FULL\` so the 9 other unit tests + every production caller (none currently pass the param) are unaffected.

## Verified locally

- \`composer test:unit\` → \`OK (354 tests, 849 assertions)\` (was 354/353 + 1 error before)
- \`composer phpcs\` → clean across all 49 scanned files