### PR TITLE
chore(security): ADR-005 — stop leaking exception messages from 3 controllers

### DIFF
--- a/lib/Controller/AdminController.php
+++ b/lib/Controller/AdminController.php
@@ -355,9 +355,10 @@ class AdminController extends Controller
 
         try {
             $this->settingsService->setGroupOrder(groupIds: $groups);
-        } catch (InvalidArgumentException $e) {
+        } catch (InvalidArgumentException) {
+            // ADR-005: do not leak raw exception messages.
             return new JSONResponse(
-                data: ['error' => $e->getMessage()],
+                data: ['error' => 'Invalid groups payload'],
                 statusCode: Http::STATUS_BAD_REQUEST
             );
         }

--- a/lib/Controller/DashboardApiController.php
+++ b/lib/Controller/DashboardApiController.php
@@ -432,9 +432,10 @@ class DashboardApiController extends Controller
                 groupId: $groupId,
                 uuid: $uuid
             );
-        } catch (DoesNotExistException $e) {
+        } catch (DoesNotExistException) {
+            // ADR-005: do not leak raw exception messages to clients.
             return new JSONResponse(
-                data: ['error' => $e->getMessage()],
+                data: ['error' => 'Dashboard not found'],
                 statusCode: Http::STATUS_NOT_FOUND
             );
         }
@@ -496,9 +497,10 @@ class DashboardApiController extends Controller
             return ResponseHelper::success(
                 data: ['dashboard' => $dashboard->jsonSerialize()]
             );
-        } catch (DoesNotExistException $e) {
+        } catch (DoesNotExistException) {
+            // ADR-005: do not leak raw exception messages to clients.
             return new JSONResponse(
-                data: ['error' => $e->getMessage()],
+                data: ['error' => 'Dashboard not found'],
                 statusCode: Http::STATUS_NOT_FOUND
             );
         } catch (\Exception $e) {
@@ -543,9 +545,10 @@ class DashboardApiController extends Controller
             );
 
             return ResponseHelper::success(data: ['status' => 'ok']);
-        } catch (DoesNotExistException $e) {
+        } catch (DoesNotExistException) {
+            // ADR-005: do not leak raw exception messages to clients.
             return new JSONResponse(
-                data: ['error' => $e->getMessage()],
+                data: ['error' => 'Dashboard not found'],
                 statusCode: Http::STATUS_NOT_FOUND
             );
         } catch (\Exception $e) {
@@ -608,9 +611,10 @@ class DashboardApiController extends Controller
                     'uuid'    => $uuid,
                 ]
             );
-        } catch (DoesNotExistException $e) {
+        } catch (DoesNotExistException) {
+            // ADR-005: do not leak raw exception messages to clients.
             return new JSONResponse(
-                data: ['error' => $e->getMessage()],
+                data: ['error' => 'Dashboard not found'],
                 statusCode: Http::STATUS_NOT_FOUND
             );
         } catch (\Exception $e) {

--- a/lib/Controller/DashboardShareApiController.php
+++ b/lib/Controller/DashboardShareApiController.php
@@ -92,9 +92,10 @@ class DashboardShareApiController extends Controller
                 data: ['error' => 'Dashboard not found'],
                 statusCode: Http::STATUS_NOT_FOUND
             );
-        } catch (Exception $e) {
+        } catch (Exception) {
+            // ADR-005: do not leak raw exception messages to clients.
             return new DataResponse(
-                data: ['error' => $e->getMessage()],
+                data: ['error' => 'Forbidden'],
                 statusCode: Http::STATUS_FORBIDDEN
             );
         }//end try
@@ -136,9 +137,10 @@ class DashboardShareApiController extends Controller
                 data: $share->jsonSerialize(),
                 statusCode: Http::STATUS_CREATED
             );
-        } catch (InvalidArgumentException $e) {
+        } catch (InvalidArgumentException) {
+            // ADR-005: do not leak raw exception messages to clients.
             return new DataResponse(
-                data: ['error' => $e->getMessage()],
+                data: ['error' => 'Invalid request'],
                 statusCode: Http::STATUS_BAD_REQUEST
             );
         } catch (DoesNotExistException) {
@@ -146,9 +148,10 @@ class DashboardShareApiController extends Controller
                 data: ['error' => 'Dashboard not found'],
                 statusCode: Http::STATUS_NOT_FOUND
             );
-        } catch (Exception $e) {
+        } catch (Exception) {
+            // ADR-005: do not leak raw exception messages to clients.
             return new DataResponse(
-                data: ['error' => $e->getMessage()],
+                data: ['error' => 'Forbidden'],
                 statusCode: Http::STATUS_FORBIDDEN
             );
         }//end try
@@ -182,9 +185,10 @@ class DashboardShareApiController extends Controller
                 data: ['error' => 'Share not found'],
                 statusCode: Http::STATUS_NOT_FOUND
             );
-        } catch (Exception $e) {
+        } catch (Exception) {
+            // ADR-005: do not leak raw exception messages to clients.
             return new DataResponse(
-                data: ['error' => $e->getMessage()],
+                data: ['error' => 'Forbidden'],
                 statusCode: Http::STATUS_FORBIDDEN
             );
         }//end try
@@ -223,9 +227,10 @@ class DashboardShareApiController extends Controller
                 array: $newShares
             );
             return new DataResponse(data: $serialized);
-        } catch (InvalidArgumentException $e) {
+        } catch (InvalidArgumentException) {
+            // ADR-005: do not leak raw exception messages to clients.
             return new DataResponse(
-                data: ['error' => $e->getMessage()],
+                data: ['error' => 'Invalid request'],
                 statusCode: Http::STATUS_BAD_REQUEST
             );
         } catch (DoesNotExistException) {
@@ -233,9 +238,10 @@ class DashboardShareApiController extends Controller
                 data: ['error' => 'Dashboard not found'],
                 statusCode: Http::STATUS_NOT_FOUND
             );
-        } catch (Exception $e) {
+        } catch (Exception) {
+            // ADR-005: do not leak raw exception messages to clients.
             return new DataResponse(
-                data: ['error' => $e->getMessage()],
+                data: ['error' => 'Forbidden'],
                 statusCode: Http::STATUS_FORBIDDEN
             );
         }//end try
@@ -269,9 +275,10 @@ class DashboardShareApiController extends Controller
                 callerId: $this->userId
             );
             return new DataResponse(data: ['deleted' => $count]);
-        } catch (InvalidArgumentException $e) {
+        } catch (InvalidArgumentException) {
+            // ADR-005: do not leak raw exception messages to clients.
             return new DataResponse(
-                data: ['error' => $e->getMessage()],
+                data: ['error' => 'Invalid request'],
                 statusCode: Http::STATUS_BAD_REQUEST
             );
         }


### PR DESCRIPTION
ADR-005 follow-up audit. Found 12 sites in lib/Controller/ where my agents' generated catch blocks were forwarding raw `\$e->getMessage()` to clients. Replaced each with a fixed safe string per HTTP-status semantics.

**Kept** (intentional, not leaks):
- `DashboardApiController.php` × 2 sites with `PersonalDashboardsDisabledException` — has `getErrorCode()` + a translated safe message designed for client display
- All `logger->warning/error` sites with `\$e->getMessage()` — server-side log context only

**ADR-014** audit also done — no action required. The repo's `REUSE.toml` (added in #34) provides external SPDX coverage for all PHP files, so per-file SPDX-License-Identifier lines are intentionally NOT required (REUSE.toml says so explicitly). My agents' new files have inline SPDX anyway, which is over-spec but harmless.