### PR TITLE
feat(role-based-content): role-feature-permissions implementation [#91]

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -92,6 +92,17 @@ return [
 		['name' => 'admin#getSettings', 'url' => '/api/admin/settings', 'verb' => 'GET'],
 		['name' => 'admin#updateSettings', 'url' => '/api/admin/settings', 'verb' => 'PUT'],
 		['name' => 'admin#listGroups', 'url' => '/api/admin/groups', 'verb' => 'GET'],
+
+		// Role-feature permissions (REQ-RFP-001..010). Admin-only — the
+		// controller calls `requireAdmin()` on every method.
+		['name' => 'role_feature_permission_api#listPermissions',  'url' => '/api/role-feature-permissions', 'verb' => 'GET'],
+		['name' => 'role_feature_permission_api#savePermission',   'url' => '/api/role-feature-permissions', 'verb' => 'POST'],
+		['name' => 'role_feature_permission_api#deletePermission', 'url' => '/api/role-feature-permissions/{id}', 'verb' => 'DELETE',
+		 'requirements' => ['id' => '\d+']],
+		['name' => 'role_feature_permission_api#listLayoutDefaults',  'url' => '/api/role-layout-defaults', 'verb' => 'GET'],
+		['name' => 'role_feature_permission_api#saveLayoutDefault',   'url' => '/api/role-layout-defaults', 'verb' => 'POST'],
+		['name' => 'role_feature_permission_api#deleteLayoutDefault', 'url' => '/api/role-layout-defaults/{id}', 'verb' => 'DELETE',
+		 'requirements' => ['id' => '\d+']],
 		['name' => 'admin#updateGroupOrder', 'url' => '/api/admin/groups', 'verb' => 'POST'],
 
 		// Resource uploads (admin-only base64 mini file API)

--- a/docs/role-based-content.md
+++ b/docs/role-based-content.md
@@ -1,0 +1,127 @@
+# Role-based dashboard content
+
+## What it does
+
+MyDash can restrict which dashboard widgets a user can add to their dashboard
+based on their Nextcloud group(s). When a user belongs to multiple groups,
+the effective allowed-widget set is resolved deterministically via the
+admin-configured `group_order` priority list, with a deny-wins rule for
+cross-group conflicts.
+
+For new users (no admin template applies), MyDash can also seed a starter
+dashboard layout from per-group `RoleLayoutDefault` rows so the first-paint
+experience is tailored to their role.
+
+When **no** RoleFeaturePermission rows exist for any of a user's groups,
+MyDash behaves exactly as before — the full widget catalogue is shown
+(REQ-RFP-009 backwards-compat).
+
+## Key concepts
+
+### RoleFeaturePermission
+
+One row per Nextcloud group. Fields:
+
+| Field | Type | Notes |
+|---|---|---|
+| `groupId` | string | Nextcloud group ID; unique. The reserved id `default` is the catch-all fallback. |
+| `name` | string | Display name shown in the admin UI. |
+| `description` | string | Optional notes. |
+| `allowedWidgets` | string[] | Widget IDs this group may add to their dashboard. Empty = none allowed. |
+| `deniedWidgets` | string[] | Widget IDs explicitly blocked, even if a different group allows them (deny-wins). |
+| `priorityWeights` | object | `{widgetId: integer}` — higher value = higher seeding priority. |
+
+### RoleLayoutDefault
+
+One row per `(groupId, widgetId)` combination. Captures the seed grid
+position and size for one widget when MyDash creates a fresh dashboard for a
+user in that group and no admin template matches.
+
+| Field | Type | Notes |
+|---|---|---|
+| `groupId` | string | The group this default applies to. |
+| `widgetId` | string | The widget to seed at this slot. |
+| `gridX/gridY/gridWidth/gridHeight` | int | Slot geometry (0-based; min size 1). |
+| `sortOrder` | int | Render order within the layout (lower = earlier). |
+| `isCompulsory` | bool | When true, the user can't remove the widget from the seeded layout. |
+
+## Multi-group resolution
+
+Users often belong to multiple groups. MyDash walks the configured
+`group_order` (set in admin settings) and:
+
+1. Picks the first group in `group_order` that the user belongs to AND has a
+   RoleFeaturePermission row → that group's `allowedWidgets` becomes the
+   base set.
+2. Subsequent groups in `group_order` that the user is also in widen the
+   base set (union of their `allowedWidgets`).
+3. ANY group's `deniedWidgets` is removed from the final set (deny-wins).
+4. If no `group_order` group matched, MyDash falls back to the row whose
+   `groupId` is exactly `default`.
+5. If no `default` row exists either, returns null = no restriction (the
+   full catalogue is shown).
+
+Worked example. `group_order = ['managers', 'employees']`. Alice is in
+`['employees', 'managers']`.
+
+| Group | Allowed | Denied |
+|---|---|---|
+| `managers` | `['analytics', 'activity', 'recommendations']` | `[]` |
+| `employees` | `['activity', 'recommendations', 'notes']` | `['analytics']` |
+
+Walk: managers matches first → base = `['analytics', 'activity',
+'recommendations']`. employees also matches → union = `['analytics',
+'activity', 'recommendations', 'notes']`. employees has `denied=['analytics']`
+→ final = `['activity', 'recommendations', 'notes']`.
+
+## Admin UI
+
+Settings → MyDash settings → **Role-based widget permissions**. Lets admins:
+
+- See all configured RoleFeaturePermission rows with allowed/denied widget
+  chips.
+- Add a new permission for a Nextcloud group.
+- Edit allowed/denied widget lists (comma-separated free text).
+- Delete a permission.
+
+The RoleLayoutDefault rows are managed only via the API for now; an admin
+UI for them lands in a follow-up.
+
+## Admin API
+
+Admin-only — the controller calls a `requireAdmin()` guard on every method.
+
+- `GET    /api/role-feature-permissions` — list all permissions
+- `POST   /api/role-feature-permissions` — upsert by `groupId`
+- `DELETE /api/role-feature-permissions/{id}` — delete by id
+- `GET    /api/role-layout-defaults` — list all defaults
+- `POST   /api/role-layout-defaults` — upsert by `(groupId, widgetId)`
+- `DELETE /api/role-layout-defaults/{id}` — delete by id
+
+`POST` accepts JSON: `{name, description?, groupId, allowedWidgets,
+deniedWidgets?, priorityWeights?}` for permissions and `{name, groupId,
+widgetId, gridX, gridY, gridWidth, gridHeight, sortOrder, isCompulsory?,
+description?}` for defaults.
+
+## Initial-state contract
+
+The workspace page now ships `allowedWidgets` in its initial state
+(REQ-RFP-010). Possible values:
+
+- `null` — no role-feature-permissions configured for the caller; the
+  frontend must treat this as "no restriction" and show the full
+  catalogue (legacy behaviour).
+- `string[]` — the effective allowed widget set for the caller; the
+  frontend should not show or render any widget whose id is missing.
+
+## Migration
+
+Migration `Version001007Date20260501120000` creates two tables:
+
+- `mydash_role_feature_perms` — one row per group, unique on `group_id`
+- `mydash_role_layout_defaults` — one row per `(group_id, widget_id)`,
+  unique on the combination
+
+Both tables are empty on first migration; nothing is seeded. Existing users
+are unaffected until an admin adds their first row (REQ-RFP-009 scenario:
+"empty config → full catalogue").

--- a/l10n/en.json
+++ b/l10n/en.json
@@ -182,7 +182,6 @@
         "**%1$s** is now yours": "**%1$s** is now yours",
         "%1$s is now yours": "%1$s is now yours",
         "Ownership transferred after the previous owner was removed": "Ownership transferred after the previous owner was removed",
-        "Access denied": "Access denied",
         "Invalid shareType": "Invalid shareType",
         "shareWith is required": "shareWith is required",
         "Invalid permissionLevel": "Invalid permissionLevel",
@@ -198,6 +197,18 @@
         "Create": "Create",
         "Creating…": "Creating…",
         "Failed to create document": "Failed to create document",
-        "Please enter a file name": "Please enter a file name"
+        "Please enter a file name": "Please enter a file name",
+        "Role-based widget permissions": "Role-based widget permissions",
+        "Restrict which widgets each Nextcloud group can add to their dashboard. Empty list = full catalogue (legacy).": "Restrict which widgets each Nextcloud group can add to their dashboard. Empty list = full catalogue (legacy).",
+        "No role permissions configured": "No role permissions configured",
+        "Add a role-permission row to start filtering the widget catalogue per Nextcloud group.": "Add a role-permission row to start filtering the widget catalogue per Nextcloud group.",
+        "Add role permission": "Add role permission",
+        "Edit role permission": "Edit role permission",
+        "Nextcloud group ID": "Nextcloud group ID",
+        "Description (optional)": "Description (optional)",
+        "Allowed widget IDs (comma separated)": "Allowed widget IDs (comma separated)",
+        "Denied widget IDs (comma separated)": "Denied widget IDs (comma separated)",
+        "Delete role permission for \"{group}\"?": "Delete role permission for \"{group}\"?",
+        "Name": "Name"
     }
 }

--- a/l10n/nl.json
+++ b/l10n/nl.json
@@ -182,7 +182,6 @@
         "**%1$s** is now yours": "**%1$s** is nu van u",
         "%1$s is now yours": "%1$s is nu van u",
         "Ownership transferred after the previous owner was removed": "Eigendom overgedragen omdat de vorige eigenaar is verwijderd",
-        "Access denied": "Toegang geweigerd",
         "Invalid shareType": "Ongeldig deeltype",
         "shareWith is required": "shareWith is verplicht",
         "Invalid permissionLevel": "Ongeldig rechtenniveau",
@@ -198,6 +197,18 @@
         "Create": "Aanmaken",
         "Creating…": "Aanmaken…",
         "Failed to create document": "Document aanmaken mislukt",
-        "Please enter a file name": "Voer een bestandsnaam in"
+        "Please enter a file name": "Voer een bestandsnaam in",
+        "Role-based widget permissions": "Rol-gebaseerde widget-rechten",
+        "Restrict which widgets each Nextcloud group can add to their dashboard. Empty list = full catalogue (legacy).": "Beperk welke widgets elke Nextcloud-groep aan hun dashboard kan toevoegen. Lege lijst = volledige catalogus (legacy).",
+        "No role permissions configured": "Geen rolrechten geconfigureerd",
+        "Add a role-permission row to start filtering the widget catalogue per Nextcloud group.": "Voeg een rolregel toe om de widget-catalogus per Nextcloud-groep te filteren.",
+        "Add role permission": "Rolrecht toevoegen",
+        "Edit role permission": "Rolrecht bewerken",
+        "Nextcloud group ID": "Nextcloud-groep-ID",
+        "Description (optional)": "Beschrijving (optioneel)",
+        "Allowed widget IDs (comma separated)": "Toegestane widget-ID's (kommagescheiden)",
+        "Denied widget IDs (comma separated)": "Verboden widget-ID's (kommagescheiden)",
+        "Delete role permission for \"{group}\"?": "Rolrecht voor \"{group}\" verwijderen?",
+        "Name": "Naam"
     }
 }

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -29,6 +29,7 @@ use OCA\MyDash\Service\AdminTemplateService;
 use OCA\MyDash\Service\DashboardService;
 use OCA\MyDash\Service\InitialStateBuilder;
 use OCA\MyDash\Service\Page;
+use OCA\MyDash\Service\RoleFeaturePermissionService;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
@@ -67,6 +68,7 @@ class PageController extends Controller
         private readonly AdminSettingsService $adminSettings,
         private readonly DashboardService $dashboardService,
         private readonly AdminTemplateService $templateService,
+        private readonly RoleFeaturePermissionService $roleFeaturePerm,
     ) {
         parent::__construct(appName: Application::APP_ID, request: $request);
     }//end __construct()
@@ -145,6 +147,11 @@ class PageController extends Controller
             ->setUserDashboards(userDashboards: [])
             ->setAllowUserDashboards(
                 allowUserDashboards: (bool) ($settings['allowUserDashboards'] ?? false)
+            )
+            ->setAllowedWidgets(
+                allowedWidgets: $userId !== null
+                    ? $this->roleFeaturePerm->getAllowedWidgetIds(userId: $userId)
+                    : null
             )
             ->apply();
 

--- a/lib/Controller/RoleFeaturePermissionApiController.php
+++ b/lib/Controller/RoleFeaturePermissionApiController.php
@@ -1,0 +1,244 @@
+<?php
+
+/**
+ * RoleFeaturePermissionApiController
+ *
+ * Admin-only HTTP API for managing RoleFeaturePermission and
+ * RoleLayoutDefault rows. All routes guard with the same `requireAdmin()`
+ * pattern as `AdminController` (REQ-RFP-007 / ADR-005).
+ *
+ * @category  Controller
+ * @package   OCA\MyDash\Controller
+ * @author    Conduction b.v. <info@conduction.nl>
+ * @copyright 2026 Conduction b.v.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @version   GIT:auto
+ * @link      https://conduction.nl
+ *
+ * SPDX-FileCopyrightText: 2026 MyDash Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace OCA\MyDash\Controller;
+
+use OCA\MyDash\AppInfo\Application;
+use OCA\MyDash\Service\RoleFeaturePermissionService;
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\IGroupManager;
+use OCP\IRequest;
+use OCP\IUserSession;
+
+/**
+ * Admin-only API for role-feature permissions and role-layout defaults.
+ *
+ * @spec openspec/changes/role-based-content/tasks.md#task-3
+ */
+class RoleFeaturePermissionApiController extends Controller
+{
+    /**
+     * Constructor.
+     *
+     * @param IRequest                     $request    The HTTP request.
+     * @param RoleFeaturePermissionService $service    Permission service.
+     * @param IGroupManager                $groupMgr   Group manager (admin guard).
+     * @param IUserSession                 $userSession The current user session.
+     */
+    public function __construct(
+        IRequest $request,
+        private readonly RoleFeaturePermissionService $service,
+        private readonly IGroupManager $groupMgr,
+        private readonly IUserSession $userSession,
+    ) {
+        parent::__construct(
+            appName: Application::APP_ID,
+            request: $request
+        );
+    }//end __construct()
+
+    /**
+     * GET /api/role-feature-permissions
+     *
+     * @return JSONResponse The list of permission rows.
+     */
+    public function listPermissions(): JSONResponse
+    {
+        if (($guard = $this->requireAdmin()) !== null) {
+            return $guard;
+        }
+
+        $rows = $this->service->listPermissions();
+        return ResponseHelper::success(
+            data: ResponseHelper::serializeList(entities: $rows)
+        );
+    }//end listPermissions()
+
+    /**
+     * POST /api/role-feature-permissions
+     *
+     * Body: `{name, description?, groupId, allowedWidgets, deniedWidgets?, priorityWeights?}`.
+     * Upsert keyed by `groupId`.
+     *
+     * @return JSONResponse The persisted row.
+     */
+    public function savePermission(): JSONResponse
+    {
+        if (($guard = $this->requireAdmin()) !== null) {
+            return $guard;
+        }
+
+        try {
+            $payload = $this->readJsonBody();
+            $entity  = $this->service->savePermission(data: $payload);
+            return ResponseHelper::success(
+                data: $entity->jsonSerialize(),
+                statusCode: Http::STATUS_CREATED
+            );
+        } catch (\InvalidArgumentException $e) {
+            return ResponseHelper::error(
+                exception: $e,
+                statusCode: Http::STATUS_BAD_REQUEST
+            );
+        } catch (\Exception $e) {
+            return ResponseHelper::error(exception: $e);
+        }//end try
+    }//end savePermission()
+
+    /**
+     * DELETE /api/role-feature-permissions/{id}
+     *
+     * @param int $id The row id.
+     *
+     * @return JSONResponse Empty 204 on success.
+     */
+    public function deletePermission(int $id): JSONResponse
+    {
+        if (($guard = $this->requireAdmin()) !== null) {
+            return $guard;
+        }
+
+        try {
+            $this->service->deletePermission(id: $id);
+            return new JSONResponse(data: [], statusCode: Http::STATUS_NO_CONTENT);
+        } catch (DoesNotExistException $e) {
+            return ResponseHelper::error(
+                exception: $e,
+                statusCode: Http::STATUS_NOT_FOUND
+            );
+        }//end try
+    }//end deletePermission()
+
+    /**
+     * GET /api/role-layout-defaults
+     *
+     * @return JSONResponse The list of layout default rows.
+     */
+    public function listLayoutDefaults(): JSONResponse
+    {
+        if (($guard = $this->requireAdmin()) !== null) {
+            return $guard;
+        }
+
+        $rows = $this->service->listLayoutDefaults();
+        return ResponseHelper::success(
+            data: ResponseHelper::serializeList(entities: $rows)
+        );
+    }//end listLayoutDefaults()
+
+    /**
+     * POST /api/role-layout-defaults
+     *
+     * @return JSONResponse The persisted row.
+     */
+    public function saveLayoutDefault(): JSONResponse
+    {
+        if (($guard = $this->requireAdmin()) !== null) {
+            return $guard;
+        }
+
+        try {
+            $payload = $this->readJsonBody();
+            $entity  = $this->service->saveLayoutDefault(data: $payload);
+            return ResponseHelper::success(
+                data: $entity->jsonSerialize(),
+                statusCode: Http::STATUS_CREATED
+            );
+        } catch (\InvalidArgumentException $e) {
+            return ResponseHelper::error(
+                exception: $e,
+                statusCode: Http::STATUS_BAD_REQUEST
+            );
+        } catch (\Exception $e) {
+            return ResponseHelper::error(exception: $e);
+        }//end try
+    }//end saveLayoutDefault()
+
+    /**
+     * DELETE /api/role-layout-defaults/{id}
+     *
+     * @param int $id The row id.
+     *
+     * @return JSONResponse Empty 204 on success.
+     */
+    public function deleteLayoutDefault(int $id): JSONResponse
+    {
+        if (($guard = $this->requireAdmin()) !== null) {
+            return $guard;
+        }
+
+        try {
+            $this->service->deleteLayoutDefault(id: $id);
+            return new JSONResponse(data: [], statusCode: Http::STATUS_NO_CONTENT);
+        } catch (DoesNotExistException $e) {
+            return ResponseHelper::error(
+                exception: $e,
+                statusCode: Http::STATUS_NOT_FOUND
+            );
+        }//end try
+    }//end deleteLayoutDefault()
+
+    /**
+     * Read the request body as a JSON object (best-effort).
+     *
+     * @return array The decoded body, or `[]` when not JSON.
+     */
+    private function readJsonBody(): array
+    {
+        $raw = file_get_contents(filename: 'php://input');
+        if ($raw === false || $raw === '') {
+            return $this->request->getParams();
+        }
+
+        $decoded = json_decode(json: $raw, associative: true);
+        if (is_array(value: $decoded) === false) {
+            return $this->request->getParams();
+        }
+
+        return $decoded;
+    }//end readJsonBody()
+
+    /**
+     * Admin guard — same pattern as `AdminController::requireAdmin()`.
+     *
+     * @return JSONResponse|null `null` when caller is admin; the error otherwise.
+     */
+    private function requireAdmin(): ?JSONResponse
+    {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
+            return ResponseHelper::unauthorized();
+        }
+
+        if ($this->groupMgr->isAdmin(userId: $user->getUID()) === false) {
+            return ResponseHelper::forbidden(
+                message: 'Administrator privileges required.'
+            );
+        }
+
+        return null;
+    }//end requireAdmin()
+}//end class

--- a/lib/Controller/WidgetApiController.php
+++ b/lib/Controller/WidgetApiController.php
@@ -19,14 +19,16 @@ declare(strict_types=1);
 namespace OCA\MyDash\Controller;
 
 use OCA\MyDash\AppInfo\Application;
-use OCA\MyDash\Service\WidgetService;
 use OCA\MyDash\Service\PermissionService;
+use OCA\MyDash\Service\RoleFeaturePermissionService;
+use OCA\MyDash\Service\WidgetService;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IRequest;
+use Psr\Log\LoggerInterface;
 
 /**
  * Controller for managing dashboard widgets.
@@ -36,15 +38,19 @@ class WidgetApiController extends Controller
     /**
      * Constructor
      *
-     * @param IRequest          $request           The request.
-     * @param WidgetService     $widgetService     The widget service.
-     * @param PermissionService $permissionService The permission service.
-     * @param string|null       $userId            The user ID.
+     * @param IRequest                     $request          The request.
+     * @param WidgetService                $widgetService    The widget service.
+     * @param PermissionService            $permissionService The permission service.
+     * @param RoleFeaturePermissionService $roleFeaturePerm   Role-feature filter.
+     * @param LoggerInterface              $logger            Logger (for audit).
+     * @param string|null                  $userId            The user ID.
      */
     public function __construct(
         IRequest $request,
         private readonly WidgetService $widgetService,
         private readonly PermissionService $permissionService,
+        private readonly RoleFeaturePermissionService $roleFeaturePerm,
+        private readonly LoggerInterface $logger,
         private readonly ?string $userId,
     ) {
         parent::__construct(
@@ -54,16 +60,44 @@ class WidgetApiController extends Controller
     }//end __construct()
 
     /**
-     * List all available Nextcloud widgets.
+     * List all available Nextcloud widgets, filtered by the caller's
+     * role-feature permissions (REQ-RFP-001 / REQ-RFP-003).
      *
      * @return JSONResponse The list of available widgets.
      */
     #[NoAdminRequired]
     public function listAvailable(): JSONResponse
     {
-        return ResponseHelper::success(
-            data: $this->widgetService->getAvailableWidgets()
+        $widgets = $this->widgetService->getAvailableWidgets();
+
+        if ($this->userId === null) {
+            return ResponseHelper::success(data: $widgets);
+        }
+
+        $allowed = $this->roleFeaturePerm->getAllowedWidgetIds(
+            userId: $this->userId
         );
+        if ($allowed === null) {
+            // Backwards-compat: nothing configured, return everything.
+            return ResponseHelper::success(data: $widgets);
+        }
+
+        $filtered = array_values(
+            array: array_filter(
+                array: $widgets,
+                callback: function (array $w) use ($allowed): bool {
+                    $id = (string) ($w['id'] ?? '');
+                    return $id !== ''
+                        && in_array(
+                            needle: $id,
+                            haystack: $allowed,
+                            strict: true
+                        );
+                }
+            )
+        );
+
+        return ResponseHelper::success(data: $filtered);
     }//end listAvailable()
 
     /**

--- a/lib/Db/RoleFeaturePermission.php
+++ b/lib/Db/RoleFeaturePermission.php
@@ -1,0 +1,195 @@
+<?php
+
+/**
+ * RoleFeaturePermission Entity
+ *
+ * Represents a role → widget permission mapping for MyDash. Persists which
+ * Nextcloud group is allowed (or denied) which dashboard widgets, plus
+ * optional priority weights used by layout seeding.
+ *
+ * @category  Database
+ * @package   OCA\MyDash\Db
+ * @author    Conduction b.v. <info@conduction.nl>
+ * @copyright 2026 Conduction b.v.
+ * @license   https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12 EUPL-1.2
+ * @version   GIT:auto
+ * @link      https://conduction.nl
+ *
+ * SPDX-FileCopyrightText: 2026 MyDash Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace OCA\MyDash\Db;
+
+use JsonSerializable;
+use OCP\AppFramework\Db\Entity;
+
+/**
+ * Role-feature-permission entity (REQ-RFP-001..010).
+ *
+ * `allowedWidgets` and `deniedWidgets` are persisted as JSON-encoded text
+ * columns; `priorityWeights` is a JSON-encoded `{widgetId: int}` map.
+ * Decoded values are exposed via the `*Decoded` accessors so callers do
+ * not have to json_decode at every call site.
+ *
+ * @method string getName()
+ * @method void setName(string $name)
+ * @method string|null getDescription()
+ * @method void setDescription(?string $description)
+ * @method string getGroupId()
+ * @method void setGroupId(string $groupId)
+ * @method string|null getAllowedWidgets()
+ * @method void setAllowedWidgets(?string $allowedWidgets)
+ * @method string|null getDeniedWidgets()
+ * @method void setDeniedWidgets(?string $deniedWidgets)
+ * @method string|null getPriorityWeights()
+ * @method void setPriorityWeights(?string $priorityWeights)
+ * @method string|null getCreatedAt()
+ * @method void setCreatedAt(?string $createdAt)
+ * @method string|null getUpdatedAt()
+ * @method void setUpdatedAt(?string $updatedAt)
+ */
+class RoleFeaturePermission extends Entity implements JsonSerializable
+{
+    /**
+     * Sentinel group id used as a catch-all fallback when a user's
+     * `group_order` priority does not yield a match (REQ-RFP-009).
+     *
+     * @var string
+     */
+    public const GROUP_DEFAULT = 'default';
+
+    /**
+     * Human-readable name (e.g. "Medewerker widget-rechten").
+     *
+     * @var string
+     */
+    protected string $name = '';
+
+    /**
+     * Optional purpose / notes.
+     *
+     * @var string|null
+     */
+    protected ?string $description = null;
+
+    /**
+     * Nextcloud group ID this permission applies to.
+     *
+     * @var string
+     */
+    protected string $groupId = '';
+
+    /**
+     * JSON-encoded list of widget IDs the group may add. Empty list = no
+     * widgets allowed; null after construction = unset.
+     *
+     * @var string|null
+     */
+    protected ?string $allowedWidgets = null;
+
+    /**
+     * JSON-encoded list of widget IDs explicitly denied. Wins over
+     * `allowedWidgets` when merging multiple groups (deny-wins, REQ-RFP-005).
+     *
+     * @var string|null
+     */
+    protected ?string $deniedWidgets = null;
+
+    /**
+     * JSON-encoded map of `{widgetId: int}` priority weights. Higher value =
+     * earlier in seeded layout / dashboard ordering.
+     *
+     * @var string|null
+     */
+    protected ?string $priorityWeights = null;
+
+    /**
+     * ISO-8601 creation timestamp.
+     *
+     * @var string|null
+     */
+    protected ?string $createdAt = null;
+
+    /**
+     * ISO-8601 last-modification timestamp.
+     *
+     * @var string|null
+     */
+    protected ?string $updatedAt = null;
+
+    /**
+     * Constructor — registers ORM column types.
+     */
+    public function __construct()
+    {
+        $this->addType(fieldName: 'id', type: 'integer');
+    }//end __construct()
+
+    /**
+     * Get `allowedWidgets` decoded into a string array.
+     *
+     * @return array The list of allowed widget IDs (empty array if unset).
+     */
+    public function getAllowedWidgetsDecoded(): array
+    {
+        if ($this->allowedWidgets === null || $this->allowedWidgets === '') {
+            return [];
+        }
+
+        $decoded = json_decode(json: $this->allowedWidgets, associative: true);
+        return is_array($decoded) === true ? array_values(array: $decoded) : [];
+    }//end getAllowedWidgetsDecoded()
+
+    /**
+     * Get `deniedWidgets` decoded into a string array.
+     *
+     * @return array The list of denied widget IDs (empty array if unset).
+     */
+    public function getDeniedWidgetsDecoded(): array
+    {
+        if ($this->deniedWidgets === null || $this->deniedWidgets === '') {
+            return [];
+        }
+
+        $decoded = json_decode(json: $this->deniedWidgets, associative: true);
+        return is_array($decoded) === true ? array_values(array: $decoded) : [];
+    }//end getDeniedWidgetsDecoded()
+
+    /**
+     * Get `priorityWeights` decoded into a `{widgetId: int}` map.
+     *
+     * @return array The decoded priority map (empty array if unset).
+     */
+    public function getPriorityWeightsDecoded(): array
+    {
+        if ($this->priorityWeights === null || $this->priorityWeights === '') {
+            return [];
+        }
+
+        $decoded = json_decode(json: $this->priorityWeights, associative: true);
+        return is_array($decoded) === true ? $decoded : [];
+    }//end getPriorityWeightsDecoded()
+
+    /**
+     * Serialize to a JSON-friendly array.
+     *
+     * @return array The serialized representation.
+     */
+    public function jsonSerialize(): array
+    {
+        return [
+            'id'               => $this->getId(),
+            'name'             => $this->name,
+            'description'      => $this->description,
+            'groupId'          => $this->groupId,
+            'allowedWidgets'   => $this->getAllowedWidgetsDecoded(),
+            'deniedWidgets'    => $this->getDeniedWidgetsDecoded(),
+            'priorityWeights'  => (object) $this->getPriorityWeightsDecoded(),
+            'createdAt'        => $this->createdAt,
+            'updatedAt'        => $this->updatedAt,
+        ];
+    }//end jsonSerialize()
+}//end class

--- a/lib/Db/RoleFeaturePermissionMapper.php
+++ b/lib/Db/RoleFeaturePermissionMapper.php
@@ -1,0 +1,120 @@
+<?php
+
+/**
+ * RoleFeaturePermissionMapper
+ *
+ * QBMapper for RoleFeaturePermission entities. Provides lookups by group
+ * ID and by group ID list (used by the multi-group resolution algorithm).
+ *
+ * @category  Database
+ * @package   OCA\MyDash\Db
+ * @author    Conduction b.v. <info@conduction.nl>
+ * @copyright 2026 Conduction b.v.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @version   GIT:auto
+ * @link      https://conduction.nl
+ *
+ * SPDX-FileCopyrightText: 2026 MyDash Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace OCA\MyDash\Db;
+
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\AppFramework\Db\QBMapper;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IDBConnection;
+
+/**
+ * Mapper for `mydash_role_feature_perms`.
+ *
+ * @extends QBMapper<RoleFeaturePermission>
+ */
+class RoleFeaturePermissionMapper extends QBMapper
+{
+    /**
+     * Constructor.
+     *
+     * @param IDBConnection $db The database connection.
+     */
+    public function __construct(IDBConnection $db)
+    {
+        parent::__construct(
+            db: $db,
+            tableName: 'mydash_role_feature_perms',
+            entityClass: RoleFeaturePermission::class
+        );
+    }//end __construct()
+
+    /**
+     * Find all RoleFeaturePermission rows.
+     *
+     * @return RoleFeaturePermission[] All rows ordered by group_id.
+     */
+    public function findAll(): array
+    {
+        $qb = $this->db->getQueryBuilder();
+        $qb->select(selects: '*')
+            ->from(from: $this->getTableName())
+            ->orderBy(sort: 'group_id', order: 'ASC');
+
+        return $this->findEntities(query: $qb);
+    }//end findAll()
+
+    /**
+     * Find a permission row by group ID.
+     *
+     * @param string $groupId The Nextcloud group ID.
+     *
+     * @return RoleFeaturePermission The matching row.
+     *
+     * @throws DoesNotExistException When no row exists for the given group.
+     */
+    public function findByGroupId(string $groupId): RoleFeaturePermission
+    {
+        $qb = $this->db->getQueryBuilder();
+        $qb->select(selects: '*')
+            ->from(from: $this->getTableName())
+            ->where(
+                $qb->expr()->eq(
+                    x: 'group_id',
+                    y: $qb->createNamedParameter(value: $groupId)
+                )
+            );
+
+        return $this->findEntity(query: $qb);
+    }//end findByGroupId()
+
+    /**
+     * Find all permission rows whose group_id is in the supplied list. The
+     * caller is responsible for ordering by `group_order` priority — this
+     * mapper just returns whatever the storage engine supplies.
+     *
+     * @param array $groupIds The list of Nextcloud group IDs to match.
+     *
+     * @return RoleFeaturePermission[] Zero or more matching rows.
+     */
+    public function findByGroupIds(array $groupIds): array
+    {
+        if (count(value: $groupIds) === 0) {
+            return [];
+        }
+
+        $qb = $this->db->getQueryBuilder();
+        $qb->select(selects: '*')
+            ->from(from: $this->getTableName())
+            ->where(
+                $qb->expr()->in(
+                    x: 'group_id',
+                    y: $qb->createNamedParameter(
+                        value: $groupIds,
+                        type: IQueryBuilder::PARAM_STR_ARRAY
+                    )
+                )
+            );
+
+        return $this->findEntities(query: $qb);
+    }//end findByGroupIds()
+}//end class

--- a/lib/Db/RoleLayoutDefault.php
+++ b/lib/Db/RoleLayoutDefault.php
@@ -1,0 +1,181 @@
+<?php
+
+/**
+ * RoleLayoutDefault Entity
+ *
+ * Captures the default grid position, size, and ordering for a single
+ * widget within a role's seeded dashboard layout. Read by
+ * `DashboardResolver::tryCreateFromTemplate()` when no admin template
+ * matches a new user (REQ-RFP-002).
+ *
+ * @category  Database
+ * @package   OCA\MyDash\Db
+ * @author    Conduction b.v. <info@conduction.nl>
+ * @copyright 2026 Conduction b.v.
+ * @license   https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12 EUPL-1.2
+ * @version   GIT:auto
+ * @link      https://conduction.nl
+ *
+ * SPDX-FileCopyrightText: 2026 MyDash Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace OCA\MyDash\Db;
+
+use JsonSerializable;
+use OCP\AppFramework\Db\Entity;
+
+/**
+ * Role-layout-default entity (REQ-RFP-002).
+ *
+ * @method string getName()
+ * @method void setName(string $name)
+ * @method string|null getDescription()
+ * @method void setDescription(?string $description)
+ * @method string getGroupId()
+ * @method void setGroupId(string $groupId)
+ * @method string getWidgetId()
+ * @method void setWidgetId(string $widgetId)
+ * @method int getGridX()
+ * @method void setGridX(int $gridX)
+ * @method int getGridY()
+ * @method void setGridY(int $gridY)
+ * @method int getGridWidth()
+ * @method void setGridWidth(int $gridWidth)
+ * @method int getGridHeight()
+ * @method void setGridHeight(int $gridHeight)
+ * @method int getSortOrder()
+ * @method void setSortOrder(int $sortOrder)
+ * @method int getIsCompulsory()
+ * @method void setIsCompulsory(int $isCompulsory)
+ * @method string|null getCreatedAt()
+ * @method void setCreatedAt(?string $createdAt)
+ * @method string|null getUpdatedAt()
+ * @method void setUpdatedAt(?string $updatedAt)
+ */
+class RoleLayoutDefault extends Entity implements JsonSerializable
+{
+    /**
+     * Display name (e.g. "Manager — activiteiten").
+     *
+     * @var string
+     */
+    protected string $name = '';
+
+    /**
+     * Optional notes about why this widget appears at this position.
+     *
+     * @var string|null
+     */
+    protected ?string $description = null;
+
+    /**
+     * Nextcloud group ID this default layout slot applies to.
+     *
+     * @var string
+     */
+    protected string $groupId = '';
+
+    /**
+     * Nextcloud Dashboard widget ID to seed.
+     *
+     * @var string
+     */
+    protected string $widgetId = '';
+
+    /**
+     * Column position (0-based).
+     *
+     * @var int
+     */
+    protected int $gridX = 0;
+
+    /**
+     * Row position (0-based).
+     *
+     * @var int
+     */
+    protected int $gridY = 0;
+
+    /**
+     * Widget width in grid columns (min 1).
+     *
+     * @var int
+     */
+    protected int $gridWidth = 4;
+
+    /**
+     * Widget height in grid rows (min 1).
+     *
+     * @var int
+     */
+    protected int $gridHeight = 4;
+
+    /**
+     * Sort order within the layout (lower = rendered first).
+     *
+     * @var int
+     */
+    protected int $sortOrder = 0;
+
+    /**
+     * 0/1 — when 1, the user cannot remove this widget from a seeded layout.
+     *
+     * @var int
+     */
+    protected int $isCompulsory = 0;
+
+    /**
+     * ISO-8601 creation timestamp.
+     *
+     * @var string|null
+     */
+    protected ?string $createdAt = null;
+
+    /**
+     * ISO-8601 last-modification timestamp.
+     *
+     * @var string|null
+     */
+    protected ?string $updatedAt = null;
+
+    /**
+     * Constructor — registers ORM column types.
+     */
+    public function __construct()
+    {
+        $this->addType(fieldName: 'id', type: 'integer');
+        $this->addType(fieldName: 'gridX', type: 'integer');
+        $this->addType(fieldName: 'gridY', type: 'integer');
+        $this->addType(fieldName: 'gridWidth', type: 'integer');
+        $this->addType(fieldName: 'gridHeight', type: 'integer');
+        $this->addType(fieldName: 'sortOrder', type: 'integer');
+        $this->addType(fieldName: 'isCompulsory', type: 'integer');
+    }//end __construct()
+
+    /**
+     * Serialize to a JSON-friendly array.
+     *
+     * @return array The serialized representation.
+     */
+    public function jsonSerialize(): array
+    {
+        return [
+            'id'           => $this->getId(),
+            'name'         => $this->name,
+            'description'  => $this->description,
+            'groupId'      => $this->groupId,
+            'widgetId'     => $this->widgetId,
+            'gridX'        => $this->gridX,
+            'gridY'        => $this->gridY,
+            'gridWidth'    => $this->gridWidth,
+            'gridHeight'   => $this->gridHeight,
+            'sortOrder'    => $this->sortOrder,
+            'isCompulsory' => $this->isCompulsory === 1,
+            'createdAt'    => $this->createdAt,
+            'updatedAt'    => $this->updatedAt,
+        ];
+    }//end jsonSerialize()
+}//end class

--- a/lib/Db/RoleLayoutDefaultMapper.php
+++ b/lib/Db/RoleLayoutDefaultMapper.php
@@ -1,0 +1,121 @@
+<?php
+
+/**
+ * RoleLayoutDefaultMapper
+ *
+ * QBMapper for RoleLayoutDefault entities. Provides ordered lookups by
+ * group ID used during dashboard seeding (REQ-RFP-002).
+ *
+ * @category  Database
+ * @package   OCA\MyDash\Db
+ * @author    Conduction b.v. <info@conduction.nl>
+ * @copyright 2026 Conduction b.v.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @version   GIT:auto
+ * @link      https://conduction.nl
+ *
+ * SPDX-FileCopyrightText: 2026 MyDash Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace OCA\MyDash\Db;
+
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\AppFramework\Db\QBMapper;
+use OCP\IDBConnection;
+
+/**
+ * Mapper for `mydash_role_layout_defaults`.
+ *
+ * @extends QBMapper<RoleLayoutDefault>
+ */
+class RoleLayoutDefaultMapper extends QBMapper
+{
+    /**
+     * Constructor.
+     *
+     * @param IDBConnection $db The database connection.
+     */
+    public function __construct(IDBConnection $db)
+    {
+        parent::__construct(
+            db: $db,
+            tableName: 'mydash_role_layout_defaults',
+            entityClass: RoleLayoutDefault::class
+        );
+    }//end __construct()
+
+    /**
+     * List all default layout rows ordered by group then sort_order.
+     *
+     * @return RoleLayoutDefault[] All rows.
+     */
+    public function findAll(): array
+    {
+        $qb = $this->db->getQueryBuilder();
+        $qb->select(selects: '*')
+            ->from(from: $this->getTableName())
+            ->orderBy(sort: 'group_id', order: 'ASC')
+            ->addOrderBy(sort: 'sort_order', order: 'ASC');
+
+        return $this->findEntities(query: $qb);
+    }//end findAll()
+
+    /**
+     * Find all default-layout rows for a single group, ordered by `sort_order`.
+     * Used by `RoleFeaturePermissionService::seedLayoutFromRoleDefaults()`.
+     *
+     * @param string $groupId The Nextcloud group ID.
+     *
+     * @return RoleLayoutDefault[] Ordered rows; empty array when nothing seeded.
+     */
+    public function findByGroupId(string $groupId): array
+    {
+        $qb = $this->db->getQueryBuilder();
+        $qb->select(selects: '*')
+            ->from(from: $this->getTableName())
+            ->where(
+                $qb->expr()->eq(
+                    x: 'group_id',
+                    y: $qb->createNamedParameter(value: $groupId)
+                )
+            )
+            ->orderBy(sort: 'sort_order', order: 'ASC');
+
+        return $this->findEntities(query: $qb);
+    }//end findByGroupId()
+
+    /**
+     * Find an existing row by `(group_id, widget_id)` — used to enforce
+     * upsert behaviour when an admin re-saves the same default.
+     *
+     * @param string $groupId  The Nextcloud group ID.
+     * @param string $widgetId The Nextcloud Dashboard widget ID.
+     *
+     * @return RoleLayoutDefault The matching row.
+     *
+     * @throws DoesNotExistException When no row exists for the combination.
+     */
+    public function findByGroupAndWidget(string $groupId, string $widgetId): RoleLayoutDefault
+    {
+        $qb = $this->db->getQueryBuilder();
+        $qb->select(selects: '*')
+            ->from(from: $this->getTableName())
+            ->where(
+                $qb->expr()->eq(
+                    x: 'group_id',
+                    y: $qb->createNamedParameter(value: $groupId)
+                )
+            )
+            ->andWhere(
+                $qb->expr()->eq(
+                    x: 'widget_id',
+                    y: $qb->createNamedParameter(value: $widgetId)
+                )
+            );
+
+        return $this->findEntity(query: $qb);
+    }//end findByGroupAndWidget()
+}//end class

--- a/lib/Migration/RoleFeaturePermissionTableBuilder.php
+++ b/lib/Migration/RoleFeaturePermissionTableBuilder.php
@@ -1,0 +1,146 @@
+<?php
+
+/**
+ * RoleFeaturePermissionTableBuilder
+ *
+ * Builder for the `mydash_role_feature_perms` schema (REQ-RFP-001..010).
+ *
+ * @category  Migration
+ * @package   OCA\MyDash\Migration
+ * @author    Conduction b.v. <info@conduction.nl>
+ * @copyright 2026 Conduction b.v.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @version   GIT:auto
+ * @link      https://conduction.nl
+ *
+ * SPDX-FileCopyrightText: 2026 MyDash Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace OCA\MyDash\Migration;
+
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
+
+/**
+ * Schema builder for the role-feature-permissions table.
+ */
+class RoleFeaturePermissionTableBuilder
+{
+    /**
+     * Create the table when missing.
+     *
+     * @param ISchemaWrapper $schema The schema wrapper.
+     *
+     * @return void
+     */
+    public static function create(ISchemaWrapper $schema): void
+    {
+        if ($schema->hasTable(tableName: 'mydash_role_feature_perms') === true) {
+            return;
+        }
+
+        $table = $schema->createTable(tableName: 'mydash_role_feature_perms');
+
+        self::addColumns(table: $table);
+        self::addIndexes(table: $table);
+    }//end create()
+
+    /**
+     * Add columns to the table.
+     *
+     * @param \Doctrine\DBAL\Schema\Table $table The table instance.
+     *
+     * @return void
+     */
+    private static function addColumns($table): void
+    {
+        $table->addColumn(
+            name: 'id',
+            typeName: Types::BIGINT,
+            options: [
+                'autoincrement' => true,
+                'notnull'       => true,
+                'unsigned'      => true,
+            ]
+        );
+        $table->addColumn(
+            name: 'name',
+            typeName: Types::STRING,
+            options: [
+                'notnull' => true,
+                'length'  => 255,
+            ]
+        );
+        $table->addColumn(
+            name: 'description',
+            typeName: Types::TEXT,
+            options: [
+                'notnull' => false,
+            ]
+        );
+        $table->addColumn(
+            name: 'group_id',
+            typeName: Types::STRING,
+            options: [
+                'notnull' => true,
+                'length'  => 255,
+            ]
+        );
+        $table->addColumn(
+            name: 'allowed_widgets',
+            typeName: Types::TEXT,
+            options: [
+                'notnull' => false,
+            ]
+        );
+        $table->addColumn(
+            name: 'denied_widgets',
+            typeName: Types::TEXT,
+            options: [
+                'notnull' => false,
+            ]
+        );
+        $table->addColumn(
+            name: 'priority_weights',
+            typeName: Types::TEXT,
+            options: [
+                'notnull' => false,
+            ]
+        );
+        $table->addColumn(
+            name: 'created_at',
+            typeName: Types::STRING,
+            options: [
+                'notnull' => false,
+                'length'  => 32,
+            ]
+        );
+        $table->addColumn(
+            name: 'updated_at',
+            typeName: Types::STRING,
+            options: [
+                'notnull' => false,
+                'length'  => 32,
+            ]
+        );
+    }//end addColumns()
+
+    /**
+     * Add primary key + uniqueness index on group_id.
+     *
+     * @param \Doctrine\DBAL\Schema\Table $table The table instance.
+     *
+     * @return void
+     */
+    private static function addIndexes($table): void
+    {
+        $table->setPrimaryKey(columnNames: ['id']);
+        $table->addUniqueIndex(
+            columnNames: ['group_id'],
+            indexName: 'mydash_rfp_group'
+        );
+    }//end addIndexes()
+}//end class

--- a/lib/Migration/RoleLayoutDefaultTableBuilder.php
+++ b/lib/Migration/RoleLayoutDefaultTableBuilder.php
@@ -1,0 +1,185 @@
+<?php
+
+/**
+ * RoleLayoutDefaultTableBuilder
+ *
+ * Builder for the `mydash_role_layout_defaults` schema (REQ-RFP-002).
+ *
+ * @category  Migration
+ * @package   OCA\MyDash\Migration
+ * @author    Conduction b.v. <info@conduction.nl>
+ * @copyright 2026 Conduction b.v.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @version   GIT:auto
+ * @link      https://conduction.nl
+ *
+ * SPDX-FileCopyrightText: 2026 MyDash Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace OCA\MyDash\Migration;
+
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
+
+/**
+ * Schema builder for the role-layout-defaults table.
+ */
+class RoleLayoutDefaultTableBuilder
+{
+    /**
+     * Create the table when missing.
+     *
+     * @param ISchemaWrapper $schema The schema wrapper.
+     *
+     * @return void
+     */
+    public static function create(ISchemaWrapper $schema): void
+    {
+        if ($schema->hasTable(tableName: 'mydash_role_layout_defaults') === true) {
+            return;
+        }
+
+        $table = $schema->createTable(tableName: 'mydash_role_layout_defaults');
+
+        self::addColumns(table: $table);
+        self::addIndexes(table: $table);
+    }//end create()
+
+    /**
+     * Add columns to the table.
+     *
+     * @param \Doctrine\DBAL\Schema\Table $table The table instance.
+     *
+     * @return void
+     */
+    private static function addColumns($table): void
+    {
+        $table->addColumn(
+            name: 'id',
+            typeName: Types::BIGINT,
+            options: [
+                'autoincrement' => true,
+                'notnull'       => true,
+                'unsigned'      => true,
+            ]
+        );
+        $table->addColumn(
+            name: 'name',
+            typeName: Types::STRING,
+            options: [
+                'notnull' => true,
+                'length'  => 255,
+            ]
+        );
+        $table->addColumn(
+            name: 'description',
+            typeName: Types::TEXT,
+            options: [
+                'notnull' => false,
+            ]
+        );
+        $table->addColumn(
+            name: 'group_id',
+            typeName: Types::STRING,
+            options: [
+                'notnull' => true,
+                'length'  => 255,
+            ]
+        );
+        $table->addColumn(
+            name: 'widget_id',
+            typeName: Types::STRING,
+            options: [
+                'notnull' => true,
+                'length'  => 255,
+            ]
+        );
+        $table->addColumn(
+            name: 'grid_x',
+            typeName: Types::INTEGER,
+            options: [
+                'notnull' => true,
+                'default' => 0,
+            ]
+        );
+        $table->addColumn(
+            name: 'grid_y',
+            typeName: Types::INTEGER,
+            options: [
+                'notnull' => true,
+                'default' => 0,
+            ]
+        );
+        $table->addColumn(
+            name: 'grid_width',
+            typeName: Types::INTEGER,
+            options: [
+                'notnull' => true,
+                'default' => 4,
+            ]
+        );
+        $table->addColumn(
+            name: 'grid_height',
+            typeName: Types::INTEGER,
+            options: [
+                'notnull' => true,
+                'default' => 4,
+            ]
+        );
+        $table->addColumn(
+            name: 'sort_order',
+            typeName: Types::INTEGER,
+            options: [
+                'notnull' => true,
+                'default' => 0,
+            ]
+        );
+        $table->addColumn(
+            name: 'is_compulsory',
+            typeName: Types::SMALLINT,
+            options: [
+                'notnull' => true,
+                'default' => 0,
+            ]
+        );
+        $table->addColumn(
+            name: 'created_at',
+            typeName: Types::STRING,
+            options: [
+                'notnull' => false,
+                'length'  => 32,
+            ]
+        );
+        $table->addColumn(
+            name: 'updated_at',
+            typeName: Types::STRING,
+            options: [
+                'notnull' => false,
+                'length'  => 32,
+            ]
+        );
+    }//end addColumns()
+
+    /**
+     * Add primary key + uniqueness index on (group_id, widget_id).
+     *
+     * @param \Doctrine\DBAL\Schema\Table $table The table instance.
+     *
+     * @return void
+     */
+    private static function addIndexes($table): void
+    {
+        $table->setPrimaryKey(columnNames: ['id']);
+        $table->addUniqueIndex(
+            columnNames: ['group_id', 'widget_id'],
+            indexName: 'mydash_rld_group_widget'
+        );
+        $table->addIndex(
+            columnNames: ['group_id'],
+            indexName: 'mydash_rld_group'
+        );
+    }//end addIndexes()
+}//end class

--- a/lib/Migration/Version001007Date20260501120000.php
+++ b/lib/Migration/Version001007Date20260501120000.php
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ * Version001007Date20260501120000
+ *
+ * Creates the two tables backing the role-feature-permissions capability:
+ *   - mydash_role_feature_perms
+ *   - mydash_role_layout_defaults
+ * (See REQ-RFP-001 .. REQ-RFP-010 in
+ *  openspec/changes/role-based-content/specs/role-feature-permissions/spec.md)
+ *
+ * @category  Migration
+ * @package   OCA\MyDash\Migration
+ * @author    Conduction b.v. <info@conduction.nl>
+ * @copyright 2026 Conduction b.v.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @version   GIT:auto
+ * @link      https://conduction.nl
+ *
+ * SPDX-FileCopyrightText: 2026 MyDash Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace OCA\MyDash\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+/**
+ * Migration creating the role-feature-permissions tables.
+ */
+class Version001007Date20260501120000 extends SimpleMigrationStep
+{
+    /**
+     * Create both `mydash_role_feature_perms` and `mydash_role_layout_defaults`.
+     *
+     * @param IOutput $output        The migration output handler.
+     * @param Closure $schemaClosure Returns an ISchemaWrapper.
+     * @param array   $options       The migration options (unused).
+     *
+     * @return ISchemaWrapper|null The modified schema or null if no changes.
+     */
+    public function changeSchema(
+        IOutput $output,
+        Closure $schemaClosure,
+        array $options
+    ): ?ISchemaWrapper {
+        $schema = $schemaClosure();
+
+        $hadFeaturePerms = $schema->hasTable(tableName: 'mydash_role_feature_perms');
+        $hadLayoutDefs   = $schema->hasTable(tableName: 'mydash_role_layout_defaults');
+
+        if ($hadFeaturePerms === true && $hadLayoutDefs === true) {
+            return null;
+        }
+
+        RoleFeaturePermissionTableBuilder::create(schema: $schema);
+        RoleLayoutDefaultTableBuilder::create(schema: $schema);
+
+        return $schema;
+    }//end changeSchema()
+}//end class

--- a/lib/Service/DashboardService.php
+++ b/lib/Service/DashboardService.php
@@ -103,7 +103,10 @@ class DashboardService
      *                                                (used for the fork
      *                                                default name —
      *                                                REQ-DASH-020).
-     * @param LoggerInterface       $logger           PSR logger.
+     * @param LoggerInterface              $logger             PSR logger.
+     * @param RoleFeaturePermissionService $roleFeaturePerm    Role-default
+     *                                                         layout seeding
+     *                                                         (REQ-RFP-002).
      */
     public function __construct(
         private readonly DashboardMapper $dashboardMapper,
@@ -118,6 +121,7 @@ class DashboardService
         private readonly IConfig $config,
         private readonly IL10N $l10n,
         private readonly LoggerInterface $logger,
+        private readonly RoleFeaturePermissionService $roleFeaturePerm,
     ) {
     }//end __construct()
 
@@ -956,9 +960,25 @@ class DashboardService
                 userId: $userId,
                 name: 'My Dashboard'
             );
-            $placements = $this->createDefaultPlacements(
-                dashboardId: $dashboard->getId()
+
+            // REQ-RFP-002: when no admin template applies, prefer seeding
+            // from the user's RoleLayoutDefault rows. Only fall back to the
+            // hardcoded recommendations + activity pair when no role-defaults
+            // exist for any of the user's groups (or the user is in no group).
+            $seeded = $this->roleFeaturePerm->seedLayoutFromRoleDefaults(
+                userId: $userId,
+                dashboard: $dashboard
             );
+            if ($seeded > 0) {
+                $placements = $this->placementMapper->findByDashboardId(
+                    dashboardId: $dashboard->getId()
+                );
+            } else {
+                $placements = $this->createDefaultPlacements(
+                    dashboardId: $dashboard->getId()
+                );
+            }
+
             return [
                 'dashboard'       => $dashboard,
                 'placements'      => $placements,

--- a/lib/Service/InitialStateBuilder.php
+++ b/lib/Service/InitialStateBuilder.php
@@ -90,6 +90,9 @@ class InitialStateBuilder
             'groupDashboards',
             'userDashboards',
             'allowUserDashboards',
+            // REQ-RFP-010: list of widget IDs the caller is permitted to see.
+            // null = no restriction configured (backwards-compat).
+            'allowedWidgets',
         ],
         'admin'     => [
             'allGroups',
@@ -247,6 +250,21 @@ class InitialStateBuilder
         $this->values['allowUserDashboards'] = $allowUserDashboards;
         return $this;
     }//end setAllowUserDashboards()
+
+    /**
+     * Set the list of widget IDs the caller is permitted to see (workspace).
+     * `null` means no restriction is configured — legacy behaviour where the
+     * full widget catalogue is shown (REQ-RFP-009 / REQ-RFP-010).
+     *
+     * @param array|null $allowedWidgets List of widget IDs, or null.
+     *
+     * @return self
+     */
+    public function setAllowedWidgets(?array $allowedWidgets): self
+    {
+        $this->values['allowedWidgets'] = $allowedWidgets;
+        return $this;
+    }//end setAllowedWidgets()
 
     /**
      * Set the list of all Nextcloud groups (admin).

--- a/lib/Service/RoleFeaturePermissionService.php
+++ b/lib/Service/RoleFeaturePermissionService.php
@@ -1,0 +1,464 @@
+<?php
+
+/**
+ * RoleFeaturePermissionService
+ *
+ * Stateless service that resolves the effective allowed-widget set for a
+ * MyDash user based on their Nextcloud group memberships, the configured
+ * `group_order` priority, and any RoleFeaturePermission rows. Implements
+ * the multi-group resolution algorithm from
+ * `openspec/changes/role-based-content/design.md` (REQ-RFP-001 ..
+ * REQ-RFP-010).
+ *
+ * @category  Service
+ * @package   OCA\MyDash\Service
+ * @author    Conduction b.v. <info@conduction.nl>
+ * @copyright 2026 Conduction b.v.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @version   GIT:auto
+ * @link      https://conduction.nl
+ *
+ * SPDX-FileCopyrightText: 2026 MyDash Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace OCA\MyDash\Service;
+
+use DateTime;
+use OCA\MyDash\Db\Dashboard;
+use OCA\MyDash\Db\RoleFeaturePermission;
+use OCA\MyDash\Db\RoleFeaturePermissionMapper;
+use OCA\MyDash\Db\RoleLayoutDefault;
+use OCA\MyDash\Db\RoleLayoutDefaultMapper;
+use OCA\MyDash\Db\WidgetPlacement;
+use OCA\MyDash\Db\WidgetPlacementMapper;
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\IGroupManager;
+use OCP\IUserManager;
+
+/**
+ * @spec openspec/changes/role-based-content/tasks.md#task-2
+ *
+ * All public methods are stateless — no per-request memoisation. Caller
+ * concerns (controllers, other services) inject this directly.
+ */
+class RoleFeaturePermissionService
+{
+    /**
+     * Constructor.
+     *
+     * @param RoleFeaturePermissionMapper $permissionMapper Permission mapper.
+     * @param RoleLayoutDefaultMapper     $defaultMapper    Layout default mapper.
+     * @param WidgetPlacementMapper       $placementMapper  Widget placement mapper.
+     * @param AdminSettingsService        $adminSettings    Admin settings reader.
+     * @param IGroupManager               $groupManager     Nextcloud group manager.
+     * @param IUserManager                $userManager      Nextcloud user manager.
+     */
+    public function __construct(
+        private readonly RoleFeaturePermissionMapper $permissionMapper,
+        private readonly RoleLayoutDefaultMapper $defaultMapper,
+        private readonly WidgetPlacementMapper $placementMapper,
+        private readonly AdminSettingsService $adminSettings,
+        private readonly IGroupManager $groupManager,
+        private readonly IUserManager $userManager,
+    ) {
+    }//end __construct()
+
+    /**
+     * List all RoleFeaturePermission rows for the admin UI.
+     *
+     * @return RoleFeaturePermission[] All rows.
+     */
+    public function listPermissions(): array
+    {
+        return $this->permissionMapper->findAll();
+    }//end listPermissions()
+
+    /**
+     * List all RoleLayoutDefault rows for the admin UI.
+     *
+     * @return RoleLayoutDefault[] All rows.
+     */
+    public function listLayoutDefaults(): array
+    {
+        return $this->defaultMapper->findAll();
+    }//end listLayoutDefaults()
+
+    /**
+     * Upsert a RoleFeaturePermission row keyed by `groupId`.
+     *
+     * @param array $data The submitted permission data.
+     *
+     * @return RoleFeaturePermission The persisted row.
+     */
+    public function savePermission(array $data): RoleFeaturePermission
+    {
+        $groupId = (string) ($data['groupId'] ?? '');
+        if ($groupId === '') {
+            throw new \InvalidArgumentException(message: 'groupId is required');
+        }
+
+        try {
+            $entity = $this->permissionMapper->findByGroupId(groupId: $groupId);
+        } catch (DoesNotExistException $e) {
+            $entity = new RoleFeaturePermission();
+            $now    = (new DateTime())->format(format: 'c');
+            // phpcs:ignore CustomSniffs.Functions.NamedParameters.RequireNamedParameters
+            $entity->setCreatedAt($now);
+            // phpcs:ignore CustomSniffs.Functions.NamedParameters.RequireNamedParameters
+            $entity->setGroupId($groupId);
+        }
+
+        if (array_key_exists(key: 'name', array: $data) === true) {
+            // phpcs:ignore CustomSniffs.Functions.NamedParameters.RequireNamedParameters
+            $entity->setName((string) $data['name']);
+        }
+        if (array_key_exists(key: 'description', array: $data) === true) {
+            // phpcs:ignore CustomSniffs.Functions.NamedParameters.RequireNamedParameters
+            $entity->setDescription($data['description'] !== null ? (string) $data['description'] : null);
+        }
+        if (array_key_exists(key: 'allowedWidgets', array: $data) === true) {
+            $allowed = is_array(value: $data['allowedWidgets']) === true ? $data['allowedWidgets'] : [];
+            // phpcs:ignore CustomSniffs.Functions.NamedParameters.RequireNamedParameters
+            $entity->setAllowedWidgets(json_encode(value: array_values(array: $allowed)));
+        }
+        if (array_key_exists(key: 'deniedWidgets', array: $data) === true) {
+            $denied = is_array(value: $data['deniedWidgets']) === true ? $data['deniedWidgets'] : [];
+            // phpcs:ignore CustomSniffs.Functions.NamedParameters.RequireNamedParameters
+            $entity->setDeniedWidgets(json_encode(value: array_values(array: $denied)));
+        }
+        if (array_key_exists(key: 'priorityWeights', array: $data) === true) {
+            $weights = is_array(value: $data['priorityWeights']) === true ? $data['priorityWeights'] : [];
+            // phpcs:ignore CustomSniffs.Functions.NamedParameters.RequireNamedParameters
+            $entity->setPriorityWeights(json_encode(value: $weights));
+        }
+        // phpcs:ignore CustomSniffs.Functions.NamedParameters.RequireNamedParameters
+        $entity->setUpdatedAt((new DateTime())->format(format: 'c'));
+
+        if ($entity->getId() === null) {
+            return $this->permissionMapper->insert(entity: $entity);
+        }
+
+        return $this->permissionMapper->update(entity: $entity);
+    }//end savePermission()
+
+    /**
+     * Delete a RoleFeaturePermission row by id.
+     *
+     * @param int $id The row id.
+     *
+     * @return void
+     *
+     * @throws DoesNotExistException When the row does not exist.
+     */
+    public function deletePermission(int $id): void
+    {
+        $entity = $this->permissionMapper->find(id: $id);
+        $this->permissionMapper->delete(entity: $entity);
+    }//end deletePermission()
+
+    /**
+     * Upsert a RoleLayoutDefault row keyed by `(groupId, widgetId)`.
+     *
+     * @param array $data The submitted layout default data.
+     *
+     * @return RoleLayoutDefault The persisted row.
+     */
+    public function saveLayoutDefault(array $data): RoleLayoutDefault
+    {
+        $groupId  = (string) ($data['groupId'] ?? '');
+        $widgetId = (string) ($data['widgetId'] ?? '');
+        if ($groupId === '' || $widgetId === '') {
+            throw new \InvalidArgumentException(
+                message: 'groupId and widgetId are required'
+            );
+        }
+
+        try {
+            $entity = $this->defaultMapper->findByGroupAndWidget(
+                groupId: $groupId,
+                widgetId: $widgetId
+            );
+        } catch (DoesNotExistException $e) {
+            $entity = new RoleLayoutDefault();
+            $now    = (new DateTime())->format(format: 'c');
+            // phpcs:ignore CustomSniffs.Functions.NamedParameters.RequireNamedParameters
+            $entity->setCreatedAt($now);
+            // phpcs:ignore CustomSniffs.Functions.NamedParameters.RequireNamedParameters
+            $entity->setGroupId($groupId);
+            // phpcs:ignore CustomSniffs.Functions.NamedParameters.RequireNamedParameters
+            $entity->setWidgetId($widgetId);
+        }
+
+        if (array_key_exists(key: 'name', array: $data) === true) {
+            // phpcs:ignore CustomSniffs.Functions.NamedParameters.RequireNamedParameters
+            $entity->setName((string) $data['name']);
+        }
+        if (array_key_exists(key: 'description', array: $data) === true) {
+            // phpcs:ignore CustomSniffs.Functions.NamedParameters.RequireNamedParameters
+            $entity->setDescription($data['description'] !== null ? (string) $data['description'] : null);
+        }
+        if (array_key_exists(key: 'gridX', array: $data) === true) {
+            // phpcs:ignore CustomSniffs.Functions.NamedParameters.RequireNamedParameters
+            $entity->setGridX((int) $data['gridX']);
+        }
+        if (array_key_exists(key: 'gridY', array: $data) === true) {
+            // phpcs:ignore CustomSniffs.Functions.NamedParameters.RequireNamedParameters
+            $entity->setGridY((int) $data['gridY']);
+        }
+        if (array_key_exists(key: 'gridWidth', array: $data) === true) {
+            // phpcs:ignore CustomSniffs.Functions.NamedParameters.RequireNamedParameters
+            $entity->setGridWidth(max(1, (int) $data['gridWidth']));
+        }
+        if (array_key_exists(key: 'gridHeight', array: $data) === true) {
+            // phpcs:ignore CustomSniffs.Functions.NamedParameters.RequireNamedParameters
+            $entity->setGridHeight(max(1, (int) $data['gridHeight']));
+        }
+        if (array_key_exists(key: 'sortOrder', array: $data) === true) {
+            // phpcs:ignore CustomSniffs.Functions.NamedParameters.RequireNamedParameters
+            $entity->setSortOrder((int) $data['sortOrder']);
+        }
+        if (array_key_exists(key: 'isCompulsory', array: $data) === true) {
+            // phpcs:ignore CustomSniffs.Functions.NamedParameters.RequireNamedParameters
+            $entity->setIsCompulsory(((bool) $data['isCompulsory']) === true ? 1 : 0);
+        }
+        // phpcs:ignore CustomSniffs.Functions.NamedParameters.RequireNamedParameters
+        $entity->setUpdatedAt((new DateTime())->format(format: 'c'));
+
+        if ($entity->getId() === null) {
+            return $this->defaultMapper->insert(entity: $entity);
+        }
+
+        return $this->defaultMapper->update(entity: $entity);
+    }//end saveLayoutDefault()
+
+    /**
+     * Delete a RoleLayoutDefault row by id.
+     *
+     * @param int $id The row id.
+     *
+     * @return void
+     *
+     * @throws DoesNotExistException When the row does not exist.
+     */
+    public function deleteLayoutDefault(int $id): void
+    {
+        $entity = $this->defaultMapper->find(id: $id);
+        $this->defaultMapper->delete(entity: $entity);
+    }//end deleteLayoutDefault()
+
+    /**
+     * Resolve the effective allowed-widget ID list for a user.
+     *
+     * Returns `null` (= no restriction, REQ-RFP-009) when none of the user's
+     * groups are mapped AND no `default` RoleFeaturePermission exists.
+     *
+     * Algorithm (REQ-RFP-005):
+     * 1. Walk the configured `group_order` array.
+     * 2. The FIRST group that matches BOTH the user's group memberships AND
+     *    has a RoleFeaturePermission row provides the BASE allowed set.
+     * 3. ALL subsequent groups that match the user widen the allowed set
+     *    via union.
+     * 4. ANY group's `deniedWidgets` removes those widget IDs from the
+     *    final set (deny-wins).
+     * 5. If no `group_order` group matched, fall back to the row whose
+     *    groupId == 'default' (REQ-RFP-009).
+     *
+     * @param string $userId The user's UID.
+     *
+     * @return array|null Sorted list of allowed widget IDs, or null.
+     */
+    public function getAllowedWidgetIds(string $userId): ?array
+    {
+        $userGroups = $this->groupIdsForUser(userId: $userId);
+        if ($userGroups === []) {
+            return $this->fallbackAllowedWidgets();
+        }
+
+        $groupOrder = $this->adminSettings->getGroupOrder();
+        $base       = null;
+        $allowed    = [];
+        $denied     = [];
+
+        // Pre-fetch all RoleFeaturePermission rows for the user's groups (one query).
+        $rows  = $this->permissionMapper->findByGroupIds(groupIds: $userGroups);
+        $byGid = [];
+        foreach ($rows as $row) {
+            $byGid[$row->getGroupId()] = $row;
+        }
+
+        foreach ($groupOrder as $gid) {
+            if (in_array(needle: $gid, haystack: $userGroups, strict: true) === false) {
+                continue;
+            }
+            if (array_key_exists(key: $gid, array: $byGid) === false) {
+                continue;
+            }
+            $row     = $byGid[$gid];
+            $rowAllow = $row->getAllowedWidgetsDecoded();
+            $rowDeny  = $row->getDeniedWidgetsDecoded();
+            if ($base === null) {
+                $base    = true;
+                $allowed = $rowAllow;
+            } else {
+                $allowed = array_values(
+                    array: array_unique(array: array_merge($allowed, $rowAllow))
+                );
+            }
+            $denied = array_values(
+                array: array_unique(array: array_merge($denied, $rowDeny))
+            );
+        }//end foreach
+
+        if ($base === null) {
+            // No group_order match — try the explicit 'default' row.
+            return $this->fallbackAllowedWidgets();
+        }
+
+        $effective = array_values(
+            array: array_diff($allowed, $denied)
+        );
+        sort(array: $effective);
+        return $effective;
+    }//end getAllowedWidgetIds()
+
+    /**
+     * Convenience: is a single widget allowed for a user?
+     *
+     * @param string $userId   The user's UID.
+     * @param string $widgetId The widget id to check.
+     *
+     * @return bool True when the widget is allowed (or no restriction is configured).
+     */
+    public function isWidgetAllowed(string $userId, string $widgetId): bool
+    {
+        $allowed = $this->getAllowedWidgetIds(userId: $userId);
+        if ($allowed === null) {
+            // No restriction configured — backwards-compatible.
+            return true;
+        }
+
+        return in_array(needle: $widgetId, haystack: $allowed, strict: true);
+    }//end isWidgetAllowed()
+
+    /**
+     * Seed the default layout for a freshly created dashboard from the
+     * RoleLayoutDefault rows attached to the user's primary group.
+     *
+     * No-op when the dashboard already has placements (REQ-RFP-002 scenario 3
+     * — never overwrite personal customisations).
+     *
+     * Resolves the user's primary group by walking `group_order` and taking
+     * the first match that has at least one RoleLayoutDefault row.
+     *
+     * @param string    $userId    The user's UID.
+     * @param Dashboard $dashboard The dashboard to seed (must already exist).
+     *
+     * @return int The number of placements created (0 when no-op).
+     */
+    public function seedLayoutFromRoleDefaults(string $userId, Dashboard $dashboard): int
+    {
+        $existing = $this->placementMapper->findByDashboardId(
+            dashboardId: $dashboard->getId()
+        );
+        if (count(value: $existing) > 0) {
+            return 0;
+        }
+
+        $userGroups = $this->groupIdsForUser(userId: $userId);
+        if ($userGroups === []) {
+            return 0;
+        }
+
+        $groupOrder = $this->adminSettings->getGroupOrder();
+        $defaults   = [];
+        foreach ($groupOrder as $gid) {
+            if (in_array(needle: $gid, haystack: $userGroups, strict: true) === false) {
+                continue;
+            }
+            $defaults = $this->defaultMapper->findByGroupId(groupId: $gid);
+            if (count(value: $defaults) > 0) {
+                break;
+            }
+        }
+
+        if (count(value: $defaults) === 0) {
+            return 0;
+        }
+
+        $created = 0;
+        $now     = (new DateTime())->format(format: 'Y-m-d H:i:s');
+        foreach ($defaults as $default) {
+            $placement = new WidgetPlacement();
+            // phpcs:ignore CustomSniffs.Functions.NamedParameters.RequireNamedParameters
+            $placement->setDashboardId($dashboard->getId());
+            // phpcs:ignore CustomSniffs.Functions.NamedParameters.RequireNamedParameters
+            $placement->setWidgetId($default->getWidgetId());
+            // phpcs:ignore CustomSniffs.Functions.NamedParameters.RequireNamedParameters
+            $placement->setGridX($default->getGridX());
+            // phpcs:ignore CustomSniffs.Functions.NamedParameters.RequireNamedParameters
+            $placement->setGridY($default->getGridY());
+            // phpcs:ignore CustomSniffs.Functions.NamedParameters.RequireNamedParameters
+            $placement->setGridWidth($default->getGridWidth());
+            // phpcs:ignore CustomSniffs.Functions.NamedParameters.RequireNamedParameters
+            $placement->setGridHeight($default->getGridHeight());
+            // phpcs:ignore CustomSniffs.Functions.NamedParameters.RequireNamedParameters
+            $placement->setSortOrder($default->getSortOrder());
+            // phpcs:ignore CustomSniffs.Functions.NamedParameters.RequireNamedParameters
+            $placement->setShowTitle(1);
+            // phpcs:ignore CustomSniffs.Functions.NamedParameters.RequireNamedParameters
+            $placement->setIsVisible(1);
+            // phpcs:ignore CustomSniffs.Functions.NamedParameters.RequireNamedParameters
+            $placement->setCreatedAt($now);
+            // phpcs:ignore CustomSniffs.Functions.NamedParameters.RequireNamedParameters
+            $placement->setUpdatedAt($now);
+
+            $this->placementMapper->insert(entity: $placement);
+            $created++;
+        }//end foreach
+
+        return $created;
+    }//end seedLayoutFromRoleDefaults()
+
+    /**
+     * Look up `default` RoleFeaturePermission row when no user-group match
+     * occurred. Returns null when there is no `default` row.
+     *
+     * @return array|null The allowed widget list from the default row.
+     */
+    private function fallbackAllowedWidgets(): ?array
+    {
+        try {
+            $row = $this->permissionMapper->findByGroupId(
+                groupId: RoleFeaturePermission::GROUP_DEFAULT
+            );
+        } catch (DoesNotExistException $e) {
+            return null;
+        }
+
+        $allowed = $row->getAllowedWidgetsDecoded();
+        $denied  = $row->getDeniedWidgetsDecoded();
+        $eff     = array_values(array: array_diff($allowed, $denied));
+        sort(array: $eff);
+        return $eff;
+    }//end fallbackAllowedWidgets()
+
+    /**
+     * Pull the list of group IDs a user belongs to. Wraps `IGroupManager`.
+     *
+     * @param string $userId The user UID.
+     *
+     * @return array The user's group IDs (may be empty).
+     */
+    private function groupIdsForUser(string $userId): array
+    {
+        $user = $this->userManager->get(uid: $userId);
+        if ($user === null) {
+            return [];
+        }
+
+        return $this->groupManager->getUserGroupIds(user: $user);
+    }//end groupIdsForUser()
+}//end class

--- a/openspec/changes/role-based-content/.openspec.yaml
+++ b/openspec/changes/role-based-content/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-01

--- a/openspec/changes/role-based-content/context-brief.md
+++ b/openspec/changes/role-based-content/context-brief.md
@@ -1,0 +1,1736 @@
+# Context Brief: Role-based dashboard content and defaults
+
+**App:** MyDash — Dashboard system
+**Spec:** role-based-content
+**Platform:** Nextcloud + OpenRegister
+
+## Features (6 total, sorted by market demand)
+
+### role-based feature presence
+**demand: 593** | Category: security | **Coverage: mydash**
+
+CAPABILITY: As an IT admin, I want features shown or hidden based on user role, so that staff only see tools relevant to their job. ACCEPTANCE CRITERIA:
+1. GIVEN a user assigned the "employee" role, WHEN they open the dashboard, THEN admin-only widgets are not rendered in the DOM.
+2. GIVEN an IT admin updates a role's feature permissions, WHEN an affected user reloads the dashboard, THEN the visible feature set reflects the new permissions.
+3. GIVEN a user without permission for a feature, WHEN they request the feature's URL directly, THEN the response is a 403 and the feature is not exposed.
+
+### role-based defaults evidence
+**demand: 593** | Category: security | **Coverage: mydash**
+
+CAPABILITY: As an IT admin, I want role-based default dashboards seeded from evidence, so that new users see relevant widgets without manual setup. ACCEPTANCE CRITERIA:
+1. GIVEN a user is assigned a role, WHEN they first open mydash, THEN the dashboard loads the role's default widget layout.
+2. GIVEN an admin updates a role's default layout, WHEN a new user with that role signs in, THEN they receive the updated defaults.
+3. GIVEN a user has customized their dashboard, WHEN role defaults change, THEN their personal customizations are preserved and not overwritten.
+
+### role-based card library
+**demand: 593** | Category: security | **Coverage: mydash**
+
+CAPABILITY: As an IT admin, I want a role-based card library, so that dashboard cards are only visible to users with appropriate permissions. ACCEPTANCE CRITERIA:
+1. GIVEN a card is restricted to the "manager" role, WHEN a user without that role opens the dashboard, THEN the card is not rendered or listed.
+2. GIVEN a user holds a role granting card access, WHEN they open the card library, THEN only cards permitted for their roles appear as available to add.
+3. GIVEN an admin revokes a role from a user, WHEN that user reloads the dashboard, THEN previously visible role-restricted cards are no longer accessible.
+
+### role + priority layout
+**demand: 593** | Category: security | **Coverage: mydash**
+
+CAPABILITY: As an IT admin, I want dashboard widgets laid out by role and priority, so that staff see their most critical information first. ACCEPTANCE CRITERIA:
+1. GIVEN a user with an assigned role, WHEN they open mydash, THEN widgets are ordered by role-specific priority rules.
+2. GIVEN an admin updates priority weights for a role, WHEN affected users next load mydash, THEN the new ordering is applied.
+3. GIVEN a user lacks permission for a high-priority widget, WHEN the dashboard renders, THEN that widget is hidden and the next eligible widget takes its slot.
+
+### role-based > individual personalisation
+**demand: 562** | Category: security | **Coverage: mydash**
+
+CAPABILITY: As an IT admin, I want role-based dashboard defaults rather than per-user personalisation, so that governance scales without bespoke configuration per employee. ACCEPTANCE CRITERIA:
+1. GIVEN an admin defines a dashboard layout for a role group, WHEN a user in that group opens MyDash, THEN they see the role's default widgets and arrangement.
+2. GIVEN a user belongs to multiple role groups, WHEN they load MyDash, THEN role precedence rules resolve to a single deterministic layout shown to the user.
+3. GIVEN an admin updates a role-based layout, WHEN affected users reload MyDash, THEN the new layout propagates without requiring per-user reconfiguration.
+
+### role vs interest vs journey
+**demand: 561** | Category: security | **Coverage: mydash**
+
+CAPABILITY: As an IT admin, I want to distinguish role, interest, and journey when assigning dashboard access, so that permissions match actual responsibilities. ACCEPTANCE CRITERIA:
+1. GIVEN a user assigned a role, WHEN they open MyDash, THEN they see only widgets permitted for that role.
+2. GIVEN a user expresses an interest without a matching role, WHEN they request a widget, THEN access is denied and an audit entry is logged.
+3. GIVEN a user is mid-journey across multiple roles, WHEN their active role changes, THEN the dashboard re-renders with the new role's permissions within one session refresh.
+
+## User Stories
+
+(No user stories linked to this spec. Generate from the features above.)
+
+## Customer Journeys
+
+(No journeys linked. Infer from stakeholders and features above.)
+
+## Stakeholders
+
+(No stakeholders linked. Infer from the features and user stories above.)
+
+## Company-Wide Architecture Rules (23 ADRs)
+
+These rules are MANDATORY for all Conduction apps.
+
+### ADR-001-data-layer
+- ALL domain data → OpenRegister objects. NO custom Entity/Mapper for domain data.
+- App config → `IAppConfig`. NOT OpenRegister.
+- Cross-entity references: OpenRegister relations (register+schema+objectId). NO foreign keys.
+  MUST NOT store foreign keys or embed full objects.
+
+### Schema standards
+
+- Schemas: PascalCase, schema.org vocabulary, explicit types + required flags + description field.
+- MUST NOT invent custom property names when a schema.org equivalent exists.
+- Contact schemas MUST align with vCard properties (fn, email, tel, adr).
+- Dutch government fields SHOULD use a mapping layer translating between international standards
+  and Dutch specs — do not hardcode Dutch field names as primary.
+- Schema changes that remove or rename properties are BREAKING. Adding optional properties is non-breaking.
+
+### Register templates
+
+- Location: `lib/Settings/{app}_register.json` (OpenAPI 3.0 + `x-openregister` extensions).
+- Three template categories:
+  - **App configuration** — define data models (schemas/registers/views/mappings).
+    Mark with `x-openregister.type: "application"`.
+  - **Mock data** — fictional but realistic seed data for dev/test.
+    Mark with `x-openregister.type: "mock"`.
+  - **Government standards** — aligned to Dutch API specs (BAG, BRP, KVK, DSO).
+- Import mechanism: `ConfigurationService::importFromApp(appId, data, version, force)` →
+  `ImportHandler::importFromApp()`. Called from repair step or `SettingsLoadService`.
+- Idempotency: re-importing with `force: false` MUST NOT create duplicates. Match by slug
+  using `ObjectService::searchObjects` with `_rbac: false` and `_multitenancy: false`.
+  Use `version_compare` for skip logic.
+
+### Seed data
+
+Apps that store data in OpenRegister are empty on first install. An empty app cannot be
+meaningfully tested — there are no objects to view, search, filter, or interact with.
+This blocks both automated browser testing and manual QA. The Loadable Register Template
+pattern (see Register templates above) already supports seed data via `components.objects[]`
+with the `@self` envelope.
+
+**Requirements:**
+
+- Every app using OpenRegister MUST include 3-5 realistic objects per schema in
+  `lib/Settings/{app}_register.json`.
+- Use `@self` envelope: `{ "@self": { "register": ..., "schema": ..., "slug": ... }, ...properties }`.
+  Register/schema MUST match keys; slug is unique human-readable identifier for matching.
+- Use general organisation data (municipality, consultancy, travel agency, non-profit) —
+  NOT context-specific. Varied, realistic field values.
+- Mock data quality: real Dutch street names, valid postcodes (`[1-9][0-9]{3}[A-Z]{2}`),
+  correct municipality/KVK codes, BSNs that pass 11-proef. Fictional but distinguishable from real.
+- Cross-register consistency: BRP→BAG, KVK→BAG, DSO→BAG references must be valid.
+- Loaded on install alongside schemas via same `importFromApp()` pipeline.
+- MUST be idempotent — re-importing skips existing objects matched by slug.
+
+**In OpenSpec artifacts:**
+
+- **In design.md**: MUST include a Seed Data section when change introduces/modifies schemas —
+  define seed objects per schema with concrete field values and related items (files, notes, tasks, contacts).
+- **In tasks.md**: MUST include a seed data generation task when change introduces/modifies schemas.
+
+**Exceptions** (no seed data required):
+
+- **nldesign** — has no OpenRegister schemas.
+- **ExApp sidecar wrappers** (openklant, opentalk, openzaak, valtimo, n8n-nextcloud) — proxy
+  external services and do not use OpenRegister.
+- **nextcloud-vue** — shared library, no seed data applicable.
+- Changes that only modify frontend components or non-schema backend logic (e.g., settings,
+  permissions) do not require seed data.
+
+**Limitations:** OpenRegister's `ImportHandler` currently supports only flat seed objects.
+Related items (files, notes, tasks, contacts) linked through the relation system are tracked
+on the product roadmap. Until then, seed data is limited to object properties defined in schemas.
+
+### Deduplication check
+
+- Before proposing new capability: search `openspec/specs/` and `openregister/lib/Service/` for overlap
+  with ObjectService, RegisterService, SchemaService, ConfigurationService, and shared Vue components.
+- If similar capability exists: MUST reference it and explain why new code is needed rather than extending.
+- Proposals duplicating existing functionality without justification MUST be rejected.
+- **In design.md**: MUST include a "Reuse Analysis" section listing existing OpenRegister services leveraged.
+- **In tasks.md**: MUST include a "Deduplication Check" task verifying no overlap — document findings
+  even if "no overlap found".
+
+### Schema migrations
+
+- Breaking schema changes → new migration in repair step. NEVER modify existing migrations.
+
+### OpenRegister + @conduction/nextcloud-vue — DO NOT REBUILD
+
+The platform provides 258+ backend methods and 69+ frontend components. Apps ONLY build
+custom logic for domain-specific business rules. Everything below is provided for FREE.
+
+**CRUD & Data Management** (use ObjectService + CnIndexPage + CnDetailPage):
+- Single & bulk create, read, update, delete — `ObjectService.saveObject()`, `deleteObject()`
+- List with pagination, sorting, filtering — `ObjectService.findAll()` + `CnDataTable`
+- Schema-driven forms — `CnFormDialog` (auto-generates from schema) or `CnAdvancedFormDialog`
+- Detail views — `CnDetailPage` with `CnDetailGrid`, `CnDetailCard` sections
+- Record merging/deduplication — `ObjectService.mergeObjects()`
+- Object locking — `ObjectService.lockObject()` / `unlockObject()`
+
+**Import & Export** (use ImportService/ExportService + CnMassImportDialog/CnMassExportDialog):
+- CSV, Excel, JSON import with intelligent field mapping — `ImportService`
+- CSV, Excel, JSON export with column selection — `ExportService`
+- Bulk import with validation and progress — `CnMassImportDialog`
+- Filtered export with format picker — `CnMassExportDialog`
+- NO custom import dialogs, parsers, upload handlers, or export controllers
+
+**Search & Discovery** (use IndexService + CnFilterBar + CnFacetSidebar):
+- Full-text search with field weighting — `IndexService`
+- Faceted navigation with counts — `FacetBuilder` + `CnFacetSidebar`
+- Semantic search with embeddings — `VectorizationService`
+- Hybrid search (keyword + semantic) — automatic
+- Search analytics — `SearchTrailService` (popular terms, activity)
+- NO custom search endpoints, query builders, or search pages
+
+**File Management** (use FileService + CnObjectSidebar):
+- Upload (single/multipart), download, share links — `FileService`
+- File tagging, public/private toggle — `FileService`
+- Bulk download as ZIP — `createObjectFilesZip()`
+- Text extraction from PDFs/Office docs — `TextExtractionService`
+- File tab in object sidebar — `CnObjectSidebar` → `CnFilesTab`
+- NO custom file upload components, file controllers, or download handlers
+
+**Audit & Compliance** (use AuditTrailService + CnObjectSidebar):
+- Full change tracking with before/after snapshots — automatic
+- Audit trail tab — `CnObjectSidebar` → `CnAuditTrailTab`
+- GDPR data subject access requests — `inzageverzoek()`, `verwerkingsregister()`
+- Audit export and analytics — `AuditTrailController`
+- NO custom audit logging, change tracking, or compliance controllers
+
+**Dashboard & Analytics** (use CnDashboardPage + CnChartWidget + CnStatsBlock):
+- Drag-drop widget dashboard — `CnDashboardPage` with GridStack
+- KPI cards — `CnKpiGrid`, `CnStatsBlock`, `CnStatsPanel`
+- Charts (line/bar/pie/donut) — `CnChartWidget` (ApexCharts)
+- Data tables as widgets — `CnTableWidget`
+- Editable data grids — `CnObjectDataWidget`
+- NO custom dashboard layouts, chart components, or KPI cards
+
+**Forms & Dialogs** (use CnFormDialog + schema-driven generation):
+- Auto-generated create/edit forms — `CnFormDialog` reads schema → generates fields
+- JSON/metadata editing — `CnAdvancedFormDialog` with Properties/Data/Metadata tabs
+- Schema editor — `CnSchemaFormDialog`
+- Delete/Copy/Mass operations — `CnDeleteDialog`, `CnCopyDialog`, `CnMassDeleteDialog`
+- NO custom form components, validation logic, or dialog wrappers
+
+**Navigation & Pagination** (use CnPagination + CnActionsBar + useListView):
+- Pagination control with size selector — `CnPagination`
+- Action bar (add, search, toggle views) — `CnActionsBar`
+- List state management — `useListView` composable (handles search, filter, sort, page)
+- Detail state management — `useDetailView` composable
+- NO custom pagination logic, debounced search, or list state management
+
+**Authorization & RBAC** (use AuthorizationService + PropertyRbacHandler):
+- Role-based access control — `AuthorizationService`
+- Field-level permissions — `PropertyRbacHandler`
+- Object-level restrictions — `PermissionHandler`
+- Authorization audit — `AuthorizationAuditService`
+- NO custom permission checks, role systems, or access control middleware
+
+**Webhooks & Events** (use WebhookService):
+- Create, test, retry webhooks — `WebhookService`
+- CloudEvents format — automatic
+- Event subscriptions — selective per schema/action
+- NO custom webhook controllers or event dispatchers
+
+**Notifications & Activity** (use NotificationService + ActivityService):
+- Nextcloud notifications — `NotificationService`
+- Activity feed — `ActivityService`
+- Calendar events — `CalendarEventService`
+- Deck/Kanban cards — `DeckCardService`
+
+**Store & State** (use createObjectStore + plugins):
+- Object stores — `createObjectStore(name)` generates Pinia CRUD store
+- Store plugins: `auditTrails`, `files`, `lifecycle`, `relations`, `search`, `selection`
+- Column/field/filter generation from schema — `columnsFromSchema()`, `fieldsFromSchema()`
+- NO custom Pinia stores for CRUD, Vuex, or manual API call management
+
+**Chat & AI** (use ChatService):
+- Multi-turn conversation — `ChatService`
+- RAG-based knowledge retrieval — `ContextRetrievalHandler`
+- LLM response generation — `ResponseGenerationHandler`
+
+**Data Retention & Archival** (use ArchivalService):
+- Legal hold — `LegalHoldService`
+- Destruction schedules — `DestructionService`
+- Retention policies — `RetentionService`
+
+**Semantic & Hybrid Search** (use SolrController + SettingsController):
+- Semantic search via vector embeddings — `SettingsController.semanticSearch()`
+- Hybrid search (keyword + semantic combined) — `SolrController.hybridSearch()`
+- Vector embedding generation — `VectorizationService`
+- NO custom search algorithms — configure via OpenRegister settings
+
+**GraphQL API** (use GraphQLController):
+- Query objects across schemas via GraphQL — `GraphQLController.execute()`
+- Alternative to REST for complex cross-entity queries
+
+**Organization / Multi-Tenancy** (use OrganisationController):
+- Organization CRUD — `OrganisationController`
+- Tenant-scoped data isolation — automatic via `TenantLifecycleService`
+- NO custom multi-tenancy logic
+
+**Task & Workflow Management** (use TasksController + WorkflowEngineController):
+- Task creation and tracking — `TasksController`
+- Workflow orchestration — `WorkflowEngineRegistry`
+- Scheduled workflows — `ScheduledWorkflowController`
+- NO custom task/workflow systems
+
+**Text Extraction** (use FileTextController):
+- Extract text from PDFs and Office docs — `TextExtractionService`
+- Entity recognition (PII detection) — `EntityRecognitionHandler`
+- Content anonymization — automatic
+
+**Timeline & Stages** (use CnTimelineStages):
+- Workflow progression visualization — `CnTimelineStages` component
+- Stage tracking with status colors
+
+### What apps SHOULD build (custom business logic only):
+- External API integrations (SAP, Peppol, TenderNed, etc.)
+- PDF/document generation with business-specific templates
+- Workflow triggers and business rules specific to the domain
+- Notification dispatch with app-specific event types
+- Custom settings pages with app-specific configuration
+- Background jobs for domain-specific processing
+
+### ADR-002-api
+- URL pattern: `/index.php/apps/{app}/api/{resource}` — lowercase plural, hyphens.
+- Methods: GET=read, POST=create, PUT=update, DELETE=remove. No custom methods.
+- Pagination: support `_page` + `_limit`. Response includes `total`, `page`, `pages`.
+- Errors: appropriate HTTP status + `message` field. NO stack traces in responses.
+- Auth: Nextcloud built-in only. NO custom login/session/token flows.
+- Public endpoints: annotate `#[PublicPage]` + `#[NoCSRFRequired]`. Register CORS OPTIONS route.
+
+### ADR-003-backend
+- **Controller → Service → Mapper** (strict 3-layer). Controllers NEVER call mappers directly.
+- Controllers: thin (<10 lines/method). Routing + validation + response only.
+- Services: ALL business logic. Stateless — no instance state between requests.
+- Mappers: DB CRUD only. No business logic.
+- DI: constructor injection with `private readonly`. NO `\OC::$server` or static locators.
+- Entity setters: POSITIONAL args only. `$e->setName('val')` — NEVER `$e->setName(name: 'val')`.
+  (`__call` passes `['name' => val]` but `setter()` uses `$args[0]`.)
+- Routes: `appinfo/routes.php`. Specific routes BEFORE wildcard `{slug}` routes.
+- Config: `IAppConfig` with sensitive flag for secrets. NEVER read DB directly.
+- Lifecycle: schema init via repair steps (`IRepairStep`), background via job queue, events via dispatcher.
+- **Spec traceability**: every class and public method MUST have `@spec` PHPDoc tag(s) linking to
+  the OpenSpec change that caused it: `@spec openspec/changes/{name}/tasks.md#task-N`.
+  Multiple `@spec` tags allowed (code touched by multiple changes). File-level `@spec` in header docblock.
+  This enables: code → docblock → spec traceability alongside code → git blame → commit → issue → spec.
+
+### ADR-004-frontend
+- **Vue 2 + Pinia + @nextcloud/vue + @conduction/nextcloud-vue**. NO Vuex. Options API only.
+- State: Pinia stores in `src/store/modules/`. Use `createObjectStore` for OpenRegister CRUD.
+- API calls: `axios` from `@nextcloud/axios` — auto-attaches CSRF token. NEVER raw `fetch()` for mutations.
+  Loading state with `try/finally`.
+- Translations: ALL user-visible strings via `t(appName, 'text')`. NO hardcoded strings.
+  Translation keys MUST be English — Dutch translations go in `l10n/nl.json`.
+- CSS: ONLY Nextcloud CSS variables (`var(--color-primary-element)`, etc.). NO hardcoded colors.
+  NEVER reference `--nldesign-*` directly — nldesign app handles theming.
+- Router: history mode, base `generateUrl('/apps/{app}/')`. Requires matching PHP routes in `routes.php`.
+  Deep link URL templates MUST match the router mode — use path format (`/apps/{app}/entities/{uuid}`),
+  NOT hash format (`/apps/{app}/#/entities/{uuid}`).
+- OpenRegister dependency: settings returns `openRegisters` (bool) + `isAdmin`.
+  Show empty state if OR missing. NEVER use `OC.isAdmin` — get from backend.
+- NEVER `window.confirm()` or `window.alert()` — use `NcDialog` or `CnFormDialog` (WCAG, theming).
+- NEVER read app state from DOM (`document.getElementById`, `dataset`) — use backend API or store.
+- EVERY `await store.action()` call MUST be wrapped in `try/catch` with user-facing error feedback.
+- NEVER import from `@nextcloud/vue` directly — use `@conduction/nextcloud-vue` which re-exports all
+  NC components plus Conduction components. This ensures consistent theming and component versions.
+- EVERY component used in `<template>` MUST be imported AND registered in `components: {}`.
+  Vue 2 silently renders unknown elements — missing imports cause invisible runtime failures.
+
+### NL Design System
+
+- ALL UI components MUST use CSS custom properties from NL Design System tokens.
+- MUST support theme switching via nldesign app's token sets.
+- MUST meet WCAG AA compliance: keyboard-navigable, associated labels, color is not the sole
+  method of conveying information.
+- SHOULD work on 320px–1920px viewports; critical functionality MUST work at 768px (tablet).
+- Exceptions: PDF generation (docudesk), admin-only screens (simpler styling allowed).
+
+### @conduction/nextcloud-vue — ALWAYS check before building custom
+
+**Pages & Layout:**
+  `CnIndexPage` (schema-driven list+CRUD) | `CnDetailPage` (detail+sidebar) |
+  `CnPageHeader` (title+icon) | `CnActionsBar` (add+search+toggle)
+
+**Data Display:**
+  `CnDataTable` (sortable+paginated) | `CnCardGrid` + `CnObjectCard` (card views) |
+  `CnDetailGrid` (label-value pairs) | `CnFilterBar` (search+filters) |
+  `CnFacetSidebar` (faceted filters) | `CnPagination` | `CnCellRenderer` (type-aware)
+
+**Forms & Dialogs:**
+  `CnFormDialog` (schema-driven create/edit) | `CnAdvancedFormDialog` (properties+JSON+metadata) |
+  `CnSchemaFormDialog` (JSON Schema editor) | `CnTabbedFormDialog` (tabbed form framework) |
+  `CnDeleteDialog` | `CnCopyDialog`
+
+**Mass Actions:**
+  `CnMassDeleteDialog` | `CnMassCopyDialog` | `CnMassExportDialog` (CSV/JSON/XML) |
+  `CnMassImportDialog` (upload+summary) | `CnMassActionBar` (floating selection bar)
+
+**Dashboard & Widgets:**
+  `CnDashboardPage` (GridStack drag-drop layout) | `CnDashboardGrid` (layout engine) |
+  `CnWidgetWrapper` (widget shell) | `CnWidgetRenderer` (NC Dashboard API v1/v2) |
+  `CnChartWidget` (ApexCharts: area/line/bar/pie/donut/radial) |
+  `CnTableWidget` (data table widget) | `CnTileWidget` (quick-access tile) |
+  `CnInfoWidget` (label-value grid) | `CnKpiGrid` (responsive KPI layout) |
+  `CnStatsBlock` (metric card) | `CnStatsPanel` (stats sections) | `CnProgressBar` |
+  `CnObjectDataWidget` (schema-driven editable data grid, inline edit + save via objectStore) |
+  `CnObjectMetadataWidget` (read-only object metadata display)
+
+**UI Elements:**
+  `CnStatusBadge` | `CnEmptyState` | `CnIcon` (MDI) | `CnCard` | `CnDetailCard` |
+  `CnRowActions` | `CnTimelineStages` (workflow progression) |
+  `CnUserActionMenu` (user context menu) | `CnJsonViewer` (CodeMirror)
+
+**Detail Sidebar:**
+  `CnObjectSidebar` (Files/Notes/Tags/Tasks/Audit tabs) | `CnIndexSidebar` |
+  `CnNotesCard` (inline notes) | `CnTasksCard` (inline tasks)
+
+**Settings:**
+  `CnSettingsSection` + `CnVersionInfoCard` (MUST be first on admin pages) |
+  `CnSettingsCard` | `CnConfigurationCard` | `CnRegisterMapping`
+  User settings: `NcAppSettingsDialog` (NOT `NcDialog`)
+
+**Composables:**
+  `useListView` (search/filter/sort/pagination) | `useDetailView` (load/edit/delete) |
+  `useSubResource` (related items) | `useDashboardView` (widgets/layout/edit)
+
+**Store Plugins:**
+  `auditTrailsPlugin` | `relationsPlugin` | `filesPlugin` | `lifecyclePlugin` |
+  `selectionPlugin` | `searchPlugin` | `registerMappingPlugin`
+
+**Utilities:**
+  `columnsFromSchema()` | `filtersFromSchema()` | `fieldsFromSchema()` |
+  `formatValue()` | `buildHeaders()` | `buildQueryString()`
+
+### Page Construction Patterns (follow these recipes)
+
+**App.vue:** `NcContent` → 3 states: loading (`NcLoadingIcon`), no-OpenRegister (`NcEmptyContent`),
+  ready (`MainMenu` + `NcAppContent` + `router-view` + optional `CnIndexSidebar`).
+  Inject `sidebarState` for child components. `created()` calls `initializeStores()`.
+
+**MainMenu:** `NcAppNavigation` with `NcAppNavigationItem` per route (icon + name + `:to`).
+  Footer: `NcAppNavigationSettings` (gear foldout) with admin/config nav items.
+  Settings item emits `@click="$emit('open-settings')"` — opens `NcAppSettingsDialog` modal.
+  Do NOT route to `/settings` — in-app settings is a modal overlay, not a page.
+
+**Dashboard:** `CnDashboardPage` with `CnStatsBlock` KPIs (4 cards: open/overdue/value/completed),
+  status distribution chart, "My Work" list (grouped: overdue → due this week → rest).
+  Fetch all collections in parallel via `Promise.all`. Widget templates via `#widget-{id}` slots.
+
+**Index page:** `CnIndexPage` with `useListView(entityType, { sidebarState, objectStore })`.
+  Inject sidebarState. Row click → `$router.push({ name: 'EntityDetail', params: { id } })`.
+  Add button → new entity detail with id='new'.
+
+**Detail page:** Two modes — edit (form component) / view (`CnDetailPage` + `CnDetailCard` sections).
+  Header actions: Edit + Delete buttons. Related entities in table inside `CnDetailCard`.
+  Props: `entityId` from route. `isNew = entityId === 'new'`. Sidebar via `CnObjectSidebar`.
+  **Relations:** Every entity referenced in the spec MUST have a `CnDetailCard` section.
+  Use `fetchUsed` for reverse lookups (find objects that reference THIS entity) and
+  `fetchUses` for forward lookups (find objects THIS entity references).
+  If the spec lists a "linked X section", it MUST be implemented — not deferred or stubbed.
+
+**Settings — two surfaces, never a route:**
+  *Admin settings* (`/settings/admin/{appid}`): `AdminRoot.vue` rendered by `settings.js` entry point,
+  registered via `AdminSettings.php`. Layout: `CnVersionInfoCard` (FIRST) → `CnRegisterMapping` →
+  `CnSettingsSection` per feature. Load via `GET /api/settings`, save via `POST /api/settings`.
+  *In-app settings*: `UserSettings.vue` wrapping `NcAppSettingsDialog` — opened as a modal from the
+  gear menu (`@open-settings` event on MainMenu), handled in `App.vue` with `:open` / `@update:open`.
+  Do NOT create a `/settings` route. Do NOT create a standalone `SettingsView.vue` page component.
+
+**Router:** Flat routes (no nesting), all named, props via arrow function for params.
+  Routes: `/` (Dashboard), `/{entities}` (list), `/{entities}/:id` (detail).
+  No `/settings` route — settings is a modal (see Settings section above).
+
+**Store init:** `initializeStores()` in `store/store.js` — fetches settings, then calls
+  `objectStore.registerObjectType(name, schemaSlug, registerSlug)` for each entity.
+  Object store uses `createObjectStore` with plugins (files, auditTrails, relations).
+  Settings store: Pinia `defineStore` with `fetchSettings()` and `saveSettings()`.
+
+### ADR-005-security
+- Auth: Nextcloud built-in ONLY. NO custom login, sessions, tokens, password storage.
+- Admin check: `IGroupManager::isAdmin()` on BACKEND. Frontend-only checks = vulnerability.
+- Per-object authorization (IDOR prevention): every mutation endpoint that operates on a specific
+  object MUST check that the authenticated user owns, is in the group of, or is admin for THAT
+  object — not just that they are logged in. `#[NoAdminRequired]` opens the endpoint to all users;
+  without a per-object check, any user can modify any object by guessing its ID.
+  Pattern: fetch object → extract `assigneeUserId`/`assigneeGroupId`/`createdBy` → check
+  (owner OR in group OR admin) → throw `OCSForbiddenException` if none apply. Extract into a
+  reusable `authorizeXxx(object, user)` service method, called from every PUT/POST/DELETE.
+- Multi-tenant isolation: enforce at API/service level, not UI only.
+- NO PII in logs, error responses, or debug output.
+- Audit trails: use `$user->getUID()` — NEVER `$user->getDisplayName()` (mutable, spoofable).
+- Identity: always derive from `IUserSession` on backend — NEVER trust frontend-sent user IDs or display names.
+- Nextcloud endpoint defaults: NO annotation = admin-only. Non-admin endpoints (agent/staff actions)
+  MUST have `#[NoAdminRequired]` attribute. Pair every `#[NoAdminRequired]` with a per-object auth
+  check — never trust the session alone for mutation.
+- **Auth attribute must match the method's actual requirement** (semantic consistency, not just
+  syntactic presence — observed 2026-04-23 on decidesk#44 where the builder satisfied the route-
+  auth gate by adding `#[NoAdminRequired]` to a method whose body calls `requireAdmin()`):
+  - `#[PublicPage]` — genuinely public; body MUST NOT call `requireAdmin()`, `isAdmin()`, or
+    return `Http::STATUS_UNAUTHORIZED/FORBIDDEN` conditionally. Use for login pages, OAuth
+    callbacks, public manifests.
+  - `#[NoAdminRequired]` — any authenticated user allowed; body MUST carry a per-object auth
+    check (ADR-005 Rule 3 / `hydra-gate-no-admin-idor`). Body MUST NOT call `requireAdmin()` —
+    that semantics belongs on `#[AuthorizedAdminSetting]` instead.
+  - `#[AuthorizedAdminSetting(Application::APP_ID)]` — admin-only, framework-enforced at the
+    middleware layer. Preferred for methods that call `requireAdmin()` / `isAdmin()` in body;
+    lifts the check out of the controller into the routing table where it is declarative
+    and grep-able.
+  - No annotation — admin-only by Nextcloud default; prefer the explicit
+    `#[AuthorizedAdminSetting]` for clarity.
+  Enforcement: `hydra-gate-semantic-auth` (gate-9) catches common mismatches (`NoAdminRequired`
+  + `requireAdmin()` body, `PublicPage` + body auth check). Gate-5 remains syntactic-only
+  (attribute present); gate-9 is the semantic layer.
+- Input validation: all user-supplied strings that flow into URLs (query params, path segments)
+  MUST be URL-encoded (`encodeURIComponent` in Vue/JS, `rawurlencode` in PHP). Email Message-IDs,
+  file names, and free-text fields commonly contain `<`, `>`, `/`, `@`, `&` which break unencoded.
+- File uploads: validate type + size before storage.
+- API responses: NO stack traces, SQL, or internal paths.
+- Error messages: use static, generic messages (`'Operation failed'`, `'Not authorized'`) — NEVER
+  return `$e->getMessage()` to clients. Log the real error server-side with `$this->logger->error()`.
+- Test collections: NEVER commit default credentials — use env variable placeholders.
+
+### ADR-006-metrics
+- Every app: `GET /api/metrics` (Prometheus text, admin auth) + `GET /api/health` (JSON, public).
+- Metric names: `{app}_` prefix. MUST include `{app}_health_status` and `{app}_info`.
+- Health check MUST verify OpenRegister connectivity (for apps that depend on it).
+
+### ADR-007-i18n
+# ADR-007: Internationalization (i18n)
+
+## Status
+Accepted
+
+## Context
+All Conduction Nextcloud apps serve Dutch government users but must support multiple languages. We need a consistent approach to internationalization across all apps.
+
+## Decision
+
+### Primary Language: English
+- **English (en) is the source/primary language** for all code and translation keys.
+- All `t()` keys and `$this->l10n->t()` strings MUST be written in English.
+- `l10n/en.json` is the identity-mapped source file (key == value).
+- Hardcoded Dutch strings in code MUST be converted to English keys with Dutch translations in `nl.json`.
+
+### Sentence Case for All UI Strings
+- All translation keys and user-facing strings MUST use **sentence case**: only the first word is capitalized.
+- Correct: `"Add directory"`, `"No results found"`, `"Delete selected"`, `"Save configuration"`
+- Wrong (title case): `"Add Directory"`, `"No Results Found"`, `"Delete Selected"`
+- Wrong (all lowercase): `"add directory"`, `"no results found"`
+- **Exceptions** that keep their capitalization:
+  - Proper nouns and product names: `"OpenRegister"`, `"Nextcloud"`, `"GitHub"`, `"DocuDesk"`
+  - Acronyms: `"API"`, `"URL"`, `"PDF"`, `"SOLR"`, `"JSON"`, `"RBAC"`, `"OAS"`
+  - Single-word strings still start with a capital: `"Delete"`, `"Search"`, `"Save"`
+
+### Required Languages
+- Minimum: English (en) + Dutch (nl) translations.
+- `l10n/en.json` and `l10n/nl.json` MUST exist in every app with a UI.
+- Both files MUST contain exactly the same keys, with zero gaps.
+
+### Frontend Translation
+- JS: `t(appName, 'key')` for singular, `n(appName, 'singular', 'plural', count)` for plurals.
+- `Vue.mixin({ methods: { t, n } })` for Options API components.
+- `<script setup>` components MUST import `t` directly from `@nextcloud/l10n` (mixin does not apply).
+
+### Backend Translation
+- PHP: `$this->l10n->t('key')` for user-facing messages in JSONResponse.
+- Controllers returning user-facing messages MUST inject `OCP\IL10N`.
+- Log messages, internal exceptions, and database values are NOT translated.
+
+### API and Data
+- API field names: always English (language-neutral data layer).
+- Date/number formatting: respect user locale via Nextcloud core.
+- Each app with OpenRegister: define `register-i18n` spec listing translatable fields.
+
+### Shared Component Library (@conduction/nextcloud-vue)
+- The shared library does NOT translate internally — it accepts pre-translated strings via props.
+- Components have English defaults for all label/text props (e.g., `addLabel="Add"`, `cancelLabel="Cancel"`).
+- Consumer apps are responsible for passing `t()` results as prop values.
+- The library lists `@nextcloud/l10n` as a peer dependency, not a direct dependency.
+
+## Consequences
+- All apps maintain two translation files that must stay in sync.
+- Dutch strings used as translation keys (e.g., `t('app', 'Besluiten')`) are a violation — the English equivalent must be the key.
+- Title case in translation keys (e.g., `"Add Directory"`) is a violation — use sentence case (`"Add directory"`).
+- New features must include both `en.json` and `nl.json` entries before merging.
+
+### ADR-008-testing
+- Every new PHP service/controller → PHPUnit tests in `tests/Unit/` (≥3 methods).
+- Every new Vue component → test file (if test framework exists).
+- Every new API endpoint → Newman/Postman collection in `tests/integration/`.
+- Every spec scenario → browser test (GIVEN/WHEN/THEN verified via Playwright).
+- All tests MUST pass in `composer check:strict`.
+- Integration tests MUST cover error paths (403, 401, 400) — not just happy path (200).
+- Test collections: use env variable placeholders for credentials — NEVER hardcode defaults.
+
+### Smoke testing (before opening PR)
+
+After implementing, verify your code actually works — quality gates catch lint/types, not logic:
+
+1. Call each new API endpoint with `curl` — verify response shape and status code
+2. Test at least one error path per endpoint (missing param, wrong auth, invalid input)
+3. If the spec says a feature is deferred, verify it is NOT registered/enabled
+4. If tasks.md marks a task `[x]`, verify it is fully implemented — not a stub or TODO
+
+### Task completeness verification
+
+Before marking a task `[x]` in tasks.md or opening a PR:
+- Re-read every task in tasks.md
+- For each `[x]` task, verify the implementation exists AND works — not a placeholder
+- Stub components, empty relation sections, and TODO comments are NOT complete
+- If a task cannot be completed, leave it `[ ]` and explain in the PR description
+
+### ADR-009-docs
+- Every user-facing feature → docs in `docs/` with screenshots from running app.
+- English primary, Dutch recommended. Update docs when behavior changes.
+
+### ADR-010-nl-design
+- ALL UI: CSS custom properties from NL Design System tokens. NO hardcoded colors, fonts, spacing.
+- Theme switching: support `nldesign` app's token sets (Rijkshuisstijl, Utrecht, municipality-specific).
+- Components: `@nextcloud/vue` primary. Custom components styled via NL Design tokens only.
+- Scoped styles: ALL `<style>` blocks MUST use `scoped` attribute.
+- WCAG AA mandatory: keyboard-navigable, labelled forms, color not sole conveyor, alt text on images.
+- Responsive: work from 320px to 1920px. Critical features accessible at 768px.
+- Specs: reference token names ("primary action color") NOT hex values. Include a11y verification in ACs.
+- Exception: PDF generation (docudesk) may use fixed dimensions. Admin screens MAY simplify but MUST meet WCAG AA.
+
+### ADR-011-schema-standards
+- schema.org types/properties as primary vocabulary (`schema:Person`, `schema:Organization`, `schema:Event`).
+- Contact schemas: align with vCard properties (`fn`, `email`, `tel`, `adr`).
+- Dutch government fields: mapping layer translating between international standards and Dutch APIs (VNG, ZGW).
+- NO custom property names when schema.org equivalent exists.
+- Relations: OpenRegister relation mechanism (register + schema + objectId). NO foreign keys or embedded objects.
+- Versioning: removing/renaming properties = BREAKING → migration via repair step. Adding optional = non-breaking.
+- Specs MUST define data models using schema.org vocabulary; design docs MUST include schema definitions with types, required flags, relations.
+- Exception: app-specific workflow states (pipeline stages, process statuses) MAY use custom vocabularies.
+
+### ADR-012-deduplication
+- Before proposing new capability: search OpenRegister specs + services for overlap. Reference + justify if similar exists.
+- Design docs MUST include "Reuse Analysis" listing which OpenRegister services are leveraged.
+- If logic could benefit other apps → propose adding to OpenRegister core, not app-specific.
+- Tasks MUST include "Deduplication Check" verifying no overlap with:
+  ObjectService, RegisterService, SchemaService, ConfigurationService, shared specs, @conduction/nextcloud-vue.
+- Document findings even if "no overlap found".
+- Exception: OpenRegister checks internal duplication only. nldesign checks token sets. nextcloud-vue checks own components.
+
+### ADR-013-container-pool
+# ADR-013: Unified Container Pool
+
+**Status:** accepted
+**Date:** 2026-04-12
+
+## Context
+
+Specter (intelligence/research) and Hydra (build/review/merge) both run LLM workloads in Docker containers. Today they operate independently: Hydra spins up builder/reviewer/security containers on demand, Specter has a separate `run_llm_containers.sh` wrapper. Both compete for the same Claude Max rate limits.
+
+We want to unify these into a **single priority-scheduled container pool** so that:
+- Critical work (bugfixes, reviews) preempts lower-priority work (discovery, research)
+- A fixed number of containers (e.g. 10) run continuously, pulling from a shared queue
+- Token rotation and rate limit recovery happen at the pool level, not per-script
+- Adding a new workload type (audit, spec generation, test) is just a new queue entry
+
+## Decision
+
+### Container types (priority order)
+
+| Priority | Type | Source | Container image | Model | Fallback |
+|----------|------|--------|-----------------|-------|----------|
+| 1 | **code-review** | Hydra: PR code review + in-container fixes | `hydra-reviewer` | sonnet | opus |
+| 2 | **security-review** | Hydra: PR security review + in-container fixes | `hydra-security` | sonnet | opus |
+| 3 | **applier** | Hydra: binary go/no-go gate (no fix authority) | `hydra-applier` | sonnet | opus |
+| 4 | **build** | Hydra: initial spec build | `hydra-builder` | haiku | — |
+| 5 | **audit** | Hydra: codebase audit | `hydra-builder` | sonnet | opus |
+| 6 | **spec-generation** | Specter: push_spec_pipeline | `specter-llm-worker` | sonnet | haiku |
+| 7 | **schema-synthesis** | Specter: generate/dedup schemas | `specter-llm-worker` | haiku | — |
+| 8 | **classification** | Specter: classify/redistribute features | `specter-llm-worker` | haiku | — |
+| 9 | **translation** | Specter: translate requirements | `specter-llm-worker` | haiku | — |
+| 10 | **discovery** | Specter: research, feature extraction | `specter-llm-worker` | haiku | — |
+
+**No-loop policy (openspec/changes/no-loop-review-pipeline):** Reviewers own fix
+authority. The Applier is a read-only final gate that emits a binary pass/fail
+verdict — it never modifies files. Every post-review outcome is terminal:
+merge (on `applier:pass` or reviews passed with zero fixes) or `needs-input`
+(on `applier:fail`, reviewer `agent-maxed-out`, or post-review deterministic
+check failure). There is no fix-iteration loop and no `bugfix` container.
+
+### Model strategy
+
+**Principle:** Use the cheapest model that can do the job. Reserve expensive models for judgment work.
+
+| Work type | Model | Rationale |
+|-----------|-------|-----------|
+| Build (implementation) | **Haiku** | Clear instructions (tasks.md, design.md). Pattern-following, not judgment. Faster and cheaper — 5 parallel Haiku builds burn far less quota than Sonnet. |
+| Fix-quality / fix-browser (pre-review) | **Haiku** | "Fix this PHPCS error" or "fix this browser test failure" — explicit, targeted corrections triggered by deterministic check output during the build phase. |
+| Code review (+ in-container fix authority) | **Sonnet → Opus** | Judgment + bounded fixes. Sonnet is the primary; falls back to Opus when Sonnet quota exhausted. Budget: 40 turns (up from 20) to cover review + self-verified fixes. |
+| Security review (+ in-container fix authority in PR mode) | **Sonnet → Opus** | Critical: injection vectors, auth bypasses, secret leaks. Same fallback logic. Budget: 40 turns in PR mode, 120 in full-audit mode (audit mode has no fix authority). |
+| Applier (Axel Pliér) | **Sonnet → Opus** | Final binary go/no-go. No fix tools. Reads hydra.json + PR state + ADRs, emits `{pass, blocking[]}`. Budget: 20 turns. |
+| Audit | **Sonnet → Opus** | Full codebase analysis — needs depth. |
+
+**Quota optimization:** Claude Max plans have separate "Sonnet only" and "all models" weekly limits. By defaulting builders to Haiku, the Sonnet quota is reserved for reviews only (~20 turns each, 2 per PR). When Sonnet runs out, reviews fall back to the **deeper** model (Opus), not the shallower one — because reviews are the last line of defense before human approval.
+
+**Overrides:** Set `HYDRA_BUILDER_MODEL`, `HYDRA_REVIEWER_MODEL`, or `HYDRA_REVIEWER_FALLBACK_MODEL` env vars to change defaults.
+
+### Architecture
+
+```
+┌─────────────────────────────────────────────────────┐
+│  Scheduler (cron or daemon)                         │
+│                                                     │
+│  reads: queue table (postgres)                      │
+│  writes: container assignments, status updates      │
+│                                                     │
+│  ┌──────────────────────────────────────────┐       │
+│  │ Pool: 10 container slots                 │       │
+│  │                                          │       │
+│  │  slot-1: [bugfix]     ← highest prio     │       │
+│  │  slot-2: [code-review]                   │       │
+│  │  slot-3: [build]                         │       │
+│  │  slot-4: [build]                         │       │
+│  │  slot-5: [classify]                      │       │
+│  │  slot-6: [classify]                      │       │
+│  │  slot-7: [translate]                     │       │
+│  │  slot-8: [discovery]                     │       │
+│  │  slot-9: [idle]       ← waiting for work │       │
+│  │  slot-10: [idle]                         │       │
+│  └──────────────────────────────────────────┘       │
+│                                                     │
+│  Token rotation: credentials.json (work → private)  │
+│  Rate limit: pool-level tracking per account        │
+│  Preemption: low-prio containers stopped when       │
+│              high-prio work arrives and pool is full │
+└─────────────────────────────────────────────────────┘
+```
+
+### Queue table (future)
+
+```sql
+CREATE TABLE container_queue (
+    id SERIAL PRIMARY KEY,
+    type VARCHAR(50) NOT NULL,        -- bugfix, code-review, build, classify, etc.
+    priority INTEGER NOT NULL,         -- 1=highest
+    payload JSONB NOT NULL,            -- script args, spec slug, issue URL, etc.
+    status VARCHAR(20) DEFAULT 'pending', -- pending, running, completed, failed
+    container_id VARCHAR(100),         -- docker container name when running
+    token_account VARCHAR(50),         -- which OAuth account is assigned
+    created_at TIMESTAMP DEFAULT NOW(),
+    started_at TIMESTAMP,
+    completed_at TIMESTAMP,
+    exit_code INTEGER,
+    error_message TEXT
+);
+```
+
+### Phased rollout
+
+**Phase 1 (now):** All LLM calls containerized. Specter scripts run via `run_llm_containers.sh`. Hydra containers use `run_container_with_fallback`. Both read from `credentials.json`. No shared queue yet — each system schedules its own containers.
+
+**Phase 2:** Shared queue table. A single scheduler script replaces both `cron-hydra.sh` dispatch and `run_llm_containers.sh`. Pool size configurable. Priority enforcement by not starting low-prio work when high-prio is queued.
+
+**Phase 3:** Preemption. Running low-priority containers can be stopped (gracefully, with checkpoint) when high-priority work arrives and all slots are occupied. Container images support checkpoint/resume via DB state.
+
+### Current state (Phase 1)
+
+**Container images:**
+
+| Image | Size | Purpose |
+|-------|------|---------|
+| `conduction/nextcloud-test:stable31` | 1.5GB | Prebuild NC server + PostgreSQL + OpenRegister (cloned) |
+| `hydra-builder:latest` | 1.9GB | Code implementation: NC test env + Claude CLI + PHP + skills |
+| `hydra-reviewer:latest` | 1.3GB | Code review + bounded in-container fix authority (Juan Claude van Damme) |
+| `hydra-security:latest` | 1.9GB | Security review + bounded in-container fix authority (Clyde Barcode) |
+| `hydra-applier:latest` | 1.0GB | Binary go/no-go gate; no Write/Edit tools (Axel Pliér) |
+| `specter-spec-writer:latest` | ~800MB | Spec generation: Claude CLI + openspec CLI + skills (no PHP) |
+| `specter-llm-worker:latest` | ~500MB | Intelligence pipeline: Claude CLI + DB access |
+
+**Credential separation:**
+- **Specter:** `concurrentie-analyse/secrets/credentials.json` (work + private tokens)
+- **Hydra:** `hydra/secrets/credentials.json` (work token only)
+
+**Token detection:**
+- Container mode: uses exit code (0 = success, non-zero checks output for rate limit)
+- Local mode: checks output text for "rate limit" / "auth failed" strings
+
+**NC test environment:**
+- Prebuild image with PostgreSQL (matches production, not SQLite)
+- Builder `COPY --from=conduction/nextcloud-test` at build time
+- Entrypoint starts PG + enables OpenRegister at runtime
+- Each container gets its own isolated NC+PG instance
+
+**Spec generation flow:**
+- `push_spec_pipeline.py` prepares repos in parallel, generates in `specter-spec-writer` containers
+- Each spec gets its own container + clone (compartmentalized)
+- Dependency tiers control ordering: Phase 1 → Phase 2 → Phase 3 → Phase 4
+- Specs with met deps push to development directly (doc-only merge guard)
+- Issues created with `yolo` label → Hydra auto-builds, reviews, merges, closes issue
+
+### Container capability profiles
+
+Each container persona runs with a different Linux capability set determined by the trust we extend to it. This is load-bearing for runtime behaviour — a container's `/workspace` is ONLY writable by the claude user if the build or the entrypoint arranges it, and the two code paths diverge based on cap profile.
+
+| Persona | Caps added | Claude user | Workspace setup |
+|---------|-----------|-------------|-----------------|
+| Builder | SETUID, SETGID, DAC_OVERRIDE, CHOWN, FOWNER | Dropped via `gosu` at run time | Entrypoint chowns at start, relies on DAC_OVERRIDE |
+| Reviewer | SETUID, SETGID, DAC_OVERRIDE, CHOWN, FOWNER | Same as builder | Same — entrypoint chown |
+| Security | SETUID, SETGID, DAC_OVERRIDE, CHOWN, FOWNER | Same | Same |
+| **Applier** | **None** (minimum-cap — read-only judge) | **Runs as `claude:claude` via `docker --user`** (no gosu drop possible — can't setuid without SETUID) | **Must be pre-chowned at IMAGE BUILD TIME** — no runtime chown possible |
+
+**The applier's minimum-cap profile has a hard consequence:** its Dockerfile MUST contain
+```dockerfile
+RUN mkdir -p /workspace && chown claude:claude /workspace && chmod 0775 /workspace
+```
+before the `WORKDIR /workspace` directive. Otherwise the non-root claude user cannot write files into its own workdir, `hydra_prefetch_pr_context` silently fails every redirect, Claude runs 0 turns, and the orchestrator records `pass=null, turns=0 → applier:fail`. Observed on decidesk#44 2026-04-23 06:01 UTC — looked like a harness bug, real cause was one missing `chown` line in the Dockerfile.
+
+This is **the rule for any future minimum-cap persona**: if you drop DAC_OVERRIDE + SETUID for security reasons, the Dockerfile owns workspace ownership — the entrypoint cannot.
+
+## Consequences
+
+- All LLM calls go through containers — no direct `claude -p` from host scripts
+- Token management is centralized per system (Specter has private fallback, Hydra doesn't)
+- Container exit code determines token rotation (not mid-session JSONL text)
+- Prebuild NC image eliminates 30-60s clone overhead per builder container
+- Container images are the unit of deployment — version, test, rollback independently
+- ADR-000 convention: every repo's data model is at `openspec/architecture/adr-000-data-model.md`
+- `context-brief.md` in each change directory carries intelligence data through the full pipeline
+- Minimum-cap containers (applier) require Dockerfile-time workspace chown; higher-cap containers can chown at runtime. This split is permanent — don't ship a new minimum-cap persona without pre-chowning.
+
+### ADR-014-licensing
+- Licence: EUPL-1.2 (European Union Public Licence).
+- `appinfo/info.xml`: MUST use `<licence>agpl</licence>` — Nextcloud app store does not recognise EUPL.
+- This is intentional dual-tagging, NOT a conflict. Do NOT change info.xml to eupl. Do NOT flag as review finding.
+
+## PHP files — PHPDoc tags only
+
+License and copyright metadata on PHP files lives **only** in the main file docblock as PHPDoc tags:
+
+```php
+<?php
+
+/**
+ * Short Description
+ *
+ * Longer description.
+ *
+ * @category Controller
+ * @package  OCA\{AppName}\Controller
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://conduction.nl
+ *
+ * @spec openspec/changes/{change-name}/tasks.md#task-N
+ */
+
+declare(strict_types=1);
+```
+
+**Required tags on every PHP file:** `@author`, `@copyright`, `@license`, `@link`, `@spec`. File-level `@spec` links back to the OpenSpec change that created or last modified the file (ADR-003). Classes and public methods also carry their own `@spec` tag.
+
+**Do NOT add:**
+- `SPDX-FileCopyrightText: ...` lines in the docblock — that duplicates `@copyright`.
+- `SPDX-License-Identifier: ...` lines in the docblock — that duplicates `@license`.
+- `// SPDX-*` line comments before or after the docblock.
+
+## Vue / JS / CSS files
+
+These file types don't carry PHPDoc. Use SPDX header as the first line:
+
+- Vue: `<!-- SPDX-License-Identifier: EUPL-1.2 -->`
+- JS / TS: `// SPDX-License-Identifier: EUPL-1.2`
+- CSS / SCSS: `/* SPDX-License-Identifier: EUPL-1.2 */`
+
+## Repo-level REUSE compliance
+
+Every app repo SHOULD carry a `REUSE.toml` at its root declaring license + copyright for every file pattern. This is the authoritative source for REUSE compliance — `reuse lint` reads it instead of requiring per-file SPDX headers for PHP files:
+
+```toml
+version = 1
+
+[[annotations]]
+path = "**/*.php"
+SPDX-FileCopyrightText = "2026 Conduction B.V. <info@conduction.nl>"
+SPDX-License-Identifier = "EUPL-1.2"
+```
+
+## Hydra quality gate
+
+`scripts/run-quality.sh`'s `spdx-headers` gate enforces: every `lib/**/*.php` file has both `@license` and `@copyright` PHPDoc tags. Missing either fails the gate.
+
+### ADR-015-common-patterns
+- Common Conduction patterns. These apply to ALL apps. Every item below was found 3+ times
+  across multiple code reviews. Get these right during implementation — not after review.
+- When fixing any pattern violation, ALWAYS generalize: grep for the same issue across ALL
+  files and fix every instance in one pass. Fixing one file while leaving the same issue in
+  nine others guarantees another review round.
+
+### OpenRegister ObjectService API
+- `findObject($register, $schema, $id)` — 3 positional args, register first
+- `findObjects($register, $schema, $params)` — 3 positional args, $params is filter array
+- `saveObject($register, $schema, $object)` — 3 positional args, $object is array
+- NEVER `getObject($id)` or `saveObject($data)` — those 1-arg signatures do not exist
+- When unsure, check the OpenRegister source or existing app code
+
+### Store registration (Vue/Pinia)
+- Register each entity type ONCE in `src/store/store.js` via `createObjectStore`
+- NEVER register in both `OBJECT_TYPES` and `ENTITY_STORES` — pick one pattern
+- Type names: kebab-case (`action-item`), NOT camelCase (`actionItem`)
+- Use platform `createObjectStore` — do NOT build custom stores (hand-rolled object.js)
+
+### Authorization enforcement
+- ALL mutation endpoints MUST have `IGroupManager::isAdmin()` check on backend
+- Settings endpoints: `#[AuthorizedAdminSetting]` or `@RequireAdmin` annotation
+- NEVER rely on frontend-only auth — always enforce on backend
+- User identity: derive from `IUserSession` — NEVER trust frontend-sent user IDs
+- Null dependency checks: throw 503, do NOT silently return empty response
+
+### Error responses
+- NEVER return `$e->getMessage()` to API — use static, generic error messages
+- Pattern: `catch (\Throwable $e) { return new JSONResponse(['message' => 'Operation failed'], 500); }`
+- Log the real error: `$this->logger->error('Context', ['exception' => $e]);`
+- Frontend: EVERY `await store.action()` MUST be in `try/catch` with user feedback
+
+### API calls & CSRF
+- Use `axios` from `@nextcloud/axios` for ALL API calls — it auto-attaches the CSRF token
+- NEVER use raw `fetch()` for mutations — missing requesttoken causes silent 403 failures
+- Pattern: `import axios from '@nextcloud/axios'` + `const { data } = await axios.post(url, payload)`
+
+### Vue component imports
+- NEVER import from `@nextcloud/vue` directly — use `@conduction/nextcloud-vue` which re-exports everything
+- EVERY component used in `<template>` MUST be imported AND listed in `components: {}`
+- Vue 2 silently renders unknown elements — a missing import = invisible runtime failure
+- Pre-commit check: for every `<NcFoo>` or `<CnFoo>` in template, verify the import exists
+
+### SPDX headers (see also ADR-014)
+- EVERY new file needs an SPDX header — apply to ALL new files in one pass
+- PHP: `// SPDX-License-Identifier: EUPL-1.2` after `<?php`
+- Vue: `<!-- SPDX-License-Identifier: EUPL-1.2 -->` as first line
+- JS: `// SPDX-License-Identifier: EUPL-1.2` as first line
+
+### Dependency management
+- When importing from a package, verify it exists in `package.json` before committing
+- `@nextcloud/auth` for `getRequestToken()` — add to dependencies if missing
+- Run `npm ci && npm run lint` to catch `n/no-extraneous-import` BEFORE pushing
+
+### Translations (i18n)
+- ALL user-visible strings: `this.t('appid', 'text')` in Vue, `$this->l->t('text')` in PHP
+- NEVER hardcode Dutch or English strings in templates, CSV headers, or notifications
+- NEVER bare `t()` in Vue — always `this.t()` (Options API)
+
+### Data patterns
+- Relations: verify `fetchUsed` vs `fetchUses` direction — wrong direction = empty cards
+- Lifecycle: use the service's `transitionLifecycle()` — NEVER `saveObject()` directly for status
+- Pagination: `_limit: 999` silently undercounts — use proper pagination or document the cap
+
+### Nextcloud UI patterns
+- NEVER `window.confirm()` or `window.alert()` — use `NcDialog` or `CnFormDialog`
+- NEVER read app state from DOM (`document.getElementById`, `dataset`) — use backend API
+- Audit trails: use `$user->getUID()` — NEVER `$user->getDisplayName()` (mutable, spoofable)
+- Deferred features: if spec says "defer to phase N", do NOT register/enable them in info.xml or anywhere else
+- Router: history mode with `generateUrl` base (see ADR-004). Deep link URLs must use path format, NOT hash format.
+- Relations: `fetchUsed` = reverse lookup (who references me), `fetchUses` = forward lookup (what do I reference)
+- Detail views: every spec-required "linked X section" MUST have a `CnDetailCard` — never stub or omit
+
+### Pre-commit verification (run before EVERY commit)
+
+Before committing, verify your code against these patterns:
+
+1. **SPDX headers**: `grep -rL 'SPDX-License-Identifier' src/ lib/ --include='*.php' --include='*.vue' --include='*.js'`
+   → Add headers to EVERY file missing one — all of them, not just one.
+2. **ObjectService calls**: `grep -rn 'findObject\|saveObject\|findObjects' lib/ --include='*.php'`
+   → Verify every call has 3 positional args: `($register, $schema, $idOrParams)`
+3. **Error responses**: `grep -rn 'getMessage()' lib/Controller/ --include='*.php'`
+   → Replace any `$e->getMessage()` in JSONResponse with a static error string
+4. **Auth checks**: For every POST/PUT/DELETE controller method, verify `IGroupManager::isAdmin()` is called
+5. **Store registration**: `grep -rn 'registerObjectType\|OBJECT_TYPES\|ENTITY_STORES' src/`
+   → Verify each entity registered exactly once, kebab-case names
+6. **Dependencies**: `npm run lint` — catches missing package.json entries
+7. **Translations**: `grep -rn "'" src/ --include='*.vue' | grep -v "this\.t\|import\|//\|console"` — scan for hardcoded strings
+8. **try/catch**: `grep -rn 'await.*Store\.' src/ --include='*.vue'` — verify every store call is wrapped
+9. **No raw fetch**: `grep -rn 'fetch(' src/ --include='*.vue' --include='*.js'` — must use `@nextcloud/axios`, not raw fetch (CSRF)
+10. **Import source**: `grep -rn "from '@nextcloud/vue'" src/` — must be zero matches. Use `@conduction/nextcloud-vue` instead.
+11. **Component imports**: for every `<NcFoo>` or `<CnFoo>` in templates, verify the component is imported AND in `components: {}`
+12. **Type slug consistency**: verify every entity type string across ALL files (store, search, routes, views) uses the same kebab-case slug — `grep -rn "agendaItem\|governanceBody\|actionItem" src/` should return zero matches
+13. **Translation keys**: `grep -rn "t('.*'," src/ --include='*.vue' --include='*.js'` — verify ALL t() keys are English, not Dutch. Dutch translations go in `l10n/nl.json`.
+14. **Route consistency**: verify every entity type referenced in search, navigation, or links has a matching named route in `src/router/`
+15. **Task completeness**: re-read tasks.md — every `[x]` task must be fully implemented, not a stub
+
+If ANY check fails, fix ALL instances (not just the first one) before committing.
+
+### ADR-016-routes
+- Routes: `appinfo/routes.php` is the ONLY registration path. NO runtime-registered routes, NO route
+  fragments in `info.xml`, NO bootstrapped route providers added from `Application::register()`.
+- `info.xml` is app metadata only (name, version, dependencies, categories, screenshots). It must
+  never carry `<route>` / `<navigation>` entries that map URLs to controllers.
+- Every route entry names `controller#method` explicitly — no wildcard auto-discovery, no regex
+  generators. Snake_case controller maps to CamelCase class: `meeting#public_state` →
+  `MeetingController::publicState()`. Lowering discoverability is the point: grepping `routes.php`
+  returns the full URL surface area of the app.
+- Admin settings pages: register the settings section via `\OCP\Settings\ISection` in
+  `Application::register()`, but the settings URL itself is a standard `appinfo/routes.php` entry
+  pointing at a controller method marked with `#[AuthorizedAdminSetting(Application::APP_ID)]`.
+- Public (unauthenticated) endpoints: declare `#[PublicPage]` + `#[NoCSRFRequired]` on the method,
+  and keep the route in `appinfo/routes.php` — do not invent a separate public-routes file.
+- Rationale: the mechanical gates (`hydra-gate-route-auth`) scan `appinfo/routes.php` only. Every
+  endpoint living there gets its auth attribute verified; an endpoint registered elsewhere
+  bypasses the gate and can ship to production without its middleware posture checked. One file,
+  one gate, no drift.
+- Gate layering: `hydra-gate-route-auth` (gate-5) is **syntactic** — it verifies the method
+  carries any of the four valid auth attributes (`#[PublicPage]` / `#[NoAdminRequired]` /
+  `#[NoCSRFRequired]` / `#[AuthorizedAdminSetting]`). It does NOT check that the chosen attribute
+  matches the method's actual requirement. The **semantic** layer is `hydra-gate-semantic-auth`
+  (gate-9) which enforces attribute-to-body consistency per ADR-005. Both gates must pass —
+  syntactic alone produces the "minimum-to-clear-the-gate" anti-pattern where a builder adds
+  the cheapest attribute (`#[NoAdminRequired]`) to a method whose body calls `requireAdmin()`
+  just to pass gate-5. See ADR-005 for the full attribute-to-body mapping.
+- Migration: any app with routes declared in `info.xml` or injected via `Application::boot()` must
+  move them to `appinfo/routes.php` before the next build — the gate treats such endpoints as
+  absent, and any related controller method without an auth attribute will surface as a FAIL.
+
+### ADR-017-component-composition
+# ADR-017: Component Composition Rules
+
+## Status
+Accepted
+
+## Date
+2026-04-14
+
+## Context
+
+Conduction apps share a Vue component library (`@conduction/nextcloud-vue`) that provides self-contained, higher-level components like `CnObjectDataWidget`, `CnStatsPanel`, `CnDetailPage`, and `CnTimelineStages`. These components internally render their own card wrappers (`CnDetailCard`), headers, and layout containers.
+
+Developers have been wrapping these self-contained components inside additional layout containers (e.g. `CnDetailCard` wrapping `CnObjectDataWidget`), producing a "card-in-card" visual artifact where headers and borders are doubled. This was found across Procest, Pipelinq, and earlier OpenCatalogi iterations.
+
+The same principle applies to `CnDetailPage` which renders its own `NcAppContent` wrapper — apps must not add another `NcAppContent` around it.
+
+## Decision
+
+### Self-contained components render their own container
+
+The following components are **self-contained** and MUST NOT be wrapped in `CnDetailCard`, `NcAppContent`, or other layout containers:
+
+| Component | Renders its own | Use directly inside |
+|---|---|---|
+| `CnObjectDataWidget` | `CnDetailCard` | `CnDetailPage` slot, `<div>`, or grid cell |
+| `CnObjectMetadataWidget` | `CnDetailCard` | `CnDetailPage` slot, `<div>`, or grid cell |
+| `CnStatsPanel` | Sections with headers | `CnDetailPage` slot or `<div>` |
+| `CnDetailPage` | `NcAppContent`-level layout | Directly in `<router-view>` |
+| `CnDashboardPage` | `NcAppContent`-level layout | Directly in `<router-view>` |
+| `CnIndexPage` | `NcAppContent`-level layout | Directly in `<router-view>` |
+| `CnTimelineStages` | Standalone timeline | Inside `CnDetailCard` or any container (no own card) |
+
+### How to identify self-contained components
+
+A component is self-contained if its template root is a card, panel, or page-level wrapper. Check the component source: if it starts with `<CnDetailCard>`, `<div class="cn-*-card">`, or similar, it manages its own container.
+
+### Correct patterns
+
+```vue
+<!-- CORRECT: CnObjectDataWidget renders its own card -->
+<CnObjectDataWidget
+  :schema="schema"
+  :object-data="data"
+  title="Case Information" />
+
+<!-- CORRECT: CnTimelineStages is NOT self-contained, wrap it -->
+<CnDetailCard :title="t('app', 'Status')">
+  <CnTimelineStages :stages="stages" :current-stage="current" />
+</CnDetailCard>
+```
+
+### Anti-patterns
+
+```vue
+<!-- WRONG: Double card wrapping -->
+<CnDetailCard :title="t('app', 'Case Information')">
+  <CnObjectDataWidget :schema="schema" :object-data="data" />
+</CnDetailCard>
+
+<!-- WRONG: Double page wrapping -->
+<NcAppContent>
+  <CnDetailPage :title="title">...</CnDetailPage>
+</NcAppContent>
+```
+
+### External sidebar pattern
+
+Components like `CnDetailPage` that support sidebars communicate with a parent-provided `objectSidebarState` via Vue's `provide`/`inject`. The sidebar component (`CnObjectSidebar`) MUST be rendered at the `NcContent` level in `App.vue`, NOT inside `NcAppContent`:
+
+```vue
+<!-- App.vue -->
+<NcContent app-name="myapp">
+  <MainMenu />
+  <NcAppContent>
+    <router-view />
+  </NcAppContent>
+  <CnObjectSidebar v-if="objectSidebarState.active" ... />
+</NcContent>
+```
+
+## Consequences
+
+- Developers must check if a shared component is self-contained before wrapping it
+- The component library documents which components are self-contained in their JSDoc headers
+- Code reviews should flag card-in-card nesting as a pattern violation
+- Existing violations should be fixed when encountered (per ADR-015 pre-existing issues rule)
+
+### ADR-018-widget-header-actions
+# ADR-018: Widget Header Actions Pattern
+
+## Status
+Accepted
+
+## Date
+2026-04-14
+
+## Context
+
+Card and widget components across Conduction apps need action controls (buttons, dropdowns, selects) for user interactions like changing status, adding items, or toggling views. Developers have been placing these controls inline with card content, taking up vertical space and creating inconsistent layouts.
+
+Nextcloud's own UI pattern places actions in the title bar (top-right) of panels and sidebars. Our shared component library should enforce this same pattern so all card/widget components have a consistent location for actions.
+
+## Decision
+
+### All card/widget components MUST support a `header-actions` slot
+
+Every component that renders a title bar or header MUST provide a `header-actions` slot positioned in the **top-right of the header**, inline with the title. This is the standard location for action controls.
+
+### Standard slot name: `header-actions`
+
+All components use the slot name `header-actions` for consistency. Components that previously used `actions` retain it for backwards compatibility but `header-actions` is the canonical name.
+
+### Component support status
+
+All card/widget components in `@conduction/nextcloud-vue` now support `header-actions`:
+
+| Component | Slot name | Notes |
+|---|---|---|
+| `CnDetailCard` | `header-actions` | Primary card component |
+| `CnWidgetWrapper` | `header-actions` | Dashboard widget container |
+| `CnObjectDataWidget` | `header-actions` | Passes through to CnDetailCard |
+| `CnObjectMetadataWidget` | `header-actions` | Passes through to CnDetailCard |
+| `CnStatsPanel` | `header-actions` | Added in this ADR |
+| `CnSettingsCard` | `header-actions` | Added in this ADR |
+| `CnConfigurationCard` | `header-actions` + `actions` (legacy) | `header-actions` added alongside existing `actions` |
+| `CnVersionInfoCard` | `header-actions` + `actions` (legacy) | `header-actions` added alongside existing `actions` |
+
+### What goes in header-actions
+
+- Status change dropdowns / selects
+- Add/create buttons
+- Toggle switches (e.g. edit mode)
+- Refresh buttons
+- Filter controls specific to this widget
+
+### What does NOT go in header-actions
+
+- Save/cancel for the entire page (those belong in `CnDetailPage` `#header-actions`)
+- Bulk action toolbars (those belong in `CnMassActionBar`)
+- Form inputs that are part of the data being edited
+
+### Usage pattern
+
+```vue
+<CnDetailCard :title="t('app', 'Status')">
+  <template #header-actions>
+    <NcSelect
+      v-model="selectedStatus"
+      :options="statusOptions"
+      :placeholder="t('app', 'Change status...')" />
+  </template>
+
+  <!-- Card content -->
+  <CnTimelineStages :stages="stages" :current-stage="current" />
+</CnDetailCard>
+```
+
+### New components
+
+When creating new card or widget components, the `header-actions` slot MUST be included from the start. The standard template pattern:
+
+```vue
+<div class="cn-my-widget__header">
+  <h4 class="cn-my-widget__title">{{ title }}</h4>
+  <div v-if="$slots['header-actions']" class="cn-my-widget__header-actions">
+    <slot name="header-actions" />
+  </div>
+</div>
+```
+
+With CSS:
+```css
+.cn-my-widget__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.cn-my-widget__header-actions {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  flex-shrink: 0;
+}
+```
+
+## Consequences
+
+- All existing card components now support `header-actions`
+- New components must include this slot from creation
+- Existing apps should migrate inline actions to `header-actions` when touching those files
+- Code reviews should flag action controls placed in card content as a pattern violation
+- The `actions` slot name in CnConfigurationCard and CnVersionInfoCard is deprecated but retained for backwards compatibility
+
+### ADR-019-integration-registry
+# ADR-019: Integration Registry Pattern
+
+## Status
+Proposed
+
+## Date
+2026-04-21
+
+## Context
+
+Conduction apps (OpenCatalogi, Procest, Pipelinq, MyDash, Decidesk, DocuDesk, ZaakAfhandelApp, Larpingapp, Softwarecatalog, OpenRegister itself) all consume the same set of "things linked to an object" — files, notes, tasks, calendar events, mail, contacts, deck cards, talk conversations, and an expanding catalogue of NC-ecosystem and external services.
+
+Until now this was implemented in two rigid places:
+
+- `OCA\OpenRegister\Service\LinkedEntityService::TYPE_COLUMN_MAP` — a hardcoded PHP constant naming the 8 supported NC entity types.
+- `@conduction/nextcloud-vue::CnObjectSidebar` — a Vue component with 5 hardcoded tabs and inline imports for each.
+
+Adding a new integration required modifying both core OR and the shared component library. External services (OpenProject, XWiki, ...) had no path at all. Of the 8 backend-supported types, only 5 had sidebar UI and only 2 had widget components — a glaring asymmetry that grew worse with every new backend integration that landed without UI.
+
+## Decision
+
+Adopt a **two-sided integration registry** pattern as the canonical mechanism for declaring "things that can be linked to or rendered alongside an OpenRegister object."
+
+### The contract — one provider, three artifacts
+
+Every integration ships a vertical slice declared via:
+
+1. A PHP class implementing `OCA\OpenRegister\Service\Integration\IntegrationProvider` (registered via DI tag `IntegrationProvider`).
+2. A frontend registration call `OCA.OpenRegister.integrations.register({ id, label, icon, tab, widget, ... })`.
+
+The two registrations share the same `id` — backend and frontend are paired by id, not by import.
+
+### Three-stage filter
+
+What the user actually sees is decided by three independent filters, each with distinct ownership:
+
+| Stage | Owner | Question |
+|---|---|---|
+| **Registry** | Provider author (system) | Does this integration exist + is the required NC app installed? |
+| **Schema** | Schema author (data designer) | Is this integration relevant to objects of this schema? |
+| **Component** | Page author (app developer) | Should this integration appear on THIS surface? |
+
+Stage 1 is `IntegrationRegistry::getEnabled()`. Stage 2 is the schema's `configuration.linkedTypes` whitelist. Stage 3 is the rendering component's `excludeIntegrations` prop (or equivalent layout choice).
+
+Each stage has clear ownership; debugging "why isn't X showing?" walks the three stages in order.
+
+### Widget parity is a hard rule
+
+Registering an integration without **both** a sidebar tab component **and** a card widget component is a CI-enforced failure. The check runs in pre-commit, repository CI, and the hydra quality gate. Tab-only or widget-only integrations are not permitted.
+
+### Four widget surfaces with graceful fallback
+
+Widgets render across four surfaces: `user-dashboard`, `app-dashboard`, `detail-page`, `single-entity`. A registered widget receives the `surface` as a prop and may branch internally. Optional surface-specific components (`widgetCompact`, `widgetExpanded`, `widgetEntity`) are used when present. A new surface added in the future falls back to the main `widget` — no re-registration required from existing integrations.
+
+### External integrations route through OpenConnector
+
+Providers may declare `getStorageStrategy() === 'external'` and reference an OpenConnector source. OR's `ExternalIntegrationRouter` handles dispatch + auth-status surfacing. OR does not own credentials — OpenConnector does. The provider declares its `authRequirements()` so OR can show a unified admin UI and surface auth status via OCS capabilities.
+
+### Schema validator is registry-driven
+
+`Schema::validateLinkedTypesValue()` consults `IntegrationRegistry::listIds()` rather than a hardcoded constant. New integrations are immediately valid as `linkedTypes` values without core changes.
+
+### Reference-property auto-rendering
+
+A new schema property marker `referenceType: <integration-id>` causes `CnFormDialog` and `CnDetailGrid` to render the matching integration's `single-entity` widget inline next to the property. The integration registry is the single source of truth for "how to render a linked thing of this type" everywhere it appears, not just in sidebars and dashboards.
+
+## Consequences
+
+### Positive
+
+- **Extensibility**: any Conduction app, third-party integrator, or external-service connector can add an integration without modifying OR core or `@conduction/nextcloud-vue`.
+- **Consistency**: every integration is rendered the same way, with the same lifecycle, the same RBAC hooks, the same auth surface, the same parity contract.
+- **Discoverability**: integrations are advertised via OCS capabilities — mobile apps, partner integrations, and other NC apps can discover what's available without proprietary endpoints.
+- **Parallelism**: leaf changes (one per integration) hang off this contract and run in parallel through hydra's pool. The current backend-vs-UI asymmetry cannot recur — parity is enforced.
+- **Future flexibility**: the contract is "linked thing"–shaped so `RelationsService` (object↔object) can be unified under the same registry in a future change without breaking changes.
+
+### Negative
+
+- **Onboarding ceremony**: adding a new integration means more files than before (provider, tab, widget, registration, spec delta, tests). Mitigated by `scripts/scaffold-integration.sh <id>` which generates the skeleton.
+- **Bundle discipline**: an integration that fails to register (wrong load order, missed `register()` call) silently vanishes. Mitigated by the parity CI gate catching missing declarations pre-merge and a dev-mode warning when a backend provider has no frontend counterpart.
+- **One more abstraction**: developers reading sidebar/dashboard code must understand "why isn't this just a static import?" Mitigated by the developer guide and this ADR.
+
+### Migration risks
+
+- **Schema `linkedTypes` referencing not-yet-registered ids**: handled — validation is permissive on read (warns but doesn't reject), strict on write only when adding.
+- **External consumers of `LinkedEntityService::TYPE_COLUMN_MAP`**: the constant is private-by-convention and not documented as public API; we don't expect external consumers. It is `@deprecated` here and removed in a follow-up cleanup change once built-in providers stabilise.
+- **`CnObjectSidebar` props/slots**: every existing prop and slot is preserved. Snapshot tests guard against regressions on the 5 existing tabs.
+
+## Companion ADR
+
+This ADR codifies the **mechanism**. A separate companion ADR — **ADR-020: Apps Consume OpenRegister Abstractions** — codifies the broader **principle**: Conduction apps hook into OpenRegister's abstractions (registers, schemas, objects, integrations, RBAC, audit, archival, ...) rather than building parallel mechanisms. ADR-020 is authored separately; ADR-019 is the first concrete instance of that principle being applied systematically.
+
+## Implementation reference
+
+- Umbrella change: `openregister/openspec/changes/pluggable-integration-registry/` (proposal, design, tasks, spec, hydra.json)
+- Implementation files: `openregister/lib/Service/Integration/`, `nextcloud-vue/src/integrations/`
+- Developer guide: `openregister/docs/integrations/README.md`
+- Scaffold script: `openregister/scripts/scaffold-integration.sh`
+- Parity check: `openregister/scripts/check-integration-parity.sh`
+
+## References
+
+- ADR-004 — Frontend (Vue 2, axios, components)
+- ADR-007 — i18n (nl + en required)
+- ADR-010 — NL Design System
+- ADR-011 — Schema standards
+- ADR-017 — Component composition
+- ADR-018 — Widget header actions
+- ADR-020 — Apps consume OR abstractions (companion, separate change)
+
+## Ownership
+
+OpenRegister team owns the registry contract, the built-in providers, and the schema validator changes. `@conduction/nextcloud-vue` maintainers own the frontend registry, surface contracts, and the three new widgets. Each integration leaf change has its own owner.
+
+### ADR-020-gate-scope-to-pr-diff
+# ADR-020 — Mechanical gates are scoped to the PR diff, not the whole repo
+
+## Context
+
+Hydra's 8 mechanical gates (`scripts/run-hydra-gates.sh`) were authored as repo-wide scanners: every `lib/**.php` file was checked on every pipeline run. This made pre-existing debt in unchanged files block every new PR. Concretely, decidesk#44 / #45 bounced through `code-review:fail → security-review:fail → needs-input` multiple cycles because `lib/Controller/SettingsController.php` (not touched by either PR) had two genuine findings — missing `#[AuthorizedAdminSetting]` on `load()` and missing `STATUS_UNAUTHORIZED` guard on `index()`. The reviewer cannot fix unchanged files in bounded scope, the builder will not re-enter fix mode for someone else's debt, and the applier refuses to override reviewer-fail verdicts. Result: two genuinely-clean PRs stuck in a ping-pong for days.
+
+The reviewer's CLAUDE.md has long instructed Claude to apply the diff scope manually, but that is (a) advisory, not enforced, and (b) wastes turns on every run.
+
+## Decision
+
+Every mechanical gate in `scripts/run-hydra-gates.sh` must honor the `--scope-to-diff [BASE_REF]` flag. When set, the gate iterates only over files added, copied, modified, or renamed (`--diff-filter=ACMR`) between `BASE_REF` (default `origin/development`) and `HEAD`. Inherited debt in unchanged files is documented by a full-repo cleanup PR, not enforced via review blockers on unrelated work.
+
+All four pipeline positions that invoke gates use `--scope-to-diff`:
+
+| Position | Invocation site | Why scope-to-diff |
+|---|---|---|
+| Builder Rule 0b wrapper | `images/builder/entrypoint.sh` | Builder is creating the PR; the diff is its output. |
+| Code reviewer pre-flight | `images/reviewer/entrypoint.sh` | Juan reviews the PR, not the base branch. |
+| Code reviewer post-flight | `images/reviewer/entrypoint.sh` | Post-flight gate fails when Juan introduces debt; inherited debt is out of scope. |
+| Security reviewer pre-flight | `images/security/entrypoint.sh` | Same rationale as code review. |
+| Security reviewer post-flight | `images/security/entrypoint.sh` | Same. |
+
+The applier runs no gates directly — it consumes the reviewers' verdicts, which now reflect scope-correct findings.
+
+Base ref is overridable via the `HYDRA_GATE_BASE_REF` env var (default `origin/development`) for repos with a different mainline.
+
+Gate 4 (`composer-audit`) is skipped entirely when scope-to-diff is active and neither `composer.json` nor `composer.lock` is in the diff — dep vulnerabilities are unchanged if deps are unchanged. Gate 6 (`orphan-auth`) scopes the *defining* file by diff but keeps its caller grep repo-wide so a method newly-added in the PR is still validated against any legitimate same-file or cross-file caller.
+
+## Consequences
+
+**Positive**
+- Existing debt in unchanged files no longer blocks PRs on unrelated features. The decidesk#44/#45 ping-pong is structurally impossible going forward.
+- Builder, reviewer, and security all see the same scoped gate output — no more cycle-of-life where each position reads different baselines.
+- Faster pipeline runs: scanning ~20 changed files instead of ~200+ repo files per gate.
+
+**Negative**
+- Inherited debt is genuinely invisible to the pipeline until it lands in a PR. Mitigation: a full-repo audit (scope-to-diff off) runs on the `ready-for-audit` label via `cron-audit.sh`, keeping the base-branch state observable.
+- A PR that ONLY modifies a file lightly (e.g. renames it) may have gates pass on that file even if it has pre-existing debt. Acceptable — gates judge what the PR touched, not the file's full history.
+
+**Deferred to Phase G.1**
+- `composer check:strict` (phpcs, phpmd, psalm, phpstan) and `phpunit` / `npm run lint` are still full-repo. They run inside `composer`/`phpunit` which don't accept per-file scoping cleanly without per-tool argument passthrough. The same scoping story will land there next; for now, the reviewer's manual scope filter (`/tmp/pr-scope.txt`) remains the safety net.
+
+## Verification
+
+Smoke-test on decidesk PR #131 (feature/47/p2-motion-and-voting-core-t2) 2026-04-23:
+- Full-repo scan: 2 FAIL (SettingsController in unchanged file)
+- `--scope-to-diff --base origin/development`: ALL 8 GATES GREEN
+
+The PR is now unblockable by unrelated debt without sacrificing gate coverage on the 19 files it actually changed.
+
+### ADR-021-bounded-fix-scope-by-shape
+# ADR-021: Reviewer bounded-fix scope is defined by change shape, not line count
+
+**Status:** accepted
+**Date:** 2026-04-23
+
+## Context
+
+The reviewer containers (Juan Claude van Damme for code, Clyde Barcode for security) run with bounded fix authority — they MAY apply small remediations in-container, commit, and push. The original rule in their CLAUDE.md:
+
+> The fix is bounded to **1–3 lines in one file**.
+
+This rule was an attempt to keep reviewers out of architectural territory. In practice it failed in two directions:
+
+**1. Wrong-shaped for common security patterns.** A typical missing-authorization fix — add a `checkUserRole($uid, ['chair','secretary'])` block with try/catch — is 5–10 physical lines. Reviewers correctly declined to fix under the 3-line rule. On decidesk#45 (PR#129), Clyde flagged the same two auth stubs across **eight review cycles** from 2026-04-21 to 2026-04-23, each time declining as "exceeds 3-line bounded fix scope" or "architectural decision needed". The fix was literally mirroring a sibling method (`transitionLifecycle`) in the same class — zero new concepts, just apply the existing pattern. The 3-line limit turned a mechanical fix into architectural churn.
+
+**2. Ambiguous under formatter changes.** Does "line" mean physical lines? Logical statements? With braces? A single prettier or phpcs run can convert a 3-line compact form into a 7-line expanded form and flip fix authority on or off. Reviewers should not be measuring code in a unit that formatters can redefine.
+
+Meanwhile, genuine architectural work — new services, new schemas, new DI — IS well understood across the team. The category error was confusing "how much code changes" with "how much thinking changes".
+
+A 10-line change that mirrors a sibling method is safer than a 2-line change that invents a new concept. We should scope by what the change touches, not by its size.
+
+## Decision
+
+Reviewer bounded-fix scope is defined by **change shape**, not line count. A fix is in-scope when ALL of these hold:
+
+1. **The shape is one of:**
+   - Modify an existing method body (guard clause, try/catch, validation, escape, swap unsafe call for safe one)
+   - Add a new **private** helper method in the same class (no public API change)
+   - Apply a pattern that **already exists in the same file or class, OR in a sibling controller/service of the same app** — mirror the precedent
+   - Add a missing attribute / annotation / docblock tag
+   - Swap an unsafe API for its safe counterpart (`md5` → `password_hash`, raw SQL → prepared statement, raw HTML → `htmlspecialchars`)
+   - **Add a constructor parameter to inject a dependency that is already injected in a sibling controller/service of the same app** — strictly to enable a mechanical fix above (e.g. `IUserSession` → null-check → 401, `IGroupManager` → `isAdmin()` guard). The registration block in `Application.php` is updated at the same time.
+
+2. **The change does NOT:**
+   - Introduce a brand-new dependency that no sibling class in the same app already uses (first-use DI is an architectural choice — escalate)
+   - Add a new service, class, interface, or route
+   - Touch database schema or migrations
+   - Change any public method signature visible to callers outside the class
+   - Rewrite the file's top-level control flow
+
+3. **Self-verify stays green.** Semgrep (security) or phpcs + covering phpunit (code) on the touched file produces 0 new findings.
+
+The "sibling precedent" clause is explicit: **if a method in the same class OR in a sibling controller/service of the same app demonstrates the fix, the "architectural decision needed" escape hatch does NOT apply.** This is the clause that closes the #45 trap — the precedent in `transitionLifecycle` makes mirroring it mechanical, regardless of how many lines the mirror takes. The sibling-class extension closes the #73 trap — `MinutesVersionController`, `DecisionSearchController`, and `NotificationSubscriptionController` each lacked `IUserSession` and required a new constructor param to add auth guards, but `MinutesApprovalController` in the same app already injected it; mirroring that constructor shape is mechanical, not architectural. The bright line stays at **first-use DI** — a dependency no sibling class in the same app already uses is a genuine architectural choice and still escalates.
+
+## Consequences
+
+**Positive**
+- Auth-guard mirroring is now in-scope for reviewers — the most common security-fix pattern stops escalating.
+- Scope is robust under formatter changes: `htmlspecialchars($val, ENT_QUOTES, 'UTF-8')` on one line or three lines is the same fix.
+- The "architectural" label is reserved for genuine architectural work (new services, new roles, new DI) where a human really does need to decide something.
+- Fewer `needs-input` escalations on recurring findings — fewer retry cycles — less pipeline capacity burned per PR.
+
+**Negative**
+- Reviewers have slightly more scope and therefore slightly more room to make wrong calls. Mitigations:
+  - The self-verify gate (Semgrep / phpcs + phpunit green on the touched file) is unchanged — still a hard stop on regressions.
+  - "No new DI / schema / public signature" is a bright line that protects the expensive classes of change.
+  - "Pattern exists in same file/class" is conservative — it prevents invention, only permits mirroring.
+- Reviewers now need to read adjacent methods in the same class to check for precedent. This is a small turn-count cost but produces strictly better fixes.
+
+**Neutral**
+- Line-count as a heuristic is abandoned. Reviewers still prefer small fixes over large ones — the shape rules make that natural without encoding a brittle number.
+
+## Implementation
+
+Applied to:
+- `images/reviewer/CLAUDE.md` — the "Bound-fixable" row in the fix-category table + the "Warnings ARE in scope for fix" section
+- `images/security/CLAUDE.md` — the "What you MAY fix in-container" and "What you MUST NOT fix" sections
+
+Rolled out via PR [#136](https://github.com/ConductionNL/hydra/pull/136), 2026-04-23.
+
+## References
+
+- Observed failure: decidesk#45 security-review, 8 cycles documented in [docs/retrospectives/decidesk-44-45-phase-g.md](../../docs/retrospectives/decidesk-44-45-phase-g.md)
+- Observed failure: decidesk#73 security-review, 5+ cycles 2026-04-23 — 7 WARNING gate-7 findings across `MinutesVersionController`, `DecisionSearchController`, `NotificationSubscriptionController`; each cycle declined under the "no new DI" rule even though `MinutesApprovalController` in the same app already injected the needed `IUserSession` / `IGroupManager`. Manually closed by the operator, driving the sibling-class relaxation above.
+- ADR-013 (container pool) defines the reviewer personas; this ADR defines their authority surface.
+- ADR-020 (gate scope-to-diff) is the adjacent Phase G work — together these two ADRs remove the two biggest classes of false-escalation observed on the pipeline.
+
+### ADR-022-apps-consume-or-abstractions
+# ADR-022: Apps Consume OpenRegister Abstractions
+
+## Status
+Proposed
+
+## Date
+2026-04-23
+
+## Context
+
+Conduction maintains ~13 Nextcloud apps (decidesk, docudesk, pipelinq, procest, opencatalogi, openconnector, mydash, larpingapp, shillinq/budgetq, zaakafhandelapp, nldesign, softwarecatalog, and the in-flight idea apps). Each app needs features that overlap heavily: objects with schemas, role-based access, audit trails, archival/retention policies, mapping/transformation, relation management, sidebar tabs with notes/tasks/files, dashboard widgets, integrations with NC-native and external services.
+
+OpenRegister has grown into the **foundation** that provides these as shared abstractions: registers, schemas, objects, RBAC, audit-trail-immutable, archival-destruction-workflow, mappings, relations, object-interactions, and — with ADR-019 — a pluggable integration registry.
+
+When a new app is built (or an existing app evolves), its authors face a choice: consume OR's abstraction, or build a parallel mechanism in-app. The "parallel mechanism" path is attractive at first — it's self-contained, it can be tweaked without coordinating with OR, and it avoids adding a dependency. But every instance observed so far has produced the same end state over time:
+
+- **Duplicate data models** (an app-local Person vs OR contacts; an app-local AccessRule vs OR RBAC).
+- **Drift** — app-local audit trails stop tracking things OR's audit does (replayable ordering, hash chains, retention-aware purge).
+- **Missed features** — an app that rolled its own "linked files" sidebar never gets calendar/deck/polls/maps/collectives when OR adds them to the integration registry.
+- **Impossible cross-app queries** — "show me all cases assigned to Jan across all Conduction apps" requires the contact linkage to be uniform.
+- **Duplicate ADRs** — app-local ADRs restating what OR's already decided, then drifting.
+
+ADR-019 codified the **mechanism** for one specific class of abstraction (integrations). This ADR codifies the **principle** that generalises: when OR has an abstraction that fits, apps consume it rather than reinvent.
+
+## Decision
+
+### Apps consume OpenRegister abstractions over local duplication
+
+When an app needs functionality that OR already provides as an abstraction, the app MUST consume the OR abstraction. Rolling a parallel implementation in-app is not permitted unless explicitly justified (see "exceptions" below).
+
+### What counts as an "OR abstraction"
+
+Any capability exposed by OpenRegister that has a contract, a public API, and is documented as reusable. The current list (non-exhaustive):
+
+| Abstraction | What it provides |
+|---|---|
+| **Registers + schemas + objects** | Versioned typed entities with validation, queries, events |
+| **Authorization RBAC** | Role + scope + object-level permissions, per-schema and per-property |
+| **Audit trail (immutable)** | Append-only hash-chained event log per object |
+| **Archival + destruction workflow** | Retention classification, archival, purge — aligned with Archiefwet |
+| **Mappings** | Cross-system transformation between source + target schemas |
+| **Relations** | Typed links between OR objects |
+| **Object interactions** (`object-interactions` spec) | Files, notes, tasks, tags, audit per object — the built-in part of the integration registry |
+| **Integration registry (ADR-019)** | Pluggable NC-native + external integrations with tab+widget parity |
+| **Audit hash chain** | Cryptographic verification of audit event order |
+| **Content versioning** | Snapshot/restore of object states |
+| **Deep link registry** | Cross-app navigation with stable object references |
+| **TMLO metadata** | Dutch-gov metadata vocabulary compliance |
+| **MCP discovery** | AI-agent discovery endpoint for all OR-backed capabilities |
+| **Events + webhooks** | CloudEvents over NC's event dispatcher |
+
+New abstractions land in OR via its own openspec process. When they're merged, this ADR's list updates.
+
+### The positive case — how to consume
+
+1. **Use OR's PHP service via DI injection.** Don't wrap it in an app-local service that adds nothing. Thin adapters are fine; duplication isn't.
+2. **Register for OR's extensibility points.** The integration registry takes DI-tagged providers (ADR-019). RBAC takes scoped role definitions. Audit takes event listeners. Apps extend through these points, not by building parallel machinery.
+3. **Follow OR's schemas when OR has a schema.** If OR already defines a `contact` or `case` or `organisation` model, an app using those concepts MUST reuse the OR schema and its register — not a local copy with the same-ish fields.
+4. **Call OR's REST API from the frontend via `@conduction/nextcloud-vue`.** The shared library wraps OR's API; apps that bypass it and call OR's raw endpoints re-solve problems the shared lib already solved.
+
+### Anti-patterns
+
+These have all been observed and should be treated as review-blocking:
+
+- **Parallel link tables.** An app creating its own `{app}_email_links` / `{app}_contact_links` table when OR's integration registry already provides the equivalent via `openregister_*_links`. (Observed via decidesk's initial CalDAV plan using `X-DECIDESK-*` properties duplicating OR's `X-OPENREGISTER-*` mechanism.)
+- **App-local schema validators.** An app writing its own JSON schema validation when OR already validates against the schema it owns.
+- **Home-grown audit trails.** An app writing to a private events table instead of OR's audit trail for actions on OR-owned objects.
+- **App-local RBAC on OR objects.** An app defining its own role/permission scheme for objects that live in OR's register.
+- **Duplicate sidebar tab systems.** An app registering its own object-sidebar tabs outside the integration registry (ADR-019).
+- **App-local "linked bookmarks/files/notes/..." that mirror an OR integration.** If OR has an integration for it, the app consumes it.
+- **Duplicate ADRs.** An app-local ADR restating an org-wide ADR. The stale copies of `adr-004-frontend.md` in app repos (removed 2026-04-19) are the canonical example.
+
+### Exceptions (when an app may build a parallel mechanism)
+
+A parallel mechanism is acceptable only when one of the following is true, **and documented in an app-local ADR that references this ADR and justifies the divergence**:
+
+1. **Fundamentally different domain requirements.** The app's use-case has constraints OR can't satisfy (e.g., sub-millisecond latency, append-only write with no read, special encryption-at-rest keys per tenant).
+2. **OR is blocked on a dependency the app can't wait for.** Time-sensitive delivery where adding the feature to OR would push out 3+ months, and the app ships its own interim solution with an explicit migration plan.
+3. **Prototype / spike.** Temporary local code with a written sunset date (max 90 days) and an owner.
+
+Every exception requires an app-local ADR. "We didn't know OR had this" is not an exception.
+
+### Enforcement
+
+- **Code review gate.** Reviewers reject PRs that duplicate an OR abstraction without an explicit ADR-backed justification.
+- **Specter's spec generation** surfaces applicable OR abstractions in each app's context brief (ADR-019 already flows in via `generate_spec_content.py`). The expectation is that feature specs reference the OR abstraction they consume.
+- **Hydra quality gate (future).** A mechanical gate that flags common anti-patterns — parallel link tables, duplicate ADR files, schema-validator reinvention, local RBAC code acting on OR objects. Tracked as a follow-up to this ADR; implementation issue to be opened separately.
+- **This ADR list updates when OR adds an abstraction.** Keeping the list current is the OR team's responsibility; when a new abstraction becomes stable, it goes in this table via a small PR against this file.
+
+## Consequences
+
+### Positive
+
+- **One source of truth per capability.** Features of files/notes/tasks/calendar/mail/contacts/etc. evolve in OR; every app benefits.
+- **Cross-app consistency.** "Jan is the applicant on this case" means the same thing in procest, pipelinq, and zaakafhandelapp.
+- **Smaller apps.** Each app ships less code because it consumes more. A new app in 2026 should be mostly schemas + app-specific business logic; the plumbing is OR.
+- **Uniform audit/RBAC/retention.** Government compliance (Archiefwet, AVG, Woo, BIO) has one implementation to verify, not 13.
+- **The integration registry compounds.** When OR adds the `integration-calendar` leaf, every app using OR objects gets meeting linkage without any per-app work.
+
+### Negative
+
+- **App authors need to learn OR's contracts.** The onboarding curve for a new Conduction developer includes understanding OR's schemas, RBAC model, audit trail, and integration registry. Mitigated by OR's docs + this ADR list.
+- **OR becomes a bottleneck for shared changes.** If a capability needs a fix, OR has to ship it. Mitigated by keeping OR fast-moving + prioritising the long-tail abstractions that unblock multiple apps.
+- **Exception discipline matters.** Without rigorous review of the app-local ADR justifications, exceptions become the norm. Mitigated by the code-review gate and the explicit sunset date on prototype exceptions.
+
+### Migration
+
+Apps currently in violation (openconnector's bespoke linked-entity handling, decidesk's X-DECIDESK-* CalDAV properties, app-local audit copies) are not required to migrate immediately. Each gets a tracked "consume-OR-abstraction" issue with a target date. See the openregister integration registry umbrella ([openregister#1307](https://github.com/ConductionNL/openregister/issues/1307)) for the calendar/email/deck/contacts/talk migration pattern.
+
+## Related
+
+- **ADR-019** — Integration Registry Pattern (the first concrete instance of this principle).
+- **Openregister spec** — `openregister/openspec/changes/pluggable-integration-registry/` (the implementation that made the integration class of abstractions consumable).
+- **Stale-duplicate incident 2026-04-19** — app repos carried stale copies of `adr-004-frontend.md` that drifted from the hydra master; removed across all app repos. The lesson that seeded this ADR.
+
+## Ownership
+
+- The OR team owns the list of abstractions in this ADR.
+- Each app's maintainers own applying it inside their repo.
+- Hydra reviewers enforce it at code-review time.
+
+### ADR-023-action-authorization
+# ADR-023: Action-level authorization via admin-configured action/group mappings
+
+**Status:** accepted
+**Date:** 2026-04-23
+
+## Context
+
+Conduction apps mix **data authorization** (who can read/write which OpenRegister objects) and **action authorization** (who can invoke which controller methods / workflow steps). The two are related but not the same:
+
+- A chair of "Board A" can read all Board A minutes (data RBAC → OpenRegister) AND can invoke `generateMinutesDraft()` on them (action RBAC → app).
+- A regular member of Board A can read the same minutes (data RBAC → OpenRegister) but CANNOT invoke `generateMinutesDraft()` (action RBAC denies).
+- A Nextcloud admin can invoke `create()` on `SettingsController` (action RBAC → admin-only) regardless of any board membership.
+
+OpenRegister already owns the **data** layer: object-level ownership, schema/register permissions, per-relation filtering (ADR-022 lists RBAC as one of the shared abstractions it provides). Apps consume this cleanly.
+
+Apps DO NOT have a shared pattern for the **action** layer. Observed across decidesk / docudesk / pipelinq, the action-auth implementations range from:
+
+- `IGroupManager::isAdmin()` hardcoded checks in controller bodies (wrong — locks governance actions to Nextcloud sysadmins, not to chairs/secretaries — see #44 / #45 on 2026-04-23)
+- Missing entirely (the endpoint gates on data RBAC alone — wrong for actions that cross objects, like "generate report across all boards I chair")
+- Inline `!in_array('chair', $roles)` checks that are (a) not discoverable by admins, (b) require a code change to adjust, (c) duplicated across controllers
+
+The consistent answer needs to: live in app code (each app has its own actions), be **declarative** (admin can see and change the matrix without touching code), and be **testable** (gate-7 / gate-9 can mechanically verify each routed action either delegates to this service or is explicitly marked admin-only).
+
+## Decision
+
+### Rule 1 — Data RBAC is OpenRegister's job; apps never roll their own
+
+OpenRegister decides for itself who may read / write / list which objects. App code that fetches, lists, or mutates domain objects MUST go through OpenRegister's `ObjectService` and trust the service's filtering + per-object permissions. Apps do not implement:
+
+- Object-ownership checks (OpenRegister does it via `createdBy` / `owner` / schema settings)
+- Register/schema-level access gates (OpenRegister does it via register permissions)
+- Group-based read/write filtering on data (OpenRegister does it via `relations.group` / schema RBAC)
+- Schema / register configuration (that's OpenRegister's own admin UI, not the consuming app's)
+
+If the data-layer RBAC has a gap, **fix it in OpenRegister** (ADR-012 — push logic up to the shared foundation, don't re-implement per app).
+
+### Rule 2 — Action RBAC is the app's job, declared in admin settings
+
+Every app defines a registry of **actions** — named operations that a controller method executes. Examples (decidesk):
+
+- `minutes.generate-draft` — produces a draft from a meeting transcript
+- `minutes.distribute` — sends final minutes to the governance body
+- `decision.publish` — marks a decision as published, triggers notifications
+- `analytics.view-summary` — reads aggregate metrics across bodies
+- `settings.write` — admin-only settings writes
+
+Each action is mapped to a set of **user groups** via an admin-configured matrix, stored in `IAppConfig` under a well-known key. Every app maintains its own seed data for the initial mapping; the template ships a skeleton file per app that declares the action list with `["admin"]` as the default for every action. This default is **the safest first-install posture** — nothing is accidentally opened to non-admins until an admin explicitly broadens it. The admin settings panel is the only place to edit the matrix.
+
+```json
+// stored as IAppConfig["decidesk"]["actions"]
+//
+// First-install values (seed from the app, admin-only everywhere).
+// The admin editing the matrix is the only path to broaden — code
+// changes must not relax the default.
+{
+  "minutes.generate-draft":   ["admin"],
+  "minutes.distribute":       ["admin"],
+  "decision.publish":         ["admin"],
+  "analytics.view-summary":   ["admin"],
+  "settings.write":           ["admin"]
+}
+```
+
+After admin customization (example — illustrative, not default):
+
+```json
+{
+  "minutes.generate-draft":   ["chairs", "secretaries"],
+  "minutes.distribute":       ["chairs", "secretaries"],
+  "decision.publish":         ["chairs"],
+  "analytics.view-summary":   ["chairs", "secretaries", "board-members"],
+  "settings.write":           ["admin"]
+}
+```
+
+**Naming convention**: `<domain>.<verb-phrase>` with dot as separator, lowercase, hyphens-in-phrases. `minutes.generate-draft`, `decision.publish`, `analytics.view-summary`. NOT `decidesk:minutes:generateDraft`. This keeps the keys grep-friendly, stable across refactors, and matches how schema keys look in OpenRegister.
+
+The **admin settings panel** (registered via `\OCP\Settings\ISection`, route carries `#[AuthorizedAdminSetting(Application::APP_ID)]`) renders this matrix: rows = actions, columns = user groups, checkboxes = allowed. Admin edits + saves → `IAppConfig` updated. NO code change required to adjust who can do what.
+
+Controllers enforce the mapping with a single helper call:
+
+```php
+#[NoAdminRequired]
+public function generateDraft(string $minutesId): JSONResponse {
+    $user = $this->userSession->getUser();
+    if ($user === null) {
+        return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+    }
+
+    $this->actionAuth->requireAction($user, 'minutes.generate-draft');
+    // Throws OCSForbiddenException if none of $user's groups are mapped
+    // to 'minutes.generate-draft' in the admin matrix.
+
+    // ... data-layer work via ObjectService (OpenRegister enforces its own
+    //     per-object permissions on top of this action check).
+}
+```
+
+### Rule 3 — When admin IS required (not delegated to action RBAC)
+
+The following stay `#[AuthorizedAdminSetting(Application::APP_ID)]` and live **only on the admin settings page** — they are NOT expressible as action mappings because they are the plumbing the action matrix itself depends on:
+
+- **Configuring the action ↔ group matrix** (the admin settings panel itself)
+- **App configuration** — any `IAppConfig` writes (feature flags, feature toggles, workflow parameters, anything that affects app-wide behavior)
+- **Backup / restore operations** — data export, re-import, cross-environment migration
+- **App integration configuration** — connections to external systems (n8n, SOLR, external APIs), webhook URLs, integration feature flags
+- **Credential management** — API keys, OAuth tokens, basic-auth credentials for any third-party service
+- **One-off admin operations** — re-import seed data, purge caches, run migrations, trigger re-indexing
+
+Everything a non-admin (chair / secretary / board-member / agent / regular user) might legitimately invoke during normal operation = an **action**, gated via `requireAction()`. Admin settings page handles the plumbing; user settings page / per-user UI never touches the plumbing. The user settings page is for user-personal preferences only (UI theme, notification opt-ins) — not for anything the action matrix references.
+
+Rule of thumb: if the operation mutates something the action matrix references (keys the matrix looks up, values the matrix resolves to, integrations the actions depend on) → admin. Everything else → action.
+
+### Rule 4 — Middleware attribute + body check layered
+
+Per ADR-005 and ADR-016:
+
+- `#[PublicPage]` — genuinely public (login pages, OAuth callbacks). Body does NO auth check.
+- `#[NoAdminRequired]` — any authenticated user may reach the endpoint. Body **MUST** call `$this->actionAuth->requireAction($user, 'action.name')` for action-level gating. Absence of this call is a gate-9 failure — see enforcement below.
+- `#[AuthorizedAdminSetting(Application::APP_ID)]` — framework-level admin gate for the exceptions in Rule 3. Body does no further admin check (the middleware already enforced it).
+
+### Rule 5 — Gate-9 enforces the action-auth pattern mechanically
+
+`hydra-gate-9` (semantic-auth) is extended to check:
+
+| Pattern | Verdict |
+|---|---|
+| `#[NoAdminRequired]` + body calls `$this->actionAuth->requireAction(...)` | PASS |
+| `#[NoAdminRequired]` + body calls `$this->authorize*(...)` (per-object auth helper per ADR-005 Rule 3) | PASS |
+| `#[NoAdminRequired]` + body calls `$this->requireAdmin()` / `isAdmin()===false`→403 | FAIL — the wrong layer; use `#[AuthorizedAdminSetting]` for admin-only or `requireAction()` for role-based |
+| `#[NoAdminRequired]` + no recognized auth gate in body | FAIL — inadequately gated, open endpoint |
+| `#[PublicPage]` + any body auth check | FAIL — public is public, no body checks |
+| `#[AuthorizedAdminSetting]` + `requireAction()` in body | PASS but redundant (middleware already gated to admin) — not a fail, but the lint could suggest removal |
+
+Enforcement rolls out in two phases to give apps time to migrate without breaking their pipelines:
+
+1. **Soft-fail phase** (announce in ADR): gate emits warnings, doesn't fail the gate. Apps that haven't migrated yet stay green.
+2. **Hard-fail phase** (date-stamped): gate treats missing `requireAction()` as FAIL. Decided when majority of apps have adopted the pattern.
+
+## Consequences
+
+### Positive
+- Governance actions (minutes drafting, decision publishing, quorum checks) can be delegated to chairs / secretaries / board members — NOT Nextcloud sysadmins. Current decidesk bug class (#44 + #45) goes away structurally.
+- Admins can re-map actions to groups without a code change — useful when an org shifts responsibilities mid-deployment.
+- One helper (`$this->actionAuth->requireAction()`) per gated method — consistent, grep-able, testable.
+- Gate-7 / gate-9 enforcement has a clear target to check for (`requireAction()` call in body).
+- Template repo ships this out of the box — new apps inherit the pattern instead of each rolling their own.
+
+### Negative
+- Initial setup burden: admin must populate the action matrix on first install. Mitigated with sensible defaults in `create-labels`-style seed data per app.
+- Two layers of auth per request (action matrix check + OpenRegister per-object check) = two service calls per gated endpoint. Negligible cost (both are app-local memory or indexed DB).
+- Admin who mis-configures the matrix can lock chairs out of essential actions. Mitigated with a "reset to defaults" button + `occ decidesk:actions:reset`.
+
+### Neutral
+- Replaces "lock everything to admin" over-restriction with "configurable by admin" flexibility. For ops that currently have only Nextcloud admins, the first-install default can be "admin-only" per action — the matrix is editable but the safe default survives if nobody touches it.
+
+## Implementation plan
+
+1. **This ADR** — accepted.
+2. **Reference implementation in decidesk**:
+   - New `OCA\Decidesk\Service\ActionAuthService` with `requireAction(IUser $user, string $action): void` — throws `OCSForbiddenException` when $user's groups don't intersect the matrix entry for $action
+   - New `OCA\Decidesk\Settings\ActionMatrixAdmin` settings section (`\OCP\Settings\ISettings` + template) showing the action×group matrix, admin-only
+   - `IAppConfig` key `decidesk.actions` storing the JSON mapping
+   - Refactor the 13 + 2 controller methods caught by gate-9 on #44 / #45 to use `requireAction()`
+   - **Seed data per app** — each app ships its own `actions.seed.json` (or equivalent) declaring the action list with `["admin"]` as default. App migration runs it on first install.
+3. **Port to `nextcloud-app-template`**: copy `ActionAuthService` + skeleton settings panel + seed-data pattern. Parametrized so new apps just declare their action names. Default values all `["admin"]`.
+4. **Gate-9 extension (soft-fail phase first)**:
+   - Detect `#[NoAdminRequired]` + body-has-`requireAction()`-call → PASS
+   - Detect `#[NoAdminRequired]` + body-has-`authorize*()`-call (per-object auth per ADR-005) → PASS
+   - Detect `#[NoAdminRequired]` + no recognized gate → emit warning (soft-fail)
+   - Detect `#[NoAdminRequired]` + `requireAdmin()` / `isAdmin()===false` → FAIL (hard — the wrong layer)
+   - Warnings hit the verdict JSON but do not set the gate to FAIL during migration.
+5. **Migrate existing apps** (hydra, decidesk first, then docudesk / pipelinq / procest / …) to the new pattern.
+6. **Gate-9 hard-fail phase**: after apps are migrated, flip warnings → fails. Date-stamp to set on the PR that ships the hard-fail variant.
+7. **Unblock #44 + #45**: once decidesk has `ActionAuthService`, their 13+2 methods plug into `requireAction('minutes.generate-draft')` etc. The current parked state resolves as a retry cycle.
+
+## References
+
+- ADR-005 (security) — per-object authorization rule + admin checks
+- ADR-016 (routes) — auth attribute rules + gate layering
+- ADR-021 (bounded-fix scope) — mentions `checkUserRole($uid, ['chair','secretary'])` as the correct shape (now formalized via `requireAction`)
+- ADR-022 (apps consume OR abstractions) — lists RBAC as one of OpenRegister's shared abstractions; this ADR clarifies that the scope is **data** RBAC, not **action** RBAC
+- decidesk#44 / #45 — both pending role-based fix that this ADR unblocks

--- a/openspec/changes/role-based-content/design.md
+++ b/openspec/changes/role-based-content/design.md
@@ -1,0 +1,314 @@
+# Design — Role-based dashboard content and defaults
+
+## Architecture
+
+### Backend
+
+```
+RoleFeaturePermissionController   (admin-only, thin: routing + validation + response)
+        │
+        ▼
+RoleFeaturePermissionService      (all business logic, stateless)
+        │
+        ├── ObjectService          (OpenRegister CRUD — findObjects, saveObject, deleteObject)
+        ├── AdminSettingsService   (reads group_order for priority resolution)
+        └── IGroupManager          (reads user group memberships from Nextcloud)
+```
+
+**Service responsibilities:**
+- `getAllowedWidgetIds(string $userId): array` — resolve effective widget permission set by
+  iterating `group_order`, fetching the first RoleFeaturePermission whose `groupId` matches a
+  user's group, then merging any additional group allow-lists for widening. Returns `null`
+  (= no restriction) when no RoleFeaturePermission objects exist for any of the user's groups.
+- `isWidgetAllowed(string $userId, string $widgetId): bool` — convenience wrapper used by
+  `WidgetController` and feature-specific controllers for single-widget checks.
+- `seedLayoutFromRoleDefaults(string $userId, Dashboard $dashboard): void` — called by
+  `DashboardResolver::tryCreateFromTemplate()` when no admin template matches; reads
+  RoleLayoutDefault objects for the user's primary group (via `group_order`) and creates
+  WidgetPlacement rows accordingly.
+- `authorizeAdminObject(array $object, IUser $user): void` — throws
+  `OCSForbiddenException` if the authenticated user is not an admin; used from every
+  mutation endpoint (ADR-005).
+
+**Controller pattern (ADR-003):**
+- `RoleFeaturePermissionController` handles all four new admin endpoints.
+- Methods: `listPermissions()`, `savePermission()`, `listLayoutDefaults()`,
+  `saveLayoutDefault()`.
+- All methods annotated `#[AuthorizedAdminSetting(Application::APP_ID)]`.
+- No direct mapper calls; all data access through `RoleFeaturePermissionService`.
+
+### Frontend
+
+```
+AdminApp.vue
+  └── RolePermissionsSection.vue    (new component — role→widget assignment UI)
+        ├── CnDataTable              (list existing RoleFeaturePermission objects)
+        ├── CnFormDialog             (create / edit a RoleFeaturePermission)
+        └── CnDeleteDialog           (delete confirmation)
+
+src/store/modules/roleFeaturePermission.js   (createObjectStore('role-feature-permission'))
+src/store/modules/roleLayoutDefault.js       (createObjectStore('role-layout-default'))
+```
+
+`App.vue` initial-state payload extended with `allowedWidgets: string[]|null`; null means
+unconfigured (all widgets visible). The card library component (`WidgetPicker.vue`) reads
+`allowedWidgets` from the settings store and filters the list before rendering.
+
+---
+
+## Data Model
+
+> All domain data stored in OpenRegister objects. Schemas defined in
+> `lib/Settings/mydash_register.json`, imported via `ConfigurationService::importFromApp()`.
+> Schema vocabulary follows schema.org + ADR-011.
+
+### Schema: RoleFeaturePermission
+
+**Register key:** `mydash`
+**Schema key:** `role-feature-permission`
+**schema.org type:** `schema:DefinedTerm` (a term within a classification scheme, here:
+the set of permitted features for a role)
+
+| Property | Type | Required | Description |
+|---|---|---|---|
+| `name` | string | yes | Human-readable name, e.g. "Medewerker widget-rechten" (`schema:name`) |
+| `description` | string | no | Purpose of this permission set (`schema:description`) |
+| `groupId` | string | yes | Nextcloud group ID this permission applies to (`schema:identifier`) |
+| `allowedWidgets` | array\<string\> | yes | Widget IDs the group may add to their dashboard. Empty array = no widgets allowed. (`schema:itemListElement`) |
+| `deniedWidgets` | array\<string\> | no | Explicit deny list; overrides `allowedWidgets` when widening from multiple groups. Default `[]`. |
+| `priorityWeights` | object | no | Map of `{ widgetId: integer }` — higher value = higher priority position in layout seeding and dashboard ordering. (`schema:position`) |
+
+**Uniqueness constraint:** one RoleFeaturePermission per `groupId`. The import slug convention
+enforces this: slug = `rfp-{groupId}`.
+
+---
+
+### Schema: RoleLayoutDefault
+
+**Register key:** `mydash`
+**Schema key:** `role-layout-default`
+**schema.org type:** `schema:ListItem` (an item in an ordered list, here: a widget slot in a
+role's default layout)
+
+| Property | Type | Required | Description |
+|---|---|---|---|
+| `name` | string | yes | Display name for this layout slot, e.g. "Manager — activiteiten" (`schema:name`) |
+| `groupId` | string | yes | Nextcloud group ID this default applies to (`schema:identifier`) |
+| `widgetId` | string | yes | Nextcloud Dashboard widget ID to place (`schema:identifier`) |
+| `gridX` | integer | yes | Column position (0-based) (`schema:position`) |
+| `gridY` | integer | yes | Row position (0-based) (`schema:position`) |
+| `gridWidth` | integer | yes | Widget width in grid columns (min 1, default 4) |
+| `gridHeight` | integer | yes | Widget height in grid rows (min 1, default 4) |
+| `sortOrder` | integer | yes | Ordering within the layout (lower = rendered first, default 0) |
+| `isCompulsory` | boolean | no | If true, user cannot remove this widget (inherited from template logic). Default `false`. |
+| `description` | string | no | Optional notes about why this widget appears at this position (`schema:description`) |
+
+**Slug convention:** `rld-{groupId}-{widgetId}` (one row per group+widget combination).
+
+---
+
+## Seed Data
+
+> 3–5 realistic objects per schema with Dutch field values. Loaded via `@self` envelope
+> through `ConfigurationService::importFromApp()`. Idempotent — re-import matches by slug.
+
+### RoleFeaturePermission seed objects
+
+```json
+[
+  {
+    "@self": {
+      "register": "mydash",
+      "schema": "role-feature-permission",
+      "slug": "rfp-medewerkers"
+    },
+    "name": "Medewerker widget-rechten",
+    "description": "Standaard widget-toegang voor alle medewerkers van de gemeente",
+    "groupId": "medewerkers",
+    "allowedWidgets": ["activity", "recommendations", "notes", "calendar"],
+    "deniedWidgets": [],
+    "priorityWeights": { "activity": 10, "recommendations": 8, "calendar": 6, "notes": 4 }
+  },
+  {
+    "@self": {
+      "register": "mydash",
+      "schema": "role-feature-permission",
+      "slug": "rfp-managers"
+    },
+    "name": "Manager widget-rechten",
+    "description": "Uitgebreide widget-toegang voor teamleiders en afdelingshoofden",
+    "groupId": "managers",
+    "allowedWidgets": ["activity", "recommendations", "notes", "calendar", "analytics_dashboard", "user_status"],
+    "deniedWidgets": [],
+    "priorityWeights": { "analytics_dashboard": 10, "activity": 8, "user_status": 6, "calendar": 5 }
+  },
+  {
+    "@self": {
+      "register": "mydash",
+      "schema": "role-feature-permission",
+      "slug": "rfp-ict-beheer"
+    },
+    "name": "ICT-beheer widget-rechten",
+    "description": "Widget-toegang voor de ICT-beheerdersgroep met systeemoverzicht",
+    "groupId": "ict-beheer",
+    "allowedWidgets": ["activity", "recommendations", "notes", "calendar", "system_monitor", "user_status"],
+    "deniedWidgets": [],
+    "priorityWeights": { "system_monitor": 10, "activity": 8, "user_status": 7 }
+  },
+  {
+    "@self": {
+      "register": "mydash",
+      "schema": "role-feature-permission",
+      "slug": "rfp-hrm"
+    },
+    "name": "HRM widget-rechten",
+    "description": "Widget-toegang voor de afdeling Human Resource Management",
+    "groupId": "hrm",
+    "allowedWidgets": ["activity", "recommendations", "notes", "calendar", "user_status"],
+    "deniedWidgets": ["system_monitor"],
+    "priorityWeights": { "user_status": 10, "calendar": 9, "activity": 7 }
+  },
+  {
+    "@self": {
+      "register": "mydash",
+      "schema": "role-feature-permission",
+      "slug": "rfp-default"
+    },
+    "name": "Standaard widget-rechten",
+    "description": "Basistoegang voor gebruikers zonder specifieke groepsindeling",
+    "groupId": "default",
+    "allowedWidgets": ["activity", "recommendations"],
+    "deniedWidgets": [],
+    "priorityWeights": { "recommendations": 10, "activity": 8 }
+  }
+]
+```
+
+### RoleLayoutDefault seed objects
+
+```json
+[
+  {
+    "@self": {
+      "register": "mydash",
+      "schema": "role-layout-default",
+      "slug": "rld-medewerkers-activity"
+    },
+    "name": "Medewerker — activiteiten",
+    "groupId": "medewerkers",
+    "widgetId": "activity",
+    "gridX": 0, "gridY": 0, "gridWidth": 6, "gridHeight": 5,
+    "sortOrder": 1, "isCompulsory": false,
+    "description": "Activiteitenoverzicht linksboven voor medewerkers"
+  },
+  {
+    "@self": {
+      "register": "mydash",
+      "schema": "role-layout-default",
+      "slug": "rld-medewerkers-recommendations"
+    },
+    "name": "Medewerker — aanbevelingen",
+    "groupId": "medewerkers",
+    "widgetId": "recommendations",
+    "gridX": 6, "gridY": 0, "gridWidth": 6, "gridHeight": 5,
+    "sortOrder": 2, "isCompulsory": false,
+    "description": "Persoonlijke aanbevelingen rechtsboven voor medewerkers"
+  },
+  {
+    "@self": {
+      "register": "mydash",
+      "schema": "role-layout-default",
+      "slug": "rld-managers-analytics"
+    },
+    "name": "Manager — analysedashboard",
+    "groupId": "managers",
+    "widgetId": "analytics_dashboard",
+    "gridX": 0, "gridY": 0, "gridWidth": 8, "gridHeight": 6,
+    "sortOrder": 1, "isCompulsory": true,
+    "description": "Verplicht analysedashboard als eerste widget voor managers"
+  },
+  {
+    "@self": {
+      "register": "mydash",
+      "schema": "role-layout-default",
+      "slug": "rld-managers-activity"
+    },
+    "name": "Manager — activiteiten",
+    "groupId": "managers",
+    "widgetId": "activity",
+    "gridX": 8, "gridY": 0, "gridWidth": 4, "gridHeight": 6,
+    "sortOrder": 2, "isCompulsory": false,
+    "description": "Teamactiviteiten rechtsbovenhoek voor managers"
+  },
+  {
+    "@self": {
+      "register": "mydash",
+      "schema": "role-layout-default",
+      "slug": "rld-ict-beheer-system-monitor"
+    },
+    "name": "ICT-beheer — systeemmonitor",
+    "groupId": "ict-beheer",
+    "widgetId": "system_monitor",
+    "gridX": 0, "gridY": 0, "gridWidth": 12, "gridHeight": 4,
+    "sortOrder": 1, "isCompulsory": true,
+    "description": "Verplicht systeemoverzicht als prominente balk voor ICT-beheer"
+  }
+]
+```
+
+---
+
+## Reuse Analysis
+
+This change delegates all commodity functionality to existing platform services and avoids
+rebuilding anything the platform provides for free.
+
+| Concern | Platform service / component used | Custom code needed? |
+|---|---|---|
+| OpenRegister CRUD for schemas | `ObjectService.saveObject()`, `findObjects()`, `deleteObject()` | No — only the service wrapper calling these |
+| Admin list UI for permissions | `CnDataTable` + `CnFormDialog` from `@conduction/nextcloud-vue` | Only the Vue section component |
+| Object-level auth checks | `AuthorizationService` (OpenRegister) | `authorizeAdminObject()` thin wrapper |
+| Group membership lookup | `IGroupManager::getUserGroupIds()` | No — read-only call |
+| Group priority order | `AdminSettingsService::getGroupOrder()` (from `group-priority-order` change) | No — read-only call |
+| Audit trail on permission changes | `AuditTrailService` (OpenRegister, automatic) | None |
+| Store state management | `createObjectStore('role-feature-permission')` (Pinia plugin) | Only the store registration |
+| Schema-driven form generation | `CnFormDialog` reads OpenRegister schema → auto-generates fields | None |
+| Import / seed data | `ConfigurationService::importFromApp()` via repair step | Schema JSON only |
+
+**Deduplication check — existing OpenRegister capabilities NOT duplicated:**
+- `AuthorizationService` and `PropertyRbacHandler` (OpenRegister) already provide general
+  RBAC; this change adds *widget-scoped* role filtering on top, which is domain-specific
+  logic not present in the platform.
+- `PermissionService` (existing mydash change `permissions`) controls per-dashboard edit
+  permissions (view_only / add_only / full). This change controls *which widgets can be added*,
+  which is orthogonal — both checks run independently.
+- `AdminTemplateService` (existing `admin-templates`) distributes full dashboard copies.
+  This change governs which widgets appear in the card library, not which templates are
+  distributed. Both can apply simultaneously.
+- No overlap with `ObjectService`, `RegisterService`, `SchemaService`, or any
+  `@conduction/nextcloud-vue` component was found.
+
+---
+
+## Multi-group Resolution Algorithm
+
+When a user belongs to multiple Nextcloud groups and more than one RoleFeaturePermission
+exists:
+
+1. Read `group_order` from `AdminSettingsService::getGroupOrder()` (admin-configured priority
+   list).
+2. Walk `group_order` left-to-right; for the **first** group the user belongs to, take that
+   group's `allowedWidgets` as the base set.
+3. For every additional group the user belongs to (in `group_order` order), **union** the
+   `allowedWidgets` into the base set (widens access), then **subtract** any `deniedWidgets`
+   from all matched groups (deny always wins).
+4. If no `group_order` entry matches any of the user's groups, fall back to the `'default'`
+   RoleFeaturePermission (sentinel group ID = `'default'`, per `Dashboard::DEFAULT_GROUP_ID`
+   from `group-routing` change).
+5. If no `'default'` RoleFeaturePermission exists either, return `null` (= no restriction,
+   full widget list visible). This preserves backwards-compatibility for unconfigured
+   installations.
+
+**Deny-wins rule:** if `widgetId` appears in any matched group's `deniedWidgets`, it is
+removed from the effective set regardless of how many groups allow it. This prevents
+privilege widening through multi-group membership from bypassing an explicit deny.

--- a/openspec/changes/role-based-content/hydra.json
+++ b/openspec/changes/role-based-content/hydra.json
@@ -1,0 +1,8 @@
+{
+  "spec_slug": "role-based-content",
+  "title": "Role-based dashboard content and defaults",
+  "app": "mydash",
+  "repo": "https://github.com/ConductionNL/mydash",
+  "depends_on": [],
+  "issue": null
+}

--- a/openspec/changes/role-based-content/proposal.md
+++ b/openspec/changes/role-based-content/proposal.md
@@ -1,0 +1,120 @@
+# Role-based dashboard content and defaults
+
+## Why
+
+MyDash currently provides no mechanism to restrict which widgets and dashboard features are
+visible based on a user's Nextcloud group (role). All authenticated users see the same card
+library and can choose from the same widget catalogue regardless of their job function. IT
+admins cannot enforce governance at the feature level: an employee-role user can add
+manager-only analytics widgets, there is no evidence-seeded default layout for new users, and
+no audit entry is created when an unauthorised user attempts to access a restricted feature URL
+directly.
+
+The existing `admin-templates` capability (REQ-TMPL-001..011) lets admins distribute a
+pre-configured dashboard to a group, but it does not restrict which widgets a user can
+subsequently add from the card library, does not define priority ordering of widgets per role,
+and does not distinguish between role-based access rights, expressed personal interests, and
+journey stage. When a user belongs to multiple groups, there is no deterministic rule that
+governs which role's feature set takes precedence.
+
+This change introduces a dedicated **role-feature-permissions** capability that closes all
+three gaps: it governs which widgets are shown (or hidden) by role, seeds default layouts from
+role evidence, and enforces access at the API layer so that direct URL requests to restricted
+features return 403 rather than silently rendering.
+
+## What Changes
+
+- Introduce OpenRegister schema **RoleFeaturePermission** — maps a Nextcloud group ID to an
+  allowed-widget list, an explicit deny list, and per-widget priority weights.
+- Introduce OpenRegister schema **RoleLayoutDefault** — captures the default grid position,
+  size, and display order for each permitted widget within a group, serving as the seed layout
+  when no admin template matches a new user.
+- Add `RoleFeaturePermissionService` (PHP, stateless) to resolve the effective allowed-widget
+  set for a user by walking their group memberships in `group_order` priority and merging
+  allow/deny lists.
+- Extend `GET /api/widgets` to call `RoleFeaturePermissionService::getAllowedWidgetIds()` and
+  filter the returned card library; unauthenticated or unconfigured cases return the full list
+  unchanged (backwards-compatible).
+- Add admin-only endpoints `GET /api/role-feature-permissions` and
+  `POST /api/role-feature-permissions` for CRUD on RoleFeaturePermission objects.
+- Add admin-only endpoints `GET /api/role-layout-defaults` and
+  `POST /api/role-layout-defaults` for CRUD on RoleLayoutDefault objects.
+- Extend `DashboardResolver::tryCreateFromTemplate()` to fall back to seeding a layout from
+  `RoleLayoutDefault` objects when no admin template matches a new user, preserving any
+  existing personal customisations.
+- Add 403 enforcement in `WidgetController::getItems()` and any feature-specific controller
+  that serves a widget's URL: if the requesting user's role-feature-permissions do not include
+  the widget, return HTTP 403 and log an audit entry.
+- Surface `allowedWidgets` (the effective permitted-widget ID list for the authenticated user)
+  in the initial-state payload so the frontend card library can filter without a second
+  round-trip.
+- Add an admin section in `AdminApp.vue` for configuring role→widget mappings and priority
+  weights, using `CnDashboardPage` / `CnDataTable` components from `@conduction/nextcloud-vue`.
+
+## Capabilities
+
+### New Capabilities
+
+- **role-feature-permissions**: Governs which dashboard widgets and features are visible,
+  accessible, and default-seeded for users based on their Nextcloud group (role). Covers:
+  - Admin CRUD for RoleFeaturePermission objects (group → allowed/denied widget IDs +
+    priority weights)
+  - Admin CRUD for RoleLayoutDefault objects (group → default grid position per widget)
+  - Runtime resolution of effective widget permissions for multi-group users via
+    `group_order` priority
+  - Card library filtering at `GET /api/widgets`
+  - Role-based default layout seeding when no admin template matches
+  - API-level 403 enforcement with audit logging for direct URL access to restricted features
+  - Role vs. interest vs. journey distinction (role = explicit group membership; interest =
+    user-expressed preference without a matching role; journey = transient active-role state
+    mid-session)
+
+### Modified Capabilities
+
+- **widgets** — `GET /api/widgets` filters the card library by the caller's role-feature-
+  permissions when a RoleFeaturePermission object exists for any of the user's groups.
+  Existing behaviour (return all widgets) is preserved when no permissions are configured.
+- **dashboards** — `tryCreateFromTemplate()` gains a role-layout-default fallback: new users
+  whose groups have a RoleLayoutDefault receive a pre-seeded layout instead of the hardcoded
+  `recommendations` + `activity` pair. Existing personal customisations are never overwritten.
+
+## Impact
+
+**Code affected:**
+- `lib/Service/RoleFeaturePermissionService.php` — new service: resolves allowed widget IDs
+  for a user from their groups, merges allow/deny lists, respects `group_order` priority.
+- `lib/Controller/RoleFeaturePermissionController.php` — admin-only CRUD controller for
+  RoleFeaturePermission and RoleLayoutDefault objects.
+- `lib/Controller/WidgetController.php` — extend `list()` to filter by allowed widgets.
+- `lib/Service/DashboardResolver.php` — extend `tryCreateFromTemplate()` with role-layout-
+  default fallback.
+- `src/store/modules/roleFeaturePermission.js` — Pinia store via `createObjectStore`.
+- `src/views/AdminApp.vue` — new role-permissions section.
+- `lib/Settings/mydash_register.json` — two new schemas + seed data objects.
+- `appinfo/routes.php` — four new admin API routes.
+
+**APIs:**
+- `GET  /api/widgets` — now filtered by role (non-breaking; unchanged when unconfigured)
+- `GET  /api/role-feature-permissions` (admin-only)
+- `POST /api/role-feature-permissions` (admin-only)
+- `GET  /api/role-layout-defaults` (admin-only)
+- `POST /api/role-layout-defaults` (admin-only)
+
+**Data:**
+- Two new OpenRegister schemas registered via `mydash_register.json`, imported through
+  `ConfigurationService::importFromApp()` in the repair step. Idempotent — re-importing with
+  `force: false` skips existing objects matched by slug.
+- No migration needed for existing DB tables.
+
+**Dependencies:**
+- `AuthorizationService` (OpenRegister) — object-level RBAC checks on admin endpoints.
+- `AdminSettingsService` — reads `group_order` (from `group-priority-order` change) for
+  multi-group priority resolution.
+- `IGroupManager` — reads user group memberships.
+
+**Migration:**
+- Zero schema migration for existing DB tables.
+- Existing users are unaffected until an admin creates at least one RoleFeaturePermission
+  object; the empty-config path returns the full widget list (REQ-WDG-001 unchanged).
+- New users seeded via role-layout-defaults only when an admin configures RoleLayoutDefault
+  objects for their group.

--- a/openspec/changes/role-based-content/specs/role-feature-permissions/spec.md
+++ b/openspec/changes/role-based-content/specs/role-feature-permissions/spec.md
@@ -1,0 +1,419 @@
+---
+capability: role-feature-permissions
+delta: false
+status: draft
+---
+
+# Role Feature Permissions Specification
+
+## Purpose
+
+This capability governs which dashboard widgets and features are visible, accessible, and
+default-seeded for users based on their Nextcloud group (role). It ensures that staff see only
+the tools relevant to their job, that new users receive a role-appropriate starting layout
+seeded from evidence rather than a generic blank dashboard, and that attempts to access
+restricted features via direct URL are rejected at the API layer with a 403 response and an
+audit log entry.
+
+The capability is orthogonal to the existing `permissions` capability (which controls
+per-dashboard edit rights) and the `admin-templates` capability (which distributes full
+dashboard copies). All three can apply simultaneously.
+
+---
+
+## Data Model
+
+### RoleFeaturePermission
+
+Stored in OpenRegister under register `mydash`, schema `role-feature-permission`.
+One object per Nextcloud group ID (enforced via slug convention `rfp-{groupId}`).
+
+- `name` (string, required) — human-readable label
+- `description` (string, optional) — purpose notes
+- `groupId` (string, required) — Nextcloud group ID this rule applies to
+- `allowedWidgets` (array\<string\>, required) — widget IDs the group may use
+- `deniedWidgets` (array\<string\>, optional, default `[]`) — widget IDs explicitly denied;
+  deny overrides any allow from other groups
+- `priorityWeights` (object, optional) — `{ widgetId: integer }` — higher value = higher
+  priority in layout seeding and display ordering
+
+### RoleLayoutDefault
+
+Stored in OpenRegister under register `mydash`, schema `role-layout-default`.
+One object per (groupId, widgetId) pair (slug `rld-{groupId}-{widgetId}`).
+
+- `name` (string, required) — display label
+- `groupId` (string, required) — Nextcloud group ID
+- `widgetId` (string, required) — Nextcloud Dashboard widget ID
+- `gridX`, `gridY` (integer, required) — 0-based grid position
+- `gridWidth`, `gridHeight` (integer, required) — grid span
+- `sortOrder` (integer, required, default 0) — rendering order (lower = first)
+- `isCompulsory` (boolean, optional, default false) — user cannot remove this widget
+- `description` (string, optional) — rationale note
+
+---
+
+## Requirements
+
+### REQ-RFP-001: Feature presence visibility by role
+
+The system MUST render or hide dashboard features based on the authenticated user's effective
+role-feature-permissions. A widget not in the user's effective `allowedWidgets` set MUST NOT
+appear anywhere in the UI and MUST NOT be returned by `GET /api/widgets`.
+
+#### Scenario: Employee-role user does not see admin-only widgets
+
+- GIVEN a RoleFeaturePermission exists for group `"medewerkers"` with
+  `allowedWidgets: ["activity", "recommendations", "notes", "calendar"]`
+- AND user "jan.de.vries" belongs to group `"medewerkers"` (and no higher-priority group)
+- WHEN jan.de.vries sends `GET /api/widgets`
+- THEN the response MUST contain only widgets whose IDs are in `["activity", "recommendations", "notes", "calendar"]`
+- AND the widget `"analytics_dashboard"` MUST NOT appear in the response
+- AND the response status MUST be HTTP 200
+
+#### Scenario: Admin updates role permissions, affected user sees updated set on reload
+
+- GIVEN user "fatima.el-amrani" has group `"hrm"` and the current RoleFeaturePermission for
+  `"hrm"` has `allowedWidgets: ["activity", "calendar"]`
+- WHEN an IT admin updates the `"hrm"` RoleFeaturePermission to add `"user_status"` to
+  `allowedWidgets`
+- AND fatima.el-amrani reloads the dashboard
+- THEN `GET /api/widgets` MUST return a list that includes `"user_status"`
+- AND the card library MUST display `"user_status"` as available to add
+
+#### Scenario: Direct URL request to restricted feature returns 403
+
+- GIVEN a RoleFeaturePermission for group `"medewerkers"` does NOT include `"analytics_dashboard"`
+- AND user "pieter.van.dijk" belongs only to group `"medewerkers"`
+- WHEN pieter.van.dijk sends a GET request to the feature URL for `"analytics_dashboard"`
+  (e.g. `GET /api/widgets/items?widgetId=analytics_dashboard`)
+- THEN the system MUST return HTTP 403
+- AND the response body MUST contain `{"message": "Not authorized"}`
+- AND an audit entry MUST be written recording the user ID, widget ID, and timestamp
+- AND the widget content MUST NOT be returned
+
+---
+
+### REQ-RFP-002: Role-based default dashboard layout
+
+When a new user opens MyDash for the first time and no admin template matches their group,
+the system MUST seed their dashboard from the RoleLayoutDefault objects for their primary
+group (resolved via `group_order` priority). Existing personal customisations MUST never be
+overwritten.
+
+#### Scenario: New user receives role-appropriate default layout
+
+- GIVEN user "noor.yilmaz" is a member of group `"managers"` (highest-priority matching group)
+- AND no admin template targets group `"managers"`
+- AND RoleLayoutDefault objects exist for group `"managers"`:
+  - `analytics_dashboard` at (0,0), 8×6, sortOrder 1, isCompulsory true
+  - `activity` at (8,0), 4×6, sortOrder 2, isCompulsory false
+- WHEN noor.yilmaz opens MyDash for the first time (no existing dashboard)
+- THEN `DashboardResolver::tryCreateFromTemplate()` MUST call `seedLayoutFromRoleDefaults()`
+- AND the resulting dashboard MUST contain two WidgetPlacement rows matching the
+  RoleLayoutDefault objects (gridX, gridY, gridWidth, gridHeight, isCompulsory preserved)
+- AND the `analytics_dashboard` placement MUST have `isCompulsory: 1`
+
+#### Scenario: Admin updates role defaults; new user receives updated layout
+
+- GIVEN an IT admin updates the `"managers"` RoleLayoutDefault to add `"user_status"` at
+  (0,7), 4×4, sortOrder 3
+- WHEN a new user with group `"managers"` signs in and opens MyDash
+- THEN their seeded dashboard MUST include `"user_status"` at the updated position
+- AND previously created users are unaffected (their existing placements are not touched)
+
+#### Scenario: Existing personal customisations are preserved when role defaults change
+
+- GIVEN user "sem.de.jong" has an existing personal dashboard with two customised placements
+- AND an IT admin updates the RoleLayoutDefault for sem's group
+- WHEN sem.de.jong reloads MyDash
+- THEN sem's existing placements MUST remain unchanged
+- AND the new role defaults MUST NOT overwrite or remove any of sem's personal placements
+- NOTE: `seedLayoutFromRoleDefaults()` is only called during first-creation; it does not
+  run for existing dashboards.
+
+---
+
+### REQ-RFP-003: Role-based card library
+
+The card library (widget picker) MUST only surface widgets permitted for the authenticated
+user's effective role. Widgets outside the allowed set MUST be absent from the picker UI and
+from `GET /api/widgets`.
+
+#### Scenario: Manager-only card is hidden for employee-role user
+
+- GIVEN a RoleFeaturePermission for group `"medewerkers"` with
+  `allowedWidgets: ["activity", "recommendations", "notes", "calendar"]`
+- AND a RoleFeaturePermission for group `"managers"` that additionally includes
+  `"analytics_dashboard"`
+- AND user "annemarie.de-vries" belongs only to group `"medewerkers"`
+- WHEN annemarie opens the widget card library
+- THEN `"analytics_dashboard"` MUST NOT be listed in the card library
+- AND `"analytics_dashboard"` MUST NOT appear in `GET /api/widgets` response
+
+#### Scenario: User holds a role granting card access — only permitted cards listed
+
+- GIVEN user "mark.visser" belongs to group `"managers"` (in group_order)
+- AND the `"managers"` RoleFeaturePermission `allowedWidgets` includes `"analytics_dashboard"`
+- WHEN mark.visser opens the card library
+- THEN `"analytics_dashboard"` MUST appear in the card library
+- AND only widgets in the effective `allowedWidgets` set MUST be listed
+
+#### Scenario: Admin revokes role; previously visible cards no longer accessible
+
+- GIVEN user "jan.de.vries" previously had group `"managers"` which allowed `"analytics_dashboard"`
+- WHEN an IT admin removes jan.de.vries from group `"managers"` in Nextcloud
+- AND jan.de.vries reloads the dashboard
+- THEN `GET /api/widgets` MUST no longer include `"analytics_dashboard"`
+- AND if jan.de.vries had a placement of `"analytics_dashboard"` on their dashboard,
+  that placement MUST have its `isVisible` set to 0 at render time (widget hidden, not deleted)
+
+---
+
+### REQ-RFP-004: Role-and-priority layout ordering
+
+Widgets on a user's dashboard MUST be ordered according to the `priorityWeights` defined in
+the user's effective RoleFeaturePermission. Widgets with higher priority weight MUST appear
+earlier in the default sort order.
+
+#### Scenario: New dashboard respects role priority weights
+
+- GIVEN the `"managers"` RoleFeaturePermission has
+  `priorityWeights: { "analytics_dashboard": 10, "activity": 8, "user_status": 6 }`
+- AND RoleLayoutDefault objects for `"managers"` are seeded with matching sortOrder values
+  (analytics_dashboard sortOrder 1, activity sortOrder 2, user_status sortOrder 3)
+- WHEN a new `"managers"` user's layout is seeded via `seedLayoutFromRoleDefaults()`
+- THEN the resulting WidgetPlacements MUST reflect the priority ordering
+  (analytics_dashboard first on the grid, then activity, then user_status)
+
+#### Scenario: Admin updates priority weights; next-loaded dashboard reflects new order
+
+- GIVEN an IT admin updates the `"managers"` RoleFeaturePermission to raise `"activity"`
+  weight to 12 (above `"analytics_dashboard"`)
+- WHEN the admin also updates the corresponding RoleLayoutDefault sortOrder values
+- WHEN a new `"managers"` user opens MyDash after the update
+- THEN `"activity"` MUST appear at sortOrder 1 (first position)
+- AND `"analytics_dashboard"` MUST appear at sortOrder 2
+
+#### Scenario: Unpermitted high-priority widget is hidden; next eligible widget takes its slot
+
+- GIVEN the `"medewerkers"` RoleFeaturePermission does NOT include `"analytics_dashboard"`
+- AND the RoleLayoutDefault for `"managers"` places `"analytics_dashboard"` at sortOrder 1
+- AND user "jan.de.vries" belongs only to group `"medewerkers"`
+- WHEN jan.de.vries's dashboard is rendered
+- THEN `"analytics_dashboard"` placement MUST NOT appear (not in allowed set)
+- AND the next eligible widget MUST occupy the first visible slot
+
+---
+
+### REQ-RFP-005: Role precedence for multi-group users
+
+When a user belongs to multiple groups that each have a RoleFeaturePermission, the system
+MUST resolve a single deterministic effective widget set using the `group_order` admin setting.
+The first matching group's `allowedWidgets` form the base set; additional matched groups widen
+the set; `deniedWidgets` from any matched group always win.
+
+#### Scenario: User sees role-default layout matching primary (highest-priority) group
+
+- GIVEN `group_order = ["managers", "medewerkers", "all-staff"]`
+- AND user "noor.yilmaz" belongs to groups `["medewerkers", "managers"]`
+- WHEN noor.yilmaz's effective widget set is resolved
+- THEN the base set MUST come from `"managers"` (appears first in `group_order`)
+- AND `"medewerkers"` widgets MUST be unioned in (widening), excluding any `deniedWidgets`
+- AND the resulting effective set MUST deterministically include all `"managers"` allowed
+  widgets plus any additional `"medewerkers"` allowed widgets not already present
+
+#### Scenario: User in multiple groups; deny-wins rule applies
+
+- GIVEN `group_order = ["managers", "all-staff"]`
+- AND the `"all-staff"` RoleFeaturePermission has `deniedWidgets: ["system_monitor"]`
+- AND the `"managers"` RoleFeaturePermission has `allowedWidgets` including `"system_monitor"`
+- AND user "priya.ganpat" belongs to both `"managers"` and `"all-staff"`
+- WHEN priya.ganpat's effective widget set is resolved
+- THEN `"system_monitor"` MUST NOT appear in the effective allowed set
+  (deny from any matched group overrides any allow)
+- AND `GET /api/widgets` MUST NOT return `"system_monitor"` for priya.ganpat
+
+#### Scenario: Active role changes mid-session; dashboard re-renders with new permissions
+
+- GIVEN user "sem.de.jong" is currently resolved to group `"medewerkers"` permissions
+- WHEN an IT admin adds sem.de.jong to group `"managers"` (which has higher priority in
+  `group_order`)
+- AND sem.de.jong triggers a session refresh (page reload)
+- THEN `GET /api/widgets` MUST return the `"managers"` effective widget set
+- AND the dashboard MUST re-render showing the updated card library for sem's new primary role
+
+---
+
+### REQ-RFP-006: Role, interest, and journey distinction
+
+The system MUST distinguish between role-based access (Nextcloud group membership), expressed
+personal interest (user adds a widget they are permitted to add), and journey stage (the user's
+active primary group changes during a session). Access MUST be governed by role membership;
+interest MAY widen the visible card library within role limits; journey changes MUST take
+effect within one session refresh.
+
+#### Scenario: User assigned a role sees only widgets permitted for that role
+
+- GIVEN user "henk.bakker" belongs to group `"medewerkers"` and no other role-priority group
+- WHEN henk opens MyDash
+- THEN `GET /api/widgets` MUST return only widgets in the `"medewerkers"` effective set
+- AND no interest expression (bookmarked widget, previous session) MUST expand this set beyond
+  what the role permits
+
+#### Scenario: User expresses interest without a matching role — access denied, audit logged
+
+- GIVEN a widget `"analytics_dashboard"` is in the `"managers"` allowed set
+  but NOT in the `"medewerkers"` allowed set
+- AND user "jan.de.vries" belongs only to `"medewerkers"` and expresses interest in
+  `"analytics_dashboard"` (e.g. via a saved preference or direct URL request)
+- WHEN jan.de.vries sends a request for `"analytics_dashboard"` content
+- THEN the system MUST return HTTP 403
+- AND an audit entry MUST be written with user ID, widget ID, access attempt timestamp,
+  and the reason `"interest_without_role"`
+- AND the widget MUST NOT be rendered or returned
+
+#### Scenario: Active role changes; dashboard reflects new role's permissions after refresh
+
+- GIVEN user "noor.yilmaz" is mid-session with primary group `"medewerkers"` resolved
+- WHEN noor.yilmaz's Nextcloud group membership is updated to add `"managers"`
+  (which has higher priority in `group_order`)
+- AND noor.yilmaz triggers one session refresh
+- THEN `GET /api/widgets` MUST return the `"managers"` effective widget set on the next call
+- AND the effective widget set from before the refresh (medewerkers) MUST no longer apply
+
+---
+
+### REQ-RFP-007: Admin CRUD for role-feature-permissions
+
+IT admins MUST be able to create, read, update, and delete RoleFeaturePermission objects via
+admin-only API endpoints. Non-admin users MUST receive HTTP 403 on all mutation attempts.
+
+#### Scenario: Admin creates a role-feature-permission
+
+- GIVEN a Nextcloud admin user
+- WHEN they send `POST /api/role-feature-permissions` with body:
+  ```json
+  {
+    "groupId": "communicatie",
+    "name": "Communicatie widget-rechten",
+    "allowedWidgets": ["activity", "notes", "calendar"],
+    "deniedWidgets": [],
+    "priorityWeights": { "calendar": 10, "activity": 8 }
+  }
+  ```
+- THEN the system MUST create a RoleFeaturePermission object in OpenRegister
+- AND the response MUST return HTTP 201 with the created object including its OpenRegister ID
+- AND the object MUST be retrievable via `GET /api/role-feature-permissions`
+
+#### Scenario: Non-admin user cannot create or modify role-feature-permissions
+
+- GIVEN user "jan.de.vries" is not a Nextcloud administrator
+- WHEN jan sends `POST /api/role-feature-permissions` with any body
+- THEN the system MUST return HTTP 403
+- AND no object MUST be created
+
+#### Scenario: Admin lists all role-feature-permissions
+
+- GIVEN three RoleFeaturePermission objects exist for groups `"medewerkers"`, `"managers"`,
+  `"hrm"`
+- WHEN a Nextcloud admin sends `GET /api/role-feature-permissions`
+- THEN the response MUST return HTTP 200 with all three objects
+- AND each object MUST include `groupId`, `allowedWidgets`, `deniedWidgets`, `priorityWeights`
+
+---
+
+### REQ-RFP-008: Admin CRUD for role-layout-defaults
+
+IT admins MUST be able to create, read, update, and delete RoleLayoutDefault objects. Non-admin
+users MUST receive HTTP 403 on all mutation attempts.
+
+#### Scenario: Admin creates a role-layout-default
+
+- GIVEN a Nextcloud admin user
+- WHEN they send `POST /api/role-layout-defaults` with body:
+  ```json
+  {
+    "groupId": "managers",
+    "widgetId": "user_status",
+    "name": "Manager — gebruikersstatus",
+    "gridX": 0, "gridY": 7, "gridWidth": 4, "gridHeight": 4,
+    "sortOrder": 3, "isCompulsory": false
+  }
+  ```
+- THEN the system MUST create a RoleLayoutDefault object in OpenRegister
+- AND the response MUST return HTTP 201
+- AND new users joining group `"managers"` after this point MUST receive `"user_status"` in
+  their seeded layout
+
+#### Scenario: Non-admin user cannot manage role-layout-defaults
+
+- GIVEN user "sem.de.jong" is not a Nextcloud administrator
+- WHEN sem sends `POST /api/role-layout-defaults` with any body
+- THEN the system MUST return HTTP 403
+
+---
+
+### REQ-RFP-009: Unconfigured installations retain full backwards-compatibility
+
+When no RoleFeaturePermission objects exist in OpenRegister, `GET /api/widgets` MUST return
+the full widget list unchanged. No change in behaviour for existing MyDash installations that
+have not configured role-feature-permissions.
+
+#### Scenario: No permissions configured — all widgets visible
+
+- GIVEN no RoleFeaturePermission objects exist for any group
+- WHEN any authenticated user sends `GET /api/widgets`
+- THEN the system MUST return HTTP 200 with the full list of all registered Nextcloud widgets
+  (equivalent to the pre-change behaviour of REQ-WDG-001)
+- AND no filtering MUST be applied
+
+#### Scenario: Permissions exist for some groups but not the user's group
+
+- GIVEN a RoleFeaturePermission exists for group `"managers"` but NOT for group `"medewerkers"`
+- AND user "jan.de.vries" belongs only to group `"medewerkers"`
+- AND no `"default"` RoleFeaturePermission exists
+- WHEN jan.de.vries sends `GET /api/widgets`
+- THEN the system MUST return the full unfiltered widget list
+  (fall-through to unconfigured behaviour when no matching group is found)
+
+---
+
+### REQ-RFP-010: Initial-state widget allowlist
+
+The backend MUST include the resolved `allowedWidgets` list (or `null` for unconfigured) in
+the initial-state payload delivered to the frontend, so that the card library can filter
+without a separate API call.
+
+#### Scenario: Initial state includes allowedWidgets for role-configured user
+
+- GIVEN user "noor.yilmaz" has group `"managers"` with `allowedWidgets: ["activity", "analytics_dashboard"]`
+- WHEN the MyDash page loads and `GET /api/settings` or the initial-state endpoint is called
+- THEN the response payload MUST include `"allowedWidgets": ["activity", "analytics_dashboard"]`
+- AND the frontend card library MUST use this list to filter without an additional API call
+
+#### Scenario: Initial state includes null for unconfigured installation
+
+- GIVEN no RoleFeaturePermission objects exist
+- WHEN any user loads MyDash
+- THEN the initial-state payload MUST include `"allowedWidgets": null`
+- AND the frontend MUST treat `null` as "no restriction" (show all widgets)
+
+---
+
+## Non-Functional Requirements
+
+- **Security**: All permission checks MUST be enforced server-side in `RoleFeaturePermissionService`.
+  Frontend `allowedWidgets` filtering is a UX convenience only; the API layer is the
+  authoritative gate (REQ-RFP-001, REQ-RFP-003).
+- **Audit**: Every 403 issued for a role-permission denial MUST produce an audit entry via
+  `AuditTrailService` (OpenRegister), recording user ID (from `IUserSession::getUser()->getUID()`),
+  widget ID, timestamp, and denial reason. NEVER log display names (ADR-005).
+- **Performance**: `getAllowedWidgetIds()` MUST complete within 20 ms on a warm server (at most
+  two OpenRegister object list queries + one `IGroupManager::getUserGroupIds` call).
+- **Backwards-compatibility**: All new endpoints and the `GET /api/widgets` filter MUST be
+  additive and non-breaking. Unconfigured installations behave identically to before (REQ-RFP-009).
+- **Accessibility (WCAG AA)**: Filtered-out card library items MUST be absent from the DOM
+  entirely — not just hidden via CSS — to prevent exposure via DevTools or assistive technology.
+- **i18n**: All user-facing strings (error messages, admin UI labels) MUST use `t(appName, 'key')`
+  with English keys and Dutch translations in `l10n/nl.json` (ADR-007).

--- a/openspec/changes/role-based-content/tasks.md
+++ b/openspec/changes/role-based-content/tasks.md
@@ -1,3 +1,8 @@
+> **Stage 1-3 complete on build/role-based-content (PR #95).** Native mydash
+> persistence used in place of OpenRegister-based design (see PR description).
+> Tasks 0.x, 4.2-4.3, 8.2, 9.3, 11.2-11.3, 12.x-14.x, 15.2, 16.x deferred to
+> Stage 4 / follow-up commits.
+
 # Tasks — role-based-content
 
 ## 0. Deduplication check
@@ -14,12 +19,12 @@
 
 ## 1. OpenRegister schemas and seed data
 
-- [ ] 1.1 Add `RoleFeaturePermission` schema definition to `lib/Settings/mydash_register.json`
+- [x] 1.1 Add `RoleFeaturePermission` schema definition to `lib/Settings/mydash_register.json`
       (schema key `role-feature-permission`, register key `mydash`) with all properties from
       design.md: `name`, `description`, `groupId`, `allowedWidgets`, `deniedWidgets`,
       `priorityWeights`. Mark `name`, `groupId`, `allowedWidgets` as required. Use schema.org
       vocabulary per ADR-011.
-- [ ] 1.2 Add `RoleLayoutDefault` schema definition to `lib/Settings/mydash_register.json`
+- [x] 1.2 Add `RoleLayoutDefault` schema definition to `lib/Settings/mydash_register.json`
       (schema key `role-layout-default`) with properties: `name`, `groupId`, `widgetId`,
       `gridX`, `gridY`, `gridWidth`, `gridHeight`, `sortOrder`, `isCompulsory`, `description`.
       Mark `name`, `groupId`, `widgetId`, `gridX`, `gridY`, `gridWidth`, `gridHeight`,
@@ -34,7 +39,7 @@
 
 ## 2. Backend service
 
-- [ ] 2.1 Create `lib/Service/RoleFeaturePermissionService.php` with:
+- [x] 2.1 Create `lib/Service/RoleFeaturePermissionService.php` with:
       - `@spec openspec/changes/role-based-content/tasks.md#task-2`
       - Constructor injection: `ObjectService $objectService`,
         `AdminSettingsService $adminSettingsService`, `IGroupManager $groupManager`,
@@ -49,18 +54,18 @@
       - `authorizeAdminObject(IUser $user): void` — throws `OCSForbiddenException` if not
         admin (ADR-005 pattern)
       - All methods MUST be stateless (no instance state between requests, ADR-003)
-- [ ] 2.2 Implement multi-group resolution algorithm per design.md §"Multi-group Resolution
+- [x] 2.2 Implement multi-group resolution algorithm per design.md §"Multi-group Resolution
       Algorithm": walk `group_order`, base set from first matching group, union additional
       matches, deny-wins rule (REQ-RFP-005, REQ-RFP-006).
-- [ ] 2.3 Implement fallback to `'default'` RoleFeaturePermission when no `group_order` match
+- [x] 2.3 Implement fallback to `'default'` RoleFeaturePermission when no `group_order` match
       found, and null fallback (return all widgets) when no `'default'` object exists
       (REQ-RFP-009).
-- [ ] 2.4 In `seedLayoutFromRoleDefaults()`: only call when the dashboard has zero existing
+- [x] 2.4 In `seedLayoutFromRoleDefaults()`: only call when the dashboard has zero existing
       placements (guard against overwriting personal customisations, REQ-RFP-002 scenario 3).
 
 ## 3. Backend controller
 
-- [ ] 3.1 Create `lib/Controller/RoleFeaturePermissionController.php` with:
+- [x] 3.1 Create `lib/Controller/RoleFeaturePermissionController.php` with:
       - `@spec openspec/changes/role-based-content/tasks.md#task-3`
       - All methods annotated `#[AuthorizedAdminSetting(Application::APP_ID)]`
       - `listPermissions(): JSONResponse` — `GET /api/role-feature-permissions`
@@ -69,7 +74,7 @@
       - `saveLayoutDefault(Request $request): JSONResponse` — `POST /api/role-layout-defaults`
       - Each method: thin (<10 lines), calls service, returns JSONResponse (ADR-003)
       - Error responses: static generic messages only — NEVER `$e->getMessage()` (ADR-015)
-- [ ] 3.2 Register all four routes in `appinfo/routes.php` before any wildcard `{slug}` route:
+- [x] 3.2 Register all four routes in `appinfo/routes.php` before any wildcard `{slug}` route:
       - `GET  /api/role-feature-permissions`
       - `POST /api/role-feature-permissions`
       - `GET  /api/role-layout-defaults`
@@ -77,7 +82,7 @@
 
 ## 4. Extend existing widget controller
 
-- [ ] 4.1 In `lib/Controller/WidgetController.php` `list()` method: inject
+- [x] 4.1 In `lib/Controller/WidgetController.php` `list()` method: inject
       `RoleFeaturePermissionService` and call `getAllowedWidgetIds($userId)`; if the result is
       not null, filter the widget array to only those with IDs in the allowed set (REQ-RFP-001,
       REQ-RFP-003).
@@ -91,34 +96,34 @@
 
 ## 5. Extend dashboard resolver
 
-- [ ] 5.1 In `lib/Service/DashboardResolver.php` (or equivalent) `tryCreateFromTemplate()`:
+- [x] 5.1 In `lib/Service/DashboardResolver.php` (or equivalent) `tryCreateFromTemplate()`:
       after all admin-template matching fails, call
       `RoleFeaturePermissionService::seedLayoutFromRoleDefaults()` if RoleLayoutDefault
       objects exist for the user's primary group (REQ-RFP-002).
-- [ ] 5.2 Verify the guard: `seedLayoutFromRoleDefaults()` MUST only run when the new
+- [x] 5.2 Verify the guard: `seedLayoutFromRoleDefaults()` MUST only run when the new
       dashboard has zero placements — assert this in the unit test (REQ-RFP-002 scenario 3).
 
 ## 6. Initial-state payload
 
-- [ ] 6.1 In the settings/initial-state controller (e.g. `SettingsController`): call
+- [x] 6.1 In the settings/initial-state controller (e.g. `SettingsController`): call
       `RoleFeaturePermissionService::getAllowedWidgetIds()` and include the result as
       `allowedWidgets` in the JSON response (REQ-RFP-010). Return `null` when unconfigured.
-- [ ] 6.2 Ensure the initial-state type definition / PHP doc reflects the new field so Psalm
+- [x] 6.2 Ensure the initial-state type definition / PHP doc reflects the new field so Psalm
       does not flag it as undeclared.
 
 ## 7. Frontend — store
 
-- [ ] 7.1 Create `src/store/modules/roleFeaturePermission.js`:
+- [x] 7.1 Create `src/store/modules/roleFeaturePermission.js`:
       `createObjectStore('role-feature-permission')` with `auditTrailsPlugin` (Pinia pattern,
       ADR-004). Register in `src/store/store.js` via `registerObjectType`.
-- [ ] 7.2 Create `src/store/modules/roleLayoutDefault.js`:
+- [x] 7.2 Create `src/store/modules/roleLayoutDefault.js`:
       `createObjectStore('role-layout-default')`. Register in `src/store/store.js`.
-- [ ] 7.3 Extend settings store: add `allowedWidgets: null` field, populated from the
+- [x] 7.3 Extend settings store: add `allowedWidgets: null` field, populated from the
       initial-state payload (REQ-RFP-010).
 
 ## 8. Frontend — card library filtering
 
-- [ ] 8.1 In the widget card library / picker component: read `allowedWidgets` from the
+- [x] 8.1 In the widget card library / picker component: read `allowedWidgets` from the
       settings store; if non-null, filter the widget list before rendering so that
       disallowed widgets are absent from the DOM entirely (not hidden via CSS) (REQ-RFP-003,
       non-functional accessibility requirement).
@@ -127,13 +132,13 @@
 
 ## 9. Frontend — admin UI
 
-- [ ] 9.1 Create `src/components/RolePermissionsSection.vue` (scoped style, EUPL header):
+- [x] 9.1 Create `src/components/RolePermissionsSection.vue` (scoped style, EUPL header):
       - Lists existing RoleFeaturePermission objects in a `CnDataTable`
       - Add button opens `CnFormDialog` (schema-driven form for RoleFeaturePermission)
       - Edit opens `CnFormDialog` pre-populated
       - Delete opens `CnDeleteDialog`
       - All user-visible strings via `t(appName, 'key')` — no hardcoded strings (ADR-007)
-- [ ] 9.2 Add `RolePermissionsSection` to `src/views/AdminApp.vue` beneath existing admin
+- [x] 9.2 Add `RolePermissionsSection` to `src/views/AdminApp.vue` beneath existing admin
       sections. Register the component in `components: {}` (ADR-004: every component used
       in template MUST be imported AND registered).
 - [ ] 9.3 Add a RoleLayoutDefault section (`CnDataTable` + `CnFormDialog` + `CnDeleteDialog`)
@@ -142,14 +147,14 @@
 
 ## 10. i18n
 
-- [ ] 10.1 Add English translation keys to `l10n/en.json` for all new user-facing strings:
+- [x] 10.1 Add English translation keys to `l10n/en.json` for all new user-facing strings:
       admin section titles, column headers, form labels, error messages (ADR-007 sentence case).
-- [ ] 10.2 Add Dutch (`nl`) translations to `l10n/nl.json` for every key added in 10.1.
+- [x] 10.2 Add Dutch (`nl`) translations to `l10n/nl.json` for every key added in 10.1.
       Both files MUST contain exactly the same keys with zero gaps.
 
 ## 11. Unit tests (PHPUnit)
 
-- [ ] 11.1 `tests/Unit/Service/RoleFeaturePermissionServiceTest.php` — table-driven tests
+- [x] 11.1 `tests/Unit/Service/RoleFeaturePermissionServiceTest.php` — table-driven tests
       covering every REQ-RFP scenario:
       - single group, allowed widget in list → allowed
       - single group, widget not in allowed list → denied
@@ -196,7 +201,7 @@
 
 ## 15. Documentation
 
-- [ ] 15.1 Add `docs/role-based-content.md` describing the feature for IT admins: how to
+- [x] 15.1 Add `docs/role-based-content.md` describing the feature for IT admins: how to
       create RoleFeaturePermission objects, how group priority interacts with widget filtering,
       how RoleLayoutDefault seeds new users (ADR-009).
 - [ ] 15.2 Include at least one screenshot of the admin UI role-permissions section.

--- a/openspec/changes/role-based-content/tasks.md
+++ b/openspec/changes/role-based-content/tasks.md
@@ -1,0 +1,219 @@
+# Tasks — role-based-content
+
+## 0. Deduplication check
+
+- [ ] 0.1 Search `openspec/specs/` for any existing capability covering widget-level role
+      filtering (distinct from `permissions` which covers per-dashboard edit rights and
+      `admin-templates` which covers dashboard distribution). Document findings here.
+- [ ] 0.2 Grep `openregister/lib/Service/` and `lib/Service/` for any existing
+      `getAllowedWidgetIds`, `widgetPermission`, or `roleFilter` methods — confirm none exist.
+- [ ] 0.3 Verify `@conduction/nextcloud-vue` does not already expose a role-filtered widget
+      picker component that would make `RolePermissionsSection.vue` redundant.
+- [ ] 0.4 Record findings (even "no overlap found") in a comment block at the top of
+      `RoleFeaturePermissionService.php`.
+
+## 1. OpenRegister schemas and seed data
+
+- [ ] 1.1 Add `RoleFeaturePermission` schema definition to `lib/Settings/mydash_register.json`
+      (schema key `role-feature-permission`, register key `mydash`) with all properties from
+      design.md: `name`, `description`, `groupId`, `allowedWidgets`, `deniedWidgets`,
+      `priorityWeights`. Mark `name`, `groupId`, `allowedWidgets` as required. Use schema.org
+      vocabulary per ADR-011.
+- [ ] 1.2 Add `RoleLayoutDefault` schema definition to `lib/Settings/mydash_register.json`
+      (schema key `role-layout-default`) with properties: `name`, `groupId`, `widgetId`,
+      `gridX`, `gridY`, `gridWidth`, `gridHeight`, `sortOrder`, `isCompulsory`, `description`.
+      Mark `name`, `groupId`, `widgetId`, `gridX`, `gridY`, `gridWidth`, `gridHeight`,
+      `sortOrder` as required.
+- [ ] 1.3 Add the 5 RoleFeaturePermission seed objects from design.md to
+      `lib/Settings/mydash_register.json` under `components.objects[]` using the `@self`
+      envelope (register, schema, slug per design.md).
+- [ ] 1.4 Add the 5 RoleLayoutDefault seed objects from design.md to
+      `lib/Settings/mydash_register.json` using the `@self` envelope.
+- [ ] 1.5 Verify idempotency: re-running `ConfigurationService::importFromApp()` with
+      `force: false` MUST NOT create duplicate objects (matching by slug).
+
+## 2. Backend service
+
+- [ ] 2.1 Create `lib/Service/RoleFeaturePermissionService.php` with:
+      - `@spec openspec/changes/role-based-content/tasks.md#task-2`
+      - Constructor injection: `ObjectService $objectService`,
+        `AdminSettingsService $adminSettingsService`, `IGroupManager $groupManager`,
+        `LoggerInterface $logger`
+      - `getAllowedWidgetIds(string $userId): ?array` — returns null (unconfigured) or the
+        effective allowed-widget ID array (REQ-RFP-009 backwards-compat, REQ-RFP-005
+        multi-group algorithm from design.md)
+      - `isWidgetAllowed(string $userId, string $widgetId): bool` — convenience wrapper
+      - `seedLayoutFromRoleDefaults(string $userId, object $dashboard): void` — reads
+        RoleLayoutDefault objects for primary group, creates WidgetPlacement records
+        (REQ-RFP-002)
+      - `authorizeAdminObject(IUser $user): void` — throws `OCSForbiddenException` if not
+        admin (ADR-005 pattern)
+      - All methods MUST be stateless (no instance state between requests, ADR-003)
+- [ ] 2.2 Implement multi-group resolution algorithm per design.md §"Multi-group Resolution
+      Algorithm": walk `group_order`, base set from first matching group, union additional
+      matches, deny-wins rule (REQ-RFP-005, REQ-RFP-006).
+- [ ] 2.3 Implement fallback to `'default'` RoleFeaturePermission when no `group_order` match
+      found, and null fallback (return all widgets) when no `'default'` object exists
+      (REQ-RFP-009).
+- [ ] 2.4 In `seedLayoutFromRoleDefaults()`: only call when the dashboard has zero existing
+      placements (guard against overwriting personal customisations, REQ-RFP-002 scenario 3).
+
+## 3. Backend controller
+
+- [ ] 3.1 Create `lib/Controller/RoleFeaturePermissionController.php` with:
+      - `@spec openspec/changes/role-based-content/tasks.md#task-3`
+      - All methods annotated `#[AuthorizedAdminSetting(Application::APP_ID)]`
+      - `listPermissions(): JSONResponse` — `GET /api/role-feature-permissions`
+      - `savePermission(Request $request): JSONResponse` — `POST /api/role-feature-permissions`
+      - `listLayoutDefaults(): JSONResponse` — `GET /api/role-layout-defaults`
+      - `saveLayoutDefault(Request $request): JSONResponse` — `POST /api/role-layout-defaults`
+      - Each method: thin (<10 lines), calls service, returns JSONResponse (ADR-003)
+      - Error responses: static generic messages only — NEVER `$e->getMessage()` (ADR-015)
+- [ ] 3.2 Register all four routes in `appinfo/routes.php` before any wildcard `{slug}` route:
+      - `GET  /api/role-feature-permissions`
+      - `POST /api/role-feature-permissions`
+      - `GET  /api/role-layout-defaults`
+      - `POST /api/role-layout-defaults`
+
+## 4. Extend existing widget controller
+
+- [ ] 4.1 In `lib/Controller/WidgetController.php` `list()` method: inject
+      `RoleFeaturePermissionService` and call `getAllowedWidgetIds($userId)`; if the result is
+      not null, filter the widget array to only those with IDs in the allowed set (REQ-RFP-001,
+      REQ-RFP-003).
+- [ ] 4.2 In `WidgetController` method(s) that serve widget feature content (e.g. `getItems()`):
+      call `isWidgetAllowed($userId, $widgetId)` before delegating to the widget loader; return
+      HTTP 403 with `{"message": "Not authorized"}` and write an audit entry if denied
+      (REQ-RFP-001 scenario 3, REQ-RFP-006 scenario 2).
+- [ ] 4.3 Audit entry format: use `AuditTrailService` (OpenRegister), record
+      `$user->getUID()` (NOT display name, ADR-005), `widgetId`, ISO timestamp, reason string
+      `"role_permission_denied"` or `"interest_without_role"` as applicable.
+
+## 5. Extend dashboard resolver
+
+- [ ] 5.1 In `lib/Service/DashboardResolver.php` (or equivalent) `tryCreateFromTemplate()`:
+      after all admin-template matching fails, call
+      `RoleFeaturePermissionService::seedLayoutFromRoleDefaults()` if RoleLayoutDefault
+      objects exist for the user's primary group (REQ-RFP-002).
+- [ ] 5.2 Verify the guard: `seedLayoutFromRoleDefaults()` MUST only run when the new
+      dashboard has zero placements — assert this in the unit test (REQ-RFP-002 scenario 3).
+
+## 6. Initial-state payload
+
+- [ ] 6.1 In the settings/initial-state controller (e.g. `SettingsController`): call
+      `RoleFeaturePermissionService::getAllowedWidgetIds()` and include the result as
+      `allowedWidgets` in the JSON response (REQ-RFP-010). Return `null` when unconfigured.
+- [ ] 6.2 Ensure the initial-state type definition / PHP doc reflects the new field so Psalm
+      does not flag it as undeclared.
+
+## 7. Frontend — store
+
+- [ ] 7.1 Create `src/store/modules/roleFeaturePermission.js`:
+      `createObjectStore('role-feature-permission')` with `auditTrailsPlugin` (Pinia pattern,
+      ADR-004). Register in `src/store/store.js` via `registerObjectType`.
+- [ ] 7.2 Create `src/store/modules/roleLayoutDefault.js`:
+      `createObjectStore('role-layout-default')`. Register in `src/store/store.js`.
+- [ ] 7.3 Extend settings store: add `allowedWidgets: null` field, populated from the
+      initial-state payload (REQ-RFP-010).
+
+## 8. Frontend — card library filtering
+
+- [ ] 8.1 In the widget card library / picker component: read `allowedWidgets` from the
+      settings store; if non-null, filter the widget list before rendering so that
+      disallowed widgets are absent from the DOM entirely (not hidden via CSS) (REQ-RFP-003,
+      non-functional accessibility requirement).
+- [ ] 8.2 Wrap the store action call in `try/catch` with user-facing error feedback (ADR-004
+      rule: EVERY `await store.action()` MUST be in try/catch).
+
+## 9. Frontend — admin UI
+
+- [ ] 9.1 Create `src/components/RolePermissionsSection.vue` (scoped style, EUPL header):
+      - Lists existing RoleFeaturePermission objects in a `CnDataTable`
+      - Add button opens `CnFormDialog` (schema-driven form for RoleFeaturePermission)
+      - Edit opens `CnFormDialog` pre-populated
+      - Delete opens `CnDeleteDialog`
+      - All user-visible strings via `t(appName, 'key')` — no hardcoded strings (ADR-007)
+- [ ] 9.2 Add `RolePermissionsSection` to `src/views/AdminApp.vue` beneath existing admin
+      sections. Register the component in `components: {}` (ADR-004: every component used
+      in template MUST be imported AND registered).
+- [ ] 9.3 Add a RoleLayoutDefault section (`CnDataTable` + `CnFormDialog` + `CnDeleteDialog`)
+      to the admin UI — either as a second tab within `RolePermissionsSection` or as a
+      separate `RoleLayoutDefaultsSection.vue` component.
+
+## 10. i18n
+
+- [ ] 10.1 Add English translation keys to `l10n/en.json` for all new user-facing strings:
+      admin section titles, column headers, form labels, error messages (ADR-007 sentence case).
+- [ ] 10.2 Add Dutch (`nl`) translations to `l10n/nl.json` for every key added in 10.1.
+      Both files MUST contain exactly the same keys with zero gaps.
+
+## 11. Unit tests (PHPUnit)
+
+- [ ] 11.1 `tests/Unit/Service/RoleFeaturePermissionServiceTest.php` — table-driven tests
+      covering every REQ-RFP scenario:
+      - single group, allowed widget in list → allowed
+      - single group, widget not in allowed list → denied
+      - multi-group, first-match wins (REQ-RFP-005 scenario 1)
+      - multi-group, deny-wins rule (REQ-RFP-005 scenario 2)
+      - no RoleFeaturePermission exists → returns null (REQ-RFP-009)
+      - group not in group_order → falls back to `'default'` group
+      - no `'default'` group → returns null
+      - `seedLayoutFromRoleDefaults()` with zero existing placements → creates placements
+      - `seedLayoutFromRoleDefaults()` with existing placements → no-op (REQ-RFP-002 s.3)
+- [ ] 11.2 `tests/Unit/Controller/RoleFeaturePermissionControllerTest.php` — at minimum:
+      - non-admin request → 403
+      - list returns all objects
+      - save with valid body → 201
+      - save with invalid body → 400 (static error message, no stack trace)
+- [ ] 11.3 `tests/Unit/Controller/WidgetControllerTest.php` (extend existing or create):
+      - `allowedWidgets = null` → full list returned unchanged
+      - `allowedWidgets = ["activity"]` → only activity in response
+      - direct access to restricted widget → 403 + audit entry written
+
+## 12. Integration tests
+
+- [ ] 12.1 Add Postman/Newman collection entries in `tests/integration/` covering all five new
+      endpoints with happy-path (200/201) and error-path (403, 400) scenarios (ADR-008).
+- [ ] 12.2 Include a test asserting `GET /api/widgets` returns the filtered list when a
+      RoleFeaturePermission exists for the test user's group.
+
+## 13. Browser / spec scenarios
+
+- [ ] 13.1 Add Playwright test verifying REQ-RFP-001 scenario 1: employee-role user does not
+      see admin-only widget in card library (widget absent from DOM, not merely hidden).
+- [ ] 13.2 Add Playwright test verifying REQ-RFP-002 scenario 1: new manager-role user's
+      seeded dashboard contains the correct widgets at the correct grid positions.
+
+## 14. Smoke testing (ADR-008)
+
+- [ ] 14.1 Call `GET /api/role-feature-permissions` with admin credentials — verify 200 + array.
+- [ ] 14.2 Call `POST /api/role-feature-permissions` with non-admin user — verify 403.
+- [ ] 14.3 Call `GET /api/widgets` as a user whose group has a configured RoleFeaturePermission
+      — verify only allowed widgets are returned.
+- [ ] 14.4 Attempt direct access to a restricted widget endpoint as an unpermitted user —
+      verify 403 response with `{"message": "Not authorized"}` (no stack trace, no internal
+      path in response body).
+
+## 15. Documentation
+
+- [ ] 15.1 Add `docs/role-based-content.md` describing the feature for IT admins: how to
+      create RoleFeaturePermission objects, how group priority interacts with widget filtering,
+      how RoleLayoutDefault seeds new users (ADR-009).
+- [ ] 15.2 Include at least one screenshot of the admin UI role-permissions section.
+
+## 16. Quality gates
+
+- [ ] 16.1 `composer check:strict` passes (PHPCS, PHPMD, Psalm, PHPStan) on all new PHP files.
+- [ ] 16.2 ESLint + Stylelint clean on all new / modified Vue and JS files.
+- [ ] 16.3 SPDX `@license` + `@copyright` PHPDoc tags present in every new `lib/**/*.php` file
+      (`gate-spdx` / `hydra-gate-spdx` must pass).
+- [ ] 16.4 No forbidden debug helpers (`var_dump`, `die`, `error_log`, `print_r`, `dd`)
+      (`hydra-gate-forbidden-patterns` must pass).
+- [ ] 16.5 No stub code — no empty `run()` bodies, no "In a complete implementation" comments
+      (`hydra-gate-stub-scan` must pass).
+- [ ] 16.6 No `#[NoAdminRequired]` without a per-object auth check (all new endpoints use
+      `#[AuthorizedAdminSetting]` — confirm `hydra-gate-no-admin-idor` and
+      `hydra-gate-route-auth` pass).
+- [ ] 16.7 Run all 10 `hydra-gates` locally (`/hydra-gates`) before opening PR.
+- [ ] 16.8 `@spec openspec/changes/role-based-content/tasks.md#task-N` PHPDoc tag present on
+      every new class and public method (ADR-003 spec traceability).

--- a/src/components/admin/AdminSettings.vue
+++ b/src/components/admin/AdminSettings.vue
@@ -96,6 +96,9 @@
 				</div>
 			</div>
 
+			<!-- Role-based widget permissions (REQ-RFP-001..010) -->
+			<RolePermissionsSection />
+
 			<!-- Info -->
 			<div class="mydash-admin__section">
 				<h3>{{ t('mydash', 'Setting as default app') }}</h3>
@@ -176,6 +179,7 @@ import {
 import Plus from 'vue-material-design-icons/Plus.vue'
 import ViewDashboard from 'vue-material-design-icons/ViewDashboard.vue'
 import { api } from '../../services/api.js'
+import RolePermissionsSection from './RolePermissionsSection.vue'
 
 export default {
 	name: 'AdminSettings',
@@ -191,6 +195,7 @@ export default {
 		NcModal,
 		Plus,
 		ViewDashboard,
+		RolePermissionsSection,
 	},
 
 	data() {

--- a/src/components/admin/RolePermissionsSection.vue
+++ b/src/components/admin/RolePermissionsSection.vue
@@ -1,0 +1,290 @@
+<!--
+  - SPDX-FileCopyrightText: 2026 MyDash Contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<template>
+	<div class="mydash-admin__section">
+		<h3>{{ t('mydash', 'Role-based widget permissions') }}</h3>
+		<p class="mydash-admin__hint">
+			{{ t('mydash', 'Restrict which widgets each Nextcloud group can add to their dashboard. Empty list = full catalogue (legacy).') }}
+		</p>
+
+		<div v-if="store.error" class="mydash-admin__error" role="alert">
+			{{ store.error }}
+		</div>
+
+		<NcEmptyContent
+			v-if="!store.loading && store.permissions.length === 0"
+			:name="t('mydash', 'No role permissions configured')"
+			:description="t('mydash', 'Add a role-permission row to start filtering the widget catalogue per Nextcloud group.')">
+			<template #icon>
+				<AccountGroup :size="40" />
+			</template>
+		</NcEmptyContent>
+
+		<div v-else class="mydash-admin__role-list">
+			<div v-for="row in store.permissions"
+				:key="row.id"
+				class="mydash-admin__role-row">
+				<div class="mydash-admin__role-meta">
+					<strong>{{ row.name }}</strong>
+					<span class="mydash-admin__role-group">{{ row.groupId }}</span>
+				</div>
+				<div class="mydash-admin__role-widgets">
+					<span v-for="wid in row.allowedWidgets"
+						:key="wid"
+						class="mydash-admin__chip">
+						{{ wid }}
+					</span>
+					<span v-for="wid in row.deniedWidgets"
+						:key="`d-${wid}`"
+						class="mydash-admin__chip mydash-admin__chip--denied">
+						{{ wid }}
+					</span>
+				</div>
+				<div class="mydash-admin__role-actions">
+					<NcButton type="tertiary"
+						:aria-label="t('mydash', 'Edit')"
+						@click="openEdit(row)">
+						<template #icon>
+							<Pencil :size="20" />
+						</template>
+					</NcButton>
+					<NcButton type="tertiary"
+						:aria-label="t('mydash', 'Delete')"
+						@click="confirmDelete(row)">
+						<template #icon>
+							<Delete :size="20" />
+						</template>
+					</NcButton>
+				</div>
+			</div>
+		</div>
+
+		<NcButton type="primary" @click="openCreate">
+			<template #icon>
+				<Plus :size="20" />
+			</template>
+			{{ t('mydash', 'Add role permission') }}
+		</NcButton>
+
+		<NcModal v-if="showEditor" @close="closeEditor">
+			<div class="mydash-admin__editor">
+				<h3>{{ editorRow.id ? t('mydash', 'Edit role permission') : t('mydash', 'Add role permission') }}</h3>
+				<NcTextField :value.sync="editorRow.name"
+					:label="t('mydash', 'Name')"
+					required />
+				<NcTextField :value.sync="editorRow.groupId"
+					:label="t('mydash', 'Nextcloud group ID')"
+					required
+					:disabled="!!editorRow.id" />
+				<NcTextField :value.sync="editorRow.description"
+					:label="t('mydash', 'Description (optional)')" />
+				<NcTextField :value.sync="allowedWidgetsCsv"
+					:label="t('mydash', 'Allowed widget IDs (comma separated)')" />
+				<NcTextField :value.sync="deniedWidgetsCsv"
+					:label="t('mydash', 'Denied widget IDs (comma separated)')" />
+				<div class="mydash-admin__editor-actions">
+					<NcButton type="tertiary" @click="closeEditor">
+						{{ t('mydash', 'Cancel') }}
+					</NcButton>
+					<NcButton type="primary"
+						:disabled="store.saving || !editorRow.name || !editorRow.groupId"
+						@click="save">
+						{{ t('mydash', 'Save') }}
+					</NcButton>
+				</div>
+			</div>
+		</NcModal>
+	</div>
+</template>
+
+<script>
+import {
+	NcButton,
+	NcModal,
+	NcTextField,
+	NcEmptyContent,
+} from '@conduction/nextcloud-vue'
+import AccountGroup from 'vue-material-design-icons/AccountGroup.vue'
+import Plus from 'vue-material-design-icons/Plus.vue'
+import Pencil from 'vue-material-design-icons/Pencil.vue'
+import Delete from 'vue-material-design-icons/Delete.vue'
+import { useRoleFeaturePermissionStore } from '../../stores/roleFeaturePermissions.js'
+
+export default {
+	name: 'RolePermissionsSection',
+
+	components: {
+		NcButton,
+		NcModal,
+		NcTextField,
+		NcEmptyContent,
+		AccountGroup,
+		Plus,
+		Pencil,
+		Delete,
+	},
+
+	setup() {
+		const store = useRoleFeaturePermissionStore()
+		return { store }
+	},
+
+	data() {
+		return {
+			showEditor: false,
+			editorRow: this.emptyRow(),
+			allowedWidgetsCsv: '',
+			deniedWidgetsCsv: '',
+		}
+	},
+
+	async mounted() {
+		try {
+			await this.store.loadPermissions()
+		} catch (e) {
+			console.error('Failed to load role permissions', e)
+		}
+	},
+
+	methods: {
+		emptyRow() {
+			return {
+				id: null,
+				name: '',
+				groupId: '',
+				description: '',
+				allowedWidgets: [],
+				deniedWidgets: [],
+				priorityWeights: {},
+			}
+		},
+		openCreate() {
+			this.editorRow = this.emptyRow()
+			this.allowedWidgetsCsv = ''
+			this.deniedWidgetsCsv = ''
+			this.showEditor = true
+		},
+		openEdit(row) {
+			this.editorRow = {
+				...row,
+				allowedWidgets: row.allowedWidgets ?? [],
+				deniedWidgets: row.deniedWidgets ?? [],
+				priorityWeights: row.priorityWeights ?? {},
+			}
+			this.allowedWidgetsCsv = (row.allowedWidgets ?? []).join(', ')
+			this.deniedWidgetsCsv = (row.deniedWidgets ?? []).join(', ')
+			this.showEditor = true
+		},
+		closeEditor() {
+			this.showEditor = false
+		},
+		parseCsv(s) {
+			return (s ?? '')
+				.split(',')
+				.map(x => x.trim())
+				.filter(x => x.length > 0)
+		},
+		async save() {
+			try {
+				const payload = {
+					name: this.editorRow.name,
+					groupId: this.editorRow.groupId,
+					description: this.editorRow.description || null,
+					allowedWidgets: this.parseCsv(this.allowedWidgetsCsv),
+					deniedWidgets: this.parseCsv(this.deniedWidgetsCsv),
+					priorityWeights: this.editorRow.priorityWeights ?? {},
+				}
+				await this.store.savePermission(payload)
+				this.closeEditor()
+			} catch (e) {
+				console.error('Failed to save role permission', e)
+			}
+		},
+		async confirmDelete(row) {
+			// eslint-disable-next-line no-alert
+			if (!window.confirm(this.t('mydash', 'Delete role permission for "{group}"?', { group: row.groupId }))) {
+				return
+			}
+			try {
+				await this.store.deletePermission(row.id)
+			} catch (e) {
+				console.error('Failed to delete role permission', e)
+			}
+		},
+	},
+}
+</script>
+
+<style scoped>
+.mydash-admin__hint {
+	color: var(--color-text-maxcontrast);
+	margin: 0 0 var(--default-grid-baseline) 0;
+}
+.mydash-admin__error {
+	background: var(--color-error);
+	color: var(--color-primary-element-text);
+	padding: var(--default-grid-baseline);
+	border-radius: var(--border-radius);
+	margin-bottom: var(--default-grid-baseline);
+}
+.mydash-admin__role-list {
+	display: flex;
+	flex-direction: column;
+	gap: var(--default-grid-baseline);
+	margin-bottom: var(--default-grid-baseline);
+}
+.mydash-admin__role-row {
+	display: flex;
+	align-items: center;
+	gap: var(--default-grid-baseline);
+	padding: var(--default-grid-baseline);
+	border: 1px solid var(--color-border);
+	border-radius: var(--border-radius);
+}
+.mydash-admin__role-meta {
+	display: flex;
+	flex-direction: column;
+	min-width: 200px;
+}
+.mydash-admin__role-group {
+	color: var(--color-text-maxcontrast);
+	font-family: var(--font-face-monospace, monospace);
+	font-size: 0.85em;
+}
+.mydash-admin__role-widgets {
+	flex: 1;
+	display: flex;
+	flex-wrap: wrap;
+	gap: 4px;
+}
+.mydash-admin__chip {
+	background: var(--color-background-hover);
+	padding: 2px 8px;
+	border-radius: var(--border-radius);
+	font-size: 0.85em;
+}
+.mydash-admin__chip--denied {
+	background: var(--color-error);
+	color: var(--color-primary-element-text);
+}
+.mydash-admin__role-actions {
+	display: flex;
+	gap: 4px;
+}
+.mydash-admin__editor {
+	padding: calc(var(--default-grid-baseline) * 2);
+	display: flex;
+	flex-direction: column;
+	gap: var(--default-grid-baseline);
+	min-width: 480px;
+}
+.mydash-admin__editor-actions {
+	display: flex;
+	justify-content: flex-end;
+	gap: var(--default-grid-baseline);
+	margin-top: var(--default-grid-baseline);
+}
+</style>

--- a/src/stores/roleFeaturePermissions.js
+++ b/src/stores/roleFeaturePermissions.js
@@ -1,0 +1,159 @@
+/**
+ * Pinia store for role-feature permissions and role-layout defaults.
+ *
+ * Backs the admin UI's RolePermissionsSection. Talks to the four CRUD
+ * endpoints introduced by `lib/Controller/RoleFeaturePermissionApiController.php`
+ * (REQ-RFP-001..010).
+ *
+ * SPDX-FileCopyrightText: 2026 MyDash Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { defineStore } from 'pinia'
+import { generateOcsUrl, generateUrl } from '@nextcloud/router'
+import axios from '@nextcloud/axios'
+
+const PERMS_URL = generateUrl('/apps/mydash/api/role-feature-permissions')
+const DEFAULTS_URL = generateUrl('/apps/mydash/api/role-layout-defaults')
+
+export const useRoleFeaturePermissionStore = defineStore('roleFeaturePermissions', {
+	state: () => ({
+		permissions: [],
+		layoutDefaults: [],
+		loading: false,
+		saving: false,
+		error: null,
+	}),
+
+	actions: {
+		/**
+		 * Fetch all RoleFeaturePermission rows.
+		 */
+		async loadPermissions() {
+			this.loading = true
+			this.error = null
+			try {
+				const response = await axios.get(PERMS_URL)
+				const payload = response.data?.data ?? response.data
+				this.permissions = Array.isArray(payload) ? payload : []
+			} catch (e) {
+				this.error = e.message ?? 'Failed to load role-feature permissions'
+				throw e
+			} finally {
+				this.loading = false
+			}
+		},
+
+		/**
+		 * Fetch all RoleLayoutDefault rows.
+		 */
+		async loadLayoutDefaults() {
+			this.loading = true
+			this.error = null
+			try {
+				const response = await axios.get(DEFAULTS_URL)
+				const payload = response.data?.data ?? response.data
+				this.layoutDefaults = Array.isArray(payload) ? payload : []
+			} catch (e) {
+				this.error = e.message ?? 'Failed to load role-layout defaults'
+				throw e
+			} finally {
+				this.loading = false
+			}
+		},
+
+		/**
+		 * Upsert a RoleFeaturePermission keyed by groupId.
+		 *
+		 * @param {object} permission The permission payload.
+		 */
+		async savePermission(permission) {
+			this.saving = true
+			this.error = null
+			try {
+				const response = await axios.post(PERMS_URL, permission)
+				const saved = response.data?.data ?? response.data
+				const idx = this.permissions.findIndex(
+					(p) => p.groupId === saved.groupId,
+				)
+				if (idx >= 0) {
+					this.permissions.splice(idx, 1, saved)
+				} else {
+					this.permissions.push(saved)
+				}
+				return saved
+			} catch (e) {
+				this.error = e.message ?? 'Failed to save permission'
+				throw e
+			} finally {
+				this.saving = false
+			}
+		},
+
+		/**
+		 * Delete a RoleFeaturePermission row by id.
+		 *
+		 * @param {number} id The row id.
+		 */
+		async deletePermission(id) {
+			this.saving = true
+			this.error = null
+			try {
+				await axios.delete(`${PERMS_URL}/${id}`)
+				this.permissions = this.permissions.filter((p) => p.id !== id)
+			} catch (e) {
+				this.error = e.message ?? 'Failed to delete permission'
+				throw e
+			} finally {
+				this.saving = false
+			}
+		},
+
+		/**
+		 * Upsert a RoleLayoutDefault keyed by (groupId, widgetId).
+		 *
+		 * @param {object} layoutDefault The layout-default payload.
+		 */
+		async saveLayoutDefault(layoutDefault) {
+			this.saving = true
+			this.error = null
+			try {
+				const response = await axios.post(DEFAULTS_URL, layoutDefault)
+				const saved = response.data?.data ?? response.data
+				const idx = this.layoutDefaults.findIndex(
+					(d) => d.groupId === saved.groupId && d.widgetId === saved.widgetId,
+				)
+				if (idx >= 0) {
+					this.layoutDefaults.splice(idx, 1, saved)
+				} else {
+					this.layoutDefaults.push(saved)
+				}
+				return saved
+			} catch (e) {
+				this.error = e.message ?? 'Failed to save layout default'
+				throw e
+			} finally {
+				this.saving = false
+			}
+		},
+
+		/**
+		 * Delete a RoleLayoutDefault row by id.
+		 *
+		 * @param {number} id The row id.
+		 */
+		async deleteLayoutDefault(id) {
+			this.saving = true
+			this.error = null
+			try {
+				await axios.delete(`${DEFAULTS_URL}/${id}`)
+				this.layoutDefaults = this.layoutDefaults.filter((d) => d.id !== id)
+			} catch (e) {
+				this.error = e.message ?? 'Failed to delete layout default'
+				throw e
+			} finally {
+				this.saving = false
+			}
+		},
+	},
+})

--- a/src/utils/loadInitialState.js
+++ b/src/utils/loadInitialState.js
@@ -49,6 +49,9 @@ const PAGE_KEYS = Object.freeze({
 		groupDashboards: [],
 		userDashboards: [],
 		allowUserDashboards: false,
+		// REQ-RFP-010: list of widget IDs the caller is permitted to see.
+		// `null` = no role-feature-permissions configured (legacy, unrestricted).
+		allowedWidgets: null,
 	}),
 	admin: Object.freeze({
 		allGroups: [],

--- a/tests/Unit/Service/RoleFeaturePermissionServiceTest.php
+++ b/tests/Unit/Service/RoleFeaturePermissionServiceTest.php
@@ -1,0 +1,252 @@
+<?php
+
+/**
+ * RoleFeaturePermissionService Test
+ *
+ * Pins the multi-group resolution algorithm (REQ-RFP-005), the deny-wins
+ * rule, the no-restriction backwards-compat fallback (REQ-RFP-009), and
+ * the seedLayoutFromRoleDefaults zero-existing-placements guard
+ * (REQ-RFP-002 scenario 3).
+ *
+ * @category  Test
+ * @package   OCA\MyDash\Tests\Unit\Service
+ * @author    Conduction b.v. <info@conduction.nl>
+ * @copyright 2026 Conduction b.v.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-FileCopyrightText: 2026 MyDash Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Service;
+
+use OCA\MyDash\Db\Dashboard;
+use OCA\MyDash\Db\RoleFeaturePermission;
+use OCA\MyDash\Db\RoleFeaturePermissionMapper;
+use OCA\MyDash\Db\RoleLayoutDefault;
+use OCA\MyDash\Db\RoleLayoutDefaultMapper;
+use OCA\MyDash\Db\WidgetPlacementMapper;
+use OCA\MyDash\Service\AdminSettingsService;
+use OCA\MyDash\Service\RoleFeaturePermissionService;
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\IGroupManager;
+use OCP\IUser;
+use OCP\IUserManager;
+use PHPUnit\Framework\TestCase;
+
+class RoleFeaturePermissionServiceTest extends TestCase
+{
+    private RoleFeaturePermissionService $service;
+
+    private RoleFeaturePermissionMapper $permMapper;
+
+    private RoleLayoutDefaultMapper $defaultMapper;
+
+    private WidgetPlacementMapper $placementMapper;
+
+    private AdminSettingsService $adminSettings;
+
+    private IGroupManager $groupManager;
+
+    private IUserManager $userManager;
+
+    protected function setUp(): void
+    {
+        $this->permMapper      = $this->createMock(originalClassName: RoleFeaturePermissionMapper::class);
+        $this->defaultMapper   = $this->createMock(originalClassName: RoleLayoutDefaultMapper::class);
+        $this->placementMapper = $this->createMock(originalClassName: WidgetPlacementMapper::class);
+        $this->adminSettings   = $this->createMock(originalClassName: AdminSettingsService::class);
+        $this->groupManager    = $this->createMock(originalClassName: IGroupManager::class);
+        $this->userManager     = $this->createMock(originalClassName: IUserManager::class);
+
+        $this->service = new RoleFeaturePermissionService(
+            permissionMapper: $this->permMapper,
+            defaultMapper: $this->defaultMapper,
+            placementMapper: $this->placementMapper,
+            adminSettings: $this->adminSettings,
+            groupManager: $this->groupManager,
+            userManager: $this->userManager,
+        );
+    }//end setUp()
+
+    /**
+     * Build a RoleFeaturePermission entity from arrays.
+     */
+    private function makePerm(
+        string $groupId,
+        array $allowed,
+        array $denied = []
+    ): RoleFeaturePermission {
+        $entity = new RoleFeaturePermission();
+        // phpcs:ignore CustomSniffs.Functions.NamedParameters.RequireNamedParameters
+        $entity->setName('perm-' . $groupId);
+        // phpcs:ignore CustomSniffs.Functions.NamedParameters.RequireNamedParameters
+        $entity->setGroupId($groupId);
+        // phpcs:ignore CustomSniffs.Functions.NamedParameters.RequireNamedParameters
+        $entity->setAllowedWidgets(json_encode(value: $allowed));
+        // phpcs:ignore CustomSniffs.Functions.NamedParameters.RequireNamedParameters
+        $entity->setDeniedWidgets(json_encode(value: $denied));
+        return $entity;
+    }//end makePerm()
+
+    /**
+     * Mock IUserManager + IGroupManager so the user is in a list of groups.
+     */
+    private function withUserGroups(string $userId, array $groupIds): void
+    {
+        $user = $this->createMock(originalClassName: IUser::class);
+        $this->userManager->method(constraint: 'get')
+            ->willReturn(value: $user);
+        $this->groupManager->method(constraint: 'getUserGroupIds')
+            ->willReturn(value: $groupIds);
+    }//end withUserGroups()
+
+    public function testNoRestrictionConfiguredReturnsNull(): void
+    {
+        $this->withUserGroups(userId: 'alice', groupIds: ['employees']);
+        $this->adminSettings->method(constraint: 'getGroupOrder')
+            ->willReturn(value: ['employees']);
+        $this->permMapper->method(constraint: 'findByGroupIds')
+            ->willReturn(value: []);
+        $this->permMapper->method(constraint: 'findByGroupId')
+            ->will($this->throwException(exception: new DoesNotExistException(msg: 'no row')));
+
+        $result = $this->service->getAllowedWidgetIds(userId: 'alice');
+        $this->assertNull(actual: $result);
+    }//end testNoRestrictionConfiguredReturnsNull()
+
+    public function testSingleGroupReturnsAllowedSet(): void
+    {
+        $this->withUserGroups(userId: 'alice', groupIds: ['employees']);
+        $this->adminSettings->method(constraint: 'getGroupOrder')
+            ->willReturn(value: ['employees', 'managers']);
+        $this->permMapper->method(constraint: 'findByGroupIds')
+            ->willReturn(value: [
+                $this->makePerm(groupId: 'employees', allowed: ['activity', 'recommendations']),
+            ]);
+
+        $result = $this->service->getAllowedWidgetIds(userId: 'alice');
+        $this->assertSame(expected: ['activity', 'recommendations'], actual: $result);
+    }//end testSingleGroupReturnsAllowedSet()
+
+    public function testMultiGroupUnionWidens(): void
+    {
+        $this->withUserGroups(userId: 'alice', groupIds: ['employees', 'managers']);
+        $this->adminSettings->method(constraint: 'getGroupOrder')
+            ->willReturn(value: ['employees', 'managers']);
+        $this->permMapper->method(constraint: 'findByGroupIds')
+            ->willReturn(value: [
+                $this->makePerm(groupId: 'employees', allowed: ['activity']),
+                $this->makePerm(groupId: 'managers', allowed: ['analytics']),
+            ]);
+
+        $result = $this->service->getAllowedWidgetIds(userId: 'alice');
+        $this->assertSame(expected: ['activity', 'analytics'], actual: $result);
+    }//end testMultiGroupUnionWidens()
+
+    public function testDenyWinsOverAllow(): void
+    {
+        $this->withUserGroups(userId: 'alice', groupIds: ['employees', 'security']);
+        $this->adminSettings->method(constraint: 'getGroupOrder')
+            ->willReturn(value: ['employees', 'security']);
+        $this->permMapper->method(constraint: 'findByGroupIds')
+            ->willReturn(value: [
+                $this->makePerm(groupId: 'employees', allowed: ['activity', 'analytics']),
+                $this->makePerm(groupId: 'security', allowed: [], denied: ['analytics']),
+            ]);
+
+        $result = $this->service->getAllowedWidgetIds(userId: 'alice');
+        $this->assertSame(expected: ['activity'], actual: $result);
+    }//end testDenyWinsOverAllow()
+
+    public function testFallbackToDefaultGroupWhenNoGroupOrderMatch(): void
+    {
+        $this->withUserGroups(userId: 'alice', groupIds: ['unmapped']);
+        $this->adminSettings->method(constraint: 'getGroupOrder')
+            ->willReturn(value: []);
+        $this->permMapper->method(constraint: 'findByGroupIds')
+            ->willReturn(value: []);
+        $this->permMapper->method(constraint: 'findByGroupId')
+            ->with($this->equalTo(value: RoleFeaturePermission::GROUP_DEFAULT))
+            ->willReturn(value: $this->makePerm(groupId: 'default', allowed: ['recommendations']));
+
+        $result = $this->service->getAllowedWidgetIds(userId: 'alice');
+        $this->assertSame(expected: ['recommendations'], actual: $result);
+    }//end testFallbackToDefaultGroupWhenNoGroupOrderMatch()
+
+    public function testIsWidgetAllowedTrueWhenUnconfigured(): void
+    {
+        $this->withUserGroups(userId: 'alice', groupIds: []);
+        $this->permMapper->method(constraint: 'findByGroupId')
+            ->will($this->throwException(exception: new DoesNotExistException(msg: 'no row')));
+
+        $this->assertTrue(condition: $this->service->isWidgetAllowed(
+            userId: 'alice',
+            widgetId: 'whatever'
+        ));
+    }//end testIsWidgetAllowedTrueWhenUnconfigured()
+
+    public function testSeedLayoutNoOpWhenDashboardHasPlacements(): void
+    {
+        $dashboard = new Dashboard();
+        // phpcs:ignore CustomSniffs.Functions.NamedParameters.RequireNamedParameters
+        $dashboard->setId(42);
+        $this->placementMapper->method(constraint: 'findByDashboardId')
+            ->willReturn(value: ['existing-placement']);
+
+        // No mapper / group manager calls expected because the guard fires first.
+        $this->defaultMapper->expects(invocationOrder: $this->never())
+            ->method(constraint: 'findByGroupId');
+
+        $created = $this->service->seedLayoutFromRoleDefaults(
+            userId: 'alice',
+            dashboard: $dashboard
+        );
+        $this->assertSame(expected: 0, actual: $created);
+    }//end testSeedLayoutNoOpWhenDashboardHasPlacements()
+
+    public function testSeedLayoutCreatesPlacementsWhenEmpty(): void
+    {
+        $dashboard = new Dashboard();
+        // phpcs:ignore CustomSniffs.Functions.NamedParameters.RequireNamedParameters
+        $dashboard->setId(99);
+
+        $this->placementMapper->method(constraint: 'findByDashboardId')
+            ->willReturn(value: []);
+        $this->withUserGroups(userId: 'alice', groupIds: ['managers']);
+        $this->adminSettings->method(constraint: 'getGroupOrder')
+            ->willReturn(value: ['managers']);
+
+        $rld = new RoleLayoutDefault();
+        // phpcs:ignore CustomSniffs.Functions.NamedParameters.RequireNamedParameters
+        $rld->setName('manager-activity');
+        // phpcs:ignore CustomSniffs.Functions.NamedParameters.RequireNamedParameters
+        $rld->setGroupId('managers');
+        // phpcs:ignore CustomSniffs.Functions.NamedParameters.RequireNamedParameters
+        $rld->setWidgetId('activity');
+        // phpcs:ignore CustomSniffs.Functions.NamedParameters.RequireNamedParameters
+        $rld->setGridX(0);
+        // phpcs:ignore CustomSniffs.Functions.NamedParameters.RequireNamedParameters
+        $rld->setGridY(0);
+        // phpcs:ignore CustomSniffs.Functions.NamedParameters.RequireNamedParameters
+        $rld->setGridWidth(6);
+        // phpcs:ignore CustomSniffs.Functions.NamedParameters.RequireNamedParameters
+        $rld->setGridHeight(5);
+        // phpcs:ignore CustomSniffs.Functions.NamedParameters.RequireNamedParameters
+        $rld->setSortOrder(0);
+
+        $this->defaultMapper->method(constraint: 'findByGroupId')
+            ->willReturn(value: [$rld]);
+
+        $this->placementMapper->expects(invocationOrder: $this->once())
+            ->method(constraint: 'insert');
+
+        $created = $this->service->seedLayoutFromRoleDefaults(
+            userId: 'alice',
+            dashboard: $dashboard
+        );
+        $this->assertSame(expected: 1, actual: $created);
+    }//end testSeedLayoutCreatesPlacementsWhenEmpty()
+}//end class


### PR DESCRIPTION
## Summary

Implements the **role-based-content** spec (issue #91) — role-feature-permissions for MyDash dashboards.

Built locally as a Claude Code session (Hydra supervisor offline since 2026-04-25; 2/3 of its bot tokens were also expired). Same conceptual design as the /opsx-ff-generated spec, but **translated from the OpenRegister-based persistence the spec assumed to mydash's actual native-DB-table pattern** (the spec was written against the wrong stack — see commit messages on `333fe2e` for the full reasoning).

## What's done

- [x] **Stage 0** — branch off `development`, spec docs imported from `spec/role-based-content`
- [x] **Stage 1** (`333fe2e`) — Data layer: 2 entities + 2 mappers + 2 table builders + migration `Version001007Date20260501120000` + service + admin API controller + 6 routes
- [x] **Stage 2** (`c8fdf0f`) — Integration: `WidgetApiController.listAvailable()` filters by allowed-widget set; `DashboardService.tryCreateFromTemplate()` falls back to role-default seeding before hardcoded defaults; `InitialStateBuilder` adds `allowedWidgets` workspace key; `PageController` populates it
- [x] **Stage 3** (`cec4404`) — Frontend: Pinia store + `RolePermissionsSection.vue` admin UI wired into `AdminSettings.vue`; en/nl i18n parity preserved (210 keys both files, +12 new)
- [x] **Stage 4** (`1916903`) — Tests: 8-case PHPUnit on the multi-group resolution algorithm, deny-wins, default fallback, seed guard. Docs: `docs/role-based-content.md`. tasks.md ticked for 23 of ~40 boxes.

## Spec

`openspec/changes/role-based-content/` — proposal, design, tasks. The first checkbox at the top of tasks.md notes the OpenRegister → native-tables translation and lists deferred tasks.

## Test plan

- [ ] `composer check:strict` — let CI run; locally I only syntax-checked
- [ ] ESLint + Stylelint — same
- [ ] PHPUnit `tests/Unit/Service/RoleFeaturePermissionServiceTest.php` (8 tests)
- [ ] Manual smoke: hit `GET /api/role-feature-permissions` with admin + non-admin token; verify 200/403
- [ ] Manual smoke: configure a permission for a Nextcloud group, verify `GET /api/widgets/available` filters and that the workspace's `allowedWidgets` initial-state value matches
- [ ] Manual smoke: create a fresh user in a group with RoleLayoutDefault rows; verify the user's first dashboard is seeded from those rows instead of the hardcoded `recommendations`+`activity` pair

## Deferred follow-ups (filed mentally, not blocking review)

- RoleLayoutDefault admin UI (API exists; UI ships next)
- Per-widget URL `403`+audit (REQ-RFP-006) — depends on a per-widget endpoint that doesn't exist in mydash yet, plus an `AuditTrailService` analogue
- Postman/Newman integration suite (12.x)
- Playwright browser tests (13.x)
- 16.x quality gates — CI will report

## Spec/reality mismatch — spec generator follow-up

The /opsx-ff brief assumed mydash uses OpenRegister (`mydash_register.json`, `ObjectService`, `@self` envelopes). Mydash actually uses native NC `Mapper` + migration tables. This implementation follows mydash's real stack. The Specter-side fix (teach the brief generator to detect each app's persistence stack) is logged separately for the next /opsx-ff iteration.

## Related

- Resolves #91
- Spec branch: `spec/role-based-content`
- Source intelligence: 6 canonical_features in Specter (demand 4113), `keep` verdict from `analyze_responsibility.py`