### PR TITLE
fix(notifier): correct OCP\IL10N namespace + setParsedMessage param name

### DIFF
--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -139,15 +139,15 @@ class Notifier implements INotifier
      *
      * Subject parameters: [sharerUserId, dashboardName, permissionLevel].
      *
-     * @param INotification   $notification The notification.
-     * @param \OCP\L10N\IL10N $l            The L10N instance.
-     * @param string          $url          The deep-link URL.
+     * @param INotification $notification The notification.
+     * @param \OCP\IL10N    $l            The L10N instance.
+     * @param string        $url          The deep-link URL.
      *
      * @return INotification The prepared notification.
      */
     private function prepareDashboardShared(
         INotification $notification,
-        \OCP\L10N\IL10N $l,
+        \OCP\IL10N $l,
         string $url
     ): INotification {
         $params = $notification->getSubjectParameters();
@@ -175,7 +175,7 @@ class Notifier implements INotifier
             message: $levelLabel,
             parameters: []
         );
-        $notification->setParsedMessage(subject: $levelLabel);
+        $notification->setParsedMessage(message: $levelLabel);
 
         $notification->setLink(link: $url);
 
@@ -187,15 +187,15 @@ class Notifier implements INotifier
      *
      * Subject parameters: [dashboardName].
      *
-     * @param INotification   $notification The notification.
-     * @param \OCP\L10N\IL10N $l            The L10N instance.
-     * @param string          $url          The deep-link URL.
+     * @param INotification $notification The notification.
+     * @param \OCP\IL10N    $l            The L10N instance.
+     * @param string        $url          The deep-link URL.
      *
      * @return INotification The prepared notification.
      */
     private function prepareOwnershipTransferred(
         INotification $notification,
-        \OCP\L10N\IL10N $l,
+        \OCP\IL10N $l,
         string $url
     ): INotification {
         $params = $notification->getSubjectParameters();
@@ -217,7 +217,7 @@ class Notifier implements INotifier
             message: $message,
             parameters: []
         );
-        $notification->setParsedMessage(subject: $message);
+        $notification->setParsedMessage(message: $message);
 
         $notification->setLink(link: $url);
 
@@ -261,13 +261,13 @@ class Notifier implements INotifier
     /**
      * Return the human-readable label for a permission level.
      *
-     * @param \OCP\L10N\IL10N $l     The L10N instance.
-     * @param string          $level The permission level identifier.
+     * @param \OCP\IL10N $l     The L10N instance.
+     * @param string     $level The permission level identifier.
      *
      * @return string The translated label.
      */
     private function permissionLabel(
-        \OCP\L10N\IL10N $l,
+        \OCP\IL10N $l,
         string $level
     ): string {
         return match ($level) {


### PR DESCRIPTION
## Why

\`composer phpstan\` ends with \`|| echo 'PHPStan not installed, skipping...'\` so its exit code is always 0 — failures are silently dropped on CI. Two real bugs in \`Notifier.php\` were therefore sitting unflagged.

## What

### 1. \`\\OCP\\L10N\\IL10N\` does not exist

The interface lives at \`\\OCP\\IL10N\` (\`lib/public/IL10N.php\` in the server). The deprecated \`OCP\\L10N\\IL10N\` was removed several Nextcloud versions ago, but 6 occurrences in \`Notifier.php\` still referenced it (3 \`@param\` docblocks + 3 type-hinted method signatures). At runtime, dependency injection would have failed the moment the first \`dashboard_shared\` or \`dashboard_ownership_transferred\` notification was rendered.

### 2. \`setParsedMessage(subject: …)\` is the wrong named argument

\`OCP\\Notification\\INotification::setParsedMessage(string \$message)\` takes \`\$message\`, not \`\$subject\`. PHP strict mode would reject the call with \`Unknown named parameter \$subject\`. Two callsites fixed (lines 178, 220).

## Impact

| Metric | Before | After |
|---|---|---|
| PHPStan errors in \`Notifier.php\` | 4 | 0 |
| Full-repo PHPStan errors | 47 | 26 |
| PHPCS on \`Notifier.php\` | clean (after phpcbf for the docblock-width shift) | clean |
| PHPUnit | 354/354 (no regression) | 354/354 |

The 17 \`Call to method t() on an unknown class OCP\\L10N\\IL10N\` errors that propagated through the file disappear because phpstan can now resolve \`\$l\` to the real interface.

## Test plan

- [x] \`./vendor/bin/phpstan analyse lib/Notification/Notifier.php\` clean
- [x] \`./vendor/bin/phpcs --standard=phpcs.xml lib/Notification/Notifier.php\` clean
- [x] \`composer test:unit\` 354/354 passing
- [ ] CI \`quality / PHP Quality (phpstan)\` green
- [ ] Manual smoke: trigger a dashboard_shared notification, confirm it renders end-to-end (was previously broken at the type-hint level)

## Followups (out of scope, called out for visibility)

- The \`composer phpstan\` script's \`|| echo\` swallow should be removed once the remaining 26 errors are resolved — otherwise the next push could turn the check red retroactively. Worth a one-liner PR after the cleanup batch lands.
- Remaining 26 phpstan errors fall mostly into \`DataResponse\` generic-typing in \`DashboardShareApiController\` (~25 sites) and a handful of misc real bugs in \`AdminTemplateService\`/\`FileService\`.