### PR TITLE
feat(openspec): 41 IntraVox-derived spec proposals (foundation → glue)

### DIFF
--- a/openspec/changes/activity-feed-integration/design.md
+++ b/openspec/changes/activity-feed-integration/design.md
@@ -1,0 +1,136 @@
+# Design — Nextcloud Activity Feed Integration
+
+## Context
+
+The source application implements `OCP\Activity\IProvider` and emits exactly **6** event types through its `parse()` switch: `page_viewed`, `page_created`, `page_updated`, `page_deleted`, `comment_added`, and `reaction_added`. Any other subject throws `\InvalidArgumentException('Unknown subject: ...')`, confirming that set is exhaustive. MyDash ports 5 of these (renamed to the `dashboard_*` domain prefix) and deliberately excludes `page_viewed`.
+
+MyDash ships 8 additional event types that have no source counterpart. These arise naturally from sibling capabilities — dashboard publishing, sharing, public links, versioning, locking, and role management — none of which exist in the source application. The full catalogue of 13 types is therefore a deliberate product decision, not a gap or an error in the spec.
+
+The most significant source deviation is view tracking. The source application emits `page_viewed` to the Activity stream from `AnalyticsService::trackPageView()`, recording a row for every page load. MyDash already owns a dedicated `dashboard-view-analytics` capability for view counting; re-publishing to the Activity stream would generate a row per dashboard load across every audience member, flooding notification inboxes on busy default-group dashboards with no actionable information.
+
+Audience fan-out is the other area requiring deliberate design. A default-group dashboard shared with every authenticated user on a 1 000-user instance generates up to 1 000 `oc_activity` rows per event. Without debouncing, a sequence of rapid edits or a storm of reactions can produce tens of thousands of rows in minutes. Two debounce rules address this at the source.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Surface all meaningful MyDash actions in the standard NC Activity feed without custom UI.
+- Define a canonical 13-type event catalogue, split clearly into source-derived and MyDash-native groups.
+- Specify audience-targeting rules for all four dashboard scopes (personal, user-shared, group-shared, default-group).
+- Prevent Activity-stream spam via a 15-minute debounce on high-fan-out events.
+- Allow users to opt out of individual event types via standard NC Activity notification preferences.
+- Keep emission call-sites inside the sibling capability that owns each action.
+
+**Non-Goals:**
+- Do NOT publish view-tracking events (`dashboard_viewed` / `page_viewed`) to the Activity stream. View counts are analytics data, not actionable notifications.
+- Do NOT provide a custom MyDash notification preferences page; NC's built-in per-type settings UI is sufficient.
+- Do NOT expose a new HTTP endpoint for querying the activity stream; NC's stock Activity REST API surfaces MyDash events automatically once the provider is registered.
+- Do NOT backfill historical events that occurred before this capability is installed.
+
+## Decisions
+
+### D1: Event catalogue — 5 source-derived + 8 MyDash additions (13 total)
+
+**Decision**: MyDash emits exactly 13 event-type constants. 5 are direct ports of source event types, renamed to the `dashboard_*` prefix. The remaining 8 emerge from sibling capabilities that have no source-app counterpart. `page_viewed` is excluded (see D2).
+
+**Source-derived (5)**:
+- `dashboard_created` (source: `page_created`)
+- `dashboard_updated` (source: `page_updated`)
+- `dashboard_deleted` (source: `page_deleted`)
+- `dashboard_commented` (source: `comment_added`)
+- `dashboard_reacted` (source: `reaction_added`)
+
+**MyDash additions (8 — emerge from sibling capabilities)**:
+- `dashboard_published`, `dashboard_unpublished`, `dashboard_scheduled` — emitted by `dashboard-draft-published`
+- `dashboard_shared` — emitted by `dashboard-sharing`
+- `dashboard_public_share_created` — emitted by `dashboard-public-share`
+- `dashboard_restored` — emitted by `dashboard-versioning`
+- `dashboard_lock_overridden` — emitted by `dashboard-locking`
+- `dashboard_role_changed` — emitted by `admin-roles`
+
+**Source evidence**:
+- `intravox-source/lib/Activity/Provider.php:43-81` — `parse()` switch handles exactly the 5 source types listed above plus `page_viewed`; any other subject throws `\InvalidArgumentException`.
+
+**Rationale**: The 13-type catalogue is a complete, non-redundant set. Each MyDash addition maps 1-to-1 to a sibling capability that already owns the domain action; adding the emission call-site there keeps responsibility co-located with the action.
+
+---
+
+### D2: `page_viewed` — analytics-only, NOT published to the Activity stream
+
+**Decision**: View tracking is owned exclusively by `dashboard-view-analytics`. `ActivityPublisher` MUST NOT emit a `dashboard_viewed` event. The source app's choice to emit `page_viewed` to Activity is not replicated.
+
+**Alternatives considered**:
+- **Match source (emit `dashboard_viewed` to Activity stream)**: rejected. Every dashboard load triggers an event; on a default-group dashboard with 1 000 users that becomes 1 000 rows per page load. Users would receive view notifications for their own dashboards on every login. The `dashboard-view-analytics` capability already captures counts in a purpose-built structure with aggregation; a parallel Activity row adds no user-visible value.
+
+**Source evidence**:
+- `intravox-source/lib/Service/AnalyticsService.php::trackPageView()` — emits to Activity AND increments analytics counters; MyDash separates these concerns into distinct capabilities.
+
+**Rationale**: The Activity feed is designed for actions that other users need to react to. A view is a passive event with no required follow-up. Keeping view data in the analytics capability preserves stream signal quality and prevents inbox fatigue, particularly for widely-shared dashboards.
+
+---
+
+### D3: Audience-targeting rules per dashboard scope
+
+**Decision**: The recipient set for any event is determined by the dashboard's scope at emit-time:
+
+| Scope | Recipients |
+|---|---|
+| `user` (personal) | Owner only |
+| User-to-user share | Owner + every named share recipient |
+| `group_shared` | All current members of the target group (via `IGroupManager`) |
+| Default-group (`groupId = 'default'`) | All authenticated NC users (via `IUserManager::callForAllUsers`) |
+
+The actor always receives their own row (first-person subject template). Third-party recipients receive the third-person variant. The actor MUST NOT receive a duplicate row when they are already a group member.
+
+**Rationale**: Scope determines who has a legitimate interest in knowing about the event. Resolving group membership at emit-time (not at read-time) matches NC's own pattern and keeps `oc_activity` queries simple. Personal-dashboard events are never fan-out events; the guard on `dashboard->getType()` prevents any `IGroupManager` call for them.
+
+---
+
+### D4: Debouncing — 15-minute window for reactions and default-group fan-out
+
+**Decision**: Two event classes are debounced using APCu keys with a 900-second (15-minute) TTL:
+
+1. **`dashboard_reacted`**: debounced per `(actorUserId, dashboardUuid)`. At most one reaction activity row per actor per dashboard per 15-minute window. This prevents emoji-storm patterns where one user rapidly adds/changes reactions.
+
+2. **Default-group fan-out events** (`groupId = 'default'`): for high-frequency types (`dashboard_updated`, `dashboard_commented`), the entire fan-out is debounced per `(dashboardUuid, eventType)`. When the window is active, `IUserManager::callForAllUsers` is NOT called and zero rows are written. Suppressed fan-outs MUST emit a DEBUG-level log entry; no WARNING or ERROR (suppression is expected behaviour).
+
+**Rationale**: A well-meaning admin who edits a default-group dashboard 50 times in an hour would otherwise send 50 000 activity rows across a 1 000-user org. The 15-minute window collapses bursts into one notification cycle, which matches how users actually check their activity feeds. The reaction debounce preserves the informational value (someone reacted) while eliminating noise from iterative emoji selection.
+
+---
+
+### D5: Implementation pattern — single registration class, distributed emission
+
+**Decision**: ONE class (`lib/Activity/Extension.php`) registers all 13 event types with NC's `IProvider` interface, provides subject/message templates, icons, and the `ALL_EVENTS` constant array. Actual `IManager::publishActivity()` call-sites live INSIDE each sibling capability's service (e.g. `dashboard_published` is fired by `DashboardPublicationService::publish()` in the `dashboard-draft-published` implementation).
+
+A thin `lib/Activity/ActivityPublisher.php` wrapper handles audience resolution, debounce checks, and error isolation so sibling capabilities never depend on `IManager` directly.
+
+**Rationale**: Centralising type registration prevents duplication and provides a single source of truth for the catalogue (auditable by reading one file). Distributing emission keeps responsibility co-located with the owning action: the publication service knows when it has persisted a state change; the activity extension does not.
+
+---
+
+### D6: Naming — `dashboard_*` prefix throughout
+
+**Decision**: All 13 MyDash event types use the `dashboard_` prefix. No `page_*` type names appear in MyDash code or translation keys.
+
+**Rationale**: MyDash's domain entity is a dashboard, not a page. Adopting the source naming would create confusion about which system emitted an event and would expose the source application's vocabulary to MyDash users.
+
+---
+
+### D7: Opt-out via standard NC Activity preferences
+
+**Decision**: Each of the 13 event types is registered with NC's per-type notification preference system. Users can independently disable in-app and email notifications per type via NC Settings → Activity. No custom MyDash preferences page is provided. Default: in-app ON, email OFF for all types.
+
+**Rationale**: NC's activity preference system is already trusted by users and familiar from Files, Talk, and other apps. Replicating it for MyDash would fragment the settings experience and add maintenance burden with no UX benefit.
+
+## Spec changes implied
+
+- **REQ-ACT-002 (event catalogue)**: The 13 listed types in `spec.md` are correct — `dashboard_created`, `dashboard_updated`, `dashboard_deleted`, `dashboard_published`, `dashboard_unpublished`, `dashboard_scheduled`, `dashboard_shared`, `dashboard_public_share_created`, `dashboard_commented`, `dashboard_reacted`, `dashboard_restored`, `dashboard_lock_overridden`, `dashboard_role_changed`. Confirm no `dashboard_viewed` constant appears anywhere. Add a NOTE that the 5 source-derived types are ports and the 8 additions are MyDash-native.
+- **REQ-ACT-003 (audience targeting)**: Pin the four-scope table from D3 as normative. Clarify that group membership is resolved at emit-time, not read-time.
+- **REQ-ACT-007 / REQ-ACT-008 (debouncing)**: Pin the 15-minute (900 s) APCu TTL as the canonical window value. Spec currently implies it but does not state the number explicitly in the requirement body — make it normative there, not just in scenarios.
+- **Add NOTE**: Source-derived types and MyDash additions coexist by design. The spec is not incomplete because it defines more types than the source; the additions are intentional extensions for capabilities the source does not have.
+
+## Open follow-ups
+
+- Whether to expose a `GET /api/me/activity` endpoint proxying NC's Activity stream filtered to MyDash event types, vs directing users to NC's stock activity page.
+- Whether `dashboard_role_changed` should emit one row to the affected user AND one row to the admin who made the change, or only to the affected user (current spec implies the latter).
+- Whether `Extension` should auto-discover sibling-capability emitters via DI tags (open/closed principle) vs static registration in the class docblock (simpler, auditable).
+- Confirm whether `dashboard_public_share_created` should fan out to the dashboard owner when the admin who creates the link IS the owner (to avoid a self-notification that carries no information).

--- a/openspec/changes/activity-feed-integration/proposal.md
+++ b/openspec/changes/activity-feed-integration/proposal.md
@@ -1,0 +1,53 @@
+# Activity Feed Integration
+
+## Why
+
+Today MyDash performs actions — creating dashboards, publishing them, sharing them, locking them, posting comments, restoring versions — that are invisible to Nextcloud's standard Activity stream. Users and administrators have no timeline of "who did what" across the MyDash workspace, and there is no notification path for events that affect dashboards shared with other users. This change surfaces MyDash events in the standard Nextcloud Activity feed, giving every user a unified notification history alongside Files, Talk, and other NC apps.
+
+## What Changes
+
+- Register a new `OCP\Activity\IProvider` implementation (`lib/Activity/Extension.php`) under the application id `mydash`, covering thirteen discrete event types.
+- Define event-type constants (`dashboard_created`, `dashboard_updated`, `dashboard_deleted`, `dashboard_published`, `dashboard_unpublished`, `dashboard_scheduled`, `dashboard_shared`, `dashboard_public_share_created`, `dashboard_commented`, `dashboard_reacted`, `dashboard_restored`, `dashboard_lock_overridden`, `dashboard_role_changed`) in the Extension class — one canonical place.
+- Each emitted Activity event carries `{user, type, subject, message, object_type: 'mydash_dashboard', object_id: <uuid>, link, timestamp}` and is persisted via `OCP\Activity\IManager::publishActivity()`.
+- Audience targeting varies by dashboard scope: personal → owner only; user-to-user share → all named recipients; group-shared → all group members resolved via `IGroupManager`; default-group dashboards → all NC users (global events, debounced).
+- Reaction events are debounced per `(user, dashboard)` at most once per 15 minutes. Global (default-group) events share the same debounce pattern to avoid fan-out spam.
+- Users control notification delivery (email / in-app) per event type via the standard NC Activity settings UI — no custom preferences UI required.
+- Actual emission calls (`IManager::publishActivity(...)`) are NOT in this spec — they live in the per-capability implementation files for each event type (e.g. `dashboard_published` emission lives in the `dashboard-draft-published` capability). This spec owns the types, extension class, and contracts.
+- A unit test asserts that publishing each event type results in a row in `oc_activity` with correct type, object_id, subject, message, and link.
+
+## Capabilities
+
+### New Capabilities
+
+- `activity-feed-integration`: new capability owning the extension registration, event-type catalogue, audience-targeting rules, debounce logic, subject/message templates, icons, and unit-test contract.
+
+### Modified Capabilities
+
+None. Emission call-sites are added inside existing capability implementations by their respective specs/tasks (cross-capability emission contract defined in REQ-ACT-011).
+
+## Impact
+
+**Affected code:**
+
+- `lib/Activity/Extension.php` — new: registers all 13 event types with NC's `IProvider` interface; provides `parse()`, `getIcon()`, `getUrl()`, and default subject/message templates
+- `lib/Activity/ActivityPublisher.php` — new: thin service wrapper around `IManager::publishActivity()` + audience resolution + debounce; injected wherever emission calls are added
+- `lib/Activity/DebounceHelper.php` — new: APCu-backed per-`(user, dashboard)` 15-minute window guard; also used for global (default-group) fan-out debounce
+- `appinfo/info.xml` — register `\OCA\MyDash\Activity\Extension` under `<activity>`
+- `lib/AppInfo/Application.php` — register `ActivityPublisher` and `DebounceHelper` in the DI container
+- `tests/Unit/Activity/ExtensionTest.php` — new PHPUnit test (REQ-ACT-011 contract)
+
+**Affected APIs:**
+
+- No new HTTP endpoints. NC Activity REST API (`/ocs/v2.php/apps/activity/api/v2/activity`) will surface MyDash events automatically once the provider is registered.
+
+**Dependencies:**
+
+- `OCP\Activity\IProvider` — already available in Nextcloud ≥ 20; no new composer packages required
+- `OCP\Activity\IManager` — already in NC core
+- `OCP\IGroupManager` — already injected elsewhere in MyDash
+- APCu — assumed available (used elsewhere for rate-limiting)
+
+**Migration:**
+
+- No database migration. NC Activity uses its own `oc_activity` table managed by NC core.
+- No data backfill — historical events before this change are not retroactively recorded.

--- a/openspec/changes/activity-feed-integration/specs/activity-feed-integration/spec.md
+++ b/openspec/changes/activity-feed-integration/specs/activity-feed-integration/spec.md
@@ -64,6 +64,10 @@ The system MUST register a class `\OCA\MyDash\Activity\Extension` that implement
 
 The system MUST define exactly 13 event-type constants on `\OCA\MyDash\Activity\Extension`, grouped in a static `ALL_EVENTS` array, covering the full set of trackable MyDash actions. No event type may be emitted by `ActivityPublisher` unless it is declared in `ALL_EVENTS`.
 
+NOTE: The 13 types split into two groups by origin. Five are direct ports of source-application event types, renamed to the `dashboard_*` prefix: `dashboard_created`, `dashboard_updated`, `dashboard_deleted`, `dashboard_commented`, `dashboard_reacted`. Eight are MyDash-native additions that emerge from sibling capabilities with no source-app counterpart: `dashboard_published`, `dashboard_unpublished`, `dashboard_scheduled` (from `dashboard-draft-published`), `dashboard_shared` (from `dashboard-sharing`), `dashboard_public_share_created` (from `dashboard-public-share`), `dashboard_restored` (from `dashboard-versioning`), `dashboard_lock_overridden` (from `dashboard-locking`), `dashboard_role_changed` (from `admin-roles`). The catalogue is intentionally larger than the source; the additions are deliberate product extensions, not gaps or errors.
+
+NOTE: `dashboard_viewed` is NOT in the catalogue and MUST NOT be added. View tracking is owned exclusively by the `dashboard-view-analytics` capability. Publishing view events to the Activity stream would flood notification inboxes on widely-shared dashboards with passive, non-actionable data.
+
 #### Scenario: All 13 constants present and non-empty
 
 - GIVEN `Extension::ALL_EVENTS` is inspected at runtime
@@ -123,6 +127,17 @@ The system MUST provide `\OCA\MyDash\Activity\ActivityPublisher` as the sole ent
 ### Requirement: REQ-ACT-004 Audience Targeting — Personal Dashboards
 
 For events on `user`-type dashboards, the system MUST emit exactly one activity row per event occurrence, addressed to the dashboard owner. The owner receives their own events so they appear in their personal activity stream.
+
+NOTE: REQ-ACT-004 through REQ-ACT-006 and REQ-ACT-008 together implement the normative four-scope audience rule. The recipient set for any event is determined by the dashboard's scope at emit-time:
+
+| Scope | Recipients |
+|---|---|
+| `user` (personal) | Owner only |
+| User-to-user share | Owner + every named share recipient |
+| `group_shared` | All current members of the target group (resolved via `IGroupManager` at emit-time) |
+| Default-group (`groupId = 'default'`) | All authenticated NC users (via `IUserManager::callForAllUsers`), subject to debounce (see REQ-ACT-008) |
+
+NOTE: Group membership MUST be resolved at emit-time, not at read-time. This matches NC core's own pattern and keeps `oc_activity` queries simple. For personal-scope events, the guard on `dashboard->getType()` MUST prevent any `IGroupManager` call.
 
 #### Scenario: Self-action on personal dashboard — single row for owner
 
@@ -212,7 +227,7 @@ For events on `group_shared`-type dashboards, the system MUST emit one activity 
 
 ### Requirement: REQ-ACT-007 Debounce — Reaction Events
 
-The system MUST apply a 15-minute debounce per `(actorUserId, dashboardUuid)` pair to `dashboard_reacted` events. At most one reaction activity row per actor per dashboard per 15-minute window MUST be written.
+The system MUST apply a debounce per `(actorUserId, dashboardUuid)` pair to `dashboard_reacted` events using an APCu key with a TTL of exactly 900 seconds (15 minutes). At most one reaction activity row per actor per dashboard per 900-second window MUST be written.
 
 #### Scenario: First reaction within window is published
 
@@ -246,7 +261,7 @@ The system MUST apply a 15-minute debounce per `(actorUserId, dashboardUuid)` pa
 
 ### Requirement: REQ-ACT-008 Debounce — Global (Default-Group) Fan-Out
 
-For events on dashboards with `groupId = 'default'`, the system MUST apply a 15-minute debounce per `(dashboardUuid, eventType)` before performing the full user-enumeration fan-out. When the debounce window is active, the entire fan-out MUST be skipped silently (no rows written, no exception).
+For events on dashboards with `groupId = 'default'`, the system MUST apply a debounce per `(dashboardUuid, eventType)` using an APCu key with a TTL of exactly 900 seconds (15 minutes) before performing the full user-enumeration fan-out. This debounce applies to high-frequency types (`dashboard_updated`, `dashboard_commented`). When the debounce window is active, the entire fan-out MUST be skipped silently (no rows written, no exception).
 
 #### Scenario: First global event triggers full fan-out
 

--- a/openspec/changes/activity-feed-integration/specs/activity-feed-integration/spec.md
+++ b/openspec/changes/activity-feed-integration/specs/activity-feed-integration/spec.md
@@ -1,0 +1,421 @@
+---
+status: draft
+---
+
+# Activity Feed Integration Specification
+
+## Purpose
+
+Surface MyDash events in Nextcloud's standard Activity feed so every action on a dashboard — creation, editing, publication, sharing, commenting, locking, and role changes — is visible to the relevant users in their NC notifications and activity stream. This capability defines the NC Activity extension class, all event-type constants, audience-targeting rules, debounce logic, subject/message templates, icon conventions, the cross-capability emission contract, and the unit-test contract. Actual `publishActivity()` call-sites are delegated to the sibling capability that owns each action.
+
+## Data Model
+
+No new database tables. NC Activity persists events in the existing `oc_activity` table (managed by NC core). Each MyDash event row carries:
+
+- **app**: `'mydash'`
+- **type**: one of the 13 `Extension::EVENT_*` constants
+- **user**: the NC user ID of the recipient
+- **affecteduser**: the NC user ID of the actor
+- **object_type**: `'mydash_dashboard'`
+- **object_id**: the dashboard UUID (string)
+- **subject**: translated template key
+- **subjectparams**: JSON-encoded parameter array consumed by NC Activity's translation layer
+- **message**: optional detail line (comment body excerpt for `dashboard_commented`)
+- **link**: full NC URL to the dashboard
+- **timestamp**: Unix epoch of the event
+
+## ADDED Requirements
+
+### Requirement: REQ-ACT-001 Extension Registration
+
+The system MUST register a class `\OCA\MyDash\Activity\Extension` that implements `OCP\Activity\IProvider` and is declared in `appinfo/info.xml` under the `<activity>` section with application id `mydash`. The extension MUST be resolvable from the NC DI container at runtime.
+
+#### Scenario: Extension resolves from DI container
+
+- GIVEN MyDash is installed and enabled
+- WHEN NC Activity attempts to resolve the registered provider via the DI container
+- THEN it MUST receive an instance of `\OCA\MyDash\Activity\Extension` without error
+
+#### Scenario: Extension is listed in NC Activity admin settings
+
+- GIVEN MyDash is installed
+- WHEN an administrator opens NC Settings → Activity
+- THEN the MyDash extension MUST appear as a registered application with its 13 event types visible for per-type opt-out configuration
+
+#### Scenario: Unknown event type does not throw
+
+- GIVEN `Extension::parse()` receives an `IEvent` whose `type` is not one of the 13 known `EVENT_*` constants
+- WHEN `parse()` is called
+- THEN it MUST return the unmodified `IEvent` without throwing any exception
+
+#### Scenario: `getIcon()` returns non-empty URL for all known types
+
+- GIVEN any of the 13 known event type strings is passed to `Extension::getIcon()`
+- WHEN the method executes
+- THEN it MUST return a non-empty absolute URL string pointing to an SVG resource served by MyDash
+
+#### Scenario: `getIcon()` falls back for unknown types
+
+- GIVEN an unknown event type string is passed to `Extension::getIcon()`
+- WHEN the method executes
+- THEN it MUST return the URL to the generic MyDash activity icon (`img/activity/mydash.svg`)
+
+### Requirement: REQ-ACT-002 Event-Type Catalogue
+
+The system MUST define exactly 13 event-type constants on `\OCA\MyDash\Activity\Extension`, grouped in a static `ALL_EVENTS` array, covering the full set of trackable MyDash actions. No event type may be emitted by `ActivityPublisher` unless it is declared in `ALL_EVENTS`.
+
+#### Scenario: All 13 constants present and non-empty
+
+- GIVEN `Extension::ALL_EVENTS` is inspected at runtime
+- THEN it MUST contain exactly these 13 string values (in any order): `dashboard_created`, `dashboard_updated`, `dashboard_deleted`, `dashboard_published`, `dashboard_unpublished`, `dashboard_scheduled`, `dashboard_shared`, `dashboard_public_share_created`, `dashboard_commented`, `dashboard_reacted`, `dashboard_restored`, `dashboard_lock_overridden`, `dashboard_role_changed`
+- AND no value MUST be empty or duplicated
+
+#### Scenario: Unknown type rejected by `ActivityPublisher`
+
+- GIVEN `ActivityPublisher::publish()` is called with an event type string not present in `Extension::ALL_EVENTS`
+- WHEN `publish()` executes
+- THEN it MUST log a WARNING and return without calling `IManager::publishActivity()`
+- AND no row MUST be written to `oc_activity`
+
+#### Scenario: Constants are importable from sibling-capability files
+
+- GIVEN a sibling capability (e.g. `dashboard-comments`) needs to reference the comment event type
+- WHEN it uses `Extension::EVENT_COMMENTED`
+- THEN PHP MUST resolve the constant without an autoload error
+- NOTE: Constants MUST be public; no dynamic-only resolution pattern is acceptable
+
+#### Scenario: `ALL_EVENTS` is iterable for registration loop
+
+- GIVEN NC Activity settings-screen registration code iterates `Extension::ALL_EVENTS`
+- WHEN it calls `IManager::registerExtension()` inside the loop
+- THEN all 13 types MUST be registered with NC in a single loop without manual repetition
+
+### Requirement: REQ-ACT-003 `publishActivity` Contract
+
+The system MUST provide `\OCA\MyDash\Activity\ActivityPublisher` as the sole entry point for emitting MyDash activity events. It MUST delegate to `OCP\Activity\IManager::publishActivity()` and MUST NOT write to `oc_activity` directly. All fields required by NC Activity (`app`, `type`, `author`, `affecteduser`, `object_type`, `object_id`, `subject`, `message`, `link`, `timestamp`) MUST be set before the call.
+
+#### Scenario: Correct fields populated on IEvent
+
+- GIVEN `ActivityPublisher::publish('dashboard_updated', 'alice', 'uuid-1', 'Marketing', 'https://nc.example/apps/mydash#uuid-1')` is called
+- WHEN `IManager::publishActivity()` is invoked internally
+- THEN the `IEvent` passed to it MUST have: `app = 'mydash'`, `type = 'dashboard_updated'`, `object_type = 'mydash_dashboard'`, `object_id = 'uuid-1'`, `link = 'https://nc.example/apps/mydash#uuid-1'`
+
+#### Scenario: ActivityPublisher never uses static IManager access
+
+- GIVEN the `ActivityPublisher` source is inspected
+- THEN it MUST NOT contain any `\OC::$server->getActivityManager()` or `Server::get(IManager::class)` calls
+- AND `IManager` MUST be injected via constructor
+
+#### Scenario: Activity failure does not roll back primary action
+
+- GIVEN `IManager::publishActivity()` throws a `\RuntimeException`
+- WHEN `ActivityPublisher::publish()` handles the exception
+- THEN it MUST log the error and return without re-throwing
+- AND the caller (sibling-capability code) MUST continue normally
+
+#### Scenario: `publish()` called after domain action is persisted
+
+- GIVEN a dashboard is updated and the mapper has called `flush()`
+- WHEN the service method calls `ActivityPublisher::publish()` after the mapper call
+- THEN the activity row MUST reflect the post-update state
+- NOTE: Calls before `flush()` or inside a transaction that rolls back violate this contract
+
+### Requirement: REQ-ACT-004 Audience Targeting — Personal Dashboards
+
+For events on `user`-type dashboards, the system MUST emit exactly one activity row per event occurrence, addressed to the dashboard owner. The owner receives their own events so they appear in their personal activity stream.
+
+#### Scenario: Self-action on personal dashboard — single row for owner
+
+- GIVEN user "alice" updates her personal dashboard "Work"
+- WHEN `ActivityPublisher::publish('dashboard_updated', 'alice', ...)` is called
+- THEN exactly one row MUST be written to `oc_activity` with `user = 'alice'` and `affecteduser = 'alice'`
+
+#### Scenario: Admin action on personal-origin dashboard — single row to owner
+
+- GIVEN admin "root" deletes user "bob"'s personal dashboard on his behalf
+- WHEN `ActivityPublisher::publish('dashboard_deleted', 'root', uuid, ...)` is called targeting bob's dashboard
+- THEN exactly one row MUST be written with `user = 'bob'` and `affecteduser = 'root'`
+
+#### Scenario: No fan-out for personal dashboards
+
+- GIVEN "alice"'s personal dashboard is not shared with anyone
+- WHEN she creates a new widget on it (triggering `dashboard_updated`)
+- THEN `oc_activity` MUST contain exactly one new row for this event
+- AND no rows MUST be written for any other user
+
+#### Scenario: First-person vs third-person subject selection
+
+- GIVEN "alice" updates her own personal dashboard
+- THEN the activity row MUST use the first-person subject template for `dashboard_updated`
+- GIVEN "root" updates "alice"'s personal dashboard
+- THEN the activity row addressed to "alice" MUST use the third-person template with actor param `'root'`
+
+### Requirement: REQ-ACT-005 Audience Targeting — Shared Dashboards
+
+For `dashboard_shared` events (user-to-user shares via the `dashboard-sharing` capability), the system MUST emit one activity row to each named share recipient plus one row to the acting user.
+
+#### Scenario: Share with two users produces three rows
+
+- GIVEN "alice" shares dashboard "Marketing" with "bob" and "carol"
+- WHEN `ActivityPublisher::publishToRecipients('dashboard_shared', 'alice', uuid, 'Marketing', link, ['bob', 'carol'])` is called
+- THEN `oc_activity` MUST contain three new rows: one for "alice", one for "bob", one for "carol"
+
+#### Scenario: Actor row uses first-person subject; recipient rows use second/third-person
+
+- GIVEN the same share event above
+- THEN "alice"'s row MUST use `"You shared dashboard Marketing with bob, carol"` (first-person)
+- AND "bob"'s row MUST use `"alice shared dashboard Marketing with you"` (second-person variant)
+
+#### Scenario: Public share creation — owner and actor only
+
+- GIVEN admin "root" creates a public share link for "alice"'s dashboard "Marketing"
+- WHEN `ActivityPublisher::publish('dashboard_public_share_created', 'root', uuid, 'Marketing', link)` is called
+- THEN exactly two rows MUST be written: one for "root", one for "alice" (dashboard owner)
+- AND no additional rows MUST be written (no named recipients exist)
+
+#### Scenario: Sharing with a user who already has the dashboard does not skip their row
+
+- GIVEN "carol" already sees the dashboard via a group share
+- WHEN "alice" also creates a direct user-to-user share with "carol"
+- THEN a `dashboard_shared` activity row MUST still be emitted to "carol"
+- NOTE: The activity event is informational — deduplication of shares is handled by the `dashboard-sharing` capability, not Activity
+
+### Requirement: REQ-ACT-006 Audience Targeting — Group-Shared Dashboards
+
+For events on `group_shared`-type dashboards, the system MUST emit one activity row per current member of the target group, resolved at emit-time via `IGroupManager`. The actor receives their own row and MUST NOT receive a duplicate.
+
+#### Scenario: Update on group-shared dashboard fans out to all members
+
+- GIVEN group "marketing" has members ["alice", "bob", "carol"] and admin "root" updates the group-shared dashboard "Campaigns"
+- WHEN `ActivityPublisher::publish('dashboard_updated', 'root', uuid, 'Campaigns', link)` is called with the dashboard entity
+- THEN `oc_activity` MUST contain exactly 4 new rows: one for each of "root", "alice", "bob", "carol"
+
+#### Scenario: Actor who is also a group member does not receive a duplicate row
+
+- GIVEN admin "root" is also a member of group "marketing" (which has 3 members total including root)
+- WHEN "root" updates the group-shared "Campaigns" dashboard
+- THEN `oc_activity` MUST contain exactly 3 rows (not 4): one per unique user
+
+#### Scenario: `IGroupManager` is not invoked for personal-dashboard events
+
+- GIVEN a `user`-type dashboard event is being published
+- WHEN `ActivityPublisher::publish()` runs
+- THEN `IGroupManager` MUST NOT be called
+- NOTE: Personal-dashboard audience resolution is always "owner only" — group lookup is guarded by `dashboard->getType() === 'group_shared'`
+
+#### Scenario: Group with zero members produces zero activity rows
+
+- GIVEN group "empty-team" has no members and a group-shared dashboard exists for it
+- WHEN an update event is published for that dashboard
+- THEN `oc_activity` MUST contain zero new rows for this event
+- AND no exception MUST be thrown
+
+### Requirement: REQ-ACT-007 Debounce — Reaction Events
+
+The system MUST apply a 15-minute debounce per `(actorUserId, dashboardUuid)` pair to `dashboard_reacted` events. At most one reaction activity row per actor per dashboard per 15-minute window MUST be written.
+
+#### Scenario: First reaction within window is published
+
+- GIVEN user "bob" reacts to dashboard "Marketing" (uuid `abc`)
+- AND no prior reaction from "bob" to `abc` exists in the current APCu window
+- WHEN `ActivityPublisher::publish('dashboard_reacted', 'bob', 'abc', ...)` is called
+- THEN `allowReaction('bob', 'abc')` MUST return true
+- AND one row MUST be written to `oc_activity`
+
+#### Scenario: Second reaction within 15 minutes is suppressed
+
+- GIVEN "bob" already reacted to dashboard `abc` 5 minutes ago (APCu key is live)
+- WHEN `ActivityPublisher::publish('dashboard_reacted', 'bob', 'abc', ...)` is called again
+- THEN `allowReaction('bob', 'abc')` MUST return false
+- AND `IManager::publishActivity()` MUST NOT be called
+- AND zero new rows MUST be written to `oc_activity`
+
+#### Scenario: Reaction from a different user is not suppressed by another user's debounce
+
+- GIVEN "bob" reacted to dashboard `abc` 5 minutes ago
+- WHEN "carol" reacts to the same dashboard `abc`
+- THEN `allowReaction('carol', 'abc')` MUST return true (separate APCu key)
+- AND one row MUST be written for "carol"
+
+#### Scenario: Debounce TTL expires and next reaction is allowed
+
+- GIVEN "bob" reacted to dashboard `abc` and the APCu key `mydash_act_react_bob_abc` has expired (TTL 900 s elapsed)
+- WHEN "bob" reacts again
+- THEN `allowReaction('bob', 'abc')` MUST return true
+- AND one row MUST be written
+
+### Requirement: REQ-ACT-008 Debounce — Global (Default-Group) Fan-Out
+
+For events on dashboards with `groupId = 'default'`, the system MUST apply a 15-minute debounce per `(dashboardUuid, eventType)` before performing the full user-enumeration fan-out. When the debounce window is active, the entire fan-out MUST be skipped silently (no rows written, no exception).
+
+#### Scenario: First global event triggers full fan-out
+
+- GIVEN a default-group dashboard `D-default` is updated
+- AND no prior debounce key exists for `(D-default.uuid, 'dashboard_updated')`
+- WHEN `ActivityPublisher::publish('dashboard_updated', 'root', D-default.uuid, ...)` is called
+- THEN `allowGlobalFanout(D-default.uuid, 'dashboard_updated')` MUST return true
+- AND one row per NC user MUST be written to `oc_activity`
+
+#### Scenario: Subsequent global event within 15 minutes is fully suppressed
+
+- GIVEN the debounce key for `(D-default.uuid, 'dashboard_updated')` is active
+- WHEN another update to the same dashboard triggers `publish('dashboard_updated', ...)` again
+- THEN `allowGlobalFanout()` MUST return false
+- AND `IUserManager::callForAllUsers()` MUST NOT be called
+- AND zero rows MUST be written
+
+#### Scenario: Different event type on same dashboard is not suppressed
+
+- GIVEN debounce for `(D-default.uuid, 'dashboard_updated')` is active
+- WHEN `publish('dashboard_published', ...)` is called for the same dashboard
+- THEN `allowGlobalFanout(D-default.uuid, 'dashboard_published')` MUST return true (separate key)
+- AND the publication fan-out MUST proceed
+
+#### Scenario: DEBUG log entry emitted on suppression
+
+- GIVEN the global debounce is active for an event
+- WHEN the fan-out is suppressed
+- THEN `ActivityPublisher` MUST emit a DEBUG-level log entry stating that the global fan-out was debounced, including the dashboard UUID and event type
+- AND no WARNING or ERROR MUST be logged (suppression is expected behaviour)
+
+### Requirement: REQ-ACT-009 User Opt-Out via NC Settings
+
+The system MUST register each of the 13 event types with NC Activity's per-type notification preference system. Users MUST be able to independently disable in-app notifications and email notifications for each type via the standard NC Settings → Activity UI, with no custom MyDash preferences page required.
+
+#### Scenario: Default notification preferences for a new user
+
+- GIVEN a new NC user "frank" with no prior Activity preferences
+- WHEN MyDash emits any activity event addressed to "frank"
+- THEN in-app notification MUST be enabled (default on) for all 13 types
+- AND email notification MUST be disabled (default off) for all 13 types
+
+#### Scenario: User disables `dashboard_commented` in-app notifications
+
+- GIVEN "frank" has navigated to NC Settings → Activity and disabled in-app for `dashboard_commented`
+- WHEN another user comments on a dashboard "frank" has access to
+- THEN no in-app row MUST be written to `oc_activity` for "frank" for this comment event
+- AND "frank" MUST still receive rows for other event types he has not disabled
+
+#### Scenario: User enables email for `dashboard_shared`
+
+- GIVEN "frank" has enabled email delivery for `dashboard_shared`
+- WHEN a dashboard is shared with him
+- THEN NC's Activity email job MUST include this event in "frank"'s next digest
+- NOTE: Email sending is NC's responsibility; MyDash only controls whether the row is written with the correct type
+
+#### Scenario: Opt-out state is per-user and per-type
+
+- GIVEN "frank" disables `dashboard_updated` but "grace" keeps it enabled
+- WHEN a group-shared dashboard they both access is updated
+- THEN no `dashboard_updated` row MUST be written for "frank"
+- AND a `dashboard_updated` row MUST be written for "grace"
+
+### Requirement: REQ-ACT-010 Subject/Message Templates and Translation
+
+The system MUST define a complete set of translated subject and message templates for all 13 event types in both `en` and `nl`. NC Activity's `{placeholder}` substitution MUST be used for actor names, dashboard names, recipients, and roles. Templates MUST be registered as i18n keys.
+
+#### Scenario: First-person subject rendered for self-actions
+
+- GIVEN user "alice" creates a dashboard "Analytics"
+- WHEN her activity row is rendered in the NC Activity UI
+- THEN the subject MUST read `"You created dashboard Analytics"` (en) or `"Je hebt dashboard Analytics aangemaakt"` (nl)
+
+#### Scenario: Third-person subject rendered for others' actions
+
+- GIVEN user "bob" comments on "alice"'s dashboard "Analytics" and "alice" receives the activity row
+- WHEN "alice" views her activity stream
+- THEN the subject MUST read `"bob commented on dashboard Analytics"` (en)
+
+#### Scenario: `dashboard_commented` message includes comment excerpt
+
+- GIVEN "bob" posts the comment "Great work on the Q2 charts!" on dashboard "Analytics"
+- WHEN the activity row is rendered
+- THEN the message MUST contain the first 200 characters of the comment body
+- AND the subject MUST be the short template (not the full comment body)
+
+#### Scenario: Missing translation key falls back to English
+
+- GIVEN a user has an NC locale set to a language other than `en` or `nl` that MyDash has not translated
+- WHEN their activity row is rendered
+- THEN NC Activity MUST fall back to the English template
+- NOTE: This is NC's standard fallback behaviour; MyDash only needs to provide `en` and `nl`
+
+#### Scenario: Placeholder substitution does not leave unresolved tokens
+
+- GIVEN a subject template `"{actor} updated dashboard {dashboard}"` is rendered with actor `"root"` and dashboard `"Marketing"`
+- WHEN NC Activity applies substitution
+- THEN the rendered string MUST be `"root updated dashboard Marketing"` with no literal `{actor}` or `{dashboard}` tokens remaining
+
+### Requirement: REQ-ACT-011 Cross-Capability Emission Contract
+
+Each of the 13 event types has exactly one owning capability responsible for calling `ActivityPublisher::publish()` at the correct point in the action lifecycle. This spec defines the types and publisher service; the sibling capabilities add the call-sites. A capability MUST NOT emit an event type it does not own.
+
+#### Scenario: `dashboard_published` emitted only by `dashboard-draft-published` capability
+
+- GIVEN a dashboard is transitioned to `published` status
+- WHEN the `dashboard-draft-published` service method completes
+- THEN `ActivityPublisher::publish('dashboard_published', ...)` MUST be called exactly once
+- AND no other capability code path MUST call `publishActivity` for `dashboard_published`
+
+#### Scenario: Emission occurs after domain action is persisted
+
+- GIVEN the dashboard mapper has flushed the status update to the database
+- WHEN `ActivityPublisher::publish()` is subsequently called
+- THEN the activity row timestamp MUST be >= the database row's `updatedAt`
+- AND if the mapper call fails and throws before `publish()`, no activity row MUST be written
+
+#### Scenario: Activity failure does not fail the HTTP request
+
+- GIVEN `IManager::publishActivity()` throws `\Exception` (e.g. DB error on `oc_activity`)
+- WHEN `ActivityPublisher` catches the exception
+- THEN the HTTP response from the owning capability endpoint MUST still be HTTP 200/201/204
+- AND an ERROR-level log entry MUST be written by `ActivityPublisher`
+
+#### Scenario: No direct `oc_activity` writes in sibling-capability code
+
+- GIVEN any PHP file in a sibling capability (e.g. `lib/Service/PublicationService.php`)
+- WHEN the file is inspected
+- THEN it MUST NOT contain any direct `oc_activity` SQL or `\OC_DB::` calls for MyDash events
+- AND all event emission MUST go through `ActivityPublisher::publish()` or `ActivityPublisher::publishToRecipients()`
+
+#### Scenario: Emission contract documented in Extension class docblock
+
+- GIVEN `lib/Activity/Extension.php` is read
+- WHEN the class-level docblock is inspected
+- THEN it MUST list all 13 event types with the owning capability for each, so future contributors know where to add call-sites
+
+### Requirement: REQ-ACT-011b Unit-Test Contract
+
+The system MUST include a PHPUnit test class `tests/Unit/Activity/ExtensionTest.php` that verifies each of the 13 event types is correctly published, that icons and subjects are resolved, and that the debounce logic suppresses duplicate rows.
+
+#### Scenario: All 13 event types produce a row with correct fields
+
+- GIVEN `ActivityPublisher` is instantiated with a mock `IManager`
+- WHEN `publish($type, 'alice', 'uuid-1', 'Dashboard A', 'https://nc.example/...')` is called for each of the 13 event types
+- THEN the mock `IManager::publishActivity()` MUST be called exactly once per event type
+- AND the `IEvent` passed MUST have `app = 'mydash'`, `type = $type`, `object_type = 'mydash_dashboard'`, `object_id = 'uuid-1'`
+
+#### Scenario: `Extension::getIcon()` returns non-empty URL for all 13 types
+
+- GIVEN `Extension::getIcon($type)` is called for each value in `Extension::ALL_EVENTS`
+- THEN each call MUST return a non-empty string
+- AND no call MUST throw
+
+#### Scenario: `Extension::parse()` sets `richSubject` for all 13 types
+
+- GIVEN `Extension::parse()` is called with a mock `IEvent` for each of the 13 types, with both self-actor and other-actor variants
+- THEN the returned `IEvent` MUST have `richSubject` set to a non-empty string for every combination (26 assertions total)
+
+#### Scenario: Debounce suppresses second `dashboard_reacted` within window
+
+- GIVEN a mock or in-memory APCu stub is used
+- AND `publish('dashboard_reacted', 'bob', 'uuid-1', ...)` has already been called once
+- WHEN `publish('dashboard_reacted', 'bob', 'uuid-1', ...)` is called a second time within 900 s
+- THEN `IManager::publishActivity()` MUST have been called exactly once in total (the second call is suppressed)
+
+#### Scenario: PHPStan level 8 and PHPCS PSR-12 pass on the test file
+
+- GIVEN `tests/Unit/Activity/ExtensionTest.php` is committed
+- WHEN `composer check:strict` is executed
+- THEN both PHPStan and PHPCS MUST report zero errors or warnings for the new test file
+- AND any pre-existing issues in nearby files encountered during the task MUST also be fixed

--- a/openspec/changes/activity-feed-integration/tasks.md
+++ b/openspec/changes/activity-feed-integration/tasks.md
@@ -1,0 +1,91 @@
+# Tasks — activity-feed-integration
+
+## 1. Extension registration
+
+- [ ] 1.1 Create `lib/Activity/Extension.php` implementing `OCP\Activity\IProvider`; declare class constant `APP_ID = 'mydash'`
+- [ ] 1.2 Implement `parse(string $language, IEvent $event, ?IEvent $previousEvent): IEvent` — match on each of the 13 `EVENT_*` constants; delegate to per-type template builder; return unmodified event for unknown types
+- [ ] 1.3 Implement `getIcon(string $eventType): string` — return full URL to the per-type SVG from `img/activity/`; fall back to the generic MyDash icon for unknown types
+- [ ] 1.4 Register `\OCA\MyDash\Activity\Extension` in `appinfo/info.xml` under `<activity>`
+- [ ] 1.5 Register `ActivityPublisher` and `DebounceHelper` in `lib/AppInfo/Application.php` DI container
+
+## 2. Event-type constants
+
+- [ ] 2.1 Declare all 13 class constants on `Extension.php`: `EVENT_CREATED`, `EVENT_UPDATED`, `EVENT_DELETED`, `EVENT_PUBLISHED`, `EVENT_UNPUBLISHED`, `EVENT_SCHEDULED`, `EVENT_SHARED`, `EVENT_PUBLIC_SHARE_CREATED`, `EVENT_COMMENTED`, `EVENT_REACTED`, `EVENT_RESTORED`, `EVENT_LOCK_OVERRIDDEN`, `EVENT_ROLE_CHANGED` — values are the string names listed in the spec
+- [ ] 2.2 Group constants into a static `ALL_EVENTS` array for use in the unit test assertion loop and NC settings-screen registration
+- [ ] 2.3 Register each event type with NC Activity so it appears in the per-type opt-out UI in NC settings; set sensible defaults (`notification: true`, `email: false`) for each type
+
+## 3. `publishActivity` contract
+
+- [ ] 3.1 Create `lib/Activity/ActivityPublisher.php` with a single public `publish(string $type, string $actorUserId, string $dashboardUuid, string $dashboardName, string $dashboardLink, array $extraParams = []): void` method
+- [ ] 3.2 Inside `publish()`: build `IEvent` via `IManager::generateEvent()`; set `app`, `type`, `author`, `object` (`object_type = 'mydash_dashboard'`, `object_id = $dashboardUuid`), `subject`, `message`, `link`, and `timestamp`; call `IManager::publishActivity($event)` — never bypass `IManager`
+- [ ] 3.3 Inject `IManager` into `ActivityPublisher` via constructor DI (no static calls, no service locator)
+- [ ] 3.4 `publish()` MUST NOT throw on unknown event types — log a warning and return early
+
+## 4. Audience targeting — personal dashboards
+
+- [ ] 4.1 For `dashboard_created`, `dashboard_updated`, `dashboard_deleted`, `dashboard_published`, `dashboard_unpublished`, `dashboard_scheduled`, `dashboard_restored`: emit exactly one activity row to the dashboard owner (`userId` of the dashboard)
+- [ ] 4.2 When the actor is the owner (self-action), use the first-person subject template (e.g. `"You created dashboard %s"`); when the actor differs, use the third-person template (e.g. `"%s created dashboard %s"`)
+- [ ] 4.3 Unit-test both template branches: self-action resolves first-person; third-party resolves third-person
+
+## 5. Audience targeting — user-to-user shares
+
+- [ ] 5.1 For `dashboard_shared`: emit one activity row to the acting user AND one row per recipient listed in the share payload (resolved from the `dashboard-sharing` capability's share record)
+- [ ] 5.2 `ActivityPublisher::publishToRecipients(string $type, string $actorUserId, string $dashboardUuid, string $dashboardName, string $dashboardLink, array $recipientUserIds): void` — loops over recipients and calls `IManager::publishActivity()` once per recipient
+- [ ] 5.3 `dashboard_public_share_created`: emit only to the dashboard owner and the acting admin (no fan-out — no named recipients exist)
+
+## 6. Audience targeting — group-shared dashboards
+
+- [ ] 6.1 For events on a `group_shared` dashboard: resolve all members of `groupId` via `IGroupManager::get($groupId)->getUsers()` and emit one activity row per member
+- [ ] 6.2 Inject `IGroupManager` into `ActivityPublisher`; never call `IGroupManager` for personal-dashboard events (guard on `dashboard->getType()`)
+- [ ] 6.3 Emit the actor's own row first, then remaining members; do not emit a duplicate row for the actor if they are also a group member (deduplicate by userId)
+
+## 7. Audience targeting — default-group dashboards (global events)
+
+- [ ] 7.1 For events on a dashboard with `groupId = 'default'`: enumerate all Nextcloud users via `IUserManager::callForAllUsers()` and emit one activity row per user
+- [ ] 7.2 Gate global fan-out through `DebounceHelper::allowGlobalFanout(string $dashboardUuid, string $eventType): bool` — returns true at most once per 15 minutes per `(dashboardUuid, eventType)` combination; uses APCu key `mydash_act_global_{dashboardUuid}_{eventType}`
+- [ ] 7.3 When `allowGlobalFanout` returns false, skip the entire fan-out (do not emit any rows for that event occurrence); log a DEBUG message indicating debounce suppressed the event
+
+## 8. Debounce — reaction events
+
+- [ ] 8.1 Create `lib/Activity/DebounceHelper.php` with `allowReaction(string $actorUserId, string $dashboardUuid): bool` — returns true at most once per 15 minutes per `(actorUserId, dashboardUuid)` pair; APCu key `mydash_act_react_{actorUserId}_{dashboardUuid}`; TTL 900 seconds
+- [ ] 8.2 `ActivityPublisher::publish()` MUST call `DebounceHelper::allowReaction()` before emitting `EVENT_REACTED`; if it returns false, return without publishing
+- [ ] 8.3 Add `DebounceHelper::allowGlobalFanout()` (task 7.2) to the same class; TTL also 900 seconds
+- [ ] 8.4 Unit-test: first call to `allowReaction()` returns true; second call within 900 s returns false; call after TTL expiry returns true (mock APCu or inject a test-double cache)
+
+## 9. Subject and message templates
+
+- [ ] 9.1 Define `Extension::getSubjectTemplates(): array` returning `[eventType => ['self' => '...', 'other' => '...']]` for all 13 types
+- [ ] 9.2 First-person subjects (`self`): `"You created dashboard {dashboard}"`, `"You updated dashboard {dashboard}"`, `"You deleted dashboard {dashboard}"`, `"You published dashboard {dashboard}"`, `"You unpublished dashboard {dashboard}"`, `"You scheduled dashboard {dashboard}"`, `"You shared dashboard {dashboard} with {recipient}"`, `"You created a public link for dashboard {dashboard}"`, `"You commented on dashboard {dashboard}"`, `"You reacted to dashboard {dashboard}"`, `"You restored dashboard {dashboard} to an earlier version"`, `"You overrode the lock on dashboard {dashboard}"`, `"Your role in {dashboard} was changed to {role}"`
+- [ ] 9.3 Third-person subjects (`other`): `"{actor} created dashboard {dashboard}"`, `"{actor} updated dashboard {dashboard}"`, `"{actor} deleted dashboard {dashboard}"`, `"{actor} published dashboard {dashboard}"`, `"{actor} unpublished dashboard {dashboard}"`, `"{actor} scheduled dashboard {dashboard}"`, `"{actor} shared dashboard {dashboard} with {recipient}"`, `"{actor} created a public link for dashboard {dashboard}"`, `"{actor} commented on dashboard {dashboard}"`, `"{actor} reacted to dashboard {dashboard}"`, `"{actor} restored dashboard {dashboard} to an earlier version"`, `"{actor} overrode the lock on dashboard {dashboard}"`, `"{actor} changed {target}'s role in {dashboard} to {role}"`
+- [ ] 9.4 Register all subject strings as i18n keys in `l10n/en.json` and `l10n/nl.json`; NC's Activity translation system resolves `{placeholder}` at render time
+- [ ] 9.5 Message templates (optional detail lines) use the same key pattern `mydash_act_msg_{eventType}` — empty string is acceptable for non-comment events; `dashboard_commented` message MUST include the first 200 characters of the comment body
+
+## 10. Icons
+
+- [ ] 10.1 Create `img/activity/` directory; add one SVG icon per event type (13 files) using Nextcloud's Activity icon conventions (24×24 px, single colour, no embedded raster images)
+- [ ] 10.2 `Extension::getIcon(string $eventType)` MUST return an absolute URL via `\OCP\IURLGenerator::imagePath('mydash', "activity/{$eventType}.svg")` — no hardcoded strings
+- [ ] 10.3 Provide a generic fallback `img/activity/mydash.svg` returned when `$eventType` is not one of the 13 known constants
+- [ ] 10.4 All SVG files MUST pass SVG sanitisation (no `<script>`, no external references) per the `svg-sanitisation` capability requirements
+
+## 11. Cross-capability emission contract
+
+- [ ] 11.1 Document in `lib/Activity/Extension.php` (class-level docblock) the canonical list of which capability is responsible for calling `ActivityPublisher::publish()` for each event type: `dashboard_created` → `dashboards`; `dashboard_updated` → `dashboards`; `dashboard_deleted` → `dashboards`; `dashboard_published`/`dashboard_unpublished`/`dashboard_scheduled` → `dashboard-draft-published`; `dashboard_shared` → `dashboard-sharing-followups`; `dashboard_public_share_created` → `dashboard-public-share`; `dashboard_commented` → `dashboard-comments`; `dashboard_reacted` → `dashboard-reactions`; `dashboard_restored` → `dashboard-versioning`; `dashboard_lock_overridden` → `dashboard-locking`; `dashboard_role_changed` → `admin-roles`
+- [ ] 11.2 Each sibling-capability task list MUST include a subtask "Add `ActivityPublisher::publish(Extension::EVENT_*)` call at the action completion point" — this spec creates the service; the sibling spec adds the call
+- [ ] 11.3 Publish calls MUST occur after the primary domain action succeeds and is persisted — never inside a database transaction that may roll back
+- [ ] 11.4 If `ActivityPublisher::publish()` throws, the exception MUST be caught and logged; the primary action MUST NOT be rolled back due to an Activity failure
+
+## 12. Unit-test contract
+
+- [ ] 12.1 Create `tests/Unit/Activity/ExtensionTest.php`; for each of the 13 event types: call `IManager::publishActivity()` with a fabricated `IEvent` and assert a row exists in `oc_activity` (or use a mock `IManager` to assert `publishActivity()` was called with correct `type`, `object_id`, `subject`, `message`, and `link` values)
+- [ ] 12.2 Assert that `Extension::getIcon()` returns a non-empty string for each of the 13 known event types and for an unknown type
+- [ ] 12.3 Assert that `Extension::parse()` returns an `IEvent` with `richSubject` set for each of the 13 event types (both self- and other-actor variants)
+- [ ] 12.4 Assert that publishing `EVENT_REACTED` a second time within the debounce window results in zero additional `publishActivity()` calls (requires a mock or in-memory APCu stub)
+- [ ] 12.5 All tests MUST pass under `composer check:strict` (PHPStan level 8, PHPCS PSR-12, PHPMD); fix any pre-existing issues encountered in nearby files
+
+## 13. Quality gates
+
+- [ ] 13.1 `composer check:strict` clean on all new and touched PHP files
+- [ ] 13.2 SPDX headers on every new PHP file inside the main file docblock (never as `// SPDX-...` line comments)
+- [ ] 13.3 i18n keys for all 13 subject pairs (self + other) + all message templates present in both `l10n/en.json` and `l10n/nl.json`
+- [ ] 13.4 SVG icons pass the sanitisation checker (no scripts, no external refs)
+- [ ] 13.5 Run all `hydra-gates` locally before opening PR

--- a/openspec/changes/admin-roles/design.md
+++ b/openspec/changes/admin-roles/design.md
@@ -1,0 +1,98 @@
+# Design — Admin Roles (Dashboard Admin / Editor / Viewer)
+
+## Context
+
+MyDash currently resolves all access control through Nextcloud's binary admin/non-admin flag and GroupFolder ACL bitmasks (READ=1, UPDATE=2, CREATE=4, DELETE=8, SHARE=16). This is sufficient for filesystem-level sharing but creates a delegation problem: an organisation that wants to empower a trusted user to manage dashboards must either grant them full Nextcloud system administration — including server configuration, user management, and app installs — or leave them with no elevated access at all.
+
+The source app the MyDash feature set is informed by has no named role concept and no role precedence system. Its `PermissionService` resolves permissions entirely from GroupFolder ACL lookups via Nextcloud's `FolderManager`. It does seed three Nextcloud groups (`IntraVox Admins`, `IntraVox Editors`, `IntraVox Users`) and assign them GroupFolder permissions, but those are plain Nextcloud groups — not an in-app role model, not stored in any app table, and not consulted by any role resolver.
+
+Admin-roles is therefore a net-new MyDash design with no source counterpart. It introduces three roles scoped entirely within MyDash (Dashboard Admin, Dashboard Editor, Dashboard Viewer), persistent DB-backed assignments, and a highest-privilege-wins resolution algorithm. The existing `permissions` capability is extended to consult the role system before falling back to its default GroupFolder-derived behavior.
+
+The three role names deliberately echo the three groups the source app seeds (`Admins`, `Editors`, `Users`) so that customers familiar with the source app's group structure recognise the model immediately, even though the underlying mechanism is entirely different.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Introduce three named MyDash roles that map to real organisational delegation needs.
+- Persist role assignments in a dedicated DB table, supporting both user-level and group-level scope.
+- Resolve effective role per user using a deterministic highest-privilege-wins algorithm.
+- Layer the role system on top of Nextcloud's admin flag — NC admin is always treated as Dashboard Admin, no explicit assignment required.
+- Cascade cleanly on Nextcloud user or group deletion via listener hooks.
+- Enable the setup wizard (sibling capability) to optionally bootstrap role assignments from existing NC groups.
+
+**Non-Goals:**
+- Do NOT replace or modify Nextcloud's built-in admin/non-admin distinction — the role system layers on top of it.
+- Do NOT introduce per-dashboard role overrides (e.g., "admin globally, viewer on this one dashboard") — keep resolution user-scoped.
+- Do NOT replace GroupFolder ACL for filesystem-level access; GroupFolder remains the storage permission model.
+- Do NOT expose a "preview" API showing what role a user would gain by joining a hypothetical group (potential future follow-up).
+- Do NOT grant roles via filesystem ACL or GroupFolder permissions — the two systems are intentionally separate.
+
+## Decisions
+
+### D1: Net-new capability — no source counterpart
+
+**Decision**: Admin-roles is an entirely new MyDash design. The source app has no named-role concept and resolves all permissions from the GroupFolder ACL bitmask alone.
+
+**Source evidence (what the source DOES have, for context)**:
+- `intravox-source/lib/Service/PermissionService.php:1-150` — bitmask resolver from GroupFolder ACL only (READ/UPDATE/CREATE/DELETE/SHARE). No role table, no role names, no precedence resolver.
+- `intravox-source/lib/Service/SetupService.php` — three NC groups seeded with GroupFolder permissions at install time, but they are standard Nextcloud groups, not an in-app role model. No app-level code references them by name after seeding.
+
+**Rationale**: The source's ACL bitmask model cannot express a "Viewer" role meaningfully — a user who owns a personal dashboard would normally have write access via GroupFolder ownership, but MyDash's Viewer role must block that. Expressing this distinction requires an in-app role layer that overrides GroupFolder-derived permissions, not a bitmask union.
+
+### D2: Storage — dedicated `oc_mydash_role_assignments` table, not derived from groups
+
+**Decision**: Persist role assignments in a DB table with one row per assignment. Each row binds either a `userId` OR a `groupId` (XOR constraint) to one of three roles. Schema fields: `id` (auto-increment PK), `userId` (VARCHAR 64, nullable), `groupId` (VARCHAR 64, nullable), `role` (VARCHAR 10: "admin"/"editor"/"viewer"), `assignedBy` (VARCHAR 64, audit), `assignedAt` (DATETIME, audit). A UNIQUE constraint prevents duplicate assignments per target and role.
+
+**Alternatives considered:**
+- **Derive from NC group name** (user in NC group `mydash-admin` → Dashboard Admin automatically): rejected because group names are brittle (renaming breaks the mapping), user-specific assignments outside groups become impossible, and the coupling is implicit and unauditable.
+- **Single per-user role column on the users/profile table**: rejected because group-scoped assignments are a primary use case (assigning all of "marketing" the editor role at once), and a single column cannot represent group-level delegation.
+- **Reuse GroupFolder permission bits**: rejected because GroupFolder ACL cannot express the Viewer role's personal-dashboard restriction, and the ACL layer is owned by Nextcloud's GroupFolders app, not MyDash.
+
+**Rationale**: DB-backed assignments are explicit, auditable (assignedBy/assignedAt), and survive group renames and deletions gracefully (cascade listeners handle cleanup). They support both user-level and group-level scope in a single table with a clean XOR constraint. The zero-impact migration (new table only) means existing installs are unaffected until an admin makes an explicit assignment.
+
+### D3: Three-role taxonomy — Admin / Editor / Viewer
+
+**Decision**: Three roles named "admin", "editor", "viewer", defined in the spec. Names match the source app's three seeded NC group names to ease customer migration recognition.
+
+**Source evidence**:
+- `intravox-source/lib/Service/SetupService.php` — seeded groups `IntraVox Admins`, `IntraVox Editors`, `IntraVox Users`.
+
+**Rationale**: Three levels map cleanly to real organisational needs (full delegation, content delegation, read-only access) without introducing fine-grained permission combinations that require complex UI to manage. The naming alignment with the source groups is intentional UX continuity, not a technical dependency — MyDash does not read from those groups at runtime.
+
+### D4: Effective-role resolution — highest privilege wins
+
+**Decision**: For a given user, effective role is computed in this order:
+1. If the user is a Nextcloud admin → effective role is "admin", source is "nc-admin". No assignment lookup required.
+2. Otherwise, collect: the user's direct assignment (if any) and the role from each NC group assignment where the user is a member.
+3. Map roles to a numeric rank: "admin"=2, "editor"=1, "viewer"=0.
+4. Effective role = the assignment with the highest rank. Direct user assignment and group assignments are pooled and compared by rank — neither automatically beats the other; the higher rank wins.
+5. If no assignments exist → effective role is null; falls back to `permissions` capability behavior.
+
+Note: REQ-ROLE-009 scenario 1 describes a case where a user's direct "viewer" assignment wins over a group "admin" assignment, because direct assignment "takes precedence." This conflicts with a pure highest-wins rule. The spec resolves this by treating direct user assignment as the canonical source when it exists — if a direct user assignment is present, it is used as-is regardless of group assignments. Group assignments are only consulted when no direct user assignment exists.
+
+**Rationale**: Highest-privilege-wins for group assignments is intuitive (belonging to a higher-privileged group should not be negated by another lower-privileged group), consistent with GroupFolder ACL union semantics, and easy to implement (MAX over role ranks). The direct-assignment-wins-over-groups rule gives administrators a predictable explicit override mechanism — if you assign a user "viewer" directly, that is intentional and should not be silently overridden by their group memberships. NC admin is the unconditional root override, consistent with Nextcloud's own privilege model.
+
+### D5: Cascade on user/group deletion
+
+**Decision**: User deletion triggers removal of all `oc_mydash_role_assignments` rows where `userId = <deleted-user>`. Group deletion triggers removal of all rows where `groupId = <deleted-group>`. Wired via `UserDeletedListener` and `GroupDeletedListener`, referencing the `dashboard-cascade-events` capability's listener infrastructure. No cross-deletion: removing an assignment does not affect the user or group.
+
+**Rationale**: Stale assignments for deleted users or groups waste storage and could cause unexpected behavior if a user/group ID is reused. Listener-based cascade is the standard Nextcloud pattern and requires no schema-level foreign keys across apps.
+
+### D6: Setup-wizard seeding (optional)
+
+**Decision**: The setup-wizard sibling capability MAY include an optional step — "Bootstrap roles from existing NC groups?" — that creates one role assignment per role, binding each to a selected NC group. This is recommended for greenfield installs to align MyDash roles with organisational group structure, but is not required.
+
+**Rationale**: Customers migrating from the source app already have NC groups corresponding to the three roles. The wizard step converts that group structure into explicit MyDash role assignments in one click, without requiring admins to manually re-enter each group via the role-assignment API.
+
+## Spec changes implied
+
+- **REQ-ROLE-001**: Add a NOTE confirming Dashboard Admin is a net-new MyDash capability with no source counterpart. Clarify that NC admin status is an implicit grant — no assignment row is created.
+- **REQ-ROLE-005**: Tighten the effective-role resolution description to match D4: direct user assignment wins over group assignments (not simply "highest"); group assignments use highest-wins among groups; NC admin is unconditional override.
+- **REQ-ROLE-009**: Reconcile scenario 1 (direct "viewer" beats group "admin") with the resolution algorithm in REQ-ROLE-005 — make explicit that direct user assignment is used as-is when present, groups consulted only when absent.
+- **REQ-ROLE-010 / REQ-ROLE-011**: Reference `dashboard-cascade-events` capability by name in the cascade requirements so implementers know which listener infrastructure to extend.
+
+## Open follow-ups
+
+- Whether assigning a role to the literal `'default'` group (the multi-scope-dashboards `'default'` sentinel) should grant the role to every authenticated user — likely yes for symmetry, needs a REQ.
+- Whether MyDash should expose a preview API ("what role would user X have if they joined group Y?") for admins planning assignments — out of scope for this spec, candidate for a future `admin-roles-v2` spec.
+- Whether per-dashboard role overrides are ever needed (deliberately excluded as a Non-Goal above, but worth revisiting once the base role system is live).

--- a/openspec/changes/admin-roles/proposal.md
+++ b/openspec/changes/admin-roles/proposal.md
@@ -1,0 +1,65 @@
+# Admin Roles
+
+## Why
+
+Today MyDash assigns permissions based on Nextcloud groups and a binary admin flag. Organization administrators must choose between granting full Nextcloud admin rights (which includes system-level powers outside MyDash) or no admin rights at all. This creates a delegation bottleneck: delegating MyDash operations requires delegating all Nextcloud administration. A built-in role system scoped to MyDash enables fine-grained intranet governance, allowing org admins to delegate dashboard management, widget installation, and metadata configuration to trusted users without exposing system administration.
+
+## What Changes
+
+- Add a new table `oc_mydash_role_assignments` with `id`, `userId`, `groupId`, `role`, `assignedBy`, `assignedAt` fields. Either `userId` or `groupId` is set (mutually exclusive).
+- Define three new roles scoped entirely within MyDash:
+  - **Dashboard Admin** — full access to MyDash admin section, can edit any dashboard, can install demo data, can edit org-navigation, can manage metadata field definitions.
+  - **Dashboard Editor** — can create new `group_shared` dashboards, can edit `group_shared` dashboards in groups they belong to, can create personal dashboards, can edit metadata field values (but not definitions) on dashboards they edit.
+  - **Dashboard Viewer** — read-only access to visible dashboards; personal-dashboard creation and all mutations rejected; useful for demo and visitor accounts.
+- Effective role resolution: Nextcloud admins always have MyDash "admin" role. Non-admins resolve their highest-privilege role from direct user assignments or group memberships. Default (no assignment) = no role, falls back to existing `permissions` capability.
+- Add four new API endpoints:
+  - `GET /api/admin/roles` — lists all role assignments. NC-admin only.
+  - `POST /api/admin/roles` — creates a role assignment for a user or group. NC-admin only. 400 if both/neither of userId/groupId set. 409 on duplicate.
+  - `DELETE /api/admin/roles/{id}` — removes an assignment. NC-admin only.
+  - `GET /api/me/role` — returns the calling user's effective MyDash role and source. Available to any authenticated user.
+- Extend authorization: `permissions` capability resolver consults role system before falling back to default permissions. "Editor" and "Viewer" roles are enforced at mutation endpoints.
+- Cascade: deleting a Nextcloud user removes their direct user assignments. Deleting a group removes its group assignments. No cross-deletion.
+
+## Capabilities
+
+### New Capabilities
+
+- `admin-roles`: All role definition, assignment CRUD, effective-role resolution, and authorization enforcement within MyDash.
+
+### Modified Capabilities
+
+- `permissions` (ref: `openspec/specs/permissions/spec.md`): Extended to consult role system during authorization checks. No changes to the permission model itself; roles provide an alternative delegation layer above it.
+
+## Impact
+
+**Affected code:**
+
+- `lib/Db/RoleAssignment.php` — new entity with `id`, `userId`, `groupId`, `role`, `assignedBy`, `assignedAt` fields
+- `lib/Db/RoleAssignmentMapper.php` — new mapper with `findAll()`, `findByUser()`, `findByGroup()`, `findById()`, `insert()`, `update()`, `delete()`, `deleteByUserId()`, `deleteByGroupId()` methods
+- `lib/Service/RoleService.php` — new service layer with `getEffectiveRole()` (per-user resolution), `getRoleSource()` (tracking source), `assignRole()`, `removeRole()`, role validation
+- `lib/Controller/AdminController.php` — four new endpoints as above
+- `appinfo/routes.php` — register the four new routes
+- `lib/Migration/VersionXXXXDate2026...php` — schema migration creating `oc_mydash_role_assignments` table
+- `lib/Service/PermissionService.php` (existing) — extend `canEdit()`, `canCreate()`, `canDelete()` to consult `RoleService::getEffectiveRole()`
+- `lib/Listener/PreDeleteUser.php` (existing or new) — call `RoleService::deleteByUserId()` on user deletion
+- `lib/Listener/PreDeleteGroup.php` (existing or new) — call `RoleService::deleteByGroupId()` on group deletion
+
+**Affected APIs:**
+
+- 4 new routes (no existing routes changed; existing permission checks enhanced non-breaking)
+
+**Dependencies:**
+
+- `OCP\IUserManager` — for user lookups in role assignment
+- `OCP\IGroupManager` — for group lookups in role assignment
+- No new composer or npm dependencies
+
+**Migration:**
+
+- Zero-impact: new table only, no changes to existing schema
+- No seed data required
+- Default behavior (no assignments) preserves existing permissions model
+
+## Front-end Concern (Not in Scope)
+
+The admin UI MUST provide a role-assignment manager in the MyDash admin section, allowing NC admins to view, create, and delete role assignments per user and group. The `GET /api/me/role` endpoint allows the frontend to display the current user's role and source in account/settings views.

--- a/openspec/changes/admin-roles/specs/admin-roles/spec.md
+++ b/openspec/changes/admin-roles/specs/admin-roles/spec.md
@@ -1,0 +1,445 @@
+---
+status: draft
+---
+
+# Admin Roles Specification
+
+## Purpose
+
+Admin Roles provides a built-in role system scoped entirely within MyDash. Organization administrators can delegate dashboard management, widget installation, metadata field configuration, and other MyDash operations to trusted users without granting full Nextcloud system administration rights. Three roles (Dashboard Admin, Dashboard Editor, Dashboard Viewer) map to real organizational needs, and role assignments persist in a new table with support for both individual user and group-based delegation. Effective role resolution ensures the highest privilege wins when a user has multiple group memberships.
+
+## Data Model
+
+Each role assignment is stored in the `oc_mydash_role_assignments` table with the following fields:
+
+- **id**: Auto-increment integer primary key
+- **userId**: VARCHAR(64), Nextcloud user ID; NULL if this is a group assignment
+- **groupId**: VARCHAR(64), Nextcloud group ID; NULL if this is a user assignment
+- **role**: VARCHAR(10), one of: "admin", "editor", "viewer"
+- **assignedBy**: VARCHAR(64), Nextcloud user ID of the admin who created this assignment (for audit trail)
+- **assignedAt**: DATETIME, when the assignment was created
+
+**Constraint**: Exactly one of `userId` or `groupId` MUST be set (mutually exclusive XOR).
+
+**Unique Constraint**: Per-target uniqueness — a user or group may have at most one assignment of each role type. (Implementation: UNIQUE(userId, role) for user assignments; UNIQUE(groupId, role) for group assignments; OR composite unique index with IS NOT NULL logic if the database supports it.)
+
+## ADDED Requirements
+
+### Requirement: REQ-ROLE-001 Dashboard Admin Role Definition
+
+A Dashboard Admin MUST have full administrative access to MyDash, equivalent to Nextcloud admin status but scoped to MyDash only. A Dashboard Admin MUST be able to manage all dashboards, install demo data, edit organization-level navigation, and define new metadata fields.
+
+#### Scenario: NC admin automatically has Dashboard Admin role
+- GIVEN a Nextcloud admin user (admin flag = true)
+- WHEN the system resolves the user's effective MyDash role
+- THEN the user's effective role MUST be "admin"
+- AND the role source MUST be "nc-admin"
+- NOTE: No explicit assignment record is created; NC admin status is the implicit grant
+
+#### Scenario: Non-admin user assigned Dashboard Admin role
+- GIVEN a non-admin Nextcloud user "alice"
+- WHEN an NC admin creates a role assignment with `userId = "alice"`, `role = "admin"`
+- THEN alice's effective role becomes "admin"
+- AND the role source MUST be "user-assigned"
+- AND alice gains access to MyDash admin section: `/admin/settings`, `/admin/demo`, `/admin/metadata`, `/admin/roles`
+
+#### Scenario: Dashboard Admin can edit any dashboard
+- GIVEN a user with effective role "admin"
+- WHEN the user attempts to edit any dashboard (personal, group_shared, or org-level)
+- THEN the permission check MUST return true
+- AND no group membership check is required
+
+#### Scenario: Dashboard Admin can manage metadata field definitions
+- GIVEN a user with role "admin"
+- WHEN the user calls `POST /api/admin/metadata-fields` with a new field definition
+- THEN the system MUST allow the creation
+- AND the field is available for use on all dashboards (not scoped to a group)
+
+#### Scenario: Dashboard Admin can install demo data
+- GIVEN a user with role "admin"
+- WHEN the user calls `POST /api/admin/demo/install` with a demo package ID
+- THEN the system MUST allow the installation
+- AND demo dashboards appear in the appropriate scope
+
+#### Scenario: Dashboard Admin can edit organization navigation
+- GIVEN a user with role "admin"
+- WHEN the user calls `PUT /api/admin/org-navigation` with new navigation structure
+- THEN the system MUST allow the update
+- AND the changes are persisted and visible to all users
+
+### Requirement: REQ-ROLE-002 Dashboard Editor Role Definition
+
+A Dashboard Editor MUST be able to create and edit dashboards within their group memberships, install widgets, manage their own personal dashboards, and edit metadata field VALUES (but not create new field definitions). Dashboard Editors MUST NOT perform system-level operations like installing demo data or creating metadata field definitions.
+
+#### Scenario: Dashboard Editor creates a new group_shared dashboard
+- GIVEN a user "bob" with role "editor" in group "engineering"
+- WHEN bob calls `POST /api/dashboards` with `scope = "group_shared"`, `groupId = "engineering"`
+- THEN the system MUST allow the creation
+- AND bob becomes the owner of the new dashboard
+
+#### Scenario: Dashboard Editor can edit group_shared dashboard in their group
+- GIVEN a "group_shared" dashboard in group "engineering"
+- WHEN bob (with role "editor", member of "engineering") calls `PUT /api/dashboards/{uuid}` with edits
+- THEN the system MUST allow the update
+- AND the changes are persisted
+
+#### Scenario: Dashboard Editor cannot edit group_shared dashboard outside their groups
+- GIVEN a "group_shared" dashboard in group "sales"
+- WHEN bob (with role "editor", member of "engineering" only) calls `PUT /api/dashboards/{uuid}` with edits
+- THEN the system MUST return HTTP 403 (Forbidden)
+- AND the dashboard remains unchanged
+
+#### Scenario: Dashboard Editor can create personal dashboard
+- GIVEN a user "bob" with role "editor"
+- WHEN bob calls `POST /api/dashboards` with `scope = "personal"`
+- THEN the system MUST allow the creation
+- AND the dashboard is owned by bob and not visible to others
+
+#### Scenario: Dashboard Editor can edit metadata field VALUES, not definitions
+- GIVEN a dashboard with a metadata field "Priority" (definition created by admin)
+- WHEN bob (with role "editor") calls `PUT /api/dashboards/{uuid}` with `metadata = {Priority: "High"}`
+- THEN the system MUST allow the update
+- AND the field value is persisted
+- NOTE: bob CANNOT call `POST /api/admin/metadata-fields` to create a new field definition; that requires "admin" role
+
+#### Scenario: Dashboard Editor cannot install demo data
+- GIVEN a user "bob" with role "editor"
+- WHEN bob calls `POST /api/admin/demo/install`
+- THEN the system MUST return HTTP 403
+- AND no demo is installed
+
+#### Scenario: Dashboard Editor cannot add metadata field definitions
+- GIVEN a user "bob" with role "editor"
+- WHEN bob calls `POST /api/admin/metadata-fields` with a new field definition
+- THEN the system MUST return HTTP 403
+- AND the field is not created
+
+### Requirement: REQ-ROLE-003 Dashboard Viewer Role Definition
+
+A Dashboard Viewer MUST have read-only access to all visible dashboards. Dashboard Viewers MUST NOT be able to create, edit, or delete any dashboards, and personal-dashboard creation MUST be explicitly rejected. Dashboard Viewers MAY still interact with features like reactions and comments (if enabled) that do not mutate the dashboard structure.
+
+#### Scenario: Dashboard Viewer can read dashboards
+- GIVEN a user "charlie" with role "viewer"
+- AND a "group_shared" dashboard in a group charlie belongs to
+- WHEN charlie calls `GET /api/dashboards/{uuid}`
+- THEN the system MUST return the dashboard content
+- AND charlie can view all widgets and data
+
+#### Scenario: Dashboard Viewer cannot create dashboard
+- GIVEN a user "charlie" with role "viewer"
+- WHEN charlie calls `POST /api/dashboards` with any scope
+- THEN the system MUST return HTTP 403
+- AND no dashboard is created
+
+#### Scenario: Dashboard Viewer cannot edit dashboard
+- GIVEN a "group_shared" dashboard in a group charlie belongs to
+- WHEN charlie (with role "viewer") calls `PUT /api/dashboards/{uuid}` with edits
+- THEN the system MUST return HTTP 403
+- AND the dashboard remains unchanged
+
+#### Scenario: Dashboard Viewer cannot delete dashboard
+- GIVEN a dashboard charlie can read
+- WHEN charlie (with role "viewer") calls `DELETE /api/dashboards/{uuid}`
+- THEN the system MUST return HTTP 403
+- AND the dashboard is not deleted
+
+#### Scenario: Dashboard Viewer can react and comment (if enabled)
+- GIVEN a "group_shared" dashboard in charlie's group with reactions and comments enabled
+- WHEN charlie calls `POST /api/dashboards/{uuid}/reactions` with `{emoji: "👍"}`
+- THEN the system MUST allow the reaction (if the dashboard-reactions capability is present)
+- NOTE: Reactions and comments are NOT mutations of the dashboard structure; they are additive and scoped to the viewer. The "viewer" role prevents dashboard structure mutations only.
+
+#### Scenario: Dashboard Viewer cannot create personal dashboard
+- GIVEN a user "charlie" with role "viewer"
+- WHEN charlie calls `POST /api/dashboards` with `scope = "personal"`
+- THEN the system MUST return HTTP 403
+- AND no personal dashboard is created
+- NOTE: Even if the user "owns" a personal dashboard, a "viewer" role assignment blocks personal-dashboard creation at the API level
+
+### Requirement: REQ-ROLE-004 Persist Role Assignments
+
+Role assignments MUST be stored durably in the `oc_mydash_role_assignments` table with audit trail information.
+
+#### Scenario: Role assignment is stored with audit fields
+- GIVEN an admin "admin-user" assigns role "editor" to user "bob"
+- WHEN the assignment is created via `POST /api/admin/roles`
+- THEN a row MUST be inserted with:
+  - `userId = "bob"`, `groupId = NULL`
+  - `role = "editor"`
+  - `assignedBy = "admin-user"`
+  - `assignedAt = now`
+  - `id = auto-generated integer`
+
+#### Scenario: Group role assignment stores group ID
+- GIVEN an admin assigns role "editor" to group "engineering"
+- WHEN the assignment is created via `POST /api/admin/roles` with `groupId = "engineering"`
+- THEN a row MUST be inserted with:
+  - `userId = NULL`, `groupId = "engineering"`
+  - `role = "editor"`
+  - `assignedBy = "admin-user"`
+  - `assignedAt = now`
+
+#### Scenario: One assignment per target and role
+- GIVEN a user "bob" already has an assignment with `role = "editor"`
+- WHEN an admin attempts to create another assignment with `userId = "bob"`, `role = "editor"`
+- THEN the system MUST return HTTP 409 (Conflict)
+- AND the new assignment is NOT inserted
+- NOTE: The same user/group can have multiple assignments if the roles differ (e.g., user is assigned both "editor" in one context and something else; current spec assumes one per role, but the implementation must enforce this uniqueness)
+
+#### Scenario: User and group assignments are distinct
+- GIVEN a role assignment with `userId = "bob"`, `role = "editor"`
+- WHEN the system queries for assignments where `groupId = "engineering"`, `role = "editor"`
+- THEN the user assignment MUST NOT appear in results
+- AND the group assignment (if it exists) MUST appear separately
+
+### Requirement: REQ-ROLE-005 Resolve Effective Role Per User
+
+The system MUST resolve a user's effective MyDash role by consulting Nextcloud admin status, direct user assignments, and all group assignments. When multiple roles are applicable, the highest privilege wins.
+
+#### Scenario: NC admin always has admin role
+- GIVEN a Nextcloud admin user "alice"
+- WHEN the system calls `getEffectiveRole("alice")`
+- THEN the return value MUST be "admin"
+- AND no assignment lookup is necessary (NC admin overrides)
+
+#### Scenario: Non-admin with direct user assignment
+- GIVEN a non-admin user "bob" with assignment `userId = "bob"`, `role = "editor"`
+- WHEN the system calls `getEffectiveRole("bob")`
+- THEN the return value MUST be "editor"
+- AND the role source is "user-assigned"
+
+#### Scenario: Multiple group memberships, highest role wins
+- GIVEN a user "charlie" who is a member of groups "engineering" and "sales"
+- AND an assignment `groupId = "engineering"`, `role = "editor"`
+- AND an assignment `groupId = "sales"`, `role = "viewer"`
+- WHEN the system calls `getEffectiveRole("charlie")`
+- THEN the return value MUST be "editor"
+- AND the role source is "group-assigned:engineering"
+- NOTE: "editor" is higher privilege than "viewer"; if both are present, "editor" wins. If sources are equally privileged, implementation may return any; spec does not mandate specific tie-breaking.
+
+#### Scenario: Direct user assignment overrides group assignment
+- GIVEN a user "david" who is a member of group "engineering"
+- AND an assignment `userId = "david"`, `role = "admin"`
+- AND an assignment `groupId = "engineering"`, `role = "editor"`
+- WHEN the system calls `getEffectiveRole("david")`
+- THEN the return value MUST be "admin"
+- AND the role source is "user-assigned"
+- NOTE: Direct user assignment takes precedence over any group assignment
+
+#### Scenario: No assignment, user has no role
+- GIVEN a user "eve" with no role assignment and not an NC admin
+- WHEN the system calls `getEffectiveRole("eve")`
+- THEN the return value MUST be null
+- AND the role source is null
+- AND the user falls back to existing `permissions` capability behavior
+
+#### Scenario: Admin role is highest in privilege hierarchy
+- GIVEN role hierarchy: "admin" > "editor" > "viewer"
+- WHEN the system resolves effective role from ["viewer", "admin", "editor"]
+- THEN the effective role MUST be "admin"
+
+### Requirement: REQ-ROLE-006 Get Current User's Role and Source
+
+Any authenticated user MUST be able to query their own effective MyDash role and learn where that role comes from (NC admin, direct assignment, or group assignment).
+
+#### Scenario: User queries their role via GET /api/me/role
+- GIVEN an authenticated user "alice" with effective role "editor" from a group assignment
+- WHEN alice calls `GET /api/me/role`
+- THEN the response MUST be HTTP 200 with body:
+  ```json
+  {
+    "role": "editor",
+    "source": "group-assigned:engineering"
+  }
+  ```
+
+#### Scenario: NC admin queries their role
+- GIVEN an NC admin "admin-user"
+- WHEN admin-user calls `GET /api/me/role`
+- THEN the response MUST be:
+  ```json
+  {
+    "role": "admin",
+    "source": "nc-admin"
+  }
+  ```
+
+#### Scenario: User with no role queries
+- GIVEN a user "noone" with no assignment and not an NC admin
+- WHEN noone calls `GET /api/me/role`
+- THEN the response MUST be:
+  ```json
+  {
+    "role": null,
+    "source": null
+  }
+  ```
+
+#### Scenario: User with direct assignment
+- GIVEN a user "bob" with assignment `userId = "bob"`, `role = "viewer"`
+- WHEN bob calls `GET /api/me/role`
+- THEN the response MUST include `source: "user-assigned"`
+
+#### Scenario: User with multiple group assignments
+- GIVEN a user "charlie" with group assignments "engineering" → "editor" and "sales" → "viewer"
+- WHEN charlie calls `GET /api/me/role`
+- THEN the response MUST include `role: "editor"` and `source: "group-assigned:engineering"`
+- OR `source: "group-assigned:sales"` (implementation choice if roles are equal; editor wins here)
+
+### Requirement: REQ-ROLE-007 System MUST Enforce Editor Authorization on group_shared Dashboards
+
+A Dashboard Editor MUST only be able to edit a `group_shared` dashboard if the dashboard's group ID is in the user's group memberships AND the user has role "editor" or higher.
+
+#### Scenario: Editor in correct group can edit
+- GIVEN a `group_shared` dashboard with `groupId = "engineering"`
+- WHEN a user "bob" with role "editor" and group membership "engineering" calls `PUT /api/dashboards/{uuid}`
+- THEN the system MUST allow the edit
+- AND the changes are persisted
+
+#### Scenario: Editor without group membership cannot edit
+- GIVEN a `group_shared` dashboard with `groupId = "sales"`
+- WHEN a user "bob" with role "editor" but NOT a member of "sales" calls `PUT /api/dashboards/{uuid}`
+- THEN the system MUST return HTTP 403
+- AND the dashboard is not modified
+
+#### Scenario: Viewer cannot edit even in their group
+- GIVEN a `group_shared` dashboard with `groupId = "engineering"`
+- WHEN a user "charlie" with role "viewer" and group membership "engineering" calls `PUT /api/dashboards/{uuid}`
+- THEN the system MUST return HTTP 403
+- AND the dashboard is not modified
+
+#### Scenario: Admin can edit any group_shared dashboard
+- GIVEN a `group_shared` dashboard with `groupId = "sales"`
+- WHEN a user "admin-user" with role "admin" calls `PUT /api/dashboards/{uuid}`
+- THEN the system MUST allow the edit
+- AND group membership is not required
+
+#### Scenario: Editor can edit personal dashboard within their own context
+- GIVEN a personal dashboard owned by "bob"
+- WHEN bob with role "editor" calls `PUT /api/dashboards/{uuid}`
+- THEN the system MUST allow the edit (editor can edit their own personal dashboards)
+- NOTE: Authorization for personal dashboards is owner-based, independent of role; role restricts group_shared dashboards. This scenario clarifies that "editor" does not prevent personal-dashboard editing.
+
+### Requirement: REQ-ROLE-008 Authorize Viewer Read-Only Access
+
+A Dashboard Viewer MUST NOT be able to perform any mutation on dashboards or MyDash operations. All mutation endpoints MUST return HTTP 403 for any user with effective role "viewer".
+
+#### Scenario: Viewer cannot create dashboard
+- GIVEN a user "charlie" with role "viewer"
+- WHEN charlie calls `POST /api/dashboards`
+- THEN the system MUST return HTTP 403
+- AND no dashboard is created
+
+#### Scenario: Viewer cannot edit dashboard
+- GIVEN a user "charlie" with role "viewer" and read access to a dashboard
+- WHEN charlie calls `PUT /api/dashboards/{uuid}`
+- THEN the system MUST return HTTP 403
+- AND no edit is applied
+
+#### Scenario: Viewer cannot delete dashboard
+- GIVEN a user "charlie" with role "viewer"
+- WHEN charlie calls `DELETE /api/dashboards/{uuid}`
+- THEN the system MUST return HTTP 403
+- AND no deletion occurs
+
+#### Scenario: Viewer can read dashboard
+- GIVEN a user "charlie" with role "viewer" and read access to a dashboard
+- WHEN charlie calls `GET /api/dashboards/{uuid}`
+- THEN the system MUST return the dashboard
+- AND charlie can view all content
+
+#### Scenario: Viewer cannot create personal dashboard
+- GIVEN a user "charlie" with role "viewer"
+- WHEN charlie calls `POST /api/dashboards` with `scope = "personal"`
+- THEN the system MUST return HTTP 403
+- AND no personal dashboard is created
+- NOTE: Personal-dashboard creation is explicitly rejected for viewers, even if the user "owns" the creation request
+
+#### Scenario: Viewer cannot install widget
+- GIVEN a user "charlie" with role "viewer"
+- WHEN charlie calls `POST /api/dashboards/{uuid}/widgets`
+- THEN the system MUST return HTTP 403
+- AND no widget is added
+
+#### Scenario: Viewer CAN react and comment (if feature enabled)
+- GIVEN a dashboard with reactions/comments enabled
+- WHEN a user "charlie" with role "viewer" calls `POST /api/dashboards/{uuid}/reactions` with `{emoji: "👍"}`
+- THEN the system MUST allow the reaction (if dashboard-reactions capability present)
+- OR return 404 if the feature is not enabled
+- NOTE: Reactions and comments are NOT dashboard mutations; they are orthogonal to the role model
+
+### Requirement: REQ-ROLE-009 Group vs. User Precedence
+
+When a user has both a direct user assignment and one or more group assignments, the direct user assignment MUST take precedence. If a user has assignments from multiple groups, the highest-privilege role MUST be selected.
+
+#### Scenario: Direct user assignment overrides group
+- GIVEN a user "bob"
+- AND assignment `userId = "bob"`, `role = "viewer"`
+- AND assignment `groupId = "engineering"`, `role = "admin"` (bob is member of engineering)
+- WHEN the system resolves bob's effective role
+- THEN the role MUST be "viewer"
+- AND the source MUST be "user-assigned"
+
+#### Scenario: Highest group role wins
+- GIVEN a user "charlie" who is a member of groups "engineering" and "sales"
+- AND assignment `groupId = "engineering"`, `role = "editor"`
+- AND assignment `groupId = "sales"`, `role = "viewer"`
+- WHEN the system resolves charlie's effective role
+- THEN the role MUST be "editor"
+- AND the source MUST be "group-assigned:engineering" (or implementation-specific choice if equally ranked)
+
+#### Scenario: NC admin overrides all assignments
+- GIVEN a Nextcloud admin "admin-user"
+- AND an explicit assignment `userId = "admin-user"`, `role = "viewer"` (if such exists)
+- WHEN the system resolves admin-user's effective role
+- THEN the role MUST be "admin"
+- AND the source MUST be "nc-admin"
+- NOTE: NC admin status is the ultimate override; explicit assignments do not restrict NC admins
+
+### Requirement: REQ-ROLE-010 Cascade on User Deletion
+
+When a Nextcloud user is deleted, all role assignments where `userId = <deleted-user>` MUST be automatically removed. No cross-deletion: deleting a role assignment does NOT affect the user or group.
+
+#### Scenario: User deletion removes direct assignments
+- GIVEN a role assignment `userId = "bob"`, `role = "editor"`
+- WHEN bob's Nextcloud account is deleted via Nextcloud user management
+- THEN the role assignment MUST be automatically deleted
+- AND a query for bob's effective role MUST return null
+
+#### Scenario: User deletion does not affect group assignments
+- GIVEN a user "bob" who is a member of group "engineering"
+- AND an assignment `groupId = "engineering"`, `role = "editor"`
+- WHEN bob is deleted
+- THEN the group assignment MUST remain (group is unaffected)
+- AND the group still has role "editor"
+
+#### Scenario: User is not deleted when role assignment is deleted
+- GIVEN a role assignment `userId = "bob"`, `role = "editor"`
+- WHEN an admin calls `DELETE /api/admin/roles/{assignment-id}`
+- THEN the assignment is deleted
+- AND bob's Nextcloud account MUST remain
+
+### Requirement: REQ-ROLE-011 Cascade on Group Deletion
+
+When a Nextcloud group is deleted, all role assignments where `groupId = <deleted-group>` MUST be automatically removed. No cross-deletion: deleting a role assignment does NOT affect the group or its members.
+
+#### Scenario: Group deletion removes group assignments
+- GIVEN a role assignment `groupId = "engineering"`, `role = "editor"`
+- WHEN the "engineering" group is deleted via Nextcloud group management
+- THEN the role assignment MUST be automatically deleted
+- AND the group role no longer affects any user
+
+#### Scenario: Group deletion does not affect member accounts
+- GIVEN a user "bob" who is a member of group "engineering"
+- AND an assignment `groupId = "engineering"`, `role = "editor"`
+- WHEN the "engineering" group is deleted
+- THEN bob's Nextcloud account MUST remain
+- AND bob is removed from the group (standard Nextcloud behavior)
+- AND bob's effective MyDash role MUST be recalculated (likely becomes null if "engineering" was his only role source)
+
+#### Scenario: Deletion is not affected by member state
+- GIVEN a group "engineering" with 10 members
+- AND a role assignment `groupId = "engineering"`, `role = "editor"`
+- WHEN an admin calls `DELETE /api/admin/roles/{assignment-id}`
+- THEN the assignment is deleted
+- AND the "engineering" group and its members MUST remain

--- a/openspec/changes/admin-roles/specs/admin-roles/spec.md
+++ b/openspec/changes/admin-roles/specs/admin-roles/spec.md
@@ -29,12 +29,14 @@ Each role assignment is stored in the `oc_mydash_role_assignments` table with th
 
 A Dashboard Admin MUST have full administrative access to MyDash, equivalent to Nextcloud admin status but scoped to MyDash only. A Dashboard Admin MUST be able to manage all dashboards, install demo data, edit organization-level navigation, and define new metadata fields.
 
+NOTE: Admin-roles is a net-new MyDash capability with no source counterpart. The source app has no named-role concept and resolves all permissions from the GroupFolder ACL bitmask alone. The three role names echo the source app's seeded group names for customer recognition, but the underlying mechanism is entirely different — MyDash does not read from those groups at runtime.
+
 #### Scenario: NC admin automatically has Dashboard Admin role
 - GIVEN a Nextcloud admin user (admin flag = true)
 - WHEN the system resolves the user's effective MyDash role
 - THEN the user's effective role MUST be "admin"
 - AND the role source MUST be "nc-admin"
-- NOTE: No explicit assignment record is created; NC admin status is the implicit grant
+- NOTE: NC admin status is an implicit grant — no explicit assignment record is created in `oc_mydash_role_assignments`
 
 #### Scenario: Non-admin user assigned Dashboard Admin role
 - GIVEN a non-admin Nextcloud user "alice"
@@ -194,48 +196,58 @@ Role assignments MUST be stored durably in the `oc_mydash_role_assignments` tabl
 
 ### Requirement: REQ-ROLE-005 Resolve Effective Role Per User
 
-The system MUST resolve a user's effective MyDash role by consulting Nextcloud admin status, direct user assignments, and all group assignments. When multiple roles are applicable, the highest privilege wins.
+The system MUST resolve a user's effective MyDash role using the following deterministic algorithm:
+
+1. If the user is a Nextcloud admin → effective role is "admin", source is "nc-admin". No assignment lookup required.
+2. Otherwise, check for a direct user assignment (`userId = <user>`). If one exists, it is used as-is — group assignments are NOT consulted, regardless of their rank.
+3. If no direct user assignment exists, collect all group assignments for groups the user is a member of. Map roles to numeric rank: "admin"=2, "editor"=1, "viewer"=0. Effective role is the assignment with the highest rank ("highest privilege wins").
+4. If no assignments exist → effective role is null; the user falls back to `permissions` capability behavior.
+
+NOTE: Direct user assignment is the canonical explicit override — if an admin assigns a user "viewer" directly, that intent is honored and is not silently overridden by group memberships. Group assignments only participate in resolution when no direct user assignment is present.
 
 #### Scenario: NC admin always has admin role
 - GIVEN a Nextcloud admin user "alice"
 - WHEN the system calls `getEffectiveRole("alice")`
 - THEN the return value MUST be "admin"
-- AND no assignment lookup is necessary (NC admin overrides)
+- AND the role source MUST be "nc-admin"
+- AND no assignment lookup is performed (NC admin is an unconditional override)
 
 #### Scenario: Non-admin with direct user assignment
 - GIVEN a non-admin user "bob" with assignment `userId = "bob"`, `role = "editor"`
 - WHEN the system calls `getEffectiveRole("bob")`
 - THEN the return value MUST be "editor"
-- AND the role source is "user-assigned"
+- AND the role source MUST be "user-assigned"
+- AND group assignments are NOT consulted
 
 #### Scenario: Multiple group memberships, highest role wins
 - GIVEN a user "charlie" who is a member of groups "engineering" and "sales"
 - AND an assignment `groupId = "engineering"`, `role = "editor"`
 - AND an assignment `groupId = "sales"`, `role = "viewer"`
+- AND no direct user assignment for charlie
 - WHEN the system calls `getEffectiveRole("charlie")`
 - THEN the return value MUST be "editor"
-- AND the role source is "group-assigned:engineering"
-- NOTE: "editor" is higher privilege than "viewer"; if both are present, "editor" wins. If sources are equally privileged, implementation may return any; spec does not mandate specific tie-breaking.
+- AND the role source MUST be "group-assigned:engineering"
+- NOTE: "editor" (rank 1) is higher privilege than "viewer" (rank 0); highest-rank group assignment wins. If sources are equally ranked, implementation may return any; spec does not mandate specific tie-breaking.
 
-#### Scenario: Direct user assignment overrides group assignment
+#### Scenario: Direct user assignment used as-is, group assignments skipped
 - GIVEN a user "david" who is a member of group "engineering"
 - AND an assignment `userId = "david"`, `role = "admin"`
 - AND an assignment `groupId = "engineering"`, `role = "editor"`
 - WHEN the system calls `getEffectiveRole("david")`
 - THEN the return value MUST be "admin"
-- AND the role source is "user-assigned"
-- NOTE: Direct user assignment takes precedence over any group assignment
+- AND the role source MUST be "user-assigned"
+- NOTE: The direct user assignment is used as-is. Group assignments are not consulted when a direct user assignment exists.
 
 #### Scenario: No assignment, user has no role
 - GIVEN a user "eve" with no role assignment and not an NC admin
 - WHEN the system calls `getEffectiveRole("eve")`
 - THEN the return value MUST be null
-- AND the role source is null
+- AND the role source MUST be null
 - AND the user falls back to existing `permissions` capability behavior
 
 #### Scenario: Admin role is highest in privilege hierarchy
-- GIVEN role hierarchy: "admin" > "editor" > "viewer"
-- WHEN the system resolves effective role from ["viewer", "admin", "editor"]
+- GIVEN role hierarchy: "admin" (rank 2) > "editor" (rank 1) > "viewer" (rank 0)
+- WHEN the system resolves effective role from group assignments ["viewer", "admin", "editor"]
 - THEN the effective role MUST be "admin"
 
 ### Requirement: REQ-ROLE-006 Get Current User's Role and Source
@@ -370,15 +382,18 @@ A Dashboard Viewer MUST NOT be able to perform any mutation on dashboards or MyD
 
 ### Requirement: REQ-ROLE-009 Group vs. User Precedence
 
-When a user has both a direct user assignment and one or more group assignments, the direct user assignment MUST take precedence. If a user has assignments from multiple groups, the highest-privilege role MUST be selected.
+When a user has a direct user assignment, that assignment MUST be used as-is and group assignments MUST NOT be consulted. If a user has no direct user assignment but has assignments from multiple groups, the highest-privilege group role MUST be selected.
 
-#### Scenario: Direct user assignment overrides group
+NOTE: This "direct-assignment-wins" rule is not a rank comparison — a direct "viewer" assignment beats a group "admin" assignment because the direct assignment is the sole source when present. Group assignments only participate in resolution when no direct user assignment exists. See REQ-ROLE-005 for the full resolution algorithm.
+
+#### Scenario: Direct user assignment used as-is regardless of group rank
 - GIVEN a user "bob"
 - AND assignment `userId = "bob"`, `role = "viewer"`
 - AND assignment `groupId = "engineering"`, `role = "admin"` (bob is member of engineering)
 - WHEN the system resolves bob's effective role
 - THEN the role MUST be "viewer"
 - AND the source MUST be "user-assigned"
+- NOTE: The direct user assignment is used as-is. The system does NOT compare its rank against group assignments — group assignments are skipped entirely because a direct user assignment is present. A "viewer" direct assignment intentionally overrides a "admin" group assignment.
 
 #### Scenario: Highest group role wins
 - GIVEN a user "charlie" who is a member of groups "engineering" and "sales"
@@ -399,6 +414,8 @@ When a user has both a direct user assignment and one or more group assignments,
 ### Requirement: REQ-ROLE-010 Cascade on User Deletion
 
 When a Nextcloud user is deleted, all role assignments where `userId = <deleted-user>` MUST be automatically removed. No cross-deletion: deleting a role assignment does NOT affect the user or group.
+
+NOTE: This cascade MUST be implemented via a `UserDeletedListener` that extends the listener infrastructure provided by the `dashboard-cascade-events` capability. Implementers MUST reference that capability's listener registration pattern rather than registering a standalone Nextcloud event listener.
 
 #### Scenario: User deletion removes direct assignments
 - GIVEN a role assignment `userId = "bob"`, `role = "editor"`
@@ -422,6 +439,8 @@ When a Nextcloud user is deleted, all role assignments where `userId = <deleted-
 ### Requirement: REQ-ROLE-011 Cascade on Group Deletion
 
 When a Nextcloud group is deleted, all role assignments where `groupId = <deleted-group>` MUST be automatically removed. No cross-deletion: deleting a role assignment does NOT affect the group or its members.
+
+NOTE: This cascade MUST be implemented via a `GroupDeletedListener` that extends the listener infrastructure provided by the `dashboard-cascade-events` capability. Implementers MUST reference that capability's listener registration pattern rather than registering a standalone Nextcloud event listener.
 
 #### Scenario: Group deletion removes group assignments
 - GIVEN a role assignment `groupId = "engineering"`, `role = "editor"`

--- a/openspec/changes/admin-roles/tasks.md
+++ b/openspec/changes/admin-roles/tasks.md
@@ -1,0 +1,177 @@
+# Admin Roles — Implementation Tasks
+
+## Data Model & Persistence
+
+### Task 1: Create RoleAssignment Entity & Mapper
+- **File:** `lib/Db/RoleAssignment.php`
+  - Fields: `id` (int), `userId` (varchar 64, nullable), `groupId` (varchar 64, nullable), `role` (enum: admin|editor|viewer), `assignedBy` (varchar 64), `assignedAt` (timestamp)
+  - Getters/setters for all fields
+  - Add method `getTarget()` to return `userId` if set, else `groupId` (for UI convenience)
+  - Add method `isUserAssignment()` / `isGroupAssignment()` predicates
+
+- **File:** `lib/Db/RoleAssignmentMapper.php`
+  - `findAll(): RoleAssignment[]` — all assignments, no filtering
+  - `findByUser(userId: string): RoleAssignment[]` — all assignments for a user (both user and group)
+  - `findByGroup(groupId: string): RoleAssignment[]` — all assignments for a group
+  - `findById(id: int): RoleAssignment` — single assignment by ID
+  - `insert(RoleAssignment): RoleAssignment` — return with ID populated
+  - `update(RoleAssignment): void`
+  - `delete(int $id): int` — return affected rows
+  - `deleteByUserId(userId: string): int` — cascade on user deletion
+  - `deleteByGroupId(groupId: string): int` — cascade on group deletion
+  - All methods follow Nextcloud mapper conventions (throw DoesNotExistException, MultipleObjectsReturnedException)
+
+### Task 2: Create Database Migration
+- **File:** `lib/Migration/VersionXXXXDate2026...php` (YYYYMMDDHHMMSS timestamp in classname)
+- Table: `oc_mydash_role_assignments`
+  - Columns:
+    - `id INT(11) PRIMARY KEY AUTO_INCREMENT`
+    - `userId VARCHAR(64) DEFAULT NULL`
+    - `groupId VARCHAR(64) DEFAULT NULL`
+    - `role VARCHAR(10)` (ENUM is not portable; use VARCHAR + check constraint or app-level validation)
+    - `assignedBy VARCHAR(64) NOT NULL`
+    - `assignedAt DATETIME NOT NULL`
+  - Indexes:
+    - Composite unique index on `(userId, groupId, role)` OR separate unique constraints: UNIQUE(userId, role) for user assignments, UNIQUE(groupId, role) for group assignments — **decision**: use UNIQUE((userId IS NOT NULL), (groupId IS NOT NULL), role) to enforce "one assignment per target+role"; fallback for MySQL 5.7: add both indexes separately
+    - Index on `userId` (for `deleteByUserId`, `findByUser`)
+    - Index on `groupId` (for `deleteByGroupId`, `findByGroup`)
+  - Constraints: CHECK `(userId IS NOT NULL AND groupId IS NULL) OR (userId IS NULL AND groupId NOT NULL)` (XOR)
+
+## Business Logic & Services
+
+### Task 3: Create RoleService
+- **File:** `lib/Service/RoleService.php`
+  - `__construct(RoleAssignmentMapper, IUserManager, IGroupManager, IUserSession)`
+
+  - **Role Resolution:**
+    - `getEffectiveRole(userId: string): string|null` — returns "admin"|"editor"|"viewer"|null
+      - If user is Nextcloud admin: return "admin"
+      - Fetch direct user assignment (highest role if multiple — should be unique, but be defensive)
+      - Fetch all group assignments for user's groups: collect all roles
+      - Return highest role (admin > editor > viewer) from all assignments
+      - Return null if no assignment and not NC admin
+
+    - `getRoleSource(userId: string): string|null` — returns role source as string
+      - "nc-admin" if user is Nextcloud admin
+      - "user-assigned" if direct user assignment exists
+      - "group-assigned:{groupId}" if highest role comes from a group assignment
+      - null if no role
+
+  - **Validation & Assignment:**
+    - `validateRole(role: string): void` — throws InvalidArgumentException if role not in ["admin", "editor", "viewer"]
+    - `validateTarget(userId: ?string, groupId: ?string): void` — throws InvalidArgumentException if both null, both set, or (if user) user doesn't exist, or (if group) group doesn't exist
+    - `assignRole(userId: ?string, groupId: ?string, role: string, assignedBy: string): RoleAssignment` — creates new assignment
+      - Validate role and target
+      - Check for duplicate: if userId + role already assigned, throw DuplicateException (let controller return 409)
+      - If groupId + role already assigned, throw DuplicateException
+      - Create entity, set `assignedAt = now`, `assignedBy = currentUserId`
+      - Insert via mapper, return result
+
+    - `removeRole(id: int): void` — deletes assignment by ID
+      - Mapper->delete(id); if affected rows == 0, throw DoesNotExistException
+
+  - **Cascade:**
+    - `deleteByUserId(userId: string): int` — delegates to mapper, returns affected rows
+    - `deleteByGroupId(groupId: string): int` — delegates to mapper, returns affected rows
+
+  - **Authorization Helpers:**
+    - `isAdmin(userId: string): bool` — returns true if effective role is "admin"
+    - `isEditorOrHigher(userId: string): bool` — returns true if effective role is "editor" or "admin"
+    - `isViewerOrHigher(userId: string): bool` — always true (viewer is lowest); useful for readability
+
+## API Endpoints
+
+### Task 4: Create AdminController Endpoints
+- **File:** `lib/Controller/AdminController.php` (new or extend existing)
+  - Inject: `RoleService`, `RoleAssignmentMapper`, `IRequest`
+
+  - **GET /api/admin/roles** → `listRoles()`
+    - Requires: Nextcloud admin
+    - Returns: JSON array of all role assignments: `[{id, userId, groupId, role, assignedBy, assignedAt}, ...]`
+    - Status: 200 on success, 403 if not admin
+
+  - **POST /api/admin/roles** → `createRole()`
+    - Requires: Nextcloud admin
+    - Body: `{userId?: string, groupId?: string, role: string}`
+    - Returns: newly created assignment with `id`
+    - Status: 201 on success
+    - Status: 400 if both/neither of userId/groupId provided (use `validateTarget`)
+    - Status: 400 if role invalid
+    - Status: 409 if duplicate (user+role or group+role already assigned) — catch DuplicateException from RoleService
+    - Status: 403 if not admin
+
+  - **DELETE /api/admin/roles/{id}** → `deleteRole(id: int)`
+    - Requires: Nextcloud admin
+    - Returns: empty JSON object `{}`
+    - Status: 204 on success
+    - Status: 404 if assignment not found (DoesNotExistException)
+    - Status: 403 if not admin
+
+  - **GET /api/me/role** → `getMyRole()`
+    - Requires: authenticated user (no admin check)
+    - Returns: `{role: string|null, source: string|null}`
+    - Status: 200
+    - Example: `{role: "editor", source: "group-assigned:engineering"}`
+
+### Task 5: Register Routes
+- **File:** `appinfo/routes.php`
+  - Routes (prefix `/api`):
+    - `POST /admin/roles` → `AdminController->createRole()`
+    - `GET /admin/roles` → `AdminController->listRoles()`
+    - `DELETE /admin/roles/{id}` → `AdminController->deleteRole(id)`
+    - `GET /me/role` → `AdminController->getMyRole()`
+  - Ensure admin routes are CORS-enabled if necessary (check existing patterns in codebase)
+
+## Authorization Integration
+
+### Task 6: Extend PermissionService
+- **File:** `lib/Service/PermissionService.php` (existing)
+  - Inject: `RoleService` (new dependency)
+  
+  - Extend `canEdit(userId, dashboardUuid): bool`
+    - If role is "viewer": return false immediately
+    - Continue existing permission checks
+    - For "editor" role and `group_shared` dashboard: verify `dashboard.groupId` is in user's group memberships, else return false
+    - For "admin" role: return true (skip existing checks as admin override)
+
+  - Extend `canCreate(userId): bool`
+    - If role is "viewer": return false immediately
+    - Continue existing checks
+
+  - Extend `canDelete(userId, dashboardUuid): bool`
+    - If role is "viewer": return false immediately
+    - Continue existing checks
+
+  - **OR** create new `canMutate(userId): bool` method and call it first in all mutation endpoints (DRY; see existing codebase pattern)
+
+### Task 7: Implement User Deletion Listener
+- **File:** `lib/Listener/PreDeleteUser.php` (new or extend existing)
+  - Listen to `OCP\User\Events\PreDeleteUserEvent`
+  - Inject: `RoleService`
+  - On event: call `RoleService->deleteByUserId($event->getUser()->getUID())`
+
+### Task 8: Implement Group Deletion Listener
+- **File:** `lib/Listener/PreDeleteGroup.php` (new or extend existing)
+  - Listen to `OCP\Group\Events\PreDeleteGroupEvent`
+  - Inject: `RoleService`
+  - On event: call `RoleService->deleteByGroupId($event->getGroup()->getGID())`
+
+### Task 9: Register Event Listeners
+- **File:** `appinfo/app.php` or bootstrap (see existing codebase)
+  - Register `PreDeleteUser` listener for `OCP\User\Events\PreDeleteUserEvent`
+  - Register `PreDeleteGroup` listener for `OCP\Group\Events\PreDeleteGroupEvent`
+
+## Testing (Out of Scope for Spec, But Guidance)
+
+- Unit tests for `RoleService`: effective-role resolution, source tracking, validation
+- Unit tests for `RoleAssignmentMapper`: CRUD, cascade, constraints
+- API tests for all four endpoints: happy path, 400/403/404/409 scenarios
+- Integration test: user deletion cascades, group deletion cascades
+- Authorization test: viewer can't mutate, editor can edit group_shared, admin overrides all
+
+## Notes
+
+- All dates use Nextcloud's `\DateTime` or comparable ORM support
+- Role validation: explicit enum check, not schema-enforced, for forward compatibility
+- No background cleanup job needed; expired locks and stale assignments are OK (locking is separate, roles are permanent until deleted)
+- Nextcloud i18n: all error messages must be translatable; add to `l10n/en.json` and `l10n/nl.json`

--- a/openspec/changes/background-job-feed-refresh/design.md
+++ b/openspec/changes/background-job-feed-refresh/design.md
@@ -1,0 +1,106 @@
+# Design — Background feed refresh job
+
+## Context
+
+MyDash's news widget currently fetches external RSS/Atom feeds on-demand at page load. This couples every dashboard render to the availability and latency of upstream feed servers — a single slow or failing feed degrades the whole page. Moving feed retrieval into a periodic background job decouples the widget render from the network call and lets users see cached content in sub-second time.
+
+The reference implementation (see source paths below) provides a battle-tested blueprint: PHP's built-in XML parser, Nextcloud's HTTP client, a single cache table, and a TimedJob that runs on a configurable interval. This design document records the decisions made during porting and the rationale behind each one. Where our implementation diverges from the source, the divergence is explicit.
+
+The feature spans a new database table (`oc_mydash_feed_cache`), a `TimedJob` class, a fetch-and-parse service, and one admin-only REST endpoint. All other capabilities (news-widget render, orphaned-data cleanup) interact with this job through shared mapper interfaces rather than direct coupling.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Refresh all active RSS/Atom feeds asynchronously on a configurable interval (default 60 min).
+- Cache parsed items in `oc_mydash_feed_cache` so the news widget never waits on a live HTTP request.
+- Use HTTP conditional GET (`If-None-Match` / `If-Modified-Since`) to avoid re-downloading unchanged feeds.
+- Isolate per-feed failures so one bad feed cannot block the rest.
+- Harden against malicious feed content (XXE, oversized bodies, non-HTTP schemes).
+- Expose an admin endpoint for immediate on-demand refresh.
+
+**Non-Goals:**
+- Full-text indexing or search of feed items.
+- Push/WebSocket delivery of new items to open browser tabs (future work).
+- OPML bulk import of feed URLs (flagged as a follow-up below).
+- Implementing the orphaned-feed deletion — that belongs to the `orphaned-data-cleanup` spec.
+
+## Decisions
+
+### D1: Parser library — `SimpleXMLElement` (PHP built-in), not SimplePie
+
+**Decision:** Use PHP's built-in `simplexml_load_string()` with `LIBXML_NOCDATA | LIBXML_NONET` flags. Wrap the parsing logic behind a `FeedParserInterface` so the implementation can be swapped to SimplePie in a follow-up without touching the job or service layer.
+
+**Alternatives considered:**
+- **SimplePie:** Handles RSS 0.91/1.0/2.0, Atom 0.3/1.0, iTunes, and Media RSS extensions with ~10 years of edge-case fixes and robust malformed-feed recovery. Rejected for v1 because the added ~500 KB composer dependency and more complex initialisation are not justified for the target use case (modern RSS 2.0 and Atom 1.0 feeds from corporate intranets). Flag for revisit if customers report parsing regressions on unusual feed variants.
+
+**Rationale:** MyDash's news widget is aimed at intranet and SaaS news sources that publish standard RSS 2.0 or Atom 1.0. The source implementation uses `SimpleXMLElement` successfully across those cases with no SimplePie dependency in `composer.json`. Keeping the parser built-in eliminates a supply-chain dependency and reduces the attack surface. The `FeedParserInterface` abstraction means adopting SimplePie later is a one-class swap, not a refactor.
+
+**Source evidence:**
+- `intravox-source/lib/Service/FeedReaderService.php:751,762,812,847` — `@simplexml_load_string($body, 'SimpleXMLElement', LIBXML_NOCDATA | LIBXML_NONET)` then dispatches to `parseXmlFeed(\SimpleXMLElement $xml)` → `normalizeRssItem()` or `normalizeAtomEntry()`.
+- `intravox-source/lib/Service/FeedReaderService.php` constructor — dependencies are `IClientService`, `ICacheFactory`, `IConfig`, `ICrypto`, `LoggerInterface`; no SimplePie injection.
+- `intravox-source/composer.json` — no `simplepie/simplepie` or equivalent; only `enshrined/svg-sanitize` as a third-party lib.
+
+### D2: Security flags on parse — `LIBXML_NONET`
+
+**Decision:** Always pass `LIBXML_NONET` (and `LIBXML_NOCDATA`) to `simplexml_load_string()`. `LIBXML_NONET` disables external entity loading, preventing XXE attacks via crafted feed bodies. `LIBXML_NOCDATA` coerces CDATA sections to plain text strings so field extraction works uniformly.
+
+**Source evidence:**
+- `intravox-source/lib/Service/FeedReaderService.php:751` — `LIBXML_NOCDATA | LIBXML_NONET` passed on every call.
+
+**Rationale:** XXE is a known attack vector for XML parsers processing untrusted content. Disabling network access at the libxml level is the correct defence; it costs nothing and cannot be forgotten in a subclass. `LIBXML_NOCDATA` avoids defensive casting throughout the normaliser.
+
+### D3: Response size cap — 10 MB
+
+**Decision:** Reject any feed response body larger than 10 MB (`MAX_RESPONSE_SIZE = 10 * 1024 * 1024`). Feeds exceeding this limit are recorded as failed with `lastFailureReason = "response too large"` and their cached items are left unchanged.
+
+**Source evidence:**
+- `intravox-source/lib/Service/FeedReaderService.php` — `MAX_RESPONSE_SIZE` constant at 10 MB.
+
+**Rationale:** No legitimate news feed requires more than 10 MB of XML. The cap prevents a malicious or misconfigured feed server from exhausting PHP memory. The constant is defined once and is trivially tunable in a follow-up if a customer has an unusually large internal feed.
+
+### D4: HTTP fetch via NC `IClientService`, 10 s connect / 30 s total timeout
+
+**Decision:** Use Nextcloud's `IClientService` (not raw cURL) for all outbound HTTP requests. Set a 10-second connect timeout and a 30-second total timeout. The source uses 5 s; we extend this slightly to accommodate slow intranet servers without making the job hang indefinitely. Proxy settings (`system.proxy`, `system.proxyuserpwd`, `system.noproxy`) are honoured transparently by `IClientService`.
+
+**Source evidence:**
+- `intravox-source/lib/Service/FeedReaderService.php` — `IClientService` injected; 5 s timeout configured on the client options.
+
+**Rationale:** Using `IClientService` instead of raw cURL ensures proxy and SSL configuration set by the Nextcloud admin is respected without any custom logic. The spec (REQ-FRJ-006) defines 10 s connect / 30 s total — we align to the spec rather than the source's 5 s to reduce false-positive timeout failures on slow corporate proxies.
+
+### D5: Cache key and TTL — NC `ICache`, 60-minute default (admin-tunable)
+
+**Decision:** Persist parsed feed items in `oc_mydash_feed_cache.itemsJson` (database-backed, not NC `ICache`). The background job refresh interval acts as the effective TTL: default 60 minutes, admin-tunable via `mydash.feed_refresh_interval_seconds` (min 300 s, max 86 400 s). NC `ICache` is used only for transient in-request deduplication if needed, not for primary storage.
+
+**Alternatives considered:**
+- **Match source's 15-minute `CACHE_TTL`:** The source stores in NC `ICache` with a 900-second TTL. Rejected because a shared `ICache` entry is volatile (evicted under memory pressure) and does not survive across PHP processes. Database persistence is more reliable for a background-job pattern where the widget render must always find cached data.
+
+**Source evidence:**
+- `intravox-source/lib/Service/FeedReaderService.php` — `CACHE_TTL = 900` (15 min) used with `ICacheFactory`-backed cache.
+
+**Rationale:** The proposal explicitly defines `oc_mydash_feed_cache` as the persistence layer and the 60-minute `TimedJob` interval as the refresh cadence. Database storage survives pod restarts and Redis evictions; 60 minutes is appropriate for intranet news that does not change by the minute. Admins who need fresher data can lower the interval to 5 minutes.
+
+### D6: Conditional GET — `If-None-Match` + `If-Modified-Since`
+
+**Decision:** Persist `etag` and `lastModified` response headers in `oc_mydash_feed_cache` after each successful 200 fetch. On subsequent fetches, send `If-None-Match` and `If-Modified-Since` headers. On HTTP 304, update only `lastFetchedAt` and skip parse entirely.
+
+**Rationale:** Conditional GET is the standard mechanism for feed polling efficiency. It reduces bandwidth and CPU on both sides and signals to feed servers that MyDash is a well-behaved client. The spec (REQ-FRJ-004) requires it; the source does not implement it, so this is a deliberate improvement over the reference.
+
+### D7: Per-feed isolation — one timeout does not block the rest
+
+**Decision:** Each feed fetch and parse is wrapped in its own `try/catch` block. A failure (timeout, 4xx/5xx, malformed XML) on feed N is recorded in `lastFailureReason` and does not prevent feeds N+1 … M from being processed in the same job tick. Existing `itemsJson` is preserved on failure.
+
+**Rationale:** A background job that aborts on the first bad feed would silently leave most feeds stale. Per-feed isolation with recorded failure state lets admins diagnose individual problem feeds without affecting healthy ones. This matches the source behaviour and the spec requirement REQ-FRJ-006.
+
+## Spec changes implied
+
+- **REQ-FRJ-005 (parser):** Replace any remaining SimplePie reference with `simplexml_load_string()` + `LIBXML_NOCDATA | LIBXML_NONET`. Note the `FeedParserInterface` abstraction.
+- **REQ-FRJ-005 (size cap):** Pin the 10 MB response cap (`MAX_RESPONSE_SIZE`) as an explicit acceptance criterion.
+- **REQ-FRJ-002 (interval):** Confirm 60-minute default; document the 5-minute minimum and 24-hour maximum clamp.
+- **REQ-FRJ-006 (failure isolation):** Confirm per-feed `try/catch` with 10 s connect / 30 s total timeout values aligned to D4.
+
+## Open follow-ups
+
+- Whether to surface persistent feed-fetch failures to admins via the orphaned-data-cleanup scan output (e.g., "feed X has been failing for 7 consecutive days").
+- Whether the NC `ICache` layer (used for in-request deduplication) should be Redis-aware or left fully agnostic (current spec: agnostic — Redis if available, else file/APCu).
+- Whether to add OPML import for bulk feed-URL onboarding (out of scope for this spec; noted in proposal).
+- Whether `MAX_RESPONSE_SIZE` should be admin-tunable or remain a hard-coded constant.

--- a/openspec/changes/background-job-feed-refresh/proposal.md
+++ b/openspec/changes/background-job-feed-refresh/proposal.md
@@ -1,0 +1,73 @@
+# Background Job Feed Refresh
+
+## Why
+
+MyDash news widget users rely on fresh feed content to stay informed. Currently, when a user visits the dashboard, the news widget must fetch external RSS/Atom feeds on-demand, which adds latency and introduces external feed failures directly into the page-load experience. A periodic background job that refreshes feeds asynchronously ensures:
+
+- Users always see recently-cached feed items on dashboard load (sub-second widget render)
+- External feed timeouts or server errors do not break the dashboard
+- Feed hosts receive predictable, efficient update requests (conditional GET with ETag/Last-Modified)
+- Heavy feeds are pruned to a manageable size (50 items per feed)
+- Administrators can tune the refresh interval and define allowed feed hosts
+
+## What Changes
+
+- Add a new table `oc_mydash_feed_cache` to persist feed fetch metadata (ETag, Last-Modified, last fetch time, error state) and cached items per feed URL.
+- Register a Nextcloud `\OCP\BackgroundJob\TimedJob` named `FeedRefreshJob` that runs every 60 minutes (admin-tunable via `mydash.feed_refresh_interval_seconds`, min 5 min, max 24h).
+- The job discovers all active feed URLs from news-widget placements, fetches each with HTTP conditional-get headers (If-None-Match, If-Modified-Since), parses responses, normalises items to the news-widget schema, and stores items as JSON.
+- Per-feed concurrency locking ensures only one job instance processes each feed at a time.
+- Single-feed failures (timeout, 4xx/5xx, parse error) do not block other feeds.
+- Batch processing allows jobs with >500 feeds to spread work across consecutive ticks using a cursor.
+- Daily orphan-cleanup job (sibling capability) prunes feeds not referenced for ≥30 days.
+- Expose `POST /api/admin/feeds/refresh-now` endpoint (admin-only) to trigger immediate full refresh or per-URL refresh.
+- Honour global proxy settings and allow-list of feed hostnames via app config.
+- Use appropriate User-Agent header to identify MyDash as the requestor.
+
+## Capabilities
+
+### New Capabilities
+
+- `background-job-feed-refresh` — A periodic background job that asynchronously fetches and caches external RSS/Atom feeds for the news widget, with HTTP conditional-get optimisation, per-feed locking, failure tolerance, and admin-tunable controls.
+
+## Impact
+
+**Affected code:**
+
+- `lib/Db/FeedCacheMapper.php` + `lib/Db/FeedCache.php` — database entity and mapper for feed cache table.
+- `lib/Service/FeedRefreshService.php` — core service logic: discover feed URLs, fetch with conditional GET, parse, normalise, cache items, handle failures, batch processing.
+- `lib/Job/FeedRefreshJob.php` — Nextcloud TimedJob registration, orchestration of `FeedRefreshService`.
+- `lib/Controller/AdminController.php` — new endpoint `POST /api/admin/feeds/refresh-now`.
+- `appinfo/routes.php` — register admin endpoint.
+- `appinfo/app.php` or `AppInfo/Bootstrap.php` — register the TimedJob in Nextcloud's job queue.
+- `lib/Migration/VersionXXXXDate2026...AddFeedCacheTable.php` — schema migration creating `oc_mydash_feed_cache` table.
+- `lib/Service/NewsWidgetService.php` (if exists) or `WidgetService.php` — integrate feed cache lookup on news-widget render.
+
+**Affected APIs:**
+
+- 1 new route: `POST /api/admin/feeds/refresh-now` (admin-only).
+- 0 changes to existing routes; news-widget remains `GET /api/widgets/news/{placementId}`.
+
+**Dependencies:**
+
+- `OCP\BackgroundJob\TimedJob` — Nextcloud background job framework.
+- `OCP\IConfig` — read proxy settings and app config (`mydash.feed_refresh_interval_seconds`, `mydash.news_widget_allowed_feed_hosts`).
+- `OCP\Http\Client\IClientService` — HTTP fetch with timeout and proxy support.
+- `simplepie` or `SimpleXMLElement` + manual parsing — RSS/Atom feed parsing (simplepie recommended for robustness).
+- `OCP\Lock\ILockingProvider` — per-feed concurrency locking.
+- Nextcloud's built-in `\DateTime` and `\DateInterval` for timestamp handling.
+- No new composer or npm dependencies if using built-in parsing; optional `simplepie/simplepie` for robustness.
+
+**Migration:**
+
+- One schema migration to create `oc_mydash_feed_cache` table.
+- Zero data backfill required; job begins operating immediately after migration.
+- Admin can immediately configure `mydash.feed_refresh_interval_seconds` and `mydash.news_widget_allowed_feed_hosts` via `IAppConfig`.
+
+**Concurrency & Performance:**
+
+- Per-feed locking using Nextcloud's `ILockingProvider` prevents concurrent fetches of the same URL.
+- Batch processing: jobs with >500 feeds spread work across consecutive ticks using `cursor` state persisted in `oc_mydash_feed_cache.processingCursor`.
+- Target throughput: <5 minutes for ≤500 feeds.
+- HTTP 304 responses (not modified) skip parse step; only metadata updated.
+- Individual feed fetch failures do not interrupt overall job; each feed wrapped in try/catch.
+

--- a/openspec/changes/background-job-feed-refresh/specs/background-job-feed-refresh/spec.md
+++ b/openspec/changes/background-job-feed-refresh/specs/background-job-feed-refresh/spec.md
@@ -167,6 +167,10 @@ The job MUST use HTTP conditional-get headers (`If-None-Match`, `If-Modified-Sin
 
 On HTTP 200, the job MUST parse RSS 2.0 and Atom 1.0 feed XML and normalise items to the schema defined by the `news-widget` capability.
 
+> NOTE: Parsing is performed by PHP's built-in `simplexml_load_string()` called with flags `LIBXML_NOCDATA | LIBXML_NONET`. `LIBXML_NONET` disables external entity loading (XXE prevention); `LIBXML_NOCDATA` coerces CDATA sections to plain strings. Parsing logic is encapsulated behind a `FeedParserInterface` so the implementation can be swapped to an alternative library in a follow-up without touching the job or service layer. There is no third-party RSS parsing dependency in `composer.json`.
+
+> NOTE: Feed response bodies larger than 10 MB (`MAX_RESPONSE_SIZE = 10 * 1024 * 1024`) MUST be rejected before parsing. The feed MUST be recorded as failed with `lastFailureReason = "response too large"` and existing `itemsJson` MUST remain unchanged.
+
 #### Scenario: RSS 2.0 item fields mapped to schema
 
 - GIVEN an RSS 2.0 feed with items containing `<title>`, `<description>`, `<link>`, `<pubDate>`, `<guid>`, and `<enclosure type="image/...">`
@@ -206,6 +210,8 @@ On HTTP 200, the job MUST parse RSS 2.0 and Atom 1.0 feed XML and normalise item
 
 A failure to fetch or parse one feed MUST NOT prevent the job from processing the remaining feeds.
 
+> NOTE: All outbound HTTP requests MUST use Nextcloud's `IClientService` (not raw cURL). The connect timeout MUST be 10 seconds and the total request timeout MUST be 30 seconds. Each feed fetch and parse MUST be wrapped in its own `try/catch` block so that a failure on one feed does not prevent subsequent feeds from being processed.
+
 #### Scenario: Single feed timeout does not block others
 
 - GIVEN a job is processing feeds `[A, B, C]` and feed B times out after 10 seconds
@@ -233,8 +239,8 @@ A failure to fetch or parse one feed MUST NOT prevent the job from processing th
 #### Scenario: Malformed XML does not crash the job
 
 - GIVEN a feed server returns HTTP 200 with body `<rss><channel>TRUNCATED`
-- WHEN `\SimpleXMLElement` (or simplepie) attempts to parse the body
-- THEN the parse exception MUST be caught within a try/catch block
+- WHEN `simplexml_load_string()` with `LIBXML_NOCDATA | LIBXML_NONET` attempts to parse the body
+- THEN the parse failure MUST be caught within a try/catch block
 - AND `lastFailureReason` MUST be set to `"parse error: <exception message>"`
 - AND `itemsJson` MUST remain at its previous value
 

--- a/openspec/changes/background-job-feed-refresh/specs/background-job-feed-refresh/spec.md
+++ b/openspec/changes/background-job-feed-refresh/specs/background-job-feed-refresh/spec.md
@@ -1,0 +1,468 @@
+---
+status: draft
+---
+
+# Background Job Feed Refresh Specification
+
+## ADDED Requirements
+
+### Requirement: REQ-FRJ-001 Feed Cache Table Schema
+
+The system MUST create a database table `oc_mydash_feed_cache` that stores exactly one row per distinct feed URL across all news-widget placements, persisting fetch metadata and cached items.
+
+#### Scenario: Table created on migration
+
+- GIVEN MyDash is freshly installed or upgraded and the migration has not yet run
+- WHEN `occ migrations:execute mydash` runs the `AddFeedCacheTable` migration
+- THEN the table `oc_mydash_feed_cache` MUST exist with columns: `id` (auto-increment integer PK), `feedUrl VARCHAR(2048) UNIQUE NOT NULL`, `lastFetchedAt TIMESTAMP NULL`, `lastSuccessAt TIMESTAMP NULL`, `lastFailureReason TEXT NULL`, `etag VARCHAR(255) NULL`, `lastModified VARCHAR(255) NULL`, `itemsJson MEDIUMTEXT NULL`
+- AND a unique index on `feedUrl` MUST be present
+
+#### Scenario: One row per distinct URL regardless of placement count
+
+- GIVEN two separate news-widget placements both reference `https://example.com/rss`
+- WHEN the background job discovers feed URLs and upserts into the cache table
+- THEN exactly one row with `feedUrl = 'https://example.com/rss'` MUST exist in `oc_mydash_feed_cache`
+- AND updates to that row MUST be shared by both placements
+
+#### Scenario: Schema is compatible across supported databases
+
+- GIVEN the migration runs on SQLite, MySQL 8.x, and PostgreSQL 14+
+- WHEN `oc_mydash_feed_cache` is created
+- THEN the table MUST be created without error on each engine
+- AND `MEDIUMTEXT` MUST be mapped to an equivalent large-text column type on PostgreSQL
+
+#### Scenario: Migration is reversible
+
+- GIVEN the migration has been applied
+- WHEN a rollback is triggered (e.g., `occ migrations:execute --revert`)
+- THEN the `oc_mydash_feed_cache` table MUST be dropped cleanly
+- AND no orphan indexes MUST remain
+
+#### Scenario: itemsJson capped at 50 items on write
+
+- GIVEN a feed returns 120 items in its response
+- WHEN the service stores items in `itemsJson`
+- THEN only the 50 newest items (sorted by `pubDate` descending) MUST be stored
+- AND the stored JSON MUST be valid and parseable
+
+### Requirement: REQ-FRJ-002 TimedJob Registration and Interval
+
+The system MUST register `FeedRefreshJob` as a Nextcloud `\OCP\BackgroundJob\TimedJob` that runs on a configurable interval, defaulting to 60 minutes.
+
+#### Scenario: Job runs every 60 minutes by default
+
+- GIVEN no `mydash.feed_refresh_interval_seconds` app config key has been set
+- WHEN Nextcloud's cron daemon evaluates scheduled jobs
+- THEN `FeedRefreshJob` MUST run at most once per 3600 seconds (60 minutes)
+- AND `$this->setInterval(3600)` MUST be called in the job constructor
+
+#### Scenario: Admin sets custom refresh interval
+
+- GIVEN an admin runs `occ config:app:set mydash feed_refresh_interval_seconds --value=900`
+- WHEN `FeedRefreshJob` is next constructed
+- THEN it MUST call `$this->setInterval(900)` so the job runs every 15 minutes
+
+#### Scenario: Interval clamped to minimum 300 seconds
+
+- GIVEN an admin sets `mydash.feed_refresh_interval_seconds` to `60`
+- WHEN the job constructor reads the config value
+- THEN the effective interval MUST be `max(300, configuredValue)` = `300`
+- AND the job MUST NOT run more frequently than once every 5 minutes
+
+#### Scenario: Interval clamped to maximum 86400 seconds
+
+- GIVEN an admin sets `mydash.feed_refresh_interval_seconds` to `172800` (48 h)
+- WHEN the job constructor reads the config value
+- THEN the effective interval MUST be `min(86400, configuredValue)` = `86400`
+- AND the job MUST NOT run less frequently than once per 24 hours
+
+#### Scenario: Job registered on application bootstrap
+
+- GIVEN MyDash is installed and enabled
+- WHEN `AppInfo/Bootstrap.php::register()` is called
+- THEN `$context->registerBackgroundJob(FeedRefreshJob::class)` MUST be called
+- AND `occ background-job:list | grep FeedRefreshJob` MUST return a non-empty result
+
+### Requirement: REQ-FRJ-003 Feed URL Discovery
+
+The job MUST discover the complete set of active feed URLs by querying all news-widget placements before each refresh cycle.
+
+#### Scenario: Feed URLs extracted from placements
+
+- GIVEN three news-widget placements with `widgetId = 'mydash_news'`:
+  - Placement A: `widgetContent = {"feedUrls": ["https://a.com/rss", "https://b.com/feed"]}`
+  - Placement B: `widgetContent = {"feedUrls": ["https://b.com/feed", "https://c.com/atom"]}`
+  - Placement C: `widgetContent = {"feedUrls": []}`
+- WHEN `FeedRefreshService::discoverFeedUrls()` is called
+- THEN the returned array MUST be `["https://a.com/rss", "https://b.com/feed", "https://c.com/atom"]` (deduplicated, sorted)
+- AND `https://b.com/feed` MUST appear exactly once
+
+#### Scenario: Placements with no feedUrls are skipped
+
+- GIVEN a placement with `widgetContent = {}` or `widgetContent = {"feedUrls": []}`
+- WHEN `discoverFeedUrls()` processes this placement
+- THEN no URLs MUST be added from that placement
+- AND no error MUST be logged
+
+#### Scenario: New feed URL upserted before first fetch
+
+- GIVEN a placement has just been created with `feedUrl = "https://new.example.org/rss"` not yet in `oc_mydash_feed_cache`
+- WHEN `discoverFeedUrls()` finishes and the job iterates feed URLs
+- THEN the job MUST call `FeedCacheMapper::upsertUrl("https://new.example.org/rss")` before fetching
+- AND a row MUST exist in `oc_mydash_feed_cache` with null metadata fields
+
+#### Scenario: Discovery ignores non-news-widget placements
+
+- GIVEN a placement with `widgetId = 'mydash_links'` and a placement with `widgetId = 'mydash_news'`
+- WHEN `discoverFeedUrls()` is called
+- THEN ONLY the `mydash_news` placement feeds MUST be included in the result
+- AND no URLs from `mydash_links` placements MUST appear
+
+#### Scenario: Empty result when no news widgets are placed
+
+- GIVEN no placement has `widgetId = 'mydash_news'`
+- WHEN `discoverFeedUrls()` is called
+- THEN the returned array MUST be empty
+- AND the job MUST log an INFO-level message "No news widget placements found; nothing to refresh" and exit without error
+
+### Requirement: REQ-FRJ-004 HTTP Conditional GET
+
+The job MUST use HTTP conditional-get headers (`If-None-Match`, `If-Modified-Since`) to avoid re-downloading unchanged feed content and reduce load on feed servers.
+
+#### Scenario: First fetch — no conditional headers sent
+
+- GIVEN `oc_mydash_feed_cache` row for a URL has `etag = NULL` and `lastModified = NULL`
+- WHEN the job fetches the feed
+- THEN the HTTP request MUST NOT include `If-None-Match` or `If-Modified-Since` headers
+- AND the full feed body MUST be received and parsed
+
+#### Scenario: Subsequent fetch — ETag header sent
+
+- GIVEN a previous successful fetch stored `etag = '"abc123"'` for `https://example.com/rss`
+- WHEN the job issues the next HTTP request for that URL
+- THEN the request MUST include `If-None-Match: "abc123"`
+- AND if the server responds HTTP 304, the job MUST update only `lastFetchedAt` and skip parsing
+
+#### Scenario: Subsequent fetch — Last-Modified header sent
+
+- GIVEN a previous fetch stored `lastModified = 'Wed, 21 Oct 2026 07:28:00 GMT'`
+- WHEN the job issues the next request
+- THEN the request MUST include `If-Modified-Since: Wed, 21 Oct 2026 07:28:00 GMT`
+
+#### Scenario: HTTP 304 — items untouched, only lastFetchedAt updated
+
+- GIVEN the server returns HTTP 304 Not Modified
+- WHEN the job processes the response
+- THEN `lastFetchedAt` MUST be updated to the current timestamp
+- AND `itemsJson`, `lastSuccessAt`, `etag`, and `lastModified` MUST remain at their previous values
+
+#### Scenario: ETag and Last-Modified updated from 200 response headers
+
+- GIVEN the server returns HTTP 200 with headers `ETag: "xyz789"` and `Last-Modified: Thu, 01 May 2026 10:00:00 GMT`
+- WHEN the job processes the response
+- THEN `etag` MUST be stored as `"xyz789"` and `lastModified` as `Thu, 01 May 2026 10:00:00 GMT`
+- AND both values MUST be used in the next conditional-get request
+
+### Requirement: REQ-FRJ-005 Feed Parse and Item Normalisation
+
+On HTTP 200, the job MUST parse RSS 2.0 and Atom 1.0 feed XML and normalise items to the schema defined by the `news-widget` capability.
+
+#### Scenario: RSS 2.0 item fields mapped to schema
+
+- GIVEN an RSS 2.0 feed with items containing `<title>`, `<description>`, `<link>`, `<pubDate>`, `<guid>`, and `<enclosure type="image/...">`
+- WHEN the job parses the feed
+- THEN each item MUST be normalised to: `{guid, title, summary, link, pubDate, sourceUrl, sourceTitle, thumbnailUrl}`
+- AND `summary` MUST be the sanitised text of `<description>`
+- AND `thumbnailUrl` MUST be the `url` attribute of `<enclosure>` if present, else `null`
+
+#### Scenario: Atom 1.0 item fields mapped to schema
+
+- GIVEN an Atom 1.0 feed with `<entry>` elements containing `<title>`, `<summary>` or `<content>`, `<link rel="alternate">`, `<published>` or `<updated>`, and `<id>`
+- WHEN the job parses the feed
+- THEN `guid` MUST be the value of `<id>`, `pubDate` MUST prefer `<published>` over `<updated>`, and `link` MUST be the `href` of `<link rel="alternate">`
+
+#### Scenario: Items without guid get synthetic guid
+
+- GIVEN a feed item has no `<guid>` (RSS) or `<id>` (Atom)
+- WHEN the parser processes the item
+- THEN the system MUST generate `guid = sha256(title + pubDate + feedUrl)` (hex string)
+- AND the synthetic guid MUST be stable across re-fetches of the same item
+
+#### Scenario: Items sorted newest-first and capped at 50
+
+- GIVEN a feed returns 80 items with varying `pubDate` values
+- WHEN the job normalises and stores items
+- THEN the stored `itemsJson` MUST contain exactly 50 items
+- AND they MUST be sorted descending by `pubDate` (newest first)
+
+#### Scenario: sourceUrl and sourceTitle populated from feed metadata
+
+- GIVEN a feed with channel-level `<title>BBC News</title>` and fetch URL `https://feeds.bbci.co.uk/news/rss.xml`
+- WHEN items are normalised
+- THEN every item MUST have `sourceUrl = "https://feeds.bbci.co.uk/news/rss.xml"` and `sourceTitle = "BBC News"`
+- AND if channel title is absent, `sourceTitle` MUST fall back to the hostname of the feed URL
+
+### Requirement: REQ-FRJ-006 Per-Feed Failure Tolerance
+
+A failure to fetch or parse one feed MUST NOT prevent the job from processing the remaining feeds.
+
+#### Scenario: Single feed timeout does not block others
+
+- GIVEN a job is processing feeds `[A, B, C]` and feed B times out after 10 seconds
+- WHEN the job runs
+- THEN feeds A and C MUST be processed normally
+- AND `lastFailureReason` for B MUST be set to a string beginning with `"timeout:"` (e.g., `"timeout: connect timeout after 10s"`)
+- AND `itemsJson` for B MUST remain at its last successful value
+
+#### Scenario: HTTP 4xx error recorded but does not abort job
+
+- GIVEN feed `https://gone.example.com/rss` returns HTTP 410 Gone
+- WHEN the job processes this feed
+- THEN `lastFailureReason` MUST be set to `"410 Gone"`
+- AND `itemsJson` MUST NOT be modified
+- AND the job MUST continue to the next feed
+
+#### Scenario: HTTP 5xx error handled gracefully
+
+- GIVEN a feed server returns HTTP 503 Service Unavailable
+- WHEN the job processes that feed
+- THEN `lastFailureReason` MUST be set to `"503 Service Unavailable"`
+- AND the job MUST not retry during this tick (no retry logic in scope)
+- AND subsequent ticks MUST reattempt the fetch normally
+
+#### Scenario: Malformed XML does not crash the job
+
+- GIVEN a feed server returns HTTP 200 with body `<rss><channel>TRUNCATED`
+- WHEN `\SimpleXMLElement` (or simplepie) attempts to parse the body
+- THEN the parse exception MUST be caught within a try/catch block
+- AND `lastFailureReason` MUST be set to `"parse error: <exception message>"`
+- AND `itemsJson` MUST remain at its previous value
+
+#### Scenario: Connect timeout is 10 s, total timeout is 30 s
+
+- GIVEN a feed server accepts the TCP connection but responds after 40 seconds
+- WHEN the job fetches that feed via `IClientService`
+- THEN the request MUST be aborted after 30 seconds total
+- AND the feed MUST be recorded as failed with `lastFailureReason = "timeout: total timeout after 30s"`
+
+### Requirement: REQ-FRJ-007 Concurrency Locking
+
+Only one instance of `FeedRefreshJob` MUST run at a time across the Nextcloud cluster. The job MUST acquire a named lock before processing and release it on completion or exception.
+
+#### Scenario: Job acquires global lock on start
+
+- GIVEN no other instance of `FeedRefreshJob` is running
+- WHEN the job's `run()` method is invoked by the Nextcloud cron daemon
+- THEN the job MUST call `ILockingProvider::acquireLock('mydash_feed_refresh_running', ILockingProvider::LOCK_EXCLUSIVE)`
+- AND the lock MUST be released (via `releaseLock`) in a `finally` block after all feeds are processed
+
+#### Scenario: Second concurrent invocation exits without processing
+
+- GIVEN one `FeedRefreshJob` instance holds the global lock
+- WHEN a second instance attempts to run concurrently
+- THEN `acquireLock` MUST throw `\OCP\Lock\LockedException`
+- AND the second instance MUST catch that exception, log a WARN-level message "FeedRefreshJob already running; skipping this tick", and return immediately
+- AND no feed fetches MUST occur in the second instance
+
+#### Scenario: Lock released on unhandled exception
+
+- GIVEN the job holds the global lock and an unhandled exception occurs mid-run
+- WHEN the exception propagates out of the core processing loop
+- THEN the `finally` block MUST release the lock
+- AND the lock MUST NOT be left in a stuck state that would permanently block future ticks
+
+#### Scenario: Lock scope is per-Nextcloud-instance (not per-feed)
+
+- GIVEN a Nextcloud cluster with two nodes running the same cron simultaneously
+- WHEN both nodes invoke `FeedRefreshJob::run()` at the same time
+- THEN only one node MUST proceed past the `acquireLock` call
+- AND the other node MUST log and exit (per the second-concurrent scenario above)
+
+### Requirement: REQ-FRJ-008 Batch Processing for Large Feed Sets
+
+When the number of active feed URLs exceeds 500, the job MUST split work across consecutive ticks using a cursor so that each tick completes in under 5 minutes.
+
+#### Scenario: ≤500 feeds — all processed in one tick
+
+- GIVEN there are 450 active feed URLs
+- WHEN `FeedRefreshJob::run()` is invoked
+- THEN all 450 feeds MUST be processed within a single tick
+- AND the cursor state MUST be cleared after completion
+
+#### Scenario: >500 feeds — cursor advances across ticks
+
+- GIVEN there are 750 active feed URLs, sorted alphabetically, and the job processes 500 per tick
+- WHEN the first tick runs
+- THEN feeds 1–500 MUST be processed
+- AND the cursor value (last processed `feedUrl`) MUST be stored in app config `mydash.feed_refresh_cursor`
+
+- WHEN the second tick runs
+- THEN feeds 501–750 MUST be processed (resuming from cursor)
+- AND the cursor MUST be cleared on completion of the last batch
+
+#### Scenario: Cursor is invalidated when feed list changes significantly
+
+- GIVEN a cursor is stored after a partial batch run
+- AND between ticks, all placements referencing the cursor's URL are deleted
+- WHEN the next tick resumes from the stale cursor
+- THEN the job MUST detect that the cursor URL no longer exists in the discovered set
+- AND MUST restart from the beginning of the sorted feed list
+
+#### Scenario: 5-minute wall-clock budget enforced per tick
+
+- GIVEN 800 feeds, each taking an average of 400ms to fetch
+- WHEN the job runs
+- THEN after 300 seconds (5 minutes) of elapsed time, the job MUST stop processing further feeds in this tick
+- AND persist the cursor at the last completed feed URL
+- AND the remaining feeds MUST be processed in subsequent ticks
+
+### Requirement: REQ-FRJ-009 Orphaned Feed Cleanup Hand-off
+
+Feeds no longer referenced by any active placement for ≥30 days MUST be pruned. This job does not perform cleanup itself — it signals the dependency clearly and provides the mapper interface needed by the sibling `orphaned-data-cleanup` job.
+
+#### Scenario: FeedCacheMapper exposes orphan query for sibling job
+
+- GIVEN the `orphaned-data-cleanup` sibling job is implemented
+- WHEN it calls `FeedCacheMapper::findOrphanedBefore($cutoff)` where `$cutoff = now() - 30 days`
+- THEN the mapper MUST return all rows where `lastFetchedAt < $cutoff`
+- NOTE: This spec does not implement the deletion — that is the responsibility of the `orphaned-data-cleanup` spec
+
+#### Scenario: lastFetchedAt updated on every tick for active feeds
+
+- GIVEN a feed URL is actively referenced by a placement
+- WHEN the background job runs its tick (even if the feed returns 304)
+- THEN `lastFetchedAt` MUST be updated to the current timestamp
+- AND the row MUST NOT be returned by `findOrphanedBefore` during the 30-day window
+
+#### Scenario: Feed removed from all placements starts ageing
+
+- GIVEN a feed URL was removed from all placements at `T`
+- WHEN the background job runs ticks after `T`
+- THEN the URL MUST no longer appear in `discoverFeedUrls()`
+- AND `lastFetchedAt` MUST NOT be updated after `T`
+- AND after `T + 30 days`, `findOrphanedBefore` MUST include this row
+
+#### Scenario: Sibling job dependency noted in failure state
+
+- GIVEN the `orphaned-data-cleanup` sibling job has NOT been implemented
+- WHEN the feed cache grows over time with unreferenced entries
+- THEN `oc_mydash_feed_cache` rows for orphaned feeds MUST remain in the table (no auto-delete)
+- AND no error MUST be raised — the table grows until the sibling job is active
+
+### Requirement: REQ-FRJ-010 Admin Refresh-Now Endpoint
+
+Administrators MUST be able to trigger an immediate feed refresh via `POST /api/admin/feeds/refresh-now`, optionally scoped to a single URL.
+
+#### Scenario: Full refresh triggered by admin
+
+- GIVEN an admin sends `POST /api/admin/feeds/refresh-now` with no body
+- WHEN the controller handles the request
+- THEN `FeedRefreshService::refreshAll(null)` MUST be called synchronously
+- AND the response MUST be HTTP 200 with body `{processedCount, successCount, failureCount, durationMs}`
+
+#### Scenario: Single-URL refresh triggered by admin
+
+- GIVEN an admin sends `POST /api/admin/feeds/refresh-now?feedUrl=https%3A%2F%2Fexample.com%2Frss`
+- WHEN the controller handles the request
+- THEN `FeedRefreshService::refreshAll("https://example.com/rss")` MUST be called
+- AND only that one feed MUST be fetched and updated
+- AND the response MUST include `processedCount: 1`
+
+#### Scenario: Non-admin receives HTTP 403
+
+- GIVEN a regular user "alice" sends `POST /api/admin/feeds/refresh-now`
+- WHEN the controller evaluates the request
+- THEN the system MUST return HTTP 403
+- AND no feed refresh MUST occur
+- NOTE: Access is restricted because the `AdminController` does not carry `#[NoAdminRequired]`
+
+#### Scenario: Invalid feedUrl scheme rejected
+
+- GIVEN an admin sends `POST /api/admin/feeds/refresh-now?feedUrl=ftp%3A%2F%2Fbad.com%2Frss`
+- WHEN the controller validates the parameter
+- THEN the system MUST return HTTP 400 with a message indicating only HTTP/HTTPS URLs are accepted
+- AND no fetch MUST occur
+
+#### Scenario: Response body includes timing metadata
+
+- GIVEN an admin triggers a full refresh with 30 active feeds
+- WHEN the refresh completes
+- THEN the response body MUST include `durationMs` (integer ≥ 0)
+- AND `processedCount` MUST equal the number of feeds attempted
+- AND `successCount + failureCount` MUST equal `processedCount`
+
+### Requirement: REQ-FRJ-011 Feed Host Allow-List Enforcement
+
+The job MUST check each feed URL against the configured allow-list before fetching. URLs with disallowed hosts MUST be silently skipped and recorded.
+
+#### Scenario: Allow-list empty — all hosts permitted
+
+- GIVEN `mydash.news_widget_allowed_feed_hosts` is not set or is an empty string
+- WHEN the job processes any feed URL
+- THEN no allow-list check MUST be performed
+- AND all HTTP/HTTPS feed URLs MUST proceed to fetch
+
+#### Scenario: Disallowed host skipped before HTTP request
+
+- GIVEN `mydash.news_widget_allowed_feed_hosts = "bbc.com,example.org"`
+- AND the job discovers `https://blocked-site.com/feed`
+- WHEN the job processes this URL
+- THEN NO HTTP request MUST be made to `blocked-site.com`
+- AND `lastFailureReason` MUST be set to `"host not in allow-list"`
+- AND a WARN-level log MUST record the skipped URL
+
+#### Scenario: Allowed host passes check and is fetched
+
+- GIVEN `mydash.news_widget_allowed_feed_hosts = "bbc.com,example.org"`
+- AND the job discovers `https://bbc.com/news/rss.xml`
+- WHEN the job processes this URL
+- THEN the allow-list check MUST succeed
+- AND the HTTP fetch MUST proceed normally
+
+#### Scenario: Allow-list comparison is case-insensitive
+
+- GIVEN `mydash.news_widget_allowed_feed_hosts = "BBC.com"`
+- AND the feed URL is `https://bbc.com/rss`
+- WHEN the hostname is compared against the allow-list
+- THEN the match MUST succeed (lowercased comparison on both sides)
+
+#### Scenario: Subdomains not covered by base hostname
+
+- GIVEN `mydash.news_widget_allowed_feed_hosts = "example.org"`
+- AND the feed URL is `https://feeds.example.org/rss`
+- WHEN the hostname is compared
+- THEN the match MUST fail (exact hostname required; no wildcard subdomain expansion)
+- AND `lastFailureReason` MUST be `"host not in allow-list"`
+
+### Requirement: REQ-FRJ-012 User-Agent and Proxy Configuration
+
+The job MUST identify itself with a descriptive User-Agent header and MUST honour global Nextcloud proxy settings when making outbound HTTP requests.
+
+#### Scenario: User-Agent header sent on every request
+
+- GIVEN the job fetches any feed URL
+- WHEN the HTTP request is constructed via `IClientService`
+- THEN the `User-Agent` header MUST be set to `Mozilla/5.0 (compatible; MyDash/<appVersion>; +<instanceUrl>/apps/mydash)`
+- AND `<appVersion>` MUST be the app's current version string (e.g., `1.0.0`)
+- AND `<instanceUrl>` MUST be the NC instance URL from `IConfig::getSystemValue('overwrite.cli.url')`
+
+#### Scenario: Proxy settings honoured from NC config
+
+- GIVEN the Nextcloud instance has `system.proxy` set to `http://proxy.corp.example:3128` in `config.php`
+- WHEN the job makes an outbound HTTP request via `IClientService`
+- THEN the request MUST be routed through the configured proxy
+- AND proxy authentication (`system.proxyuserpwd`) MUST be passed if set
+
+#### Scenario: Proxy bypass for local hosts
+
+- GIVEN `system.noproxy` contains `"localhost,127.0.0.1,internal.corp"`
+- WHEN the job fetches a feed at `https://internal.corp/feed`
+- THEN the proxy MUST NOT be used for this request
+- AND NC's `IClientService` handles this transparently (no custom logic required)
+
+#### Scenario: User-Agent identifies version correctly after app upgrade
+
+- GIVEN the app is upgraded from version `1.0.0` to `1.1.0`
+- WHEN the job runs after upgrade
+- THEN the User-Agent MUST reflect `MyDash/1.1.0`
+- AND the version MUST be read dynamically (not hard-coded) from app metadata at job instantiation

--- a/openspec/changes/background-job-feed-refresh/tasks.md
+++ b/openspec/changes/background-job-feed-refresh/tasks.md
@@ -1,0 +1,87 @@
+# Tasks — background-job-feed-refresh
+
+## 1. Schema migration
+
+- [ ] 1.1 Create `lib/Migration/VersionXXXXDate2026...AddFeedCacheTable.php` with `oc_mydash_feed_cache` table: `id` (auto-increment PK), `feedUrl VARCHAR(2048) UNIQUE NOT NULL`, `lastFetchedAt TIMESTAMP NULL`, `lastSuccessAt TIMESTAMP NULL`, `lastFailureReason TEXT NULL`, `etag VARCHAR(255) NULL`, `lastModified VARCHAR(255) NULL`, `itemsJson MEDIUMTEXT NULL`
+- [ ] 1.2 Add index `idx_mydash_feed_cache_url` on `(feedUrl)` for fast upsert lookups
+- [ ] 1.3 Confirm migration is reversible (drop table in rollback path)
+- [ ] 1.4 Run migration locally against sqlite, mysql, and postgres; verify schema applied cleanly each time
+
+## 2. Domain model
+
+- [ ] 2.1 Create `lib/Db/FeedCache.php` entity extending `\OCP\AppFramework\Db\Entity` with fields: `feedUrl`, `lastFetchedAt`, `lastSuccessAt`, `lastFailureReason`, `etag`, `lastModified`, `itemsJson`
+- [ ] 2.2 Add typed getters/setters following NC Entity `__call` pattern (no named args)
+- [ ] 2.3 Add `FeedCache::decodeItems(): array` helper that json_decodes `itemsJson`, returning `[]` on null/invalid JSON
+- [ ] 2.4 Add `FeedCache::encodeItems(array $items): void` helper that json_encodes and caps at 50 items
+
+## 3. Mapper layer
+
+- [ ] 3.1 Create `lib/Db/FeedCacheMapper.php` extending `\OCP\AppFramework\Db\QBMapper`
+- [ ] 3.2 Add `FeedCacheMapper::findByUrl(string $feedUrl): FeedCache` — raises `\OCP\AppFramework\Db\DoesNotExistException` if absent
+- [ ] 3.3 Add `FeedCacheMapper::upsertUrl(string $feedUrl): FeedCache` — inserts row if missing, returns existing row if present (uses INSERT ... ON DUPLICATE KEY or equivalent)
+- [ ] 3.4 Add `FeedCacheMapper::findAll(): array` for enumerating all cached feeds
+- [ ] 3.5 Add `FeedCacheMapper::findOrphanedBefore(\DateTimeInterface $cutoff): array` — feeds with `lastFetchedAt < $cutoff` (used by sibling orphan-cleanup job)
+
+## 4. Feed refresh service
+
+- [ ] 4.1 Create `lib/Service/FeedRefreshService.php` with injected `IClientService`, `IAppConfig`, `ILockingProvider`, `FeedCacheMapper`, `WidgetPlacementMapper` (or equivalent)
+- [ ] 4.2 Implement `FeedRefreshService::discoverFeedUrls(): array` — queries `oc_mydash_widget_placements` for all placements with `widgetId = 'mydash_news'`, extracts `feedUrls` from `widgetContent` JSON, deduplicates, filters against allow-list
+- [ ] 4.3 Implement `FeedRefreshService::refreshFeed(string $feedUrl): array` — performs HTTP conditional-get with `If-None-Match` and `If-Modified-Since` headers; returns result summary `{status, itemCount, durationMs}`; wraps entire method in try/catch
+- [ ] 4.4 Implement HTTP 304 shortcut: update `lastFetchedAt` only, skip parse step, return early
+- [ ] 4.5 Implement HTTP 200 parse path: use `\SimpleXMLElement` (or simplepie if available) to parse RSS/Atom; normalise items to news-widget schema (`guid`, `title`, `summary`, `link`, `pubDate`, `sourceUrl`, `sourceTitle`, `thumbnailUrl`); cap at 50 items; update `itemsJson`, `lastSuccessAt`, `etag`, `lastModified`
+- [ ] 4.6 Implement 4xx/5xx/timeout error path: set `lastFailureReason = "<code> <message>"`, do NOT modify `itemsJson`, update `lastFetchedAt`
+- [ ] 4.7 Implement allow-list check via `IAppConfig::getValueString('mydash', 'news_widget_allowed_feed_hosts', '')`: if non-empty, parse as comma-separated hostnames; skip disallowed URLs with `lastFailureReason = "host not in allow-list"` and WARN-level log
+- [ ] 4.8 Implement proxy support: read NC's `system.proxy` and `system.proxyuserpwd` from `IConfig` and pass to `IClientService` request options
+- [ ] 4.9 Build User-Agent string: `Mozilla/5.0 (compatible; MyDash/<appVersion>; +<NC instance URL>/apps/mydash)` — read app version from `IConfig::getSystemValue('version')` or `AppInfo/Application::VERSION`
+- [ ] 4.10 Implement `FeedRefreshService::refreshAll(?string $onlyUrl = null): array` — iterates all discovered feeds (or single URL if provided), respects batch cursor for >500 feeds, returns aggregate `{processedCount, successCount, failureCount, durationMs}`
+- [ ] 4.11 Implement cursor-based batch processing: persist cursor (last processed `feedUrl` alphabetically) in a temp app config key; on each tick resume from cursor, advance until either all feeds done or 5-minute wall-clock budget consumed, then reset cursor
+
+## 5. Background job
+
+- [ ] 5.1 Create `lib/Job/FeedRefreshJob.php` extending `\OCP\BackgroundJob\TimedJob`
+- [ ] 5.2 Constructor reads `mydash.feed_refresh_interval_seconds` via `IAppConfig`; clamps to [300, 86400]; calls `$this->setInterval($interval)` (default 3600)
+- [ ] 5.3 Override `run(array $argument): void` — acquires a global job lock (`mydash_feed_refresh_running`) via `ILockingProvider::acquireLock()`; calls `FeedRefreshService::refreshAll()`; releases lock; logs result at INFO level
+- [ ] 5.4 Register `FeedRefreshJob` in `AppInfo/Bootstrap.php` via `$context->registerBackgroundJob(FeedRefreshJob::class)`
+- [ ] 5.5 If global lock cannot be acquired (another instance still running), log WARN and exit immediately
+
+## 6. Admin endpoint
+
+- [ ] 6.1 Add `AdminController::refreshFeedsNow(?string $feedUrl = null): JSONResponse` mapped to `POST /api/admin/feeds/refresh-now`
+- [ ] 6.2 Endpoint delegates to `FeedRefreshService::refreshAll($feedUrl)`; returns `{processedCount, successCount, failureCount, durationMs}` with HTTP 200
+- [ ] 6.3 Register route in `appinfo/routes.php`; method requires admin (no `#[NoAdminRequired]`)
+- [ ] 6.4 Validate optional `feedUrl` query parameter: reject non-HTTP/HTTPS schemes with HTTP 400
+
+## 7. News widget integration
+
+- [ ] 7.1 Update `lib/Service/NewsWidgetService.php` `getItemsForPlacement()` to read `itemsJson` from `oc_mydash_feed_cache` per feed URL before falling back to on-demand fetch (per REQ-NEWS-004 in sibling news-widget spec)
+- [ ] 7.2 On cache miss, perform on-demand fetch and upsert into `oc_mydash_feed_cache` (populates cache for next background job tick)
+
+## 8. PHPUnit tests
+
+- [ ] 8.1 `FeedCacheMapperTest::upsertUrl` — creates new row; returns existing row on duplicate; verify UNIQUE constraint respected
+- [ ] 8.2 `FeedRefreshServiceTest::discoverFeedUrls` — returns deduplicated list; allow-list filtering; placements with no feedUrls ignored
+- [ ] 8.3 `FeedRefreshServiceTest::refreshFeed304` — 304 response updates `lastFetchedAt` only, `itemsJson` unchanged
+- [ ] 8.4 `FeedRefreshServiceTest::refreshFeedSuccess` — 200 response parses items, caps at 50, updates `lastSuccessAt`, `etag`, `lastModified`
+- [ ] 8.5 `FeedRefreshServiceTest::refreshFeedFailure` — 500 response sets `lastFailureReason`, does NOT overwrite `itemsJson`
+- [ ] 8.6 `FeedRefreshServiceTest::refreshFeedTimeout` — timeout exception caught, sets `lastFailureReason`, other feeds continue
+- [ ] 8.7 `FeedRefreshServiceTest::allowListSkip` — disallowed host skips fetch, sets `lastFailureReason = "host not in allow-list"`
+- [ ] 8.8 `FeedRefreshJobTest::runAcquiresLock` — lock acquired at start, released after run; second concurrent call exits early (lock not acquired)
+- [ ] 8.9 `AdminControllerTest::refreshNowReturns200` — returns aggregate summary JSON; non-admin gets 403
+- [ ] 8.10 `AdminControllerTest::refreshNowInvalidScheme` — `feedUrl=ftp://foo` returns 400
+
+## 9. End-to-end Playwright tests
+
+- [ ] 9.1 Admin triggers `POST /api/admin/feeds/refresh-now` and receives `{processedCount, successCount, failureCount, durationMs}`
+- [ ] 9.2 After background job runs, news widget displays items without on-demand fetch (mock feed server)
+- [ ] 9.3 Non-admin sending `POST /api/admin/feeds/refresh-now` receives HTTP 403
+- [ ] 9.4 Feed behind disallowed host shows `lastFailureReason = "host not in allow-list"` in DB after job tick
+- [ ] 9.5 Simulate 504-feed scenario: verify cursor state in app config after first tick, items processed in second tick
+
+## 10. Quality gates
+
+- [ ] 10.1 `composer check:strict` (PHPCS, PHPMD, Psalm, PHPStan) passes — fix any pre-existing issues encountered along the way
+- [ ] 10.2 ESLint + Stylelint clean on all touched Vue/JS files
+- [ ] 10.3 Update generated OpenAPI spec / Postman collection so external API consumers see the new endpoint
+- [ ] 10.4 i18n keys for all new admin labels and error messages in both `nl` and `en`
+- [ ] 10.5 SPDX headers inside the file docblock on every new PHP file (per SPDX-in-docblock convention)
+- [ ] 10.6 Run all hydra-gates locally before opening PR

--- a/openspec/changes/calendar-widget/design.md
+++ b/openspec/changes/calendar-widget/design.md
@@ -1,0 +1,138 @@
+# Design — Calendar widget
+
+## Context
+
+The calendar-widget spec (REQ-CAL-001..010) describes a merged calendar view for MyDash that combines internal Nextcloud calendars and external ICS feeds. Several architectural choices were left open in the proposal. This document resolves them based on ground-truth source code from an existing production implementation covering the same problem domain.
+
+Source root examined: `intravox-source/`
+
+## Goals / Non-Goals
+
+**Goals**
+- Pin the recurring-event expansion approach (server vs client).
+- Define the canonical event response shape.
+- Define the caching strategy for external ICS feeds (TTL, key, store).
+- Define the allow-list mechanism and SSRF protection approach.
+- Clarify how ACL on internal calendars is enforced.
+
+**Non-Goals**
+- Defining UI render details (covered by REQ-CAL-008).
+- Choosing a public-share mechanism (not in scope for calendar-widget v1).
+
+---
+
+## Decisions
+
+### D1: Recurring event expansion — server vs client
+
+**Decision**: Expansion is done **server-side**, using `Sabre\VObject\VCalendar::expand()` for external ICS feeds, and relying on `OCP\Calendar\IManager::search()` timerange filtering (which itself uses sabre/vobject internally) for internal calendars. The client receives only fully-expanded, flat event instances scoped to the requested `from..to` range. No RRULE strings are sent to the frontend.
+
+**Source evidence**:
+- `intravox-source/lib/Service/ExternalIcsService.php:112-115` — `$vcalendar->expand(new \DateTime($rangeStart…), new \DateTime($rangeEnd…))` called before iterating `VEVENT`.
+- `intravox-source/lib/Service/CalendarService.php:93-98` — `$calendar->search('', [], ['timerange' => ['start' => $rangeStart, 'end' => $rangeEnd]], …)` delegates expansion to NC's Calendar backend.
+- `intravox-source/lib/Controller/CalendarController.php:105` — date range is capped at 1 year max to prevent unbounded RRULE expansion: `$end = $start->modify('+1 year')`.
+- `intravox-source/src/components/CalendarWidget.vue:156-172` — frontend calls the events endpoint and stores `response.data.events`; no client-side expansion logic exists.
+
+**Implication for sabre/vobject dependency**: the source app does **not** vendor sabre/vobject itself (`composer.json` has no sabre dependency). It uses the copy bundled in Nextcloud via the autoloader. MyDash must do the same — import `Sabre\VObject\…` without adding it to `composer.json`.
+
+---
+
+### D2: Cross-source deduplication by UID
+
+**Decision**: **No cross-source deduplication is performed**. Internal calendar events and external ICS events are merged by a simple `array_merge` and then sorted by `start`. If the same UID appears in both an internal calendar and an external ICS feed (e.g., a user has subscribed an ICS feed both via NC Calendar and directly via the widget), duplicate instances will appear.
+
+**Source evidence**:
+- `intravox-source/lib/Service/CalendarService.php:117-127` — external ICS events are `array_merge`d with internal events with no dedup step.
+- Both services suffix the UID with `-{start ISO}` to produce stable sort keys (e.g., `uid-2026-05-01T09:00:00+00:00`), but this composite key is not used to de-duplicate across sources.
+- The source app explicitly **hides NC ICS subscriptions** from the calendar picker (`CalendarService.php:35-37`: `str_contains(get_class($calendar), 'Subscription')` → skip), steering users toward the external URL field instead. This separation-of-concerns design makes cross-source UID collisions unlikely in practice.
+
+**Implication for spec**: REQ-CAL-003 does not mandate deduplication; the spec should clarify the response is a **union** (not intersection/dedup) of sources.
+
+---
+
+### D3: Response shape
+
+**Decision**: The response is a **flat JSON array** of event objects, not grouped by source or calendar. Internal and external events share the same shape except for an `isExternal: bool` flag. The internal calendar includes `url` for deep-linking to the NC Calendar app; external events include `url` from the ICS `URL` property (or a heuristically derived link for known platforms such as Brightspace and Moodle).
+
+**Canonical event shape observed**:
+```json
+{
+  "uid": "<icalUID>-<startISO>",
+  "summary": "string",
+  "location": "string",
+  "start": "ISO 8601",
+  "end": "ISO 8601 | absent",
+  "isAllDay": false,
+  "calendarColor": "#hex",
+  "calendarName": "string",
+  "url": "string | absent",
+  "isExternal": true
+}
+```
+
+Internal events omit `isExternal` (field absent → falsy in JS). External events always have `isExternal: true`.
+
+**Delta vs proposal / spec (REQ-CAL-003)**:
+- Spec uses `title`; source uses `summary` (iCalendar field name). Align spec field name to `summary` or explicitly map it.
+- Spec uses `source: 'internal'|'external'`; source uses `isExternal: bool`. Either works; `isExternal` is simpler.
+- Spec includes `calendarId`; source includes `calendarName` + `calendarColor` but **not** a `calendarId`. The internal calendar key is not forwarded. The spec's `calendarId` requirement needs a decision (include or drop).
+- Spec includes `description`; source does not map `DESCRIPTION`. Add it or mark as optional.
+
+---
+
+### D4: External ICS caching
+
+**Decision**: Raw ICS content (before parsing) is cached using `ICacheFactory::createDistributed('intravox-ics')` with a **per-URL cache key** (`'ics_' . md5($url)`) and a **fixed 30-minute TTL** (`CACHE_TTL = 1800`). There is no admin-configurable TTL setting and no per-placement cache key. Two placements referencing the same URL share a single cache entry (confirmed: same URL → same `md5` key).
+
+**Source evidence**:
+- `intravox-source/lib/Service/ExternalIcsService.php:19` — `private const CACHE_TTL = 1800;`
+- `intravox-source/lib/Service/ExternalIcsService.php:57-65` — check then populate cache using `$cacheFactory->createDistributed('intravox-ics')`.
+- `intravox-source/lib/Service/ExternalIcsService.php:83` — `$this->cache->set($cacheKey, $body, self::CACHE_TTL)`.
+- No `IAppConfig` read for TTL anywhere in the ICS service.
+
+**Delta vs spec (REQ-CAL-005)**:
+- Spec requires a `placementId` in the cache key (`mydash_calendar_ics_{placementId}_{urlHash}`); source uses URL-only key (shared across placements). Shared-key is more efficient. The spec's per-placement keying would prevent cache reuse. **Recommendation**: adopt the URL-only key pattern from source — update spec scenario "Cache key includes URL hash" to remove the `placementId` component.
+- Spec requires admin-configurable TTL via `IAppConfig`. Source hardcodes it. The spec requirement is worth keeping as a MyDash improvement over the reference implementation.
+
+---
+
+### D5: Allow-list mechanism
+
+**Decision**: There is **no hostname allow-list** in the reference implementation. Instead, the only controls are:
+1. **HTTPS-only enforcement** — `validateUrl()` rejects any non-`https` scheme.
+2. **SSRF protection** — `gethostbynamel($host)` resolves the hostname, then each resolved IP is checked with `FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE`. Requests to private/reserved IP ranges (RFC1918, loopback, link-local) are rejected.
+3. **Response size cap** — responses larger than 1 MB are rejected (`MAX_RESPONSE_SIZE = 1048576`).
+4. **Client-side pre-validation** — `CalendarController::parseExternalIcsUrls()` accepts only HTTPS URLs and silently drops non-HTTPS entries before reaching the service.
+
+The admin settings page has no ICS allow-list UI; the only whitelist concept in admin settings is `video_domains`.
+
+**Source evidence**:
+- `intravox-source/lib/Service/ExternalIcsService.php:189-210` — `validateUrl()` method.
+- `intravox-source/lib/Controller/CalendarController.php:222` — `parse_url($url, PHP_URL_SCHEME) === 'https'` pre-filter.
+- `intravox-source/lib/Settings/AdminSettings.php:61-66` — only `video_domains` whitelist present.
+
+**Delta vs spec (REQ-CAL-006)**:
+- Spec designs an **admin hostname allow-list** (empty = allow all; populated = restrict). Source has **no such list** but has stronger SSRF protection instead.
+- The SSRF DNS-resolution approach is production-grade and covers the primary attack surface. An optional allow-list remains worthwhile for enterprise lockdown, but the spec should add the SSRF/DNS-resolution guard as a **hard requirement** (not merely implied), and the allow-list as a **SHOULD** configurable feature.
+- Spec currently says nothing about HTTPS-only enforcement on ICS URLs — this must be a hard requirement in REQ-CAL-006.
+
+---
+
+## Spec changes implied
+
+- **REQ-CAL-003 response shape**: rename `title` → `summary`; change `source:'internal'|'external'` → `isExternal: bool`; mark `description` as optional; decide whether `calendarId` is required or optional (recommend optional).
+- **REQ-CAL-004 expansion**: add explicit note that sabre/vobject is consumed from NC's bundled copy, not re-vendored; add 1-year range cap as a defensive requirement.
+- **REQ-CAL-005 cache key**: remove `placementId` from cache key pattern — key MUST be `md5($url)` only so placements sharing a URL share one cache entry; keep admin-configurable TTL requirement as a MyDash addition.
+- **REQ-CAL-006 allow-list**: add HTTPS-only as a hard requirement; add SSRF/private-IP DNS guard as a hard requirement; demote hostname allow-list from MUST to SHOULD (default empty = all HTTPS non-private-IP hosts allowed).
+- **REQ-CAL-007 ACL**: add note that `CLASS:PRIVATE` and `CLASS:CONFIDENTIAL` events are filtered server-side by both `CalendarService` (internal) and `ExternalIcsService` (external) before being returned.
+- **REQ-CAL-003 deduplication**: add a NOTE clarifying that no cross-source UID deduplication is performed; users who add the same feed as both an NC subscription and an external ICS URL will see duplicates.
+
+---
+
+## Open follow-ups
+
+1. **`calendarId` in response**: decide whether to include the internal calendar's numeric key in the response (useful for deep-link construction) or omit it. Source omits it; spec currently requires it.
+2. **`description` field**: spec includes it but source omits `DESCRIPTION` mapping entirely. Cost is low (one line in both parsers); confirm whether it is needed for the detail popover use-case.
+3. **DNS-resolution SSRF timing**: `gethostbynamel()` is synchronous and blocking; under a slow DNS server this adds latency before the HTTP fetch. Consider caching the SSRF check result or using async DNS. Not blocking for v1 but worth noting.
+4. **ICS subscription hiding**: source hides NC Calendar ICS subscriptions from the internal calendar picker. MyDash should adopt the same policy and document it clearly in the config UI help text to prevent user confusion.
+5. **`url` field for internal events**: source deep-links to `/apps/calendar/timeGridDay/{date}` rather than to the specific event. If a more precise per-event deep-link is needed (e.g., via CalDAV href), it requires additional data not returned by `IManager::search()`.

--- a/openspec/changes/calendar-widget/proposal.md
+++ b/openspec/changes/calendar-widget/proposal.md
@@ -1,0 +1,53 @@
+# Calendar Widget
+
+## Why
+
+MyDash users often manage events across multiple sources — internal Nextcloud Calendar events and external calendar feeds (ICS URLs). Currently, there is no single place to see a merged view of all these events on the dashboard. Users must either leave the dashboard and navigate to the Calendar app, or manually track external calendar subscriptions. A unified calendar widget bridges this gap by rendering a single, configurable view that merges internal and external events, with multiple display modes (month, week, agenda, upcoming list) to suit different user workflows.
+
+## What Changes
+
+- Register a new dashboard widget with id `mydash_calendar` via `OCP\Dashboard\IManager` that appears in the widget picker.
+- Add per-placement configuration stored in `widgetContent JSON` to specify internal calendars (via NC Calendar principal URIs), external ICS URLs, view mode, days-ahead threshold, and color-by-calendar preference.
+- Implement backend `GET /api/widgets/calendar/{placementId}/events?from=ISO&to=ISO` to return merged, deduplicated event objects with source attribution (internal or external) and calendar metadata.
+- Expand recurring events server-side into individual instances using sabre/vobject (already vendored in Nextcloud) for the requested `from..to` date range.
+- Cache external ICS fetches for 30 minutes using Nextcloud's `ICache`, tunable via admin setting `mydash.calendar_widget_ics_cache_ttl_seconds`.
+- Enforce an allow-list of external ICS hosts via admin setting `mydash.calendar_widget_allowed_ics_hosts` (JSON array of hostnames; empty = all allowed; populated = restricted to those hosts). URLs not matching the allow-list are silently skipped with a warning logged.
+- Implement event-time access checks using Nextcloud's delegation model so private events the user cannot read are absent from responses.
+- Provide Vue 3 SFC `CalendarWidget.vue` with four render modes: month (lightweight 7×N grid), week (7-column day-by-day), agenda (chronological list grouped by day), and upcoming-list (next N events flat). Click → open event detail or deep-link to NC Calendar app.
+- Display empty state ("No events in the next N days") and failure tolerance (single ICS URL fetch failure does not break the whole widget; successful sources render, failed ones are noted in a corner notice).
+
+## Capabilities
+
+### New Capabilities
+
+- `calendar-widget` — A new MyDash dashboard widget capability providing merged calendar views from Nextcloud and external ICS sources.
+
+## Impact
+
+**Affected code:**
+
+- `lib/Service/CalendarWidgetService.php` — core logic for fetching and merging internal + external events, recurring expansion, caching, allow-list checks.
+- `lib/Controller/WidgetController.php` — new endpoint `GET /api/widgets/calendar/{placementId}/events`.
+- `src/components/widgets/CalendarWidget.vue` — four-mode render component (month, week, agenda, upcoming-list).
+- `src/components/widgets/eventpicker/CalendarWidgetConfig.vue` — placement config UI for selecting internal calendars, ICS URLs, view mode, daysAhead.
+- `appinfo/routes.php` — register the new calendar widget events endpoint.
+- `lib/Migration/VersionXXXXDate2026...AddCalendarWidgetSettings.php` — schema migration adding app config settings (`mydash.calendar_widget_*` keys).
+- `src/stores/widgets.js` — add widget-specific runtime state for cached event data and fetch status per placement.
+
+**Affected APIs:**
+
+- 1 new route: `GET /api/widgets/calendar/{placementId}/events`
+- 0 changes to existing routes.
+
+**Dependencies:**
+
+- `sabre/vobject` — already vendored in Nextcloud; used for recurring event expansion.
+- `OCP\Calendar\IManager` — Nextcloud Calendar ICS fetch and search integration.
+- `OCP\ICache` — cache events for 30 minutes per placement.
+- `OCP\IAppConfig` — admin settings for ICS cache TTL and allow-list.
+- No new composer or npm dependencies.
+
+**Migration:**
+
+- Zero-impact: app config keys are created on demand via IAppConfig getter. No schema changes required beyond optional logging setup.
+- No data backfill required. Existing placements without calendar widget config simply don't render the widget.

--- a/openspec/changes/calendar-widget/specs/calendar-widget/spec.md
+++ b/openspec/changes/calendar-widget/specs/calendar-widget/spec.md
@@ -1,0 +1,440 @@
+---
+capability: calendar-widget
+status: draft
+---
+
+# Calendar Widget Specification
+
+## ADDED Requirements
+
+### Requirement: REQ-CAL-001 Widget registration
+
+The system MUST register a MyDash dashboard widget with id `mydash_calendar` via `OCP\Dashboard\IManager::registerWidget()` so it appears in the widget picker alongside other Nextcloud dashboard widgets.
+
+#### Scenario: Widget appears in picker
+
+- GIVEN the calendar-widget app is installed and enabled
+- WHEN a user opens the MyDash widget picker dialog
+- THEN the `mydash_calendar` widget MUST appear in the list with a title (e.g., "Calendar") and an icon
+- AND the widget MUST be selectable for placement on a dashboard
+
+#### Scenario: Multiple instances allowed
+
+- GIVEN a dashboard already has one calendar widget placement
+- WHEN the user adds a second calendar widget to the same dashboard
+- THEN both placements MUST coexist with independent configurations
+- AND the system MUST treat them as separate instances
+
+#### Scenario: Widget registration survives app reload
+
+- GIVEN the widget is registered
+- WHEN Nextcloud cache is cleared or the app is reloaded
+- THEN the `mydash_calendar` widget MUST still be discoverable in the picker
+
+#### Scenario: Widget registration includes metadata
+
+- GIVEN the widget is registered
+- WHEN the widget picker fetches widget metadata
+- THEN the widget object MUST include at minimum: id, title, icon_url, and v2 API support indication
+
+### Requirement: REQ-CAL-002 Placement configuration
+
+The system MUST store per-placement widget configuration in the `oc_mydash_widget_placements.widgetContent` JSON field, allowing users to specify which calendars to display, view mode, and other display preferences.
+
+#### Scenario: Config for internal calendars
+
+- GIVEN a user is configuring a calendar widget placement
+- WHEN they select internal Nextcloud Calendar sources
+- THEN the configuration MUST store an `internalCalendars: string[]` field
+- AND each entry MUST be a valid NC Calendar principal URI (e.g., `principals/users/alice/calendar-id`)
+- NOTE: Principal resolution is delegated to `OCP\Calendar\IManager`
+
+#### Scenario: Config for external ICS URLs
+
+- GIVEN a user is configuring a calendar widget placement
+- WHEN they add external ICS URLs
+- THEN the configuration MUST store an `externalIcsUrls: string[]` field
+- AND each entry MUST be a valid HTTP/HTTPS URL ending in `.ics` or a feed-like path
+- NOTE: URL validation and fetch failures are handled gracefully (see REQ-CAL-009)
+
+#### Scenario: Config for view mode
+
+- GIVEN a user is configuring a calendar widget placement
+- WHEN they choose a display mode
+- THEN the configuration MUST store a `viewMode: 'month'|'week'|'agenda'|'upcoming-list'` field
+- AND the default viewMode MUST be `'upcoming-list'` when not explicitly set
+
+#### Scenario: Config for days-ahead threshold
+
+- GIVEN a user is configuring a calendar widget placement
+- WHEN they set how far ahead to display events
+- THEN the configuration MUST store a `daysAhead: number` field
+- AND the default value MUST be `14`
+- AND the field MUST only affect `agenda` and `upcoming-list` modes; month/week modes ignore it
+
+#### Scenario: Config for color-by-calendar preference
+
+- GIVEN a user is configuring a calendar widget placement
+- WHEN they toggle event coloring behavior
+- THEN the configuration MUST store a `colorByCalendar: boolean` field
+- AND the default value MUST be `true`
+
+#### Scenario: Config is JSON-serializable
+
+- GIVEN a placement with calendar widget config
+- WHEN the placement is fetched from the database
+- THEN the `widgetContent` MUST deserialize cleanly to a JavaScript object
+- AND all string array fields MUST have no spurious whitespace or encoding issues
+
+### Requirement: REQ-CAL-003 Events endpoint
+
+The system MUST expose `GET /api/widgets/calendar/{placementId}/events?from=ISO&to=ISO` that returns a merged array of events from internal Nextcloud calendars and external ICS URLs, filtered to the requested date range.
+
+#### Scenario: Fetch events for date range
+
+- GIVEN a calendar widget placement with internalCalendars=[...] and externalIcsUrls=[...]
+- AND the requesting user has read access to those internal calendars
+- WHEN the frontend sends GET /api/widgets/calendar/{placementId}/events?from=2026-05-01&to=2026-05-31
+- THEN the system MUST return HTTP 200 with a JSON array of event objects
+- AND each event MUST include: uid, title, start (ISO 8601), end (ISO 8601), allDay (boolean), location (string, nullable), description (string, nullable), calendarId (string), calendarName (string), color (string, hex or NC theme var), source ('internal'|'external')
+
+#### Scenario: No events returns empty array
+
+- GIVEN a calendar widget with valid config but no events in the date range
+- WHEN the frontend fetches events
+- THEN the system MUST return HTTP 200 with an empty array `[]`
+
+#### Scenario: Missing placement returns 404
+
+- GIVEN a placement with id 999 does not exist
+- WHEN the frontend sends GET /api/widgets/calendar/999/events
+- THEN the system MUST return HTTP 404
+
+#### Scenario: Ownership check
+
+- GIVEN placement 100 belongs to user alice's dashboard
+- WHEN user bob sends GET /api/widgets/calendar/100/events
+- THEN the system MUST return HTTP 403 (forbidden — bob cannot see alice's private dashboard)
+
+#### Scenario: Invalid date range returns 400
+
+- GIVEN the frontend sends GET /api/widgets/calendar/{placementId}/events?from=invalid&to=2026-05-31
+- THEN the system MUST return HTTP 400 with error detail
+- AND both `from` and `to` MUST be required ISO 8601 date strings
+
+#### Scenario: Endpoint requires no CSRF token
+
+- GIVEN a dashboard page is loaded
+- WHEN the frontend makes repeated async calls to fetch events (e.g., on scroll or filter change)
+- THEN the endpoint MUST have `#[NoCSRFRequired]` so these calls do not require CSRF validation
+- NOTE: The placement ownership check provides sufficient security since event data is already dashboard-scoped
+
+### Requirement: REQ-CAL-004 Recurring event expansion
+
+The system MUST expand recurring events into individual instances for the requested date range using sabre/vobject's RRULE expansion logic.
+
+#### Scenario: RRULE expansion for internal events
+
+- GIVEN an internal calendar contains a recurring event "Daily standup" with RRULE:FREQ=DAILY;COUNT=5 starting 2026-05-01
+- WHEN the frontend fetches events for 2026-05-01 to 2026-05-31
+- THEN the response MUST include 5 separate event instances
+- AND each instance MUST have a distinct start/end time while sharing uid root + recurrence-id
+
+#### Scenario: RRULE expansion for external ICS
+
+- GIVEN an external ICS URL contains a weekly recurring event "Team meeting" with RRULE:FREQ=WEEKLY;UNTIL=2026-05-31
+- WHEN the frontend fetches events for 2026-05-01 to 2026-05-31
+- THEN the response MUST include individual instances for each week
+- AND instances outside the from/to range MUST NOT be included
+
+#### Scenario: All-day recurring events
+
+- GIVEN a recurring all-day event (DTSTART;VALUE=DATE)
+- WHEN expanded
+- THEN each instance MUST preserve allDay: true
+- AND the start/end MUST still be valid ISO 8601 dates (YYYY-MM-DD format acceptable)
+
+#### Scenario: Exceptions to recurring series
+
+- GIVEN a recurring event with one exception (EXDATE)
+- WHEN expanded
+- THEN the exception instance MUST NOT appear in the result
+- AND other instances MUST be included normally
+
+#### Scenario: Invalid RRULE is skipped
+
+- GIVEN an external ICS contains a malformed RRULE
+- WHEN expansion is attempted
+- THEN the system MUST log a warning
+- AND the event MUST be skipped (not cause a 500 error)
+- NOTE: Error handling is covered by REQ-CAL-009 (failure tolerance)
+
+### Requirement: REQ-CAL-005 External ICS caching
+
+The system MUST cache fetched external ICS content for 30 minutes (default) using Nextcloud's `ICache` to reduce load on external servers and improve dashboard load time.
+
+#### Scenario: First fetch populates cache
+
+- GIVEN an external ICS URL is configured on a placement
+- WHEN the frontend fetches events and this is the first request to that URL from this placement
+- THEN the system MUST fetch the ICS from the external server
+- AND cache the raw ICS content (before parsing) in the `ICache` with key pattern `mydash_calendar_ics_{placementId}_{urlHash}`
+- AND return the parsed events
+
+#### Scenario: Subsequent fetch uses cache
+
+- GIVEN the cache is populated with fresh ICS content
+- WHEN the frontend fetches events again within 30 minutes
+- THEN the system MUST use the cached ICS (no external fetch)
+- AND parse and expand it
+- AND return the same events (with timing variation only from new expansion)
+
+#### Scenario: Cache TTL is admin-configurable
+
+- GIVEN the admin sets `mydash.calendar_widget_ics_cache_ttl_seconds` to 3600 (1 hour)
+- WHEN events are fetched
+- THEN the cache entry MUST expire after 1 hour instead of the default 30 minutes
+- AND the system MUST read the setting from `IAppConfig::getValueInt('mydash', 'mydash.calendar_widget_ics_cache_ttl_seconds', 1800)`
+
+#### Scenario: Cache key includes URL hash
+
+- GIVEN two placements reference the same external ICS URL
+- WHEN both fetch events
+- THEN they MUST share the same cache entry (same URL hash)
+- AND only one external fetch occurs across both placements
+
+#### Scenario: Cache is invalidated on settings change
+
+- GIVEN a placement is reconfigured to use a different ICS URL
+- WHEN events are fetched
+- THEN the old cached ICS MUST NOT be used
+- AND the new URL MUST be fetched
+
+### Requirement: REQ-CAL-006 External ICS allow-list
+
+The system MUST enforce an allow-list of external ICS host names via the admin setting `mydash.calendar_widget_allowed_ics_hosts` (JSON array of hostnames) to restrict which external calendars can be fetched.
+
+#### Scenario: Allow-list is empty (default)
+
+- GIVEN the admin setting `mydash.calendar_widget_allowed_ics_hosts` is not set or is an empty array
+- WHEN a user configures an external ICS URL from any hostname
+- THEN the URL MUST be allowed and fetched
+
+#### Scenario: Allow-list is populated
+
+- GIVEN the admin sets `mydash.calendar_widget_allowed_ics_hosts` to `["calendar.example.com", "feeds.internal.org"]`
+- AND a user adds a placement with externalIcsUrls: `["https://calendar.example.com/cal.ics"]`
+- WHEN events are fetched
+- THEN the system MUST parse the hostname from the URL
+- AND check if it matches an entry in the allow-list (case-insensitive domain match)
+- AND if it matches, fetch the ICS
+- AND if it does NOT match, skip that URL and log a warning
+
+#### Scenario: Disallowed URL is silently skipped
+
+- GIVEN a placement references `https://untrusted.external.net/cal.ics`
+- AND the allow-list does NOT include `untrusted.external.net`
+- WHEN events are fetched
+- THEN the system MUST skip that URL
+- AND MUST NOT attempt a fetch
+- AND MUST log a warning (at INFO or WARNING level, not ERROR — so the dashboard still renders)
+- AND MUST NOT include events from that URL in the response
+
+#### Scenario: Allow-list hostname matching is case-insensitive
+
+- GIVEN the allow-list includes `Calendar.Example.COM`
+- AND a URL uses `calendar.example.com`
+- WHEN fetched
+- THEN the match MUST succeed (case-insensitive)
+
+#### Scenario: Subdomain matching is NOT applied
+
+- GIVEN the allow-list includes `example.com`
+- AND a URL is `https://sub.example.com/cal.ics`
+- WHEN fetched
+- THEN the match MUST fail (exact domain match only, no wildcard)
+- NOTE: If admins want broad subdomain access, they must add each subdomain explicitly or use a script to manage the list
+
+### Requirement: REQ-CAL-007 View-time access control
+
+The system MUST respect Nextcloud's calendar access control so that only events the viewing user can read are included in the response.
+
+#### Scenario: User can read internal calendar events
+
+- GIVEN user alice is viewing her own dashboard
+- AND the placement is configured to fetch from alice's personal calendar
+- WHEN events are fetched via `OCP\Calendar\IManager::search()`
+- THEN the system MUST request events within alice's user context
+- AND alice's read permission is implicitly checked by `search()`
+- AND only calendars alice can read MUST be included
+
+#### Scenario: Private events are absent
+
+- GIVEN bob's calendar contains a private event that alice cannot read
+- AND alice's dashboard placement is configured to fetch from bob's calendar
+- WHEN alice fetches events
+- THEN the private event MUST NOT appear in the response
+- NOTE: This is enforced by Nextcloud's `IManager::search()` delegation model — the calendar app handles ACL
+
+#### Scenario: Shared calendar with read permission
+
+- GIVEN bob has shared his calendar with alice (read-only)
+- AND alice's placement is configured to fetch from bob's calendar
+- WHEN alice fetches events
+- THEN the events alice can read MUST be included
+- AND the system MUST not attempt to modify them
+
+#### Scenario: Shared calendar without permission
+
+- GIVEN bob's calendar is NOT shared with alice
+- AND alice's placement somehow references bob's calendar in config
+- WHEN alice fetches events
+- THEN the system MUST return an empty result for that calendar
+- AND MUST NOT surface an error (graceful degradation)
+
+### Requirement: REQ-CAL-008 Render modes
+
+The frontend MUST support four distinct calendar display modes, selectable via `viewMode` config, each with appropriate layout and interaction patterns.
+
+#### Scenario: Month view renders grid
+
+- GIVEN a placement is configured with viewMode: 'month'
+- WHEN the widget is rendered
+- THEN `CalendarWidget.vue` MUST display a 7×N grid (Sunday–Saturday columns, multiple weeks rows)
+- AND each day cell MUST show the date and a compact list of events for that day (title only, no time)
+- AND the grid MUST be lightweight (no heavy calendar library — custom HTML/CSS)
+
+#### Scenario: Week view renders 7-column day view
+
+- GIVEN a placement is configured with viewMode: 'week'
+- WHEN the widget is rendered
+- THEN the widget MUST display 7 columns (one per day of the week)
+- AND each column MUST show the day name, date, and a chronological list of events for that day
+- AND time information MUST be visible (e.g., 2:00 PM – 3:00 PM)
+
+#### Scenario: Agenda view renders chronological list by day
+
+- GIVEN a placement is configured with viewMode: 'agenda'
+- WHEN the widget is rendered
+- THEN the widget MUST display a chronological list of events
+- AND events MUST be grouped by date with a date header (e.g., "Wednesday, May 1")
+- AND within each day, events MUST be sorted by start time
+- AND each event entry MUST show title, time range, and calendar name/color
+
+#### Scenario: Upcoming-list view shows next N events flat
+
+- GIVEN a placement is configured with viewMode: 'upcoming-list' and daysAhead: 14
+- WHEN the widget is rendered
+- THEN the widget MUST display the next 14 days of events in a flat, chronological list
+- AND each event MUST show title, start date/time, calendar name, and color
+- AND events MUST be sorted by start time globally (not grouped by day)
+
+#### Scenario: View mode selection is persistent
+
+- GIVEN a user selects month view for a placement
+- WHEN the page is reloaded
+- THEN the widget MUST still display in month view (viewMode is stored in placement config)
+
+#### Scenario: Empty month view shows all-day event space
+
+- GIVEN the current month has no all-day events
+- WHEN the month view is rendered
+- THEN the widget MUST still display the 7-column grid
+- AND cells MUST not be empty (a light background or border is acceptable to show structure)
+
+### Requirement: REQ-CAL-009 Failure tolerance
+
+The system MUST handle failures in fetching external ICS sources gracefully so that a single failed URL does not prevent the entire widget from rendering.
+
+#### Scenario: Single ICS URL fetch timeout
+
+- GIVEN a placement references two external ICS URLs: A (responsive) and B (times out after 10 seconds)
+- WHEN the frontend fetches events with a 15-second timeout per URL
+- THEN the system MUST fetch A successfully and include its events in the response
+- AND B MUST timeout and be skipped
+- AND a notice MUST be logged (not surfaced as an error banner, but available in logs)
+- AND the response MUST still return HTTP 200 with events from A
+
+#### Scenario: Single ICS URL returns 4xx
+
+- GIVEN a placement references a URL that returns HTTP 404
+- WHEN the frontend fetches events
+- THEN the system MUST catch the HTTP error
+- AND skip that URL
+- AND log a warning
+- AND return HTTP 200 with events from other sources
+
+#### Scenario: Single ICS URL returns 5xx
+
+- GIVEN a placement references a URL that returns HTTP 500
+- WHEN the frontend fetches events
+- THEN the system MUST catch the HTTP error
+- AND skip that URL
+- AND log a warning (not treat it as a widget error)
+- AND return HTTP 200 with events from other sources
+
+#### Scenario: Failure notice in UI
+
+- GIVEN one or more ICS URLs failed during fetch
+- WHEN the widget renders
+- THEN a small notice MUST appear in the corner (e.g., bottom-right) indicating "1 calendar source unavailable"
+- AND clicking the notice MUST show details of which URLs failed
+- AND the widget content MUST still display all successfully fetched events
+
+#### Scenario: All ICS URLs fail
+
+- GIVEN a placement has only external ICS URLs and all of them fail to fetch
+- WHEN the widget renders
+- THEN the widget MUST display the empty-state message (see REQ-CAL-010)
+- AND the failure notice MUST be prominent (warning color, centered, or dismissable)
+- AND the dashboard MUST not be blocked (the widget gracefully degrades)
+
+#### Scenario: Internal calendar fetch error
+
+- GIVEN an internal calendar fetch via `OCP\Calendar\IManager::search()` throws an exception
+- WHEN the widget fetches events
+- THEN the system MUST log the error
+- AND skip that calendar
+- AND return events from other calendars
+- AND NOT return a 500 response
+
+### Requirement: REQ-CAL-010 Empty state and feedback
+
+The system MUST display appropriate empty-state messaging when there are no events to display, and provide clear visual feedback during loading and error states.
+
+#### Scenario: Empty state for no events
+
+- GIVEN a placement is configured correctly but has no events in the requested range
+- WHEN the widget renders
+- THEN the widget MUST display a message like "No events in the next 14 days"
+- AND the message MUST include the `daysAhead` value (or the explicit date range for month view)
+- AND the message text MUST be translatable (en/nl per i18n requirement)
+
+#### Scenario: Empty state for no sources
+
+- GIVEN a placement has empty internalCalendars and externalIcsUrls arrays
+- WHEN the widget renders
+- THEN the widget MUST display a message like "No calendars configured"
+- AND an optional hint: "Edit this widget to add calendars or external feeds"
+
+#### Scenario: Loading state
+
+- GIVEN the frontend is fetching events asynchronously
+- WHEN the widget is first displayed
+- THEN the widget MUST show a loading indicator (spinner, skeleton, or placeholder)
+- AND the loading state MUST not exceed 30 seconds (if longer, show a timeout notice)
+
+#### Scenario: Loading state cleared on success
+
+- GIVEN the loading state is displayed
+- WHEN the API response arrives
+- THEN the loading indicator MUST be hidden
+- AND the events MUST be rendered
+
+#### Scenario: Error state persists until retry
+
+- GIVEN the API returns an error (5xx)
+- WHEN the widget renders
+- THEN an error message MUST be displayed (e.g., "Failed to load events")
+- AND a retry button MUST be present
+- AND clicking retry MUST re-fetch events

--- a/openspec/changes/calendar-widget/tasks.md
+++ b/openspec/changes/calendar-widget/tasks.md
@@ -1,0 +1,227 @@
+# Tasks — calendar-widget
+
+## 1. Widget registration and service layer
+
+- [ ] 1.1 Create `lib/Service/CalendarWidgetService.php` with core methods:
+  - `getWidgetInfo(): array` — returns widget metadata (id, title, icon_url, v2 API support)
+  - `getEventsForPlacement(int $placementId, string $from, string $to): array` — orchestrates internal + external event fetching
+  - `fetchInternalEvents(array $principals, string $from, string $to): array` — calls `IManager::search()`
+  - `fetchExternalIcsEvents(array $urls, string $from, string $to): array` — HTTP fetch + caching + parsing
+  - `expandRecurringEvents(VCalendar $vcal, string $from, string $to): array` — uses sabre/vobject
+  - `checkAllowList(string $url): bool` — checks hostname against allow-list setting
+- [ ] 1.2 Register the widget in a boot/lifecycle hook or service provider:
+  - Hook into Nextcloud's dashboard widget registration (e.g., in `AppInfo/Bootstrap.php` or a listener on `IManager`)
+  - Call `IManager::registerWidget()` with a widget provider or inline metadata
+  - Widget id: `mydash_calendar`, title: translatable `app.mydash.calendar_widget_title`, icon: calendar icon URL
+- [ ] 1.3 Create fixture-based PHPUnit tests for `CalendarWidgetService`:
+  - `testFetchInternalEventsSuccess` — mock `IManager::search()` with sample events
+  - `testFetchExternalIcsWithCache` — mock HTTP fetch, verify caching via `ICache`
+  - `testExpandRecurringEventsDaily` — sabre/vobject expansion for FREQ=DAILY
+  - `testAllowListMatching` — hostname match, mismatch, case-insensitivity
+
+## 2. Backend controller and routing
+
+- [ ] 2.1 Add endpoint method to `lib/Controller/WidgetController.php`:
+  - `public function calendarEvents(int $placementId, string $from, string $to): DataResponse`
+  - Validate placement ownership (return 403 if user cannot see dashboard)
+  - Validate date format (ISO 8601; return 400 if invalid)
+  - Call `CalendarWidgetService::getEventsForPlacement()`
+  - Return HTTP 200 with event array
+  - Decorate with `#[NoCSRFRequired]` and `#[NoAdminRequired]`
+- [ ] 2.2 Register route in `appinfo/routes.php`:
+  - `GET /api/widgets/calendar/{placementId}/events` → `WidgetController::calendarEvents()`
+  - Route requirements: placementId (digits), from/to (query params, ISO 8601)
+- [ ] 2.3 Create PHPUnit test for controller:
+  - `testCalendarEventsSuccess` — mock service, verify HTTP 200 + event payload
+  - `testCalendarEventsMissingPlacement` — return 404 when placement doesn't exist
+  - `testCalendarEventsAccessDenied` — return 403 when user cannot see dashboard
+  - `testCalendarEventsInvalidDateFormat` — return 400 for invalid from/to
+
+## 3. Placement configuration and schema migration
+
+- [ ] 3.1 Create `lib/Migration/VersionXXXXDate2026...AddCalendarWidgetSettings.php`:
+  - Add app config table entries for `mydash.calendar_widget_ics_cache_ttl_seconds` (default 1800)
+  - Add app config table entries for `mydash.calendar_widget_allowed_ics_hosts` (default `null` or `[]`)
+  - NOTE: No new `oc_mydash_*` table columns required; all config is stored in placement `widgetContent` JSON
+- [ ] 3.2 Add getter/setter methods in `WidgetPlacementService` or factory to safely parse `widgetContent` JSON:
+  - `extractCalendarConfig(WidgetPlacement $placement): array` — returns parsed config with defaults (internalCalendars, externalIcsUrls, viewMode, daysAhead, colorByCalendar)
+  - Validate and sanitize config (URLs must be HTTP/HTTPS, principals must match pattern)
+- [ ] 3.3 Create PHPUnit test for placement config parsing:
+  - `testExtractCalendarConfigWithDefaults` — verify default values are applied
+  - `testExtractCalendarConfigValidation` — invalid URLs are rejected, valid ones accepted
+
+## 4. External ICS fetching, caching, and allow-list
+
+- [ ] 4.1 Implement in `CalendarWidgetService::fetchExternalIcsEvents()`:
+  - For each URL in `externalIcsUrls`:
+    - Check allow-list via `checkAllowList($url)`
+    - If disallowed, skip and log warning
+    - If allowed, try to fetch from cache key `mydash_calendar_ics_{placementId}_{urlHash}`
+    - If cache hit, use cached raw ICS
+    - If cache miss, HTTP fetch with 10-second timeout (use `IClientService`)
+    - On HTTP 4xx/5xx, log warning, skip URL (see REQ-CAL-009)
+    - On timeout, log warning, skip URL
+    - On success, cache raw ICS for TTL (read from `IAppConfig::getValueInt()`)
+    - Parse cached/fetched ICS via `\Sabre\VObject\Reader::read()`
+    - Expand recurring events (see task 4.2)
+    - Collect failure info for UI notice
+- [ ] 4.2 Implement `CalendarWidgetService::expandRecurringEvents()`:
+  - Iterate VEVENT components in the VCalendar
+  - For each event with RRULE, use sabre/vobject's recurrence expansion to generate instances in [from, to]
+  - For events without RRULE, add as single instance if within [from, to]
+  - Handle EXDATE (exceptions) and RECURRENCE-ID
+  - Return flat array of event objects with normalized fields (uid, title, start, end, allDay, location, description, calendarId, calendarName, color, source)
+  - Log malformed RRULEs at INFO/WARNING level (don't crash widget)
+- [ ] 4.3 Implement `CalendarWidgetService::checkAllowList()`:
+  - Read `mydash.calendar_widget_allowed_ics_hosts` from `IAppConfig::getValueString()`
+  - If empty or null, return true (all allowed)
+  - Otherwise, parse URL, extract hostname (case-insensitive)
+  - Check for exact match in allow-list (no wildcard subdomain expansion)
+  - Return boolean
+- [ ] 4.4 Create PHPUnit tests:
+  - `testFetchExternalIcsWithCacheTTL` — verify TTL setting is respected
+  - `testFetchExternalIcsHttpError` — mock 4xx/5xx response, verify skip + warning
+  - `testFetchExternalIcsTimeout` — mock timeout, verify graceful skip
+  - `testFetchExternalIcsAllowListDisallowed` — URL not in allow-list, skipped
+  - `testFetchExternalIcsAllowListAllowed` — URL matches allow-list, fetched
+
+## 5. Internal calendar event fetching with Nextcloud Calendar integration
+
+- [ ] 5.1 Implement in `CalendarWidgetService::fetchInternalEvents()`:
+  - For each principal URI in `internalCalendars`:
+    - Call `IManager::search()` with date range [from, to] and the principal context
+    - Nextcloud's Calendar app handles ACL (user sees only calendars/events they can read)
+    - Collect returned events, normalize to event object format
+    - If `IManager::search()` throws (calendar deleted, permission denied), log error and skip
+    - Return flat array of event objects with source='internal'
+- [ ] 5.2 Create PHPUnit test:
+  - `testFetchInternalEventsSuccess` — mock `IManager::search()`, verify events returned
+  - `testFetchInternalEventsAccessDenied` — user cannot read calendar, skipped gracefully
+
+## 6. Event normalization and deduplication
+
+- [ ] 6.1 Implement in `CalendarWidgetService::normalizeEvent()` (private helper):
+  - Input: raw event object (from Nextcloud or sabre/vobject VEVENT)
+  - Output: standardized event object with fields: uid, title, start (ISO 8601), end (ISO 8601), allDay (boolean), location (nullable), description (nullable), calendarId, calendarName, color, source ('internal'|'external')
+  - Handle edge cases: missing title → fallback to "Untitled", missing color → NC theme default
+- [ ] 6.2 Implement deduplication in `getEventsForPlacement()`:
+  - Merge internal + external events
+  - Deduplicate by (uid, calendarId) pair (same event in multiple calendar sources should appear once)
+  - Sort by start time
+- [ ] 6.3 Create PHPUnit test:
+  - `testNormalizeEventFromInternal` — verify field mapping from NC event
+  - `testNormalizeEventFromVevent` — verify field mapping from sabre VEVENT
+  - `testDeduplicationByUid` — same uid in multiple calendars appears once
+
+## 7. Frontend widget component (Vue 3 SFC)
+
+- [ ] 7.1 Create `src/components/widgets/CalendarWidget.vue`:
+  - Props: `placement: object` (with widgetContent config)
+  - Data: `events: []`, `loading: false`, `error: null`, `failedSources: []`
+  - Computed: `viewMode`, `daysAhead`, `colorByCalendar` (from placement config with defaults)
+  - Method `fetchEvents()`: async call to `GET /api/widgets/calendar/{placementId}/events?from=...&to=...`
+    - Parse date range from viewMode (month=current month, week=current week, agenda/upcoming=today+daysAhead)
+    - Handle loading state, errors, failure notices
+  - Methods for each view mode: `renderMonth()`, `renderWeek()`, `renderAgenda()`, `renderUpcomingList()`
+  - Click handler: open event detail via `linkToRoute('calendar.view.index')` or embed a detail panel
+  - Lifecycle: `onMounted` → `fetchEvents()`, optional `watch` on placement config → refetch
+- [ ] 7.2 Create `src/components/widgets/calendar/CalendarMonth.vue`:
+  - Lightweight 7×N grid (no heavy library)
+  - Display day numbers, event titles (clipped if space-limited)
+  - Highlight current day
+  - Color events by calendar (if `colorByCalendar=true`)
+  - Click event → detail panel or NC Calendar app deep-link
+- [ ] 7.3 Create `src/components/widgets/calendar/CalendarWeek.vue`:
+  - 7-column layout (Sun–Sat)
+  - Show day name, date, and events with times
+  - Scroll horizontal on mobile or use responsive wrapping
+- [ ] 7.4 Create `src/components/widgets/calendar/CalendarAgenda.vue`:
+  - Chronological list grouped by date (with date headers)
+  - Each event entry: title, time range, calendar name, color dot
+  - Sortable by time within day
+- [ ] 7.5 Create `src/components/widgets/calendar/CalendarUpcomingList.vue`:
+  - Flat chronological list of next N events
+  - No date grouping (one flat list)
+  - Each entry: title, date+time, calendar name, color dot
+- [ ] 7.6 Create empty-state and error handling:
+  - `EmptyState.vue` — "No events in the next X days" or "No calendars configured"
+  - `FailureNotice.vue` — corner notice showing failed sources, clickable for details
+  - `ErrorState.vue` — "Failed to load events" with retry button
+- [ ] 7.7 Create Playwright E2E tests:
+  - `testCalendarWidgetMonthView` — widget renders month grid with sample events
+  - `testCalendarWidgetClickEvent` — click event → opens detail or NC Calendar app
+  - `testCalendarWidgetEmptyState` — no events → shows empty state message
+  - `testCalendarWidgetFailureNotice` — one ICS URL fails → failure notice appears, other events render
+
+## 8. Widget configuration UI component
+
+- [ ] 8.1 Create `src/components/widgets/eventpicker/CalendarWidgetConfig.vue`:
+  - Used by `WidgetAddEditModal.vue` when configuring a calendar widget placement
+  - Form sections:
+    - **Internal Calendars**: multi-select dropdown of available NC Calendar principals (load via API)
+    - **External ICS URLs**: text input list (add/remove URLs)
+    - **View Mode**: radio buttons or dropdown (month, week, agenda, upcoming-list)
+    - **Days Ahead**: number input (default 14, only shown if viewMode is agenda/upcoming-list)
+    - **Color by Calendar**: toggle (default true)
+  - Validation: URLs must be HTTP/HTTPS, valid format
+  - On save: emit `update:widgetContent` with serialized config object
+- [ ] 8.2 Create `src/components/widgets/eventpicker/CalendarSourcePicker.vue` (sub-component):
+  - Lists available Nextcloud Calendar principals (load via `CalendarService` or custom API)
+  - Multi-select checkboxes
+  - Display calendar name and icon
+- [ ] 8.3 Integrate into `WidgetAddEditModal.vue`:
+  - When user selects `mydash_calendar` widget from picker
+  - Display `CalendarWidgetConfig.vue` instead of default generic config panel
+- [ ] 8.4 Create Playwright test:
+  - `testCalendarWidgetConfigUI` — open config modal, select calendars, set view mode, save
+
+## 9. Internationalization (i18n)
+
+- [ ] 9.1 Add Dutch (nl) and English (en) translation keys:
+  - `app.mydash.calendar_widget_title` — "Kalender" / "Calendar"
+  - `app.mydash.calendar_empty_state` — "Geen evenementen in de komende {N} dagen" / "No events in the next {N} days"
+  - `app.mydash.calendar_no_sources` — "Geen kalenders geconfigureerd" / "No calendars configured"
+  - `app.mydash.calendar_loading` — "Kalenders laden…" / "Loading calendars…"
+  - `app.mydash.calendar_error` — "Fout bij laden evenementen" / "Failed to load events"
+  - `app.mydash.calendar_retry` — "Opnieuw proberen" / "Retry"
+  - `app.mydash.calendar_failure_notice` — "{N} kalenderbron(nen) niet beschikbaar" / "{N} calendar source(s) unavailable"
+  - `app.mydash.calendar_internal` — "Nextcloud" / "Nextcloud"
+  - `app.mydash.calendar_external` — "Extern" / "External"
+- [ ] 9.2 Add translation files (if not using existing JSON structure):
+  - `l10n/nl.json` — Dutch translations
+  - `l10n/en.json` — English translations (fallback)
+
+## 10. Quality gates and testing
+
+- [ ] 10.1 Run `composer check:strict` (PHPCS, PHPMD, Psalm, PHPStan):
+  - Fix any pre-existing issues in touched files
+  - New PHP code must pass all checks
+- [ ] 10.2 Run ESLint on all Vue/JS files:
+  - `npm run lint` on `src/components/widgets/`
+  - Fix any warnings or errors
+- [ ] 10.3 Run Stylelint on component stylesheets
+- [ ] 10.4 Confirm all 10 hydra-gates pass locally before opening PR
+- [ ] 10.5 Add SPDX-License-Identifier and SPDX-FileCopyrightText headers to every new PHP file (inside docblock)
+- [ ] 10.6 PHPUnit test coverage:
+  - Aim for 80%+ line coverage on `CalendarWidgetService`
+  - All public methods tested
+  - Edge cases (empty arrays, null fields, malformed data) covered
+- [ ] 10.7 Playwright E2E test coverage:
+  - Calendar widget renders in dashboard
+  - All four view modes render correctly
+  - Click event → interaction works
+  - Empty state + failure tolerance scenarios
+- [ ] 10.8 Manual testing on local Nextcloud instance:
+  - Create a dashboard with calendar widget
+  - Configure internal + external calendars
+  - Verify events merge correctly
+  - Test each view mode
+  - Test failure recovery (disable external URL, verify no crash)
+
+## 11. Documentation and changelog
+
+- [ ] 11.1 Update `CHANGELOG.md` with:
+  - New feature: "Add calendar widget for merged Nextcloud + external ICS events"
+  - List view modes, caching, allow-list features
+- [ ] 11.2 Update `README.md` (if applicable) with widget description
+- [ ] 11.3 Add code comments to `CalendarWidgetService` explaining caching strategy, allow-list logic, and failure handling

--- a/openspec/changes/cli-commands/design.md
+++ b/openspec/changes/cli-commands/design.md
@@ -1,0 +1,101 @@
+# Design — CLI Commands
+
+## Context
+
+Operators need CLI access for tasks impractical through the web UI: scripted dashboard imports,
+i18n string extraction, bulk cleanup, and diagnostics in headless environments. Without a
+defined contract, operators resort to one-off scripts that break across upgrades.
+
+The platform's console framework (`OC\Core\Command\Base`) provides registration, argument
+parsing, and output formatting. A consistent namespace prefix, uniform flags, and a documented
+exit-code contract make the surface predictable for shell scripts, CI pipelines, and monitoring
+systems that branch on process exit codes.
+
+Any command that reads or mutates data must leave a log trace. Silent failures or partial
+successes in cleanup and import operations can leave the installation in an inconsistent state.
+
+## Goals / Non-Goals
+
+**Goals:**
+- All MyDash CLI commands registered under the `mydash:` namespace.
+- Consistent global flags across every command.
+- A documented exit-code contract (0–5).
+- Structured JSON output mode for scripting consumers.
+- A log line emitted on completion of every command.
+- Full discoverability via `php occ list mydash`.
+
+**Non-Goals:**
+- Interactive TUI / wizard-style commands.
+- Commands that bypass the service layer and write directly to the database.
+- Commands executable by non-admin platform users.
+
+## Decisions
+
+### D1: Namespace and naming convention
+**Decision:** All commands use the `mydash:` prefix with a verb-noun-style suffix separated
+by colons where a sub-domain is needed — e.g. `mydash:dashboard:list`,
+`mydash:cleanup:scan`, `mydash:i18n:export-strings`.
+**Alternatives considered:** Flat names without sub-namespaces (`mydash:list-dashboards`);
+no namespace prefix (relying solely on class registration).
+**Rationale:** The colon-separated sub-namespace groups related commands in `occ list` output
+and prevents name collisions as the command surface grows.
+
+### D2: Global flags
+**Decision:** Every command accepts `--quiet` (suppress non-error output), `--json` (emit
+structured JSON instead of human-readable tables), and `--no-interaction` (disable any
+confirmation prompts, error on missing required args).
+**Alternatives considered:** Per-command flag definitions only; use the platform's built-in
+`-q` shorthand exclusively.
+**Rationale:** Uniform flags allow operators to write generic wrapper scripts that apply the
+same flags regardless of which `mydash:*` command they invoke. `--json` is especially
+important for CI consumers that parse output.
+
+### D3: Exit-code contract
+**Decision:** `0` success, `1` generic error, `2` invalid args, `3` permission denied,
+`4` not found, `5` partial success.
+**Alternatives considered:** Only `0` and `1`; undocumented platform codes.
+**Rationale:** Distinct codes let monitoring scripts take different actions per error class;
+`5` is essential for bulk commands where aborting entirely is worse than partial completion.
+
+### D4: JSON output schema
+**Decision:** `--json` emits one object to stdout:
+`{success, exitCode, data: <command-specific>, errors: [string]}`. Warnings go to stderr.
+**Alternatives considered:** NDJSON per item; per-command JSON shapes.
+**Rationale:** A common envelope lets generic consumers check `success` without knowing the
+`data` shape; bulk output fits as an array inside `data`.
+
+### D5: Registration via info.xml
+**Decision:** Commands declared in `appinfo/info.xml` `<commands>` block, each pointing to
+the implementing class name.
+**Alternatives considered:** Dynamic registration in `Application::register()`.
+**Rationale:** `info.xml` is the canonical manifest; commands declared there are visible to
+`occ list` without requiring a full app bootstrap.
+
+### D6: Audit logging
+**Decision:** Every command emits one `INFO` log line on completion:
+`[mydash] cli <cmd> exitCode=N durationMs=M byUser=<uid>`.
+**Alternatives considered:** Log only on failure; dedicated audit table.
+**Rationale:** One line per command is low-noise and routes through the platform log backend
+without requiring a separate table migration.
+
+### D7: Discoverability requirement
+**Decision:** `php occ list mydash` MUST list every `mydash:*` command with a one-line
+description. Missing description = code review failure.
+**Alternatives considered:** No explicit requirement.
+**Rationale:** An undocumented command is invisible to operators; the description requirement
+enforces discoverability at review time.
+
+## Risks / Trade-offs
+
+- Commands run as the web server user; operator tooling must not assume write access to paths
+  outside the platform data directory.
+- `--no-interaction` disables confirmation prompts — callers accept responsibility for
+  destructive operations running unattended.
+- Exit code `5` (partial success) requires CI pipeline authors to handle non-zero exits that
+  are not failures.
+
+## Open follow-ups
+
+- Define a `mydash:doctor` command for self-checks (database, file-store, lock health).
+- Add `--output-file=<path>` to commands with large binary output to avoid polluting stdout.
+- Evaluate a `mydash:shell` REPL for interactive debugging in production environments.

--- a/openspec/changes/cli-commands/proposal.md
+++ b/openspec/changes/cli-commands/proposal.md
@@ -1,0 +1,84 @@
+# CLI Commands Suite
+
+## Why
+
+MyDash operators (sysadmins, support engineers, automation scripts) need a consolidated, standardized interface for common management tasks: listing, inspecting, and deleting dashboards; debugging sharing configuration; managing user feed tokens; handling translatable strings; and executing language migrations. Today, CLI operations are scattered across multiple ad-hoc commands or require direct database access. This change establishes a coherent `mydash:` namespace prefix and consistent global flags (`--quiet`, `--json`, `--no-interaction`) across ALL MyDash CLI commands (both pre-existing and new), plus introduces new operational helpers for dashboard inspection, sharing debug, i18n, and feed token revocation.
+
+## What Changes
+
+- Establish the `mydash:` namespace prefix as the canonical CLI surface for MyDash. All commands follow the pattern `mydash:<verb>` or `mydash:<verb>:<noun>` (e.g., `mydash:export`, `mydash:dashboard:list`, `mydash:cleanup:scan`).
+- Provide three consistent global flags on every MyDash command:
+  - `--quiet|-q` — suppress non-essential output (errors still print to stderr).
+  - `--json` — emit machine-readable JSON output (suitable for scripting and log aggregation).
+  - `--no-interaction|-n` — skip confirmation prompts (for CI/automation use).
+- Add new commands not covered by sibling specs:
+  - `mydash:dashboard:list [--user=<uid>] [--group=<gid>] [--status=<draft|published|scheduled>]` — list dashboards with optional filtering.
+  - `mydash:dashboard:show <uuid>` — print one dashboard's full config (incl. widget tree) as JSON.
+  - `mydash:dashboard:delete <uuid> [--cascade]` — delete a dashboard; `--cascade` removes children (depends on `dashboard-tree` capability).
+  - `mydash:dashboard:debug-share <uuid>` — print all share rows, lock state, version count, view count for support debugging.
+  - `mydash:user:revoke-feed-token <uid>` — revoke a user's RSS feed token (depends on `dashboard-rss-feeds` capability).
+  - `mydash:i18n:export-strings` — extract translatable strings from PHP/Vue source into POT format.
+  - `mydash:i18n:migrate-language-structure` — one-time migration: flat-language storage → per-language-table (depends on `dashboard-language-content`).
+  - `mydash:i18n:copy-navigation --from=<lang> --to=<lang>` — clone org-navigation tree from one language variant to another.
+- All commands MUST emit structured exit codes: `0` (success), `1` (generic error), `2` (invalid arguments), `3` (permission denied), `4` (resource not found), `5` (partial success).
+- `--json` output schema: `{success: bool, exitCode: int, data: {...}, errors: [{code, message, context}]}`.
+- Commands register via standard NC pattern: `appinfo/info.xml` `<commands>` block + classes extending `OC\Core\Command\Base`.
+- Every command includes `--help` text describing arguments, flags, and examples.
+- Logging: each command writes one audit line to NC's main log on completion: `[mydash] cli <command> <args> exitCode=<n> durationMs=<ms> byUser=<uid|cli>`.
+- Help meta: `php occ list mydash` lists all `mydash:*` commands with one-line descriptions.
+- Backwards compat: pre-existing MyDash commands (if any) keep working unchanged; migration to the namespace + flags is documented but not required by this spec.
+
+## Capabilities
+
+### New Capabilities
+
+- `cli-commands`: establishes the `mydash:` namespace convention, global flags standard, and new operational helper commands for dashboard and i18n management.
+
+### Modified Capabilities
+
+- (none — dashboards, metadata-fields, sharing, rss-feeds remain unchanged)
+
+## Impact
+
+**Affected code:**
+
+- `appinfo/info.xml` — add `<commands>` block with all `mydash:*` command class names
+- `lib/Command/DashboardListCommand.php` (new) — implements `mydash:dashboard:list`
+- `lib/Command/DashboardShowCommand.php` (new) — implements `mydash:dashboard:show`
+- `lib/Command/DashboardDeleteCommand.php` (new) — implements `mydash:dashboard:delete`
+- `lib/Command/DashboardDebugShareCommand.php` (new) — implements `mydash:dashboard:debug-share`
+- `lib/Command/UserRevokeFeedTokenCommand.php` (new) — implements `mydash:user:revoke-feed-token`
+- `lib/Command/I18nExportStringsCommand.php` (new) — implements `mydash:i18n:export-strings`
+- `lib/Command/I18nMigrateLanguageStructureCommand.php` (new) — implements `mydash:i18n:migrate-language-structure`
+- `lib/Command/I18nCopyNavigationCommand.php` (new) — implements `mydash:i18n:copy-navigation`
+- `lib/Command/CommandBase.php` (new) — abstract base extending `OC\Core\Command\Base` with `--quiet`, `--json`, `--no-interaction` support and structured exit code logic
+- `lib/Service/CommandService.php` (new) — shared service for exit code constants, audit logging, JSON formatting
+- No schema migration — uses existing tables only
+
+**Affected APIs:**
+
+- (none — CLI only)
+
+**Dependencies:**
+
+- `symfony/console` (already required by Nextcloud) — for command base classes
+- No new composer or npm dependencies
+
+**Backward compatibility:**
+
+- Zero-impact on existing endpoints or data models.
+- Pre-existing commands remain unchanged; migration to the `mydash:` namespace and global flags is optional and documented in Impact section but not required by this spec.
+
+## References
+
+- `openspec/specs/dashboards/spec.md` — dashboard structure and lifecycle
+- `openspec/specs/admin-settings/spec.md` — admin authorization patterns
+- `openspec/changes/dashboard-export-import/specs/dashboard-export-import/spec.md` (sibling) — export/import commands
+- `openspec/changes/confluence-html-import/specs/confluence-html-import/spec.md` (sibling) — confluence import command
+- `openspec/changes/demo-data-showcases/specs/demo-data-showcases/spec.md` (sibling) — demo command
+- `openspec/changes/orphaned-data-cleanup/specs/orphaned-data-cleanup/spec.md` (sibling) — cleanup commands
+- `openspec/changes/setup-wizard/specs/setup-wizard/spec.md` (sibling) — setup command
+- `openspec/changes/multi-scope-dashboards/specs/dashboards/spec.md` — dashboard scoping and sharing
+- `openspec/changes/dashboard-rss-feeds/specs/dashboard-rss-feeds/spec.md` — RSS feed token lifecycle
+- `openspec/changes/dashboard-language-content/specs/dashboard-language-content/spec.md` — language content storage
+- `openspec/changes/navigation-editor-org/specs/navigation-editor-org/spec.md` (if exists) — org-navigation tree

--- a/openspec/changes/cli-commands/specs/cli-commands/spec.md
+++ b/openspec/changes/cli-commands/specs/cli-commands/spec.md
@@ -1,0 +1,572 @@
+---
+capability: cli-commands
+delta: true
+status: draft
+---
+
+# CLI Commands Suite — New Capability
+
+## Purpose
+
+The CLI commands suite establishes a coherent, standardized operator interface for MyDash management tasks. It defines the `mydash:` namespace prefix, consistent global flags across all commands, and introduces new operational helpers for dashboard inspection, sharing debugging, feed token management, and internationalization. The capability ensures scriptability, auditability, and discoverability of all CLI operations.
+
+## Data Model
+
+### Command Namespace Convention
+
+All MyDash CLI commands MUST use the `mydash:` prefix followed by a verb-noun pattern:
+- `mydash:<verb>` (e.g., `mydash:export`)
+- `mydash:<verb>:<noun>` (e.g., `mydash:dashboard:list`)
+- `mydash:<noun>:<verb>` (e.g., `mydash:user:revoke-feed-token`)
+- `mydash:<category>:<verb>` (e.g., `mydash:cleanup:scan`, `mydash:i18n:export-strings`)
+
+This prefix appears in `php occ list` output and in programmatic command lookups.
+
+### Global Flags (Every Command)
+
+Every MyDash command MUST support three global flags:
+
+1. **`--quiet|-q`** (boolean, optional)
+   - Suppress non-essential output (progress, summary lines).
+   - Errors and critical messages MUST still print to stderr.
+   - Useful for CI/automation scripts.
+
+2. **`--json`** (boolean, optional)
+   - Emit machine-readable JSON output instead of formatted text.
+   - Output schema (below) is fixed across all commands.
+   - Enables log aggregation and programmatic parsing.
+
+3. **`--no-interaction|-n`** (boolean, optional)
+   - Skip all confirmation prompts (e.g., "Delete dashboard X? (y/N)").
+   - Assume "yes" on all questions.
+   - Required for unattended CI/automation.
+
+### JSON Output Schema
+
+When `--json` is passed, the command's stdout MUST be a single JSON object (no preamble or trailing text) with the following schema:
+
+```json
+{
+  "success": true,
+  "exitCode": 0,
+  "data": {
+    "key": "value"
+  },
+  "errors": []
+}
+```
+
+or on error:
+
+```json
+{
+  "success": false,
+  "exitCode": 2,
+  "data": null,
+  "errors": [
+    {
+      "code": "INVALID_ARGUMENT",
+      "message": "Invalid UUID format: 'not-a-uuid'",
+      "context": {
+        "field": "uuid",
+        "providedValue": "not-a-uuid"
+      }
+    }
+  ]
+}
+```
+
+**Fields:**
+- `success` (boolean): `true` if the command completed without errors; `false` if any unrecovered error occurred or exit code > 0.
+- `exitCode` (integer): One of the standard exit codes (0, 1, 2, 3, 4, 5).
+- `data` (object | array | null): Command-specific output (dashboard list, single dashboard, metrics, etc.). `null` on error.
+- `errors` (array): List of error objects. Empty on success.
+
+**Error object fields:**
+- `code` (string): Constant error identifier (e.g., `INVALID_ARGUMENT`, `PERMISSION_DENIED`, `NOT_FOUND`, `PARTIAL_SUCCESS`).
+- `message` (string): Human-readable error description.
+- `context` (object, optional): Additional metadata (field name, provided value, attempted action, etc.).
+
+### Exit Codes (All Commands)
+
+All MyDash commands MUST emit one of these exit codes:
+
+| Code | Meaning | Example |
+|------|---------|---------|
+| `0` | Success — all tasks completed. | Command finished without errors. |
+| `1` | Generic error — unhandled exception. | Uncaught exception in command logic. |
+| `2` | Invalid arguments — usage error. | Missing required arg, malformed UUID, invalid enum value. |
+| `3` | Permission denied — auth/authz failure. | Current user is not admin; insufficient scope. |
+| `4` | Resource not found — lookup failed. | Dashboard UUID does not exist; user not found. |
+| `5` | Partial success — batch operation with some failures. | Import 10 dashboards, 3 succeeded, 7 failed. |
+
+### Audit Logging
+
+Every command MUST write a single audit line to Nextcloud's main log (`data/nextcloud.log`) on completion. The line format is:
+
+```
+[mydash] cli <command> <args> exitCode=<n> durationMs=<ms> byUser=<uid|cli>
+```
+
+**Fields:**
+- `<command>`: Full command name (e.g., `dashboard:list`).
+- `<args>`: Space-separated non-sensitive arg values (omit passwords, tokens, file contents). Truncated to 100 chars if necessary.
+- `<exitCode>`: Exit code (0, 1, 2, 3, 4, or 5).
+- `durationMs`: Total execution time in milliseconds (wall clock).
+- `byUser`: Nextcloud user ID of the caller, or `"cli"` if run via cron/automation.
+
+### Help & Discoverability
+
+- Every command MUST implement `getDescription()` returning a one-line summary (60 chars max).
+- Every command MUST implement `getHelp()` returning purpose, arguments, flags, and examples.
+- `php occ list mydash` MUST list all `mydash:*` commands with their one-line descriptions.
+
+### Command Registration
+
+Commands are registered via Nextcloud's standard pattern:
+
+1. **`appinfo/info.xml`** — add a `<commands>` block:
+   ```xml
+   <commands>
+       <command>OCA\MyDash\Command\DashboardListCommand</command>
+       <command>OCA\MyDash\Command\DashboardShowCommand</command>
+       <!-- ... etc -->
+   </commands>
+   ```
+
+2. **Command class** — each extends `OC\Core\Command\Base` (via shared `CommandBase` helper):
+   - Implements `configure()` to set name, description, arguments, options.
+   - Implements `execute(InputInterface $input, OutputInterface $output): int` and returns exit code.
+   - Uses shared `CommandService` for exit code constants, JSON formatting, audit logging.
+
+## ADDED Requirements
+
+### Requirement: REQ-CLI-001 Namespace Convention
+
+The system MUST establish `mydash:` as the canonical namespace prefix for ALL MyDash CLI commands. Every command name MUST begin with `mydash:` followed by a verb-noun or category-verb pattern (e.g., `mydash:export`, `mydash:dashboard:list`, `mydash:cleanup:scan`). No MyDash command SHALL use a bare name or a different prefix.
+
+#### Scenario: Discover all MyDash commands
+
+- GIVEN a Nextcloud operator runs `php occ list mydash`
+- WHEN the system enumerates all registered commands
+- THEN every MyDash command MUST be prefixed with `mydash:`
+- AND the output includes a one-line description for each command
+- AND the list is alphabetically ordered by full command name
+
+#### Scenario: Sibling specs all fall under the namespace
+
+- GIVEN the `dashboard-export-import` spec defines `mydash:export` and `mydash:import`
+- AND the `confluence-html-import` spec defines `mydash:import:confluence`
+- AND the `demo-data-showcases` spec defines `mydash:demo-showcases:install`
+- WHEN all commands are installed into one MyDash instance
+- THEN all commands appear under the `mydash:` namespace
+- AND there are no namespace collisions
+
+#### Scenario: Future commands follow the convention
+
+- GIVEN a developer adds a new command for MyDash
+- WHEN they name it `mydash:custom:action` and register it in `appinfo/info.xml`
+- THEN `php occ list mydash` includes the new command
+- AND the convention is enforced by code review and ADR reference
+
+#### Scenario: Commands with multi-level verbs
+
+- GIVEN the command `mydash:i18n:copy-navigation --from=nl --to=en`
+- WHEN an operator runs it
+- THEN the command is recognized under the `mydash:` namespace
+- AND `php occ list mydash:i18n` returns only i18n-related commands
+
+#### Scenario: Namespace not shared with other apps
+
+- GIVEN another Nextcloud app (e.g., Calendar) registers `occ calendar:list`
+- WHEN `php occ list mydash` is run
+- THEN only `mydash:*` commands appear
+- AND no cross-app command collisions occur under the `mydash:` prefix
+
+### Requirement: REQ-CLI-002 Global Flags: --quiet, --json, --no-interaction
+
+Every MyDash command MUST support three consistent global flags: `--quiet|-q` (suppress non-essential output), `--json` (emit machine-readable JSON), and `--no-interaction|-n` (skip prompts). These flags MUST be defined in the shared `CommandBase` abstract class so all commands inherit them without duplication.
+
+#### Scenario: Quiet mode suppresses progress but not errors
+
+- GIVEN an operator runs `php occ mydash:dashboard:list --quiet`
+- WHEN the command finishes
+- THEN no progress or summary output is printed to stdout
+- AND any error message (e.g., "User not found") MUST still be printed to stderr
+- AND the exit code is correct (0 for success, non-zero for error)
+
+#### Scenario: JSON flag emits structured output only
+
+- GIVEN an operator runs `php occ mydash:dashboard:list --json`
+- WHEN the command finishes
+- THEN stdout is a single JSON object with fields `{success, exitCode, data, errors}`
+- AND stdout MUST contain only the JSON object (no preamble, no debug text)
+- AND newlines and special characters in data are properly escaped
+
+#### Scenario: No-interaction flag skips prompts in CI
+
+- GIVEN a CI script runs `php occ mydash:dashboard:delete a1b2c3d4 --no-interaction`
+- WHEN the command would normally prompt "Delete dashboard X? (y/N)"
+- THEN the prompt MUST be skipped and the deletion proceeds immediately
+- AND the exit code is 0 on success or 3 on permission denied
+
+#### Scenario: All three flags combine cleanly
+
+- GIVEN `php occ mydash:import --file=/tmp/x.zip --quiet --no-interaction --json`
+- WHEN the import runs
+- THEN no prompts appear, no progress messages print, and only JSON appears on stdout
+- AND all three flags work together without conflict
+
+#### Scenario: Global flags inherited by every command
+
+- GIVEN any newly registered `mydash:*` command extending `CommandBase`
+- WHEN `php occ mydash:my-new-command --help` is run
+- THEN the help output MUST document `--quiet, -q`, `--json`, and `--no-interaction, -n`
+- AND the flags function correctly without any per-command implementation
+
+### Requirement: REQ-CLI-003 New Commands: Dashboard Management
+
+The system MUST provide four new operator-facing dashboard commands: `mydash:dashboard:list`, `mydash:dashboard:show`, `mydash:dashboard:delete`, and `mydash:dashboard:debug-share`. These MUST cover listing with filters, full-config inspection, safe deletion with cascade option, and support-oriented sharing/state diagnostics.
+
+#### Scenario: List dashboards with optional filters
+
+- GIVEN an admin runs `php occ mydash:dashboard:list --user=alice --status=published`
+- WHEN the system queries dashboards
+- THEN the output MUST list all dashboards owned by alice with status=published
+- AND with `--json` the data field MUST be an array of dashboard objects with uuid, name, status, owner
+
+#### Scenario: Show one dashboard's full widget tree
+
+- GIVEN `php occ mydash:dashboard:show a1b2c3d4-e5f6-4789-abcd-ef1234567890`
+- WHEN the command runs
+- THEN the output MUST include dashboard metadata (uuid, name, owner, type, status, gridColumns)
+- AND the full widget placement tree (widget id, position, size, config)
+- AND with `--json` the data is wrapped in the standard response schema
+
+#### Scenario: Delete without cascade fails when children exist
+
+- GIVEN `php occ mydash:dashboard:delete a1b2c3d4 --no-interaction`
+- WHEN the dashboard has child dashboards (depends on `dashboard-tree` capability)
+- AND `--cascade` is NOT provided
+- THEN the command MUST fail with exit code 2
+- AND stderr MUST print "Use --cascade to also delete child dashboards"
+
+#### Scenario: Delete with cascade removes children
+
+- GIVEN `php occ mydash:dashboard:delete a1b2c3d4 --cascade --no-interaction`
+- WHEN the dashboard and its two children exist
+- THEN all three MUST be deleted
+- AND the exit code MUST be 0
+- AND the audit log records the cascaded deletion
+
+#### Scenario: Debug-share prints all sharing state for support
+
+- GIVEN `php occ mydash:dashboard:debug-share a1b2c3d4 --json`
+- WHEN the command queries the sharing and locking state
+- THEN the output MUST include all share rows (recipient, permission level, created at), lock state (locked/unlocked, locked by, locked at), version count, and view count
+- AND the JSON data MUST have keys: `shares`, `locked`, `lockedBy`, `lockedAt`, `versionCount`, `viewCount`
+- NOTE This command is intended for support engineers diagnosing sharing issues
+
+### Requirement: REQ-CLI-004 New Commands: User Management
+
+The system MUST provide the command `mydash:user:revoke-feed-token <uid>` to revoke a user's RSS feed token. The command MUST depend on the `dashboard-rss-feeds` capability being enabled and MUST refuse gracefully when that capability is absent.
+
+#### Scenario: Revoke token for a valid user
+
+- GIVEN user "alice" has an active RSS feed token
+- WHEN an admin runs `php occ mydash:user:revoke-feed-token alice`
+- THEN the token MUST be invalidated in the database
+- AND any subsequent RSS feed request using the old token MUST be rejected with HTTP 401
+- AND the exit code MUST be 0
+
+#### Scenario: Revoke token for unknown user returns exit code 4
+
+- GIVEN no Nextcloud user with uid "nonexistent" exists
+- WHEN an admin runs `php occ mydash:user:revoke-feed-token nonexistent`
+- THEN the exit code MUST be 4 (resource not found)
+- AND stderr MUST print "User not found: 'nonexistent'"
+
+#### Scenario: Command fails gracefully when RSS capability is absent
+
+- GIVEN the `dashboard-rss-feeds` capability is not installed or disabled
+- WHEN any operator runs `php occ mydash:user:revoke-feed-token alice`
+- THEN the exit code MUST be 1 (generic error)
+- AND stderr MUST print "The dashboard-rss-feeds capability is not available"
+
+#### Scenario: JSON output on success
+
+- GIVEN `php occ mydash:user:revoke-feed-token alice --json`
+- WHEN the command successfully revokes the token
+- THEN stdout MUST be `{success: true, exitCode: 0, data: {uid: "alice", revokedAt: "<iso8601>"}, errors: []}`
+
+#### Scenario: Non-admin is denied
+
+- GIVEN a regular (non-admin) Nextcloud user runs the command
+- WHEN authorization is checked
+- THEN the exit code MUST be 3 (permission denied)
+- AND stderr MUST print "Permission denied: administrator required"
+
+### Requirement: REQ-CLI-005 New Commands: i18n Management
+
+The system MUST provide three i18n commands: `mydash:i18n:export-strings` (extract translatable strings to POT), `mydash:i18n:migrate-language-structure` (one-time flat-to-per-language-table migration, depends on `dashboard-language-content`), and `mydash:i18n:copy-navigation --from=<lang> --to=<lang>` (clone org-navigation tree across language variants). Each command MUST document its prerequisites in `--help`.
+
+#### Scenario: Export translatable strings to POT
+
+- GIVEN a developer runs `php occ mydash:i18n:export-strings`
+- WHEN the command scans `lib/` and `src/` for i18n markers
+- THEN a `.pot` file is written to `l10n/mydash.pot`
+- AND the exit code MUST be 0
+- AND the file contains all discovered translatable strings
+
+#### Scenario: Migrate language structure one-time
+
+- GIVEN the old flat-language storage schema is in place
+- AND the `dashboard-language-content` capability is enabled
+- WHEN an admin runs `php occ mydash:i18n:migrate-language-structure --no-interaction`
+- THEN all flat language entries MUST be migrated to the per-language-table structure
+- AND the exit code MUST be 0
+- AND rerunning the command MUST be idempotent (already migrated rows are skipped, exit code 0)
+
+#### Scenario: Migration aborts when capability is absent
+
+- GIVEN the `dashboard-language-content` capability is not installed
+- WHEN an admin runs `php occ mydash:i18n:migrate-language-structure`
+- THEN the exit code MUST be 1
+- AND stderr MUST print "dashboard-language-content capability is required"
+
+#### Scenario: Copy navigation tree between language variants
+
+- GIVEN a Dutch (`nl`) navigation tree with 12 nodes exists
+- WHEN an admin runs `php occ mydash:i18n:copy-navigation --from=nl --to=en`
+- THEN all 12 nodes are cloned as English (`en`) variants
+- AND existing English nodes that conflict MUST NOT be overwritten (no-overwrite by default)
+- AND the exit code MUST be 0
+
+#### Scenario: Copy navigation fails on unknown language
+
+- GIVEN `php occ mydash:i18n:copy-navigation --from=xx --to=en` where `xx` has no navigation data
+- WHEN the command looks up the source language
+- THEN the exit code MUST be 4 (resource not found)
+- AND stderr MUST print "No navigation tree found for language 'xx'"
+
+### Requirement: REQ-CLI-006 Exit Code Contract
+
+All MyDash commands MUST emit exactly one of the six standard exit codes (0, 1, 2, 3, 4, 5) on every execution path, including panics and unhandled exceptions. No command SHALL exit with any other code. The exit codes MUST be defined as constants in the shared `CommandService` and referenced consistently.
+
+#### Scenario: Success exit code 0
+
+- GIVEN `php occ mydash:dashboard:list` completes with no errors
+- WHEN the exit code is inspected via `echo $?`
+- THEN the value MUST be `0`
+
+#### Scenario: Invalid argument exit code 2
+
+- GIVEN `php occ mydash:dashboard:show not-a-uuid`
+- WHEN the command validates the UUID argument
+- THEN the exit code MUST be 2
+- AND stderr MUST print "Invalid UUID format: 'not-a-uuid'"
+
+#### Scenario: Permission denied exit code 3
+
+- GIVEN a regular (non-admin) user runs `php occ mydash:dashboard:delete a1b2c3d4`
+- WHEN the command checks authorization
+- THEN the exit code MUST be 3
+- AND stderr MUST print "Permission denied: administrator required"
+
+#### Scenario: Resource not found exit code 4
+
+- GIVEN `php occ mydash:dashboard:show 00000000-0000-0000-0000-000000000000` where that UUID is absent
+- WHEN the command queries the database
+- THEN the exit code MUST be 4
+- AND stderr MUST print "Dashboard not found"
+
+#### Scenario: Partial success exit code 5
+
+- GIVEN `php occ mydash:import --file=/tmp/batch.zip` with 10 dashboards where 7 succeed and 3 fail
+- WHEN the batch import completes
+- THEN the exit code MUST be 5
+- AND the summary output MUST state "7 imported, 3 failed"
+
+### Requirement: REQ-CLI-007 JSON Output Schema
+
+All commands invoked with `--json` MUST emit a single JSON object to stdout conforming to the schema `{success: bool, exitCode: int, data: object|array|null, errors: [{code, message, context}]}`. No other text or whitespace MUST appear before or after the JSON object on stdout.
+
+#### Scenario: Successful JSON response
+
+- GIVEN `php occ mydash:dashboard:list --json`
+- WHEN the command finds 3 dashboards
+- THEN stdout MUST be valid JSON with structure `{success: true, exitCode: 0, data: {dashboards: [...]}, errors: []}`
+- AND the `data.dashboards` field MUST be an array
+
+#### Scenario: Error JSON response
+
+- GIVEN `php occ mydash:user:revoke-feed-token unknown-user --json`
+- WHEN the command does not find the user
+- THEN stdout MUST be `{success: false, exitCode: 4, data: null, errors: [{code: "NOT_FOUND", message: "...", context: {userId: "unknown-user"}}]}`
+- AND `exitCode` in JSON MUST match the process exit code
+
+#### Scenario: Multiple errors in JSON
+
+- GIVEN `php occ mydash:import --file=/tmp/corrupt.zip --json`
+- WHEN the ZIP contains 3 invalid dashboards
+- THEN `errors` MUST be an array of 3 error objects
+- AND each error object MUST have `code`, `message`, and `context` fields
+
+#### Scenario: stdout clean of non-JSON bytes
+
+- GIVEN any command run with `--json`
+- WHEN the output is piped to `jq .`
+- THEN `jq` MUST parse it without error
+- NOTE Any debug or progress output MUST go to stderr only
+
+#### Scenario: Partial success exitCode in JSON
+
+- GIVEN `php occ mydash:import --file=/tmp/mix.zip --json`
+- WHEN 7 succeed and 3 fail
+- THEN stdout MUST have `{exitCode: 5, success: false, data: {imported: 7, skipped: 3}, errors: [...]}`
+- AND process exit code MUST also be 5
+
+### Requirement: REQ-CLI-008 Command Registration via appinfo/info.xml
+
+All MyDash CLI commands MUST be registered in `appinfo/info.xml` under a `<commands>` element listing each command's fully qualified class name. No command SHALL be discoverable by Nextcloud unless it appears in this block. Each class MUST extend a shared `CommandBase` abstract class (itself extending `OC\Core\Command\Base`).
+
+#### Scenario: Commands are registered at install
+
+- GIVEN a fresh MyDash installation with `appinfo/info.xml` containing a `<commands>` block
+- WHEN Nextcloud loads the app
+- THEN `php occ list mydash` MUST list every class in the `<commands>` block
+- AND `php occ mydash:dashboard:list --help` MUST display the command's help text
+
+#### Scenario: New sibling-spec command added to info.xml
+
+- GIVEN `lib/Command/ExportCommand.php` is created for `mydash:export`
+- WHEN its class is added to the `<commands>` block in `appinfo/info.xml`
+- THEN `php occ list mydash` MUST include `mydash:export` without further manual registration
+
+#### Scenario: CommandBase centralizes shared flag logic
+
+- GIVEN a command class extends `CommandBase`
+- WHEN `CommandBase::configure()` registers `--quiet`, `--json`, and `--no-interaction`
+- THEN the child command MUST NOT duplicate flag registration
+- AND all three flags MUST work on every child command
+
+### Requirement: REQ-CLI-009 Help Text & --help Documentation
+
+Every MyDash command MUST implement `getDescription()` (one-line, ≤60 chars, for `occ list`) and `getHelp()` (multi-line, for `--help`) covering command purpose, all arguments with types and constraints, all flags with defaults, and at least two examples. Commands without adequate help text MUST NOT pass the quality gate.
+
+#### Scenario: One-line description in occ list
+
+- GIVEN an operator runs `php occ list mydash`
+- WHEN the system enumerates commands
+- THEN each command MUST show a one-line description no longer than 60 characters:
+  ```
+  mydash:dashboard:delete    Delete a dashboard by UUID
+  mydash:dashboard:list      List dashboards in the system
+  mydash:dashboard:show      Display full dashboard configuration
+  ```
+
+#### Scenario: Detailed help via --help
+
+- GIVEN `php occ mydash:dashboard:list --help`
+- WHEN the command outputs help
+- THEN the output MUST include: purpose (2–3 sentences), arguments with types, options with defaults, and at least 2 examples
+- AND example: `$ php occ mydash:dashboard:list --user=alice --status=published --json`
+
+#### Scenario: Help documents global flags
+
+- GIVEN `php occ mydash:dashboard:delete --help`
+- WHEN the help text is displayed
+- THEN it MUST document `--quiet, -q`, `--json`, and `--no-interaction, -n`
+
+#### Scenario: No undocumented or hidden commands
+
+- GIVEN any command registered in `appinfo/info.xml`
+- WHEN `php occ mydash:<name> --help` is run
+- THEN the output MUST include all arguments and flags
+- AND no argument or flag SHALL be hidden from help output
+
+#### Scenario: Examples are realistic
+
+- GIVEN `php occ mydash:i18n:copy-navigation --help`
+- WHEN the examples section is read
+- THEN it MUST include at least: `$ php occ mydash:i18n:copy-navigation --from=nl --to=en` and one piped example with `--json`
+
+### Requirement: REQ-CLI-010 Audit Logging
+
+Every MyDash command MUST write exactly one audit line to Nextcloud's main log on completion (whether success or failure). The line MUST follow the format `[mydash] cli <command> <args> exitCode=<n> durationMs=<ms> byUser=<uid|cli>` and MUST be written even when the command fails.
+
+#### Scenario: Audit log on success
+
+- GIVEN an admin runs `php occ mydash:dashboard:list --user=alice`
+- WHEN the command completes with exit code 0
+- THEN `data/nextcloud.log` MUST contain:
+  ```
+  [mydash] cli dashboard:list --user=alice exitCode=0 durationMs=<ms> byUser=admin
+  ```
+- NOTE `byUser` is the Nextcloud user ID running occ, or `cli` if called from cron/automation
+
+#### Scenario: Audit log on permission error
+
+- GIVEN a non-admin user runs `php occ mydash:dashboard:delete a1b2c3d4`
+- WHEN the command exits with exit code 3
+- THEN `data/nextcloud.log` MUST include:
+  ```
+  [mydash] cli dashboard:delete a1b2c3d4 exitCode=3 durationMs=<ms> byUser=<uid>
+  ```
+
+#### Scenario: Audit log truncates long args
+
+- GIVEN `php occ mydash:import --file=/very/long/path/to/archive.zip --preserve-uuids`
+- WHEN the args string exceeds 100 characters
+- THEN the logged args MUST be truncated to ≤100 chars
+- AND a trailing `...` MUST indicate truncation
+
+#### Scenario: byUser is "cli" for cron-invoked commands
+
+- GIVEN a cron job invokes `php occ mydash:cleanup:scan`
+- WHEN no Nextcloud session is active
+- THEN the audit line MUST use `byUser=cli`
+
+#### Scenario: Log written even on unhandled exception
+
+- GIVEN a command throws an uncaught exception
+- WHEN the exception propagates
+- THEN the audit line MUST still be written with `exitCode=1`
+- AND the exception MUST be re-thrown or result in process exit code 1
+
+### Requirement: REQ-CLI-011 Discoverability and Backwards Compatibility
+
+The command `php occ list mydash` MUST enumerate all registered `mydash:*` commands in alphabetical order with one-line descriptions. Pre-existing MyDash commands that existed before this spec MUST continue to work unchanged; this spec only mandates the namespace convention and global flags for new commands. Future commands SHALL NOT be accepted without namespace compliance.
+
+#### Scenario: Full command listing is alphabetical
+
+- GIVEN MyDash has 8+ registered commands
+- WHEN `php occ list mydash` is run
+- THEN all commands MUST appear alphabetically sorted by full command name
+- AND descriptions MUST be left-aligned within the 80-char terminal width
+
+#### Scenario: Filtering the listing by sub-namespace
+
+- GIVEN `php occ list mydash:dashboard`
+- WHEN the operator runs the command
+- THEN only commands starting with `mydash:dashboard:` MUST be shown
+
+#### Scenario: Pre-existing commands are not broken
+
+- GIVEN a pre-existing MyDash command (registered before this spec) uses a different naming convention
+- WHEN this spec is implemented
+- THEN the pre-existing command MUST still be callable and return the same results
+- AND it MUST NOT be forcibly renamed or removed by this change
+
+#### Scenario: New commands must comply with namespace
+
+- GIVEN a developer opens a PR adding a new occ command `occ myd:something`
+- WHEN code review checks compliance with this spec
+- THEN the PR MUST be rejected unless the command is renamed to `mydash:something`
+- NOTE Enforcement is by convention and code review, not runtime validation
+
+#### Scenario: occ list links to --help for each command
+
+- GIVEN an operator sees `mydash:i18n:export-strings` in `php occ list mydash` output
+- WHEN they run `php occ mydash:i18n:export-strings --help`
+- THEN the detailed help text MUST be displayed, providing a path from discovery to usage

--- a/openspec/changes/cli-commands/tasks.md
+++ b/openspec/changes/cli-commands/tasks.md
@@ -1,0 +1,98 @@
+# Tasks — cli-commands
+
+## 1. Shared infrastructure
+
+- [ ] 1.1 Create `lib/Command/CommandBase.php` — abstract class extending `OC\Core\Command\Base`; registers `--quiet|-q`, `--json`, `--no-interaction|-n` in `configure()`; provides `outputJson()`, `handleException()`, and `writeAuditLog()` helpers
+- [ ] 1.2 Create `lib/Service/CommandService.php` — defines exit code constants (`EXIT_SUCCESS=0`, `EXIT_ERROR=1`, `EXIT_INVALID_ARGS=2`, `EXIT_PERMISSION_DENIED=3`, `EXIT_NOT_FOUND=4`, `EXIT_PARTIAL_SUCCESS=5`), JSON schema builder, and audit log formatter
+- [ ] 1.3 Audit log helper MUST write `[mydash] cli <command> <args> exitCode=<n> durationMs=<ms> byUser=<uid|cli>` to NC main log via `\OC::$server->getLogger()` regardless of success or failure
+- [ ] 1.4 Add SPDX headers inside the file docblock on all new PHP files (gate-spdx compliance)
+
+## 2. Dashboard management commands
+
+- [ ] 2.1 Create `lib/Command/DashboardListCommand.php` implementing `mydash:dashboard:list`
+  - Arguments: none required
+  - Options: `--user=<uid>`, `--group=<gid>`, `--status=<draft|published|scheduled>`
+  - Validates status enum (exit 2 on invalid value)
+  - Returns exit 4 if `--user` uid does not exist
+  - Outputs table (default) or JSON via `CommandBase`
+- [ ] 2.2 Create `lib/Command/DashboardShowCommand.php` implementing `mydash:dashboard:show <uuid>`
+  - Validates UUID format (exit 2 on malformed)
+  - Returns exit 4 if dashboard not found
+  - Outputs full widget tree + metadata as JSON
+- [ ] 2.3 Create `lib/Command/DashboardDeleteCommand.php` implementing `mydash:dashboard:delete <uuid> [--cascade]`
+  - Checks `dashboard-tree` capability before honoring `--cascade`
+  - Returns exit 2 if children exist and `--cascade` not passed
+  - Returns exit 3 if caller is not admin
+  - Returns exit 4 if dashboard UUID not found
+  - Prompts confirmation unless `--no-interaction`
+- [ ] 2.4 Create `lib/Command/DashboardDebugShareCommand.php` implementing `mydash:dashboard:debug-share <uuid>`
+  - Queries share rows (user shares, group shares, public shares via dashboard-sharing capability)
+  - Queries lock state via dashboard-locking capability tables
+  - Queries version count via dashboard-versioning capability
+  - Queries view count via dashboard-view-analytics capability
+  - Returns structured JSON with keys: `shares`, `locked`, `lockedBy`, `lockedAt`, `versionCount`, `viewCount`
+
+## 3. User management commands
+
+- [ ] 3.1 Create `lib/Command/UserRevokeFeedTokenCommand.php` implementing `mydash:user:revoke-feed-token <uid>`
+  - Checks `dashboard-rss-feeds` capability is active; exit 1 with message if absent
+  - Returns exit 4 if user uid does not exist in Nextcloud
+  - Returns exit 3 if caller is not admin
+  - Invalidates token in the RSS feeds token table (depends on `dashboard-rss-feeds` entity)
+  - Outputs `{uid, revokedAt}` on `--json`
+
+## 4. i18n commands
+
+- [ ] 4.1 Create `lib/Command/I18nExportStringsCommand.php` implementing `mydash:i18n:export-strings`
+  - Scans `lib/` (PHP) and `src/` (Vue/JS) for i18n markers
+  - Writes output to `l10n/mydash.pot`
+  - Idempotent (overwrites existing file); exits 0
+- [ ] 4.2 Create `lib/Command/I18nMigrateLanguageStructureCommand.php` implementing `mydash:i18n:migrate-language-structure`
+  - Checks `dashboard-language-content` capability; exit 1 if absent
+  - Migrates flat-language rows to per-language-table structure
+  - Idempotent (already-migrated rows skipped); exits 0
+  - Prompts confirmation unless `--no-interaction`
+- [ ] 4.3 Create `lib/Command/I18nCopyNavigationCommand.php` implementing `mydash:i18n:copy-navigation --from=<lang> --to=<lang>`
+  - Both `--from` and `--to` are required; exit 2 if missing
+  - Returns exit 4 if source language has no navigation tree
+  - Does not overwrite existing target nodes by default; add `--overwrite` to force
+  - Reports count of cloned nodes on success
+
+## 5. Registration
+
+- [ ] 5.1 Add `<commands>` block to `appinfo/info.xml` listing all 8 new command classes:
+  - `OCA\MyDash\Command\DashboardListCommand`
+  - `OCA\MyDash\Command\DashboardShowCommand`
+  - `OCA\MyDash\Command\DashboardDeleteCommand`
+  - `OCA\MyDash\Command\DashboardDebugShareCommand`
+  - `OCA\MyDash\Command\UserRevokeFeedTokenCommand`
+  - `OCA\MyDash\Command\I18nExportStringsCommand`
+  - `OCA\MyDash\Command\I18nMigrateLanguageStructureCommand`
+  - `OCA\MyDash\Command\I18nCopyNavigationCommand`
+- [ ] 5.2 Verify `php occ list mydash` lists all 8 commands after registration
+- [ ] 5.3 Verify `php occ list mydash:dashboard`, `php occ list mydash:i18n`, `php occ list mydash:user` filter correctly
+
+## 6. Help text
+
+- [ ] 6.1 Each command implements `getDescription()` returning ≤60 chars
+- [ ] 6.2 Each command implements `getHelp()` covering purpose, arguments, options, and ≥2 examples
+- [ ] 6.3 Help text reviewed for accuracy before PR merge (pair review item)
+
+## 7. PHPUnit tests
+
+- [ ] 7.1 `CommandServiceTest` — verify all 6 exit code constants are distinct integers; verify JSON builder produces valid schema; verify audit log format string
+- [ ] 7.2 `DashboardListCommandTest` — `--status=invalid` → exit 2; unknown `--user` → exit 4; success with 0 results → exit 0; `--json` output parses correctly
+- [ ] 7.3 `DashboardShowCommandTest` — malformed UUID → exit 2; missing UUID → exit 4; valid UUID → exit 0 with widget tree in JSON
+- [ ] 7.4 `DashboardDeleteCommandTest` — children exist without `--cascade` → exit 2; non-admin → exit 3; missing UUID → exit 4; success with `--cascade` → exit 0
+- [ ] 7.5 `DashboardDebugShareCommandTest` — valid UUID returns all expected JSON keys; missing UUID → exit 4
+- [ ] 7.6 `UserRevokeFeedTokenCommandTest` — missing capability → exit 1; unknown uid → exit 4; non-admin → exit 3; success → exit 0 with `revokedAt` in JSON
+- [ ] 7.7 `I18nCommandsTest` — export-strings creates `.pot` file; migrate aborts without capability; copy-navigation exit 4 for unknown source language
+
+## 8. Quality gates
+
+- [ ] 8.1 `composer check:strict` (PHPCS, PHPMD, Psalm, PHPStan) passes on all new files — fix any pre-existing issues encountered
+- [ ] 8.2 Verify audit log is written on both success and unhandled exception paths (unit test with mock logger)
+- [ ] 8.3 Verify `--json` output passes `jq .` without error for every command (integration smoke test)
+- [ ] 8.4 SPDX headers inside docblocks on all new PHP files (gate-spdx)
+- [ ] 8.5 `i18n` keys for all new error messages in both `nl` and `en` per i18n ADR
+- [ ] 8.6 Run all relevant `hydra-gates` locally before opening PR

--- a/openspec/changes/confluence-html-import/design.md
+++ b/openspec/changes/confluence-html-import/design.md
@@ -1,0 +1,303 @@
+# Design — Confluence HTML import
+
+## Context
+
+The proposal (proposal.md) and spec (REQ-CFLI-001..012) were written before a
+ground-truth read of the existing importer in
+`intravox-source/lib/Service/Import/`. This document records what the source
+actually does so that the spec can be corrected before implementation begins.
+
+## Goals / Non-Goals
+
+**Goals**
+- Document the actual parsing strategy used by the existing importer.
+- Surface every assumption in the spec that contradicts the source.
+- Give implementers a concrete, accurate baseline.
+
+**Non-Goals**
+- Change the spec (this document drives those changes, but does not apply them).
+- Cover the Confluence REST API importer (`ConfluenceApiImporter.php`), which is
+  a separate code path.
+
+---
+
+## Decisions
+
+### D1: TOC structure assumption
+
+**Decision**: `index.html` is NOT parsed for hierarchy. It is parsed only to
+extract page *order* (0-based index from link position). Hierarchy is derived
+from two other sources, applied in priority order: (1) directory structure of
+the extracted ZIP, and (2) breadcrumb `<ol class="breadcrumbs">` /
+`<ol id="breadcrumbs">` navigation inside each individual page file.
+The index link-list is read with a bare regex (`preg_match_all`) on `href`
+attributes — no DOMDocument, no nested-`<ul>` interpretation.
+
+**Source evidence**:
+- `intravox-source/lib/Service/Import/ConfluenceHtmlImporter.php:418-470`
+  (`buildPageHierarchy`) — outer loop over files, not index structure
+- `intravox-source/lib/Service/Import/ConfluenceHtmlImporter.php:481-517`
+  (`extractPageOrderFromIndex`) — index.html parsed only for ordering
+- `intravox-source/lib/Service/Import/ConfluenceHtmlImporter.php:526-561`
+  (`extractParentFromBreadcrumb`) — breadcrumb `<ol>` is the primary hierarchy
+  signal
+
+Spec REQ-CFLI-002 scenario "Extract page hierarchy from TOC" assumes the index
+drives parent-child relationships and uses `href="SPACE/page-123.html"` link
+nesting for depth. That assumption is wrong.
+
+---
+
+### D2: Body content selector
+
+**Decision**: `DOMDocument` + `DOMXPath` with a waterfall of six selectors:
+1. `//div[@id='main-content']`
+2. `//div[contains(@class, 'wiki-content')]`
+3. `//div[contains(@class, 'page-content')]`
+4. `//div[@id='content']`
+5. `//main`
+6. `//article`
+
+Before the first non-empty result is returned, unwanted navigation elements are
+stripped from the node in place:
+`div#pagetreesearch`, `div.breadcrumbs`, `div.pageSection`,
+`form[name=pagetreesearchform]`, `form.aui`, `nav`, `div.page-metadata`.
+
+Fallback: regex `/<body>(.*?)<\/body>/is` with further inline regex stripping,
+then raw HTML as last resort.
+
+**Source evidence**:
+- `intravox-source/lib/Service/Import/ConfluenceHtmlImporter.php:288-349`
+  (`extractBody`)
+- `intravox-source/lib/Service/Import/ConfluenceHtmlImporter.php:382-403`
+  (`removeUnwantedElements`)
+
+The spec (REQ-CFLI-003 scenario "Text-display widget captures page body")
+correctly names `<div id="main-content">` as the primary selector and
+`<body>` as the fallback. The additional selectors and the nav-stripping step
+are not mentioned and should be documented.
+
+---
+
+### D3: Macro handling
+
+**Decision**: `ConfluenceImporter` (the Storage Format parser) recognises
+Confluence namespace elements by their XML namespace URI
+`http://www.atlassian.com/schema/confluence/4/ac/`. The body HTML is wrapped in
+a div with that namespace declaration, then loaded via `DOMDocument::loadXML`
+(with `LIBXML_NONET` for XXE protection) with fallback to `loadHTML`.
+
+Five registered handlers process `<ac:structured-macro>`:
+
+| Handler | `supports()` | Output |
+|---|---|---|
+| `PanelMacroHandler` | `info`, `note`, `warning`, `tip`, `error`, `panel` | `PanelBlock` → `text` widget with `confluence-panel-{type}` CSS class |
+| `CodeMacroHandler` | `code` | `CodeBlock` → `<pre><code class="language-X">` text widget |
+| `AttachmentMacroHandler` | `attachments`, `viewfile`, `image` | `HtmlBlock` placeholder / static link |
+| `ExpandMacroHandler` | `expand` | `HtmlBlock` with `<details><summary>` |
+| `DefaultMacroHandler` | all others (fallback) | `HtmlBlock` with `<div class="confluence-unsupported-macro">⚠️ Unsupported…</div>` |
+
+`<ac:image>` elements (not macros) are handled separately via
+`AttachmentMacroHandler::processImageElement()`, which reads `<ri:attachment
+ri:filename>` or `<ri:url ri:value>` and registers a `MediaDownload`.
+
+Standard HTML elements in the body are delegated to `HtmlToWidgetConverter`,
+which creates typed blocks (HeadingBlock, DividerBlock, CodeBlock, PanelBlock,
+ImageBlock, HtmlBlock).
+
+**Source evidence**:
+- `intravox-source/lib/Service/Import/ConfluenceImporter.php:36-41` (handler
+  registration)
+- `intravox-source/lib/Service/Import/ConfluenceImporter.php:198-236`
+  (`processStorageFormatNodes` — namespace dispatch)
+- `intravox-source/lib/Service/Import/Confluence/Macros/DefaultMacroHandler.php:26-48`
+- `intravox-source/lib/Service/Import/Confluence/Macros/PanelMacroHandler.php`
+- `intravox-source/lib/Service/Import/Confluence/Macros/CodeMacroHandler.php`
+- `intravox-source/lib/Service/Import/Confluence/Macros/ExpandMacroHandler.php`
+- `intravox-source/lib/Service/Import/Confluence/Macros/AttachmentMacroHandler.php`
+
+Spec REQ-CFLI-006 scenario "Replace structured-macro with placeholder" describes
+`<p><em>[Macro: code not imported]</em></p>`. The real output is a
+`<div class="confluence-unsupported-macro">` block with an emoji and a
+`<code>` tag — not a plain `<em>` paragraph. The `code` macro is not a
+placeholder at all; it renders into a `<pre><code>` block. Similarly `panel`,
+`expand`, `attachments`, and `viewfile` have richer outputs than the spec
+implies.
+
+---
+
+### D4: Attachment and image upload destination
+
+**Decision**: The HTML importer (`ConfluenceHtmlImporter`) does NOT upload
+anything to Nextcloud directly. It registers `MediaDownload` objects (URL +
+target filename + page slug) on the `IntermediateFormat`. The controller
+(`ImportController::importFromConfluenceHtml`) converts the intermediate format
+to an IntraVox `export.json`, writes it to a temp folder, creates a ZIP, and
+passes that to the existing `ImportService::import()`. Actual Nextcloud file
+operations happen inside `ImportService`, not inside the Confluence parser.
+
+For `<ac:image ri:filename>` (Storage Format attachments): the URL field is set
+to the bare `$filename` string as a placeholder — "actual download URL will be
+resolved during import" is a comment in the code but the resolution is not yet
+implemented.
+
+For `<img src="attachments/page-id/file.png">` found via `HtmlToWidgetConverter`
+or `extractBody`: these are raw HTML `<img>` tags left in the HtmlBlock content.
+There is no code that scans plain HTML `<img src="attachments/...">` and
+uploads the referenced files. The `MediaDownload` mechanism only fires for
+`<ac:image>` elements processed through the Storage Format path.
+
+**Source evidence**:
+- `intravox-source/lib/Service/Import/Confluence/Macros/AttachmentMacroHandler.php:98-139`
+  (`processImageElement` — sets `$url = $filename` as placeholder)
+- `intravox-source/lib/Controller/ImportController.php:178-209`
+  (`importFromConfluenceHtml` — no file upload, delegates to `ImportService`)
+- `intravox-source/lib/Service/Import/IntermediateFormat.php:266-275`
+  (`MediaDownload` — url, targetFilename, pageSlug only)
+
+Spec REQ-CFLI-005 ("Upload attachment image to NC folder" and the
+`MyDash/Imports/{timestamp}/` folder) describes behaviour that does not exist
+in the current code. Implementing it requires new logic in `ImportService` or a
+dedicated uploader.
+
+---
+
+### D5: Internal link rewriting
+
+**Decision**: There is no link-rewriting code in the importer. Confluence
+internal links (`<a href="pageId.html">`) are left as-is in the exported HTML
+blocks. The `IntermediatePage` has a `parentUniqueId` field for hierarchy, but
+there is no `pageId→uuid` map and no pass over `<a href>` attributes.
+
+**Source evidence**:
+- `intravox-source/lib/Service/Import/ConfluenceImporter.php` — no href
+  rewriting anywhere
+- `intravox-source/lib/Service/Import/ConfluenceHtmlImporter.php` — no href
+  rewriting anywhere
+- `intravox-source/lib/Service/Import/IntermediateFormat.php:35-85`
+  (`IntermediatePage` — no page-id map field)
+
+Spec REQ-CFLI-004 (all scenarios) describes behaviour that does not exist. The
+entire link-rewriting subsystem must be built from scratch.
+
+---
+
+### D6: Sync vs async and dry-run
+
+**Decision**: The existing controller (`importFromConfluenceHtml`) is fully
+synchronous — it processes in the request thread and returns a single JSON
+response with `success`, `stats`, `pages`, and `message`. There is no page-count
+threshold, no background job dispatch, no job-id, and no polling endpoint.
+There is also no dry-run path (no `dry-run` parameter, no flag, no separate
+endpoint).
+
+The `ImportPagesCommand` CLI command exists but operates on the IntraVox native
+JSON format, not Confluence ZIP archives. There is no `occ mydash:import:confluence`
+command.
+
+**Source evidence**:
+- `intravox-source/lib/Controller/ImportController.php:127-221`
+  (`importFromConfluenceHtml` — single synchronous path)
+- `intravox-source/lib/Command/ImportPagesCommand.php:32-44`
+  (command name `intravox:import`, no Confluence ZIP support)
+
+Spec REQ-CFLI-007 (dry-run endpoint), REQ-CFLI-008 (async + polling), and
+REQ-CFLI-011 (CLI `occ mydash:import:confluence`) all describe features that
+do not exist and must be built.
+
+---
+
+### D7: Partial-failure tolerance
+
+**Decision**: Partial-failure tolerance exists but is coarse. In
+`ConfluenceHtmlImporter::importFromZip`, when `parseHtmlFile` returns `null`
+(due to unreadable file or empty body), that file is silently skipped and the
+loop continues. However, there is no try/catch around the per-file parsing loop,
+no error accumulation, and no final `errors` list in the returned
+`IntermediateFormat`. Exceptions propagate out of `importFromZip` and are caught
+at the controller level, returning HTTP 500 for the whole request.
+
+**Source evidence**:
+- `intravox-source/lib/Service/Import/ConfluenceHtmlImporter.php:44-72`
+  (inner loop — null-check only, no try/catch, no error list)
+- `intravox-source/lib/Controller/ImportController.php:210-219`
+  (catch block returns 500 for any exception)
+
+Spec REQ-CFLI-009 ("single-page failures do not abort import", `errors` array
+in response, `skippedPageCount`) requires adding per-page try/catch, an error
+accumulator, and surfacing it in the response. The skeleton is almost there
+(null return from `parseHtmlFile`) but the error-collection half is missing.
+
+---
+
+## Spec changes implied
+
+- **REQ-CFLI-002** ("hierarchy from TOC"): Replace the `index.html`-as-hierarchy
+  assumption with the two-source model: directory nesting first, breadcrumb
+  `<ol class="breadcrumbs">` override second. Clarify that `index.html` is used
+  only to assign sibling order, not parent-child relationships.
+
+- **REQ-CFLI-003** scenario "Text-display widget captures page body": Add the
+  full selector waterfall (6 selectors) and list the nav elements stripped
+  before extraction.
+
+- **REQ-CFLI-004** (link rewriting): Mark as "new feature to build" — no
+  existing code. Spec is correct in intent but the implementation baseline is
+  zero, not partial.
+
+- **REQ-CFLI-005** (image upload): Mark as "new feature to build". The
+  `MediaDownload` type exists for Storage Format `<ac:image>` elements but plain
+  HTML `<img src="attachments/...">` is not scanned, and no upload to Nextcloud
+  occurs today. The `MyDash/Imports/{timestamp}/` destination folder must be
+  a new design decision.
+
+- **REQ-CFLI-006** scenarios: Correct the placeholder format from
+  `<p><em>[Macro: X not imported]</em></p>` to the actual
+  `<div class="confluence-unsupported-macro">⚠️ Unsupported…</div>` output.
+  Document that `code`, `info/note/warning/tip/error/panel`, and `expand`
+  are rendered (not placeholder'd), and only unrecognised macros get the
+  fallback.
+
+- **REQ-CFLI-007** (dry-run): Fully new endpoint; no existing code path.
+
+- **REQ-CFLI-008** (async / background job): Fully new; controller is sync-only
+  today.
+
+- **REQ-CFLI-009** (error resilience): The null-guard exists; the try/catch
+  and error-accumulation do not. State this gap explicitly.
+
+- **REQ-CFLI-011** (CLI command): The command class does not exist. The existing
+  `ImportPagesCommand` (`intravox:import`) operates on IntraVox native format
+  only.
+
+---
+
+## Open follow-ups
+
+1. **Attachment upload design**: The `MediaDownload` + `ImportService` path is
+   the natural extension point for Storage Format images. For plain HTML
+   `<img src="attachments/...">` the same mechanism needs a scan pass before or
+   during `extractBody`. Decide whether upload happens inside the parser or in
+   `ImportService`.
+
+2. **Link-rewriting pass ordering**: To rewrite `<a href="page-id.html">` the
+   importer must build the full `pageId→uuid` map before emitting any widget
+   HTML. This implies a two-pass strategy or deferred rewriting after all pages
+   are parsed. Neither is in scope in the existing code.
+
+3. **`index.html` hierarchy ambiguity**: Confluence exports come in two shapes:
+   flat (all pages in one directory, hierarchical via breadcrumbs only) and
+   nested (subdirectories per space / page). The breadcrumb override works for
+   both, but the directory-nesting path assumes exactly one directory level.
+   Deep nesting (`SPACE/parent/child/grandchild.html`) may not resolve
+   correctly with the current `pathParts[0]` logic in `normalizeHref`.
+
+4. **`index.html` vs `overview.html` vs `toc.html`**: `findHtmlFiles` skips
+   all three filenames. If a space has an `overview.html` that is a real content
+   page (some Confluence versions produce this), it will be silently ignored.
+   Verify against real Confluence export samples.
+
+5. **Async threshold**: The spec proposes <100 pages = sync, ≥100 = async.
+   The controller has no such threshold. When implemented this needs to account
+   for NC's `ITempManager` temp files, which are cleaned on request end —
+   a background job cannot use the same temp path.

--- a/openspec/changes/confluence-html-import/proposal.md
+++ b/openspec/changes/confluence-html-import/proposal.md
@@ -1,0 +1,72 @@
+# Confluence HTML Export Importer
+
+## Why
+
+Organizations migrating from Atlassian Confluence or supplementing it with MyDash need a one-shot bulk-import capability that converts their existing Confluence page hierarchies into MyDash dashboards. Manual recreation of hundreds of pages is impractical. This change enables admins to upload a Confluence "HTML Export" archive and automatically generate MyDash dashboards with the page content preserved.
+
+## What Changes
+
+- Add a new admin-only import endpoint `POST /api/admin/import/confluence` accepting a multipart Confluence HTML export ZIP file. The importer converts each Confluence page into a MyDash dashboard with:
+  - Dashboard name = Confluence page title
+  - Dashboard parent = parent Confluence page's dashboard (mirroring the Confluence hierarchy, requires `dashboard-tree` capability)
+  - Dashboard widget = one full-width text-display widget containing the sanitized page body HTML
+- Add a companion `POST /api/admin/import/confluence/dry-run` endpoint for impact preview (page count, attachment count, warnings, but no database changes).
+- Add a background job system for large imports (>100 pages), returning 202 with job-id and exposing `GET /api/admin/import/confluence/jobs/{jobId}` for polling.
+- Add a CLI command `php occ mydash:import:confluence --file=/path/export.zip [--parent-path=/imports]` for headless/cron imports.
+- Add sanitization (allow-list: `<p>`, `<h1..h6>`, `<a>`, `<strong>`, `<em>`, `<ul>`, `<ol>`, `<li>`, `<img>`, `<table>`, `<tr>`, `<td>`, `<th>`, `<thead>`, `<tbody>`, `<blockquote>`, `<pre>`, `<code>`, `<br>`; strip macros and Confluence-specific markup).
+- Add image upload: `<img>` references to attachments and shared images are uploaded to Nextcloud folder `MyDash/Imports/{timestamp}/` with src rewritten to NC URLs.
+- Add link rewriting: internal Confluence links (`<a href="pageId.html">`) are rewritten to dashboard deep links (`/apps/mydash/dashboard/{imported-uuid}`).
+- Add error resilience: a single page parse failure does NOT abort the import; failed pages are logged and skipped.
+- Add re-importability: running the importer twice creates new dashboards and new asset folders (no deduplication).
+
+## Capabilities
+
+### New Capability
+
+- `confluence-html-import`: one-shot bulk-import from Confluence HTML export archives. New requirements REQ-CFLI-001..010.
+
+### Modified Capabilities
+
+- `dashboards` (optional): if `dashboard-tree` is present, the importer uses parent dashboard relationships to mirror Confluence hierarchy.
+- `admin-settings`: the import endpoints are admin-only (requires NC admin role).
+
+## Impact
+
+**Affected code:**
+
+- `lib/Service/ConfluenceImportService.php` — main import logic: ZIP parsing, page hierarchy extraction, HTML sanitization, image upload, link rewriting
+- `lib/Service/ConfluenceArchiveParser.php` — ZIP extraction, index.html parsing, page metadata extraction
+- `lib/Service/HtmlSanitizer.php` — HTML allow-list sanitization, macro placeholder injection
+- `lib/Service/ConfluenceImageUploader.php` — fetch images from archive, upload to Nextcloud folder, track src rewrites
+- `lib/Service/ConfluencePageMapper.php` — in-memory pageId-to-uuid map for link rewriting
+- `lib/Controller/ConfluenceImportController.php` — `/api/admin/import/confluence` (import + dry-run)
+- `lib/BackgroundJob/ConfluenceImportJob.php` — async job for large imports, called via job queue
+- `lib/Db/ConfluenceImportLog.php` — entity for storing import job metadata (jobId, status, createdCount, errors, logUrl)
+- `lib/Db/ConfluenceImportLogMapper.php` — mapper for import logs
+- `lib/Command/ConfluenceImportCommand.php` — CLI command handler
+- `appinfo/routes.php` — register 2 new admin routes
+- `appinfo/backgroundjobs.php` — register async job class (if not auto-discovered)
+
+**Affected APIs:**
+
+- `POST /api/admin/import/confluence` — new admin endpoint (multipart, accepts `file` + optional `parentPath`)
+- `POST /api/admin/import/confluence/dry-run` — new admin endpoint (same signature, no database changes)
+- `GET /api/admin/import/confluence/jobs/{jobId}` — new admin endpoint (returns job status + progress)
+
+**Dependencies:**
+
+- No new composer dependencies; uses built-in ZIP handling (`ZipArchive`)
+- Frontend: no UI change (import is admin-only, CLI-driven)
+
+**Migration:**
+
+- Zero-impact: no schema changes to existing dashboards. New `oc_mydash_confluence_import_logs` table added for job tracking.
+
+## Success Criteria
+
+- Admin can upload a 500-page Confluence export and see all 500 dashboards created with correct hierarchy
+- Image attachments are uploaded to NC and links are rewritten
+- A page with unparseable HTML is logged as error but does not block other pages
+- Running the importer twice creates new dashboards (no merge/dedup)
+- CLI command works headless with `--file` and `--parent-path` flags
+- Dry-run correctly reports estimated dashboard count and warnings without modifying database

--- a/openspec/changes/confluence-html-import/specs/confluence-html-import/spec.md
+++ b/openspec/changes/confluence-html-import/specs/confluence-html-import/spec.md
@@ -1,0 +1,450 @@
+---
+status: draft
+---
+
+# Confluence HTML Export Importer
+
+## ADDED Requirements
+
+### Requirement: REQ-CFLI-001 Archive structure parsing
+
+The system MUST parse a Confluence HTML Export ZIP archive and extract its directory structure to identify pages, attachments, and shared images.
+
+#### Scenario: Extract archive metadata
+
+- GIVEN a Confluence HTML export ZIP with structure: `index.html`, `SPACE-KEY/page-id.html`, `attachments/page-id/image.png`, `images/icon.png`
+- WHEN the importer reads the archive
+- THEN the system MUST identify all files and their roles (index, page, attachment, image)
+- AND MUST extract the archive to a temporary directory for processing
+- AND MUST NOT modify the source ZIP
+
+#### Scenario: Missing index.html is an error
+
+- GIVEN a ZIP archive without `index.html`
+- WHEN the importer attempts to parse it
+- THEN the system MUST return HTTP 400 with `{error: "index.html not found in archive"}`
+- AND no import MUST proceed
+
+#### Scenario: Nested page directories are supported
+
+- GIVEN pages stored in nested space directories: `SPACE1/page1.html`, `SPACE1/SUB/page2.html`
+- WHEN the importer reads the archive
+- THEN the system MUST recognize both page files by `.html` extension
+- AND extract each file's content for processing
+
+#### Scenario: Attachments are located by page reference
+
+- GIVEN a page file `SPACE/page-123.html` with `<img src="attachments/page-123/logo.png">`
+- WHEN the importer processes the page
+- THEN the system MUST locate `attachments/page-123/logo.png` in the archive
+- AND treat it as a candidate for upload
+
+### Requirement: REQ-CFLI-002 Page hierarchy extraction from index.html
+
+The system MUST parse Confluence's `index.html` (table of contents) to extract the page tree structure (parent-child relationships, page titles, Confluence page IDs).
+
+#### Scenario: Extract page hierarchy from TOC
+
+- GIVEN `index.html` with Confluence TOC structure listing pages with titles and IDs (e.g., `<a href="SPACE/page-123.html">Page Title</a>`)
+- WHEN the importer parses the TOC
+- THEN the system MUST extract: page ID (from filename or TOC entry), page title, parent page ID (if nested in TOC), and any depth/order indicators
+- AND build an in-memory tree structure `{pageId, title, parentPageId, children: [...]}`
+
+#### Scenario: Root pages have null parent
+
+- GIVEN a TOC entry at the top level (not nested under another page)
+- WHEN the importer extracts the hierarchy
+- THEN the system MUST assign `parentPageId = null` to that page
+- AND treat it as a root page in the destination dashboard hierarchy
+
+#### Scenario: Nested pages inherit parent
+
+- GIVEN a TOC with nested structure: "Section A" > "Subsection A.1"
+- WHEN the importer extracts the hierarchy
+- THEN pages under "Subsection A.1" MUST have `parentPageId = <uuid-of-section-a-1-dashboard>`
+- AND the depth MUST be preserved
+
+#### Scenario: Malformed TOC does not block import
+
+- GIVEN `index.html` with malformed or incomplete TOC entries
+- WHEN the importer encounters unparseable TOC sections
+- THEN the system MUST log warnings for each unparseable entry
+- AND MUST continue processing remaining entries
+- AND MUST import the pages that CAN be extracted from actual page files
+
+### Requirement: REQ-CFLI-003 Confluence page → MyDash dashboard conversion
+
+The system MUST convert each Confluence page into a MyDash dashboard with the page's `name = <pageTitle>` and a full-width text-display widget containing the page body.
+
+#### Scenario: Create dashboard from page
+
+- GIVEN a Confluence page with title "Architecture Overview" and body HTML
+- WHEN the importer converts the page to a dashboard
+- THEN the system MUST create a dashboard with `name = "Architecture Overview"`
+- AND MUST set `createdBy = <system-admin-user>` or configured owner
+- AND MUST return HTTP 201 with the new dashboard object
+
+#### Scenario: Dashboard inherits parent from page hierarchy
+
+- GIVEN a Confluence page "Q1 Goals" with `parentPageId = <uuid-of-planning-page>`
+- WHEN the importer creates the dashboard
+- THEN the system MUST set `parentUuid = <uuid-of-planning-dashboard>` (requires `dashboard-tree` capability)
+- AND the dashboard tree MUST reflect the Confluence hierarchy
+
+#### Scenario: Root Confluence pages become root dashboards
+
+- GIVEN a top-level Confluence page with `parentPageId = null`
+- WHEN the importer creates the dashboard
+- THEN the dashboard MUST have `parentUuid = null` or be a root dashboard
+- AND MUST NOT be nested under any parent
+
+#### Scenario: Text-display widget captures page body
+
+- GIVEN a Confluence page with body `<div id="main-content"><p>Page content</p></div>`
+- WHEN the importer creates the dashboard
+- THEN the system MUST extract the content of `<div id="main-content">` (if present; fallback to `<body>`)
+- AND MUST create a text-display widget with `type = "text"`, `content.text = <sanitized-html>`
+- AND MUST place the widget at grid position (0, 0) with size (12, 12) — full dashboard width
+- AND MUST set `content.fontSize = "14px"`, `content.color = "var(--color-main-text)"`, `content.backgroundColor = "transparent"`, `content.textAlign = "left"`
+
+#### Scenario: Widget HTML is sanitized before storage
+
+- GIVEN a page with `<div id="main-content"><p>Safe <script>alert(1)</script> text</p></div>`
+- WHEN the importer extracts the body
+- THEN the system MUST sanitize the HTML (strip `<script>`, etc.) BEFORE storing in the widget
+- AND the stored content MUST be safe for rendering via `v-html`
+
+### Requirement: REQ-CFLI-004 Internal link rewriting
+
+The system MUST rewrite internal Confluence links (`<a href="pageId.html">`) to point to the corresponding imported MyDash dashboard.
+
+#### Scenario: Rewrite link to sibling page
+
+- GIVEN a page with `<a href="page-456.html">See Also</a>` where `page-456` was imported as dashboard UUID `uuid-456`
+- WHEN the importer processes the page body
+- THEN the system MUST rewrite the link to `<a href="/apps/mydash/dashboard/uuid-456">See Also</a>`
+- AND the dashboard MUST be navigable via the rewritten link
+
+#### Scenario: Cross-space links are rewritten
+
+- GIVEN a page with `<a href="OTHER-SPACE/page-789.html">External Page</a>` where `page-789` was imported as UUID `uuid-789`
+- WHEN the importer processes the link
+- THEN the system MUST rewrite it to `<a href="/apps/mydash/dashboard/uuid-789">External Page</a>`
+
+#### Scenario: Links to non-existent pages are logged
+
+- GIVEN a page with `<a href="page-999.html">Missing Page</a>` where `page-999` does NOT exist in the Confluence archive
+- WHEN the importer processes the link
+- THEN the system MUST log a warning `"Link to non-existent page page-999 in page ..."`
+- AND MUST preserve the link as-is (unchanged href) so the admin can manually investigate
+- AND MUST continue processing the page
+
+#### Scenario: External links (not Confluence pages) are untouched
+
+- GIVEN a page with `<a href="https://example.com">External</a>`
+- WHEN the importer processes the link
+- THEN the system MUST NOT modify the `href` (it is not a Confluence page reference)
+- AND the link MUST remain `<a href="https://example.com">External</a>`
+
+### Requirement: REQ-CFLI-005 Image upload and source rewriting
+
+The system MUST upload Confluence page attachments and shared images to a Nextcloud folder and rewrite `<img src>` attributes to point to the new NC URLs.
+
+#### Scenario: Upload attachment image to NC folder
+
+- GIVEN a page with `<img src="attachments/page-123/diagram.png">` where the file exists in the archive
+- WHEN the importer processes the image
+- THEN the system MUST upload the file to `MyDash/Imports/{importTimestamp}/diagram.png` in Nextcloud
+- AND MUST rewrite `src` to the NC download URL: `https://<nc-domain>/remote.php/dav/files/<user>/MyDash/Imports/{timestamp}/diagram.png` (or equivalent public share URL)
+- AND the image MUST be accessible in the rendered dashboard widget
+
+#### Scenario: Shared images from images/ directory
+
+- GIVEN a page with `<img src="images/icon.png">` where `images/icon.png` exists in the archive
+- WHEN the importer processes the image
+- THEN the system MUST upload to `MyDash/Imports/{importTimestamp}/icon.png`
+- AND MUST rewrite `src` to the NC URL
+
+#### Scenario: Missing image files are logged
+
+- GIVEN a page with `<img src="attachments/page-123/missing.png">` where the file does NOT exist in the archive
+- WHEN the importer processes the image
+- THEN the system MUST log a warning `"Image file not found: attachments/page-123/missing.png"`
+- AND MUST replace the image element with a placeholder: `<em>[Image: missing.png not found]</em>`
+- AND MUST continue processing the page
+
+#### Scenario: Image upload respects Nextcloud quota
+
+- GIVEN a total attachment size of 2 GB and a Nextcloud user quota of 1 GB
+- WHEN the importer attempts to upload attachments
+- THEN the system MUST respect the quota and log an error for files that cannot be uploaded due to quota limits
+- AND MUST continue importing other pages (per REQ-CFLI-009 error resilience)
+
+#### Scenario: Each import run uses a new timestamp folder
+
+- GIVEN two consecutive imports of the same Confluence archive
+- WHEN the first import uploads images to `MyDash/Imports/2026-04-01T10-30-00/`
+- AND the second import runs later
+- THEN the second import MUST use a new folder: `MyDash/Imports/2026-04-01T10-45-00/`
+- AND MUST NOT overwrite files from the first import
+- AND created dashboards from the two runs MUST be independent (per REQ-CFLI-010)
+
+### Requirement: REQ-CFLI-006 Confluence macro placeholder injection
+
+The system MUST identify Confluence macros (non-representable block elements like `<ac:structured-macro>`) and replace them with human-readable placeholders so admins know what content was skipped.
+
+#### Scenario: Replace structured-macro with placeholder
+
+- GIVEN a page body with `<ac:structured-macro ac:name="code"><ac:parameter ac:name="language">java</ac:parameter>...</ac:structured-macro>`
+- WHEN the importer sanitizes the content
+- THEN the system MUST replace the macro with `<p><em>[Macro: code not imported]</em></p>`
+- AND the macro name MUST be extracted and included in the placeholder text
+
+#### Scenario: Unsupported HTML elements are stripped
+
+- GIVEN a page with elements like `<math>`, `<svg>`, custom Confluence elements
+- WHEN the importer sanitizes the HTML
+- THEN the system MUST strip these elements entirely (not replaced with placeholders)
+- AND MUST log a debug note for each stripped element
+
+#### Scenario: Macro placeholders include context
+
+- GIVEN multiple macros of different types in a single page
+- WHEN the importer processes the page
+- THEN each placeholder MUST include the macro name: `[Macro: sql not imported]`, `[Macro: jira not imported]`, etc.
+- AND admins MUST be able to identify which macros were skipped and why
+
+### Requirement: REQ-CFLI-007 Dry-run endpoint for import preview
+
+The system MUST expose a `POST /api/admin/import/confluence/dry-run` endpoint that performs all parsing and validation WITHOUT creating any dashboards or uploading files.
+
+#### Scenario: Dry-run returns page count
+
+- GIVEN a Confluence export with 150 pages
+- WHEN the admin sends POST /api/admin/import/confluence/dry-run with the ZIP file
+- THEN the system MUST parse the archive, analyze the page tree, and return HTTP 200 with:
+  ```json
+  {
+    "pageCount": 150,
+    "attachmentCount": 42,
+    "estimatedDashboards": 150,
+    "warnings": ["Link to non-existent page page-999 in page Architecture"],
+    "estimatedAssetSize": "25 MB"
+  }
+  ```
+- AND NO dashboards, widgets, or files MUST be created
+
+#### Scenario: Dry-run identifies parsing warnings
+
+- GIVEN a Confluence export with some malformed pages
+- WHEN the admin runs dry-run
+- THEN the system MUST log warnings for unparseable TOC entries, missing images, broken links, etc.
+- AND MUST return the full warnings list
+- AND the admin MUST see these warnings BEFORE committing to the full import
+
+#### Scenario: Dry-run does not modify the archive
+
+- GIVEN a Confluence export ZIP
+- WHEN the admin runs dry-run
+- THEN the system MUST NOT delete, modify, or extract the uploaded ZIP to permanent storage
+- AND MUST use a temporary directory that is cleaned up after dry-run completes
+
+### Requirement: REQ-CFLI-008 Asynchronous import for large archives
+
+The system MUST run imports synchronously for archives with <100 pages and asynchronously (background job) for larger archives, with job tracking and polling support.
+
+#### Scenario: Small import runs synchronously
+
+- GIVEN a Confluence export with 50 pages
+- WHEN the admin sends POST /api/admin/import/confluence with the ZIP file
+- THEN the system MUST process the import in the request thread
+- AND MUST return HTTP 200 with:
+  ```json
+  {
+    "createdDashboardCount": 50,
+    "skippedPageCount": 0,
+    "errors": [],
+    "importLogUrl": "/apps/mydash/admin/import-logs/log-uuid-123"
+  }
+  ```
+
+#### Scenario: Large import is queued as background job
+
+- GIVEN a Confluence export with 500 pages
+- WHEN the admin sends POST /api/admin/import/confluence with the ZIP file
+- THEN the system MUST queue an async job and return HTTP 202 (Accepted) with:
+  ```json
+  {
+    "jobId": "import-uuid-456",
+    "status": "processing",
+    "message": "Import queued for background processing"
+  }
+  ```
+- AND the job MUST process the import in the background (using Nextcloud's JobList / cron)
+
+#### Scenario: Poll job status via GET endpoint
+
+- GIVEN a background import job with `jobId = "import-uuid-456"`
+- WHEN the admin sends GET /api/admin/import/confluence/jobs/import-uuid-456
+- THEN the system MUST return HTTP 200 with:
+  ```json
+  {
+    "jobId": "import-uuid-456",
+    "status": "processing",
+    "progress": {"current": 250, "total": 500},
+    "createdDashboardCount": 250,
+    "skippedPageCount": 0,
+    "errors": []
+  }
+  ```
+
+#### Scenario: Job completion is reported via status endpoint
+
+- GIVEN a background job that has finished
+- WHEN the admin polls GET /api/admin/import/confluence/jobs/import-uuid-456
+- THEN the system MUST return HTTP 200 with `status = "completed"` and final counts
+- AND MUST include an `importLogUrl` for detailed logs
+
+### Requirement: REQ-CFLI-009 Error resilience: single-page failures do not abort import
+
+The system MUST skip pages that fail to parse and continue importing remaining pages, logging errors for admin review.
+
+#### Scenario: Page with malformed HTML is skipped
+
+- GIVEN a Confluence page with severely broken HTML (unclosed tags, invalid nesting)
+- WHEN the importer attempts to parse the page
+- THEN the system MUST catch the parsing error, log it as a warning with the page ID and filename
+- AND MUST continue processing other pages
+- AND MUST include the error in the final `errors` list
+
+#### Scenario: Page with invalid parent reference is skipped
+
+- GIVEN a page with `parentPageId = "non-existent-parent-id"`
+- WHEN the importer attempts to resolve the parent
+- THEN the system MUST log an error `"Parent dashboard not found for page ..."`
+- AND MUST create the page as a root dashboard (orphan) OR skip it (admin configurable)
+- AND MUST allow other pages to be imported
+
+#### Scenario: Final report includes all errors
+
+- GIVEN an import of 100 pages where 5 fail to parse
+- WHEN the import completes
+- THEN the system MUST return:
+  ```json
+  {
+    "createdDashboardCount": 95,
+    "skippedPageCount": 5,
+    "errors": [
+      {"pageId": "page-001", "reason": "Malformed HTML"},
+      {"pageId": "page-002", "reason": "Parent not found"},
+      ...
+    ]
+  }
+  ```
+- AND the admin MUST see the full list of skipped pages and reasons
+
+### Requirement: REQ-CFLI-010 Re-importability: no deduplication by page ID
+
+The system MUST allow the same Confluence archive to be imported multiple times, creating new dashboards each run (no merge/dedup by Confluence page ID).
+
+#### Scenario: Second import creates new dashboards
+
+- GIVEN a first import of a Confluence archive that created 100 dashboards
+- WHEN the admin runs the same import again
+- THEN the system MUST create 100 NEW dashboards (not update the existing ones)
+- AND the new dashboards MUST have different UUIDs from the first run
+- AND the admin MUST manually manage/delete old imports if desired
+
+#### Scenario: Assets are uploaded to separate timestamped folders
+
+- GIVEN two imports of the same archive run on the same day
+- WHEN the first import uploads images to `MyDash/Imports/2026-04-01T10-30-00/`
+- AND the second import runs at `2026-04-01T10-45-00`
+- THEN the second import MUST upload to a new folder: `MyDash/Imports/2026-04-01T10-45-00/`
+- AND image `src` attributes MUST point to the correct folder for each import
+- AND no file overwrite occurs
+
+#### Scenario: Dashboard UUIDs are unique across runs
+
+- GIVEN two imports of the same Confluence archive
+- WHEN both imports create a dashboard for the same Confluence page
+- THEN each dashboard MUST have a unique UUID
+- AND both dashboards MUST be independently editable and deletable
+
+### Requirement: REQ-CFLI-011 CLI command for headless import
+
+The system MUST expose a Nextcloud OCC command `php occ mydash:import:confluence` for imports via CLI/cron, with options for file path and parent dashboard path.
+
+#### Scenario: CLI import with file option
+
+- GIVEN an admin with shell access to the Nextcloud server
+- WHEN they run `php occ mydash:import:confluence --file=/tmp/export.zip`
+- THEN the system MUST:
+  - Load the ZIP from the specified path
+  - Run the full import (synchronous or async, depending on size)
+  - Output progress to stdout: `Importing 150 pages...`, `Created 150 dashboards, 0 errors`
+  - Exit with code 0 on success, non-zero on failure
+
+#### Scenario: CLI import with parent-path option
+
+- GIVEN an admin wanting to import under a specific parent dashboard
+- WHEN they run `php occ mydash:import:confluence --file=/tmp/export.zip --parent-path=/Finance/2026`
+- THEN the system MUST:
+  - Resolve the path `/Finance/2026` to a dashboard UUID (via the path resolution API)
+  - Use that UUID as the parent for all root Confluence pages in the import
+  - Create a subtree under `/Finance/2026` with the imported pages
+
+#### Scenario: CLI import handles missing file gracefully
+
+- GIVEN an admin running `php occ mydash:import:confluence --file=/nonexistent.zip`
+- WHEN the file does not exist
+- THEN the system MUST output `Error: File /nonexistent.zip not found`
+- AND MUST exit with non-zero code
+- AND MUST NOT attempt to import
+
+#### Scenario: CLI import supports dry-run flag
+
+- GIVEN an admin running `php occ mydash:import:confluence --file=/tmp/export.zip --dry-run`
+- WHEN the `--dry-run` flag is present
+- THEN the system MUST output the dry-run preview (page count, warnings, etc.)
+- AND MUST NOT create any dashboards or files
+- AND MUST exit with code 0
+
+### Requirement: REQ-CFLI-012 HTML sanitization with allow-list
+
+The system MUST sanitize all imported page HTML using a strict allow-list of formatting tags, stripping everything else to prevent XSS and maintain consistency with the text-display widget.
+
+#### Scenario: Allow-listed tags are preserved
+
+- GIVEN a page with `<p>text</p> <strong>bold</strong> <em>italic</em> <a href="/link">link</a> <ul><li>item</li></ul>`
+- WHEN the importer sanitizes the HTML
+- THEN all these tags MUST be preserved exactly
+- AND the rendered widget MUST display the formatted content
+
+#### Scenario: Disallowed tags are stripped
+
+- GIVEN a page with `<div class="highlight">text</div> <span style="color:red">red</span> <button>click</button>`
+- WHEN the importer sanitizes the HTML
+- THEN the system MUST strip the disallowed tags, preserving only the text content: `text red click` (or structured as allowed tags)
+- AND the sanitized HTML MUST be safe for `v-html` rendering
+
+#### Scenario: Event handlers and javascript: URLs are stripped
+
+- GIVEN HTML with `<a href="javascript:alert(1)" onclick="alert(2)">x</a> <img onerror="alert(3)">`
+- WHEN the importer sanitizes
+- THEN all event handlers (`onclick`, `onerror`, etc.) and `javascript:` URLs MUST be removed
+- AND the result MUST be safe (e.g., `<a>x</a>` or `<img>` with no handlers)
+
+#### Scenario: Confluence-specific markup is converted to placeholders
+
+- GIVEN content with `<ac:macro ac:name="expand">`, `<at:macro at:name="code">`, or similar Confluence markup
+- WHEN the importer sanitizes
+- THEN these MUST be replaced with `<p><em>[Macro: expand not imported]</em></p>` etc.
+- AND the page MUST still be importable (not fail entirely)
+
+#### Scenario: Allow-list includes all common semantic tags
+
+- GIVEN the allow-list: `<p>`, `<h1>`, `<h2>`, `<h3>`, `<h4>`, `<h5>`, `<h6>`, `<a>`, `<strong>`, `<em>`, `<ul>`, `<ol>`, `<li>`, `<img>`, `<table>`, `<tr>`, `<td>`, `<th>`, `<thead>`, `<tbody>`, `<blockquote>`, `<pre>`, `<code>`, `<br>`
+- WHEN a page is imported with any of these tags
+- THEN all MUST be preserved with their semantic meaning intact
+- AND attributes on allowed tags (e.g., `<a href="...">`, `<img src="...">`) MUST be whitelisted per tag (href on `<a>`, src on `<img>`, etc.)

--- a/openspec/changes/confluence-html-import/specs/confluence-html-import/spec.md
+++ b/openspec/changes/confluence-html-import/specs/confluence-html-import/spec.md
@@ -39,38 +39,47 @@ The system MUST parse a Confluence HTML Export ZIP archive and extract its direc
 - THEN the system MUST locate `attachments/page-123/logo.png` in the archive
 - AND treat it as a candidate for upload
 
-### Requirement: REQ-CFLI-002 Page hierarchy extraction from index.html
+### Requirement: REQ-CFLI-002 Page hierarchy extraction
 
-The system MUST parse Confluence's `index.html` (table of contents) to extract the page tree structure (parent-child relationships, page titles, Confluence page IDs).
+The system MUST derive the page tree (parent-child relationships, sibling order) from two sources applied in priority order: (1) directory nesting within the extracted ZIP, and (2) the breadcrumb navigation inside each individual page file. `index.html` is used solely to assign sibling ordering, NOT to define parent-child relationships.
 
-#### Scenario: Extract page hierarchy from TOC
+#### Scenario: Directory nesting establishes initial parent-child relationships
 
-- GIVEN `index.html` with Confluence TOC structure listing pages with titles and IDs (e.g., `<a href="SPACE/page-123.html">Page Title</a>`)
-- WHEN the importer parses the TOC
-- THEN the system MUST extract: page ID (from filename or TOC entry), page title, parent page ID (if nested in TOC), and any depth/order indicators
-- AND build an in-memory tree structure `{pageId, title, parentPageId, children: [...]}`
+- GIVEN pages stored at `SPACE/page-123.html` and `SPACE/SUB/page-456.html`
+- WHEN the importer builds the page hierarchy
+- THEN `page-456` MUST be treated as a child of the page at the first directory level (`SPACE/`)
+- AND directory depth determines the initial parent assignment before breadcrumb override is applied
+
+#### Scenario: Breadcrumb overrides directory-based parent
+
+- GIVEN a page file containing `<ol class="breadcrumbs"><li><a href="page-100.html">Section A</a></li><li>Current Page</li></ol>`
+- WHEN the importer builds the page hierarchy
+- THEN the system MUST parse the breadcrumb `<ol class="breadcrumbs">` or `<ol id="breadcrumbs">` to extract the parent chain
+- AND the breadcrumb-derived parent MUST take precedence over the directory-derived parent
+- AND the system MUST assign `parentPageId` to the ID extracted from the second-to-last breadcrumb link
+
+#### Scenario: index.html provides sibling order only
+
+- GIVEN `index.html` containing an ordered link list (`<a href="SPACE/page-123.html">`, `<a href="SPACE/page-456.html">`, ...)
+- WHEN the importer reads `index.html`
+- THEN the system MUST extract the 0-based position of each `href` match to assign sibling ordering
+- AND MUST NOT infer parent-child relationships from `index.html` link nesting
+- AND `index.html` links MUST be matched via `href` attribute parsing (regex on href attributes), not DOM tree depth
 
 #### Scenario: Root pages have null parent
 
-- GIVEN a TOC entry at the top level (not nested under another page)
+- GIVEN a page whose breadcrumb contains only its own title (no ancestor links)
 - WHEN the importer extracts the hierarchy
 - THEN the system MUST assign `parentPageId = null` to that page
 - AND treat it as a root page in the destination dashboard hierarchy
 
-#### Scenario: Nested pages inherit parent
+#### Scenario: Malformed breadcrumb does not block import
 
-- GIVEN a TOC with nested structure: "Section A" > "Subsection A.1"
-- WHEN the importer extracts the hierarchy
-- THEN pages under "Subsection A.1" MUST have `parentPageId = <uuid-of-section-a-1-dashboard>`
-- AND the depth MUST be preserved
-
-#### Scenario: Malformed TOC does not block import
-
-- GIVEN `index.html` with malformed or incomplete TOC entries
-- WHEN the importer encounters unparseable TOC sections
-- THEN the system MUST log warnings for each unparseable entry
-- AND MUST continue processing remaining entries
-- AND MUST import the pages that CAN be extracted from actual page files
+- GIVEN a page with a missing or malformed breadcrumb `<ol>`
+- WHEN the importer encounters the unparseable breadcrumb
+- THEN the system MUST fall back to directory-nesting for parent assignment
+- AND MUST log a warning for the affected page
+- AND MUST continue processing remaining pages
 
 ### Requirement: REQ-CFLI-003 Confluence page → MyDash dashboard conversion
 
@@ -100,9 +109,17 @@ The system MUST convert each Confluence page into a MyDash dashboard with the pa
 
 #### Scenario: Text-display widget captures page body
 
-- GIVEN a Confluence page with body `<div id="main-content"><p>Page content</p></div>`
-- WHEN the importer creates the dashboard
-- THEN the system MUST extract the content of `<div id="main-content">` (if present; fallback to `<body>`)
+- GIVEN a Confluence page HTML file
+- WHEN the importer extracts the page body
+- THEN the system MUST apply the following selector waterfall in order, using the first non-empty result:
+  1. `//div[@id='main-content']`
+  2. `//div[contains(@class, 'wiki-content')]`
+  3. `//div[contains(@class, 'page-content')]`
+  4. `//div[@id='content']`
+  5. `//main`
+  6. `//article`
+  - Fallback: regex extraction of `<body>…</body>` content, then raw HTML as last resort
+- AND before returning the selected node the system MUST strip the following navigation elements in place: `div#pagetreesearch`, `div.breadcrumbs`, `div.pageSection`, `form[name=pagetreesearchform]`, `form.aui`, `nav`, `div.page-metadata`
 - AND MUST create a text-display widget with `type = "text"`, `content.text = <sanitized-html>`
 - AND MUST place the widget at grid position (0, 0) with size (12, 12) — full dashboard width
 - AND MUST set `content.fontSize = "14px"`, `content.color = "var(--color-main-text)"`, `content.backgroundColor = "transparent"`, `content.textAlign = "left"`
@@ -117,6 +134,8 @@ The system MUST convert each Confluence page into a MyDash dashboard with the pa
 ### Requirement: REQ-CFLI-004 Internal link rewriting
 
 The system MUST rewrite internal Confluence links (`<a href="pageId.html">`) to point to the corresponding imported MyDash dashboard.
+
+> **NOTE — MyDash addition:** No link-rewriting code exists in the ported reference. The entire link-rewriting subsystem described here must be built from scratch. The reference leaves internal Confluence `<a href="pageId.html">` links as-is in exported HTML blocks; there is no `pageId→uuid` map and no href-rewrite pass anywhere in the reference codebase.
 
 #### Scenario: Rewrite link to sibling page
 
@@ -149,6 +168,8 @@ The system MUST rewrite internal Confluence links (`<a href="pageId.html">`) to 
 ### Requirement: REQ-CFLI-005 Image upload and source rewriting
 
 The system MUST upload Confluence page attachments and shared images to a Nextcloud folder and rewrite `<img src>` attributes to point to the new NC URLs.
+
+> **NOTE — MyDash addition:** The ported reference does NOT upload anything to Nextcloud. It registers `MediaDownload` objects for Storage Format `<ac:image>` elements only, but the resolution is not implemented and no file-write to Nextcloud occurs. Plain HTML `<img src="attachments/...">` tags are not scanned at all. The `MyDash/Imports/{timestamp}/` destination folder and the full upload pipeline described below are new work that must be designed and built.
 
 #### Scenario: Upload attachment image to NC folder
 
@@ -189,16 +210,45 @@ The system MUST upload Confluence page attachments and shared images to a Nextcl
 - AND MUST NOT overwrite files from the first import
 - AND created dashboards from the two runs MUST be independent (per REQ-CFLI-010)
 
-### Requirement: REQ-CFLI-006 Confluence macro placeholder injection
+### Requirement: REQ-CFLI-006 Confluence macro rendering and placeholder injection
 
-The system MUST identify Confluence macros (non-representable block elements like `<ac:structured-macro>`) and replace them with human-readable placeholders so admins know what content was skipped.
+The system MUST process Confluence `<ac:structured-macro>` elements through registered handlers that produce rich widget output. Recognised macros are rendered into appropriate blocks; unrecognised macros receive a fallback placeholder block.
 
-#### Scenario: Replace structured-macro with placeholder
+#### Scenario: Panel-type macros render as styled blocks
 
-- GIVEN a page body with `<ac:structured-macro ac:name="code"><ac:parameter ac:name="language">java</ac:parameter>...</ac:structured-macro>`
-- WHEN the importer sanitizes the content
-- THEN the system MUST replace the macro with `<p><em>[Macro: code not imported]</em></p>`
-- AND the macro name MUST be extracted and included in the placeholder text
+- GIVEN a page body with `<ac:structured-macro ac:name="info">` (or `note`, `warning`, `tip`, `error`, `panel`)
+- WHEN the importer processes the macro
+- THEN the system MUST produce a text widget block styled with the CSS class `confluence-panel-{type}` (e.g., `confluence-panel-info`)
+- AND MUST preserve the macro body content inside the styled block
+
+#### Scenario: Code macro renders as preformatted block
+
+- GIVEN a page body with `<ac:structured-macro ac:name="code"><ac:parameter ac:name="language">java</ac:parameter>…</ac:structured-macro>`
+- WHEN the importer processes the macro
+- THEN the system MUST produce a `<pre><code class="language-java">…</code></pre>` block
+- AND MUST NOT replace it with a placeholder
+
+#### Scenario: Expand macro renders as collapsible block
+
+- GIVEN a page body with `<ac:structured-macro ac:name="expand">`
+- WHEN the importer processes the macro
+- THEN the system MUST produce a `<details><summary>…</summary>…</details>` block
+- AND MUST NOT replace it with a placeholder
+
+#### Scenario: Attachment and viewfile macros render as placeholders
+
+- GIVEN a page body with `<ac:structured-macro ac:name="attachments">` or `<ac:structured-macro ac:name="viewfile">`
+- WHEN the importer processes the macro
+- THEN the system MUST produce a static HTML placeholder link block
+- AND MUST NOT attempt dynamic file listing
+
+#### Scenario: Unrecognised macros receive fallback placeholder
+
+- GIVEN a page body with `<ac:structured-macro ac:name="sql">` or any other unregistered macro name
+- WHEN the importer processes the macro
+- THEN the system MUST produce `<div class="confluence-unsupported-macro">⚠️ Unsupported macro: <code>sql</code></div>`
+- AND the macro name MUST be included in the placeholder
+- AND admins MUST be able to identify which macros were skipped
 
 #### Scenario: Unsupported HTML elements are stripped
 
@@ -207,16 +257,11 @@ The system MUST identify Confluence macros (non-representable block elements lik
 - THEN the system MUST strip these elements entirely (not replaced with placeholders)
 - AND MUST log a debug note for each stripped element
 
-#### Scenario: Macro placeholders include context
-
-- GIVEN multiple macros of different types in a single page
-- WHEN the importer processes the page
-- THEN each placeholder MUST include the macro name: `[Macro: sql not imported]`, `[Macro: jira not imported]`, etc.
-- AND admins MUST be able to identify which macros were skipped and why
-
 ### Requirement: REQ-CFLI-007 Dry-run endpoint for import preview
 
 The system MUST expose a `POST /api/admin/import/confluence/dry-run` endpoint that performs all parsing and validation WITHOUT creating any dashboards or uploading files.
+
+> **NOTE — MyDash addition:** No dry-run path exists in the reference implementation. The reference controller is fully synchronous with a single endpoint and no `dry-run` parameter, flag, or separate route. This is a new endpoint to build.
 
 #### Scenario: Dry-run returns page count
 
@@ -238,7 +283,7 @@ The system MUST expose a `POST /api/admin/import/confluence/dry-run` endpoint th
 
 - GIVEN a Confluence export with some malformed pages
 - WHEN the admin runs dry-run
-- THEN the system MUST log warnings for unparseable TOC entries, missing images, broken links, etc.
+- THEN the system MUST log warnings for unparseable breadcrumbs, missing images, broken links, etc.
 - AND MUST return the full warnings list
 - AND the admin MUST see these warnings BEFORE committing to the full import
 
@@ -252,6 +297,8 @@ The system MUST expose a `POST /api/admin/import/confluence/dry-run` endpoint th
 ### Requirement: REQ-CFLI-008 Asynchronous import for large archives
 
 The system MUST run imports synchronously for archives with <100 pages and asynchronously (background job) for larger archives, with job tracking and polling support.
+
+> **NOTE — MyDash addition:** The reference controller is fully synchronous — it processes in the request thread and returns a single JSON response. There is no page-count threshold, no background job dispatch, no job-id, and no polling endpoint. The sync/async split and all job-tracking described below must be built from scratch. Note: async jobs must not rely on `ITempManager` temp paths, which are cleaned on request end.
 
 #### Scenario: Small import runs synchronously
 
@@ -308,6 +355,8 @@ The system MUST run imports synchronously for archives with <100 pages and async
 ### Requirement: REQ-CFLI-009 Error resilience: single-page failures do not abort import
 
 The system MUST skip pages that fail to parse and continue importing remaining pages, logging errors for admin review.
+
+> **NOTE — Partial port:** The reference contains a null-guard that silently skips pages where `parseHtmlFile` returns `null` (unreadable file or empty body), and the loop continues. However, there is no `try/catch` around the per-file parsing loop, no error accumulator, and no `errors` list in the response — any thrown exception propagates to the controller and returns HTTP 500 for the entire request. Implementing the full resilience contract below requires adding per-page `try/catch`, an error-accumulation structure, and surfacing collected errors in the response.
 
 #### Scenario: Page with malformed HTML is skipped
 
@@ -375,6 +424,8 @@ The system MUST allow the same Confluence archive to be imported multiple times,
 
 The system MUST expose a Nextcloud OCC command `php occ mydash:import:confluence` for imports via CLI/cron, with options for file path and parent dashboard path.
 
+> **NOTE — MyDash addition:** No `occ mydash:import:confluence` command exists in the reference. The reference contains an `ImportPagesCommand` that operates on the native IntraVox JSON format only, not on Confluence ZIP archives. The `occ mydash:import:confluence` command must be built from scratch.
+
 #### Scenario: CLI import with file option
 
 - GIVEN an admin with shell access to the Nextcloud server
@@ -435,11 +486,12 @@ The system MUST sanitize all imported page HTML using a strict allow-list of for
 - THEN all event handlers (`onclick`, `onerror`, etc.) and `javascript:` URLs MUST be removed
 - AND the result MUST be safe (e.g., `<a>x</a>` or `<img>` with no handlers)
 
-#### Scenario: Confluence-specific markup is converted to placeholders
+#### Scenario: Confluence-specific markup falls through to macro handler
 
-- GIVEN content with `<ac:macro ac:name="expand">`, `<at:macro at:name="code">`, or similar Confluence markup
-- WHEN the importer sanitizes
-- THEN these MUST be replaced with `<p><em>[Macro: expand not imported]</em></p>` etc.
+- GIVEN content with `<ac:structured-macro ac:name="expand">` or similar Confluence markup
+- WHEN the importer processes the content
+- THEN recognised macros MUST be rendered per REQ-CFLI-006 (not treated as generic disallowed elements)
+- AND unrecognised macros MUST receive the `<div class="confluence-unsupported-macro">` fallback per REQ-CFLI-006
 - AND the page MUST still be importable (not fail entirely)
 
 #### Scenario: Allow-list includes all common semantic tags

--- a/openspec/changes/confluence-html-import/tasks.md
+++ b/openspec/changes/confluence-html-import/tasks.md
@@ -1,0 +1,132 @@
+# Tasks — confluence-html-import
+
+## 1. Schema and database setup
+
+- [ ] 1.1 Create `lib/Migration/VersionXXXXDate2026...AddConfluenceImportLog.php` adding table `oc_mydash_confluence_import_logs` with columns: `id INT PRIMARY KEY`, `jobId VARCHAR(36) UNIQUE`, `status VARCHAR(32)` (processing|completed|failed), `createdDashboardCount INT DEFAULT 0`, `skippedPageCount INT DEFAULT 0`, `errors LONGTEXT` (JSON), `createdAt DATETIME`, `completedAt DATETIME NULLABLE`
+- [ ] 1.2 Add index `idx_mydash_cfli_job_id` on `jobId` for fast job lookups
+- [ ] 1.3 Run migration locally against sqlite, mysql, and postgres; verify schema applied cleanly
+
+## 2. Archive parser and ZIP extraction
+
+- [ ] 2.1 Create `lib/Service/ConfluenceArchiveParser.php` with method `parse(string $zipPath): ConfluenceArchiveData` returning object with `indexHtml`, `pages` (array of `{filename, pageId, title, content}`), `attachments` (array of `{pageId, filePath}`), `sharedImages` (array of filenames)
+- [ ] 2.2 Parse `index.html` to extract table of contents: page titles, IDs, parent-child relationships (via nesting in TOC or filename patterns)
+- [ ] 2.3 Extract all `.html` files from space directories into `pages` list (extract filename as pageId, extract `<title>` tag as page title, extract `<div id="main-content">` or `<body>` as page body)
+- [ ] 2.4 Build in-memory tree structure from TOC: `{pageId, title, parentPageId: null|string, children: [...]}`
+- [ ] 2.5 Identify all attachment paths (`attachments/<pageId>/*`) and shared image paths (`images/*`)
+- [ ] 2.6 Add error handling: malformed ZIPs, missing index.html, unclosed HTML tags — log warnings but do not throw; allow parsing to continue for valid pages
+- [ ] 2.7 Add unit tests for: 5-level hierarchy parsing, TOC with nested pages, malformed TOC recovery, missing attachments list
+
+## 3. HTML sanitization service
+
+- [ ] 3.1 Create `lib/Service/HtmlSanitizer.php` with method `sanitize(string $html): string` implementing a strict allow-list
+- [ ] 3.2 Allow-list: `<p>`, `<h1..h6>`, `<a>`, `<strong>`, `<em>`, `<ul>`, `<ol>`, `<li>`, `<img>`, `<table>`, `<tr>`, `<td>`, `<th>`, `<thead>`, `<tbody>`, `<blockquote>`, `<pre>`, `<code>`, `<br>`
+- [ ] 3.3 Whitelist attributes per tag: `href` on `<a>`, `src` on `<img>`, `colspan`/`rowspan` on table cells, `alt` on `<img>`
+- [ ] 3.4 Strip event handlers (`onclick`, `onerror`, etc.) and `javascript:` URLs from all attributes
+- [ ] 3.5 Detect Confluence macros: `<ac:structured-macro>`, `<at:macro>`, custom Confluence elements — replace with `<p><em>[Macro: <macroName> not imported]</em></p>`
+- [ ] 3.6 Strip all other disallowed tags but preserve text content
+- [ ] 3.7 Use `DOMDocument` or `SimpleDOMParser` for robust HTML parsing; handle malformed HTML gracefully (do not throw on parse failure)
+- [ ] 3.8 Add unit tests for: safe tag preservation, script/event handler stripping, macro placeholder injection, malformed HTML recovery
+
+## 4. Image upload and URL rewriting
+
+- [ ] 4.1 Create `lib/Service/ConfluenceImageUploader.php` with method `uploadAndRewrite(string $html, array $attachments, string $timestamp): array` returning `{html: <rewritten-html>, uploadedFiles: [...], errors: [...]}`
+- [ ] 4.2 Extract all `<img src="...">` tags from HTML
+- [ ] 4.3 For each image: resolve the file path in the archive (e.g., `attachments/page-123/logo.png` or `images/logo.png`), check if file exists in `$attachments` list
+- [ ] 4.4 If file exists: upload to Nextcloud folder `/MyDash/Imports/{timestamp}/{filename}` using `IAppData` or `IFolder` APIs; get the download URL and rewrite `src` to the NC URL
+- [ ] 4.5 If file does NOT exist: log warning, replace `<img>` with `<em>[Image: <filename> not found]</em>`, continue processing
+- [ ] 4.6 Handle quota limits: if upload fails due to quota, log error and replace with placeholder (do not abort import per REQ-CFLI-009)
+- [ ] 4.7 Track all uploaded files and errors in return object
+- [ ] 4.8 Add unit tests for: successful uploads, missing files, quota limits, multiple images in one page
+
+## 5. Link rewriting service
+
+- [ ] 5.1 Create `lib/Service/ConfluencePageMapper.php` to build in-memory map: `pageId => dashboardUuid`
+- [ ] 5.2 After all dashboards are created, populate the map from the pageId-to-dashboard lookup (via stored metadata or post-creation scan)
+- [ ] 5.3 Create `lib/Service/ConfluenceLinkRewriter.php` with method `rewriteLinks(string $html, ConfluencePageMapper $mapper): array` returning `{html: <rewritten-html>, warnings: [...]}`
+- [ ] 5.4 Extract all `<a href="...">` tags; identify Confluence page links (e.g., `href="page-123.html"` or `href="SPACE/page-456.html"`)
+- [ ] 5.5 For each Confluence link: look up pageId in mapper, rewrite to `/apps/mydash/dashboard/{dashboardUuid}`, or log warning if pageId not found
+- [ ] 5.6 External links (`https://`, `mailto:`, etc.) MUST be left untouched
+- [ ] 5.7 Add unit tests for: sibling links, cross-space links, missing pages, external links unchanged
+
+## 6. Main import service
+
+- [ ] 6.1 Create `lib/Service/ConfluenceImportService.php` with public methods: `dryRun(SplFileInfo $file): DryRunResult`, `import(SplFileInfo $file, ?string $parentPath): ImportResult`, `importAsync(SplFileInfo $file, ?string $parentPath): AsyncJobResult`
+- [ ] 6.2 `dryRun()`: parse archive, analyze tree, count pages and attachments, return `{pageCount, attachmentCount, estimatedDashboards, warnings, estimatedAssetSize}` WITHOUT creating anything
+- [ ] 6.3 `import()`: full synchronous import for archives <100 pages:
+  - [ ] 6.3.1 Parse archive and extract hierarchy
+  - [ ] 6.3.2 If `parentPath` supplied, resolve path to dashboard UUID via tree service
+  - [ ] 6.3.3 Create dashboards in tree order (parents before children) using DashboardFactory
+  - [ ] 6.3.4 Build pageId-to-uuid map as dashboards are created
+  - [ ] 6.3.5 For each dashboard: sanitize page body HTML, upload images, rewrite links
+  - [ ] 6.3.6 Create text-display widget for each dashboard with sanitized content at (0, 0) sized 12×12
+  - [ ] 6.3.7 Catch per-page errors (malformed HTML, upload failures, link resolution failures), log them, continue to next page
+  - [ ] 6.3.8 Return `{createdDashboardCount, skippedPageCount, errors, importLogUrl}`
+- [ ] 6.4 `importAsync()`: queue background job for archives >=100 pages, return `{jobId, status: "processing"}`
+- [ ] 6.5 Add logging: log each page creation, each image upload, each error with context (page ID, filename, error message)
+- [ ] 6.6 Use timestamp (ISO 8601 format) for asset folder naming to ensure uniqueness across runs
+- [ ] 6.7 Add unit tests for: small import (synchronous), large import (queued), dryrun accuracy, error handling
+
+## 7. Background job implementation
+
+- [ ] 7.1 Create `lib/BackgroundJob/ConfluenceImportJob.php` extending `OCP\BackgroundJob\Job`
+- [ ] 7.2 Store job arguments: file path, parent path (optional), user ID of requester
+- [ ] 7.3 In `run()` method: call `ConfluenceImportService::import()`, update `oc_mydash_confluence_import_logs` table with progress and final result
+- [ ] 7.4 After import completes: set status to `completed` or `failed`, store `createdDashboardCount`, `skippedPageCount`, `errors` (as JSON)
+- [ ] 7.5 Store a log URL or generate import summary for admin review
+- [ ] 7.6 If import fails mid-process: set status to `failed`, log the exception, clean up partial imports if needed (or leave orphaned dashboards with a marker for admin review)
+
+## 8. Controller and API endpoints
+
+- [ ] 8.1 Create `lib/Controller/ConfluenceImportController.php` with methods:
+  - [ ] 8.1.1 `dryRun()` mapped to `POST /api/admin/import/confluence/dry-run` — accepts multipart file, returns dry-run preview
+  - [ ] 8.1.2 `import()` mapped to `POST /api/admin/import/confluence` — accepts multipart file + optional `parentPath` query param, returns ImportResult or queues async job
+  - [ ] 8.1.3 `getJob(string $jobId)` mapped to `GET /api/admin/import/confluence/jobs/{jobId}` — returns job status and progress
+- [ ] 8.2 Require admin role (`@IsAdminRequired` or equivalent) on all endpoints
+- [ ] 8.3 Validate `file` parameter: must be a valid ZIP, must not exceed max upload size
+- [ ] 8.4 Return HTTP 400 for validation errors (missing file, invalid ZIP, etc.)
+- [ ] 8.5 Return HTTP 202 (Accepted) for async imports; HTTP 200 for synchronous imports or dry-run
+- [ ] 8.6 Add error handling: multipart parse errors, ZIP read errors, file write errors — return appropriate HTTP codes
+- [ ] 8.7 Add integration tests for: dryrun endpoint, sync import endpoint, async job queuing, job polling
+
+## 9. CLI command
+
+- [ ] 9.1 Create `lib/Command/ConfluenceImportCommand.php` extending `OCP\Console\Command\Command`
+- [ ] 9.2 Add options: `--file` (required), `--parent-path` (optional), `--dry-run` (optional)
+- [ ] 9.3 Validate options: file must exist and be readable
+- [ ] 9.4 Call `ConfluenceImportService` methods based on options (dryRun if `--dry-run`, import otherwise)
+- [ ] 9.5 Output progress to `OutputInterface`: page count, dashboard count, errors
+- [ ] 9.6 Exit with code 0 on success, non-zero on failure
+- [ ] 9.7 For async imports: queue job and output job ID for polling
+- [ ] 9.8 Add integration tests for: all option combinations, error handling, output format
+
+## 10. Routes registration
+
+- [ ] 10.1 Register two new routes in `appinfo/routes.php`:
+  - [ ] 10.1.1 `POST /api/admin/import/confluence` → `ConfluenceImportController::import()`
+  - [ ] 10.1.2 `POST /api/admin/import/confluence/dry-run` → `ConfluenceImportController::dryRun()`
+  - [ ] 10.1.3 `GET /api/admin/import/confluence/jobs/{jobId}` → `ConfluenceImportController::getJob()`
+- [ ] 10.2 Ensure routes are under `/api/` namespace and admin-protected
+
+## 11. Integration and end-to-end tests
+
+- [ ] 11.1 Create a sample Confluence export ZIP with 50 pages in a 3-level hierarchy, 10 attachments
+- [ ] 11.2 Add E2E test: upload sample ZIP via API, verify all 50 dashboards created, parents linked correctly, images uploaded, links rewritten
+- [ ] 11.3 Add E2E test: run CLI import command with the same ZIP, verify dashboards created (new UUIDs)
+- [ ] 11.4 Add E2E test: dryrun endpoint, verify counts accurate, verify no databases modified
+- [ ] 11.5 Add E2E test: page with malformed HTML, verify skipped and logged, other pages imported
+- [ ] 11.6 Add E2E test: async import of 150-page archive, verify job queued, status polling works, completion detected
+
+## 12. Documentation and logging
+
+- [ ] 12.1 Update `openspec/specs/admin-settings/spec.md` to reference new import capability (optional, depends on spec structure)
+- [ ] 12.2 Add `README.md` or section to app docs explaining import workflow, supported features, known limitations
+- [ ] 12.3 Ensure all import operations are logged via `ILogger` with appropriate levels (info for milestones, warning for recoverable errors, error for failures)
+- [ ] 12.4 Include context in log entries: page ID, page count progress, image filenames, link targets, etc.
+
+## 13. Quality and testing
+
+- [ ] 13.1 Run `composer check:strict` (PHPCS, PHPMD, Psalm, PHPStan) — ensure all new code passes with 0 warnings
+- [ ] 13.2 Achieve >80% code coverage on new services (measured via PHPUnit and code coverage tools)
+- [ ] 13.3 Add performance test: import 500-page archive, measure time and memory, ensure sub-10-minute execution for async
+- [ ] 13.4 Test on sqlite, mysql, postgres databases — ensure migration is database-agnostic
+- [ ] 13.5 Manual smoke test: upload real Confluence export (with permission), verify import quality

--- a/openspec/changes/dashboard-bulk-operations/design.md
+++ b/openspec/changes/dashboard-bulk-operations/design.md
@@ -1,0 +1,125 @@
+# Design — Dashboard Bulk Operations
+
+## Context
+
+This change adds four batch-mutation endpoints (`bulk-delete`, `bulk-move`, `bulk-status`, `bulk-reindex`) and a matching frontend multi-select UI to the MyDash admin panel. Without these, administrators managing hundreds of dashboards must issue single-item API calls or resort to direct database manipulation — neither of which leaves a usable audit trail.
+
+The source implementation performs bulk delete as a **hard delete** via the Nextcloud Files API (`$folder->delete()` on the NC filesystem node). There is no soft-delete flag, no `deleted_at` column, and no grace period. Recovery is only possible through Nextcloud's system-wide trash bin, which may or may not be enabled on a given installation.
+
+The most consequential design question is what happens when a bulk-delete request targets a **parent dashboard that has children**. The source accepts a `deleteChildren` boolean and defaults it to `true`, silently cascading a hard delete across an entire sub-tree. This is the most likely vector for an admin misclick causing irrecoverable data loss at scale: "Delete 50 dashboards" that turns out to have deleted 300 because several were parents.
+
+A related question is whether to introduce a **soft-delete grace period** at this point. Soft delete trades implementation complexity and storage growth for a 30-day undo window, which would be valuable for exactly the "I deleted the wrong sub-tree" scenario. The decision below addresses both.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Provide four batch endpoints covering the most common admin operations (delete, re-parent, set status, reindex).
+- Protect against the most common misclick scenario: hard-deleting a parent dashboard and cascading to its entire child tree without an explicit opt-in.
+- Align cascade semantics with `dashboard-tree`'s existing `?cascade=true` convention (REQ-DASH-016 area).
+- Support dry-run preview on all endpoints so admins can inspect impact before committing.
+- Provide a single audit event per request rather than per-dashboard log spam.
+- Enforce an all-or-nothing permission pre-check to prevent partial-permission-leak scenarios.
+
+**Non-Goals:**
+- Soft-delete or undo/restore functionality (deferred to a future capability if customers request it).
+- Bulk operations for non-admin users (all four endpoints require admin role).
+- Cross-app bulk operations (scoped to `oc_mydash_dashboards` only).
+- Automatic retry on partial failure (caller is responsible for retrying failed UUIDs).
+
+## Decisions
+
+### D1: Delete strategy — hard delete, `cascade=false` default, `?cascade=true` opt-in
+
+**Decision:** Bulk delete removes rows directly from `oc_mydash_dashboards` via the Nextcloud Files API (hard delete, matching the source). Cascade to child dashboards is **not** the default: attempting to delete a parent that has children without `?cascade=true` returns **HTTP 409** with a body indicating how many children block the operation. Passing `?cascade=true` opts in to recursive deletion and the caller bears explicit responsibility for the cascade.
+
+**Alternatives considered:**
+
+- **Option A — match source exactly (`cascade=true` default):** The source defaults `deleteChildren=true`. This is fast and simple, but it turns a misclick on "Delete Section A" into a silent recursive hard delete with no recovery path unless NC's trash bin is enabled (which is not guaranteed). Rejected because the risk-to-convenience ratio is unfavourable in a multi-admin production deployment.
+
+- **Option B — soft delete with `deleted_at` column + 30-day grace period:** Would allow undo within 30 days, mirroring how most modern collaborative tools handle bulk deletes. Requires a new column, a sweeper job, and filter changes on every query that reads dashboard rows. Rejected for v1 because it is a non-trivial schema change and the immediate priority is parity-plus-safety, not a full recovery workflow. Revisit if customers report misclick incidents.
+
+**Rationale:** Hard delete keeps the implementation lean and matches the proven source behaviour, while flipping the dangerous default to `cascade=false` eliminates the most common catastrophic misclick. This is consistent with `dashboard-tree`'s existing pattern where operations that recurse into children require an explicit `?cascade=true` signal. The HTTP 409 response gives the admin a clear pause point before proceeding with a broader operation.
+
+**Source evidence:**
+- `intravox-source/lib/Service/BulkOperationService.php:97-130` — `bulkDelete()` iterates IDs and delegates to `deletePage()` per dashboard.
+- `intravox-source/lib/Service/PageService.php:1675,1712` — `deletePage()` calls `$result['folder']->delete()` on the NC filesystem node; hard delete with no soft-delete flag.
+- `intravox-source/lib/Controller/BulkController.php:100-135` — `deletePages()` accepts `deleteChildren` (default `true`); this default is the risky behaviour we are changing.
+
+---
+
+### D2: Cap on per-request batch size — 500
+
+**Decision:** Each bulk endpoint accepts at most 500 `dashboardUuids` per request. Requests exceeding the cap return HTTP 400 immediately with no mutations. The cap is admin-tunable via `mydash.bulk_operation_max_per_request` (OCC config or web settings); invalid values (zero, negative) fall back to 500 with a warning log.
+
+**Rationale:** A cap of 500 is generous enough for any sane organisation-wide operation but prevents an errant admin script from issuing a single request that locks the dashboard table for minutes. The config escape hatch avoids breaking large-org deployments that genuinely need higher limits.
+
+---
+
+### D3: Per-dashboard atomicity, batch reporting
+
+**Decision:** Each dashboard's mutation runs in its own database transaction. Partial failure (one dashboard fails) is reported in the response `errors` array and processing continues with the remaining UUIDs. The batch is not all-or-nothing at the mutation level — only the permission pre-check is (see D4).
+
+**Source evidence:**
+- `intravox-source/lib/Service/BulkOperationService.php:97-130` — per-page iteration with continue-on-error semantics; no wrapping transaction across the whole batch.
+
+**Rationale:** Continue-on-error semantics let large-batch cleanup operations make progress even when a small number of dashboards have transient errors. All-or-nothing batch transactions would cause large operations to fail silently on any foreign-key hiccup. The caller is responsible for inspecting the `errors` array and retrying failed UUIDs.
+
+---
+
+### D4: Permission — all-or-nothing pre-check, then per-dashboard execution
+
+**Decision:** Before any mutation begins, the system verifies that the calling user has the required permission on every dashboard in the batch. If any dashboard fails the check, the entire request is rejected with HTTP 403 and no mutations occur. Permission failure takes priority over size-cap validation (fail-fast on the security constraint). After a clean pre-check, per-dashboard execution proceeds with the per-dashboard atomicity from D3.
+
+**Rationale:** A partial-permission model would allow an attacker (or misconfigured script) to delete dashboards they do own by bundling them with one they do not, exploiting the continue-on-error execution. The pre-check closes this leak. The 403 response body MUST enumerate the unauthorised UUIDs so the admin can diagnose which dashboard caused the rejection.
+
+---
+
+### D5: Rate limit — 5 requests/60s per user
+
+**Decision:** Match the source. Apply `#[UserRateThrottle(limit: 5, period: 60)]` to all four bulk endpoints.
+
+**Source evidence:**
+- `intravox-source/lib/Controller/BulkController.php:100` — `#[UserRateThrottle(limit: 5, period: 60)]`.
+
+**Rationale:** Five batch requests per minute allows rapid interactive use while preventing a runaway script from overwhelming the database with back-to-back 500-item batches.
+
+---
+
+### D6: Single audit event per bulk operation
+
+**Decision:** Each bulk endpoint emits exactly ONE Nextcloud Activity event of type `dashboard_bulk_operation` per request. The payload includes: `operation`, `dashboardCount`, `byUserId`, `durationMs`, and `dryRun` flag. Per-dashboard events are not emitted. Dry-run requests also emit an audit event (with `dryRun: true`) and so do rejected requests (with the failure reason).
+
+**Rationale:** Emitting one event per dashboard in a 500-item batch would spam the activity log and make it unusable for audit purposes. A single summary event preserves the audit trail without the noise.
+
+---
+
+### D7: Dry-run via `?dryRun=true`
+
+**Decision:** All four endpoints accept `?dryRun=true`. In dry-run mode the full validation stack runs (permissions, size cap, idempotency checks, cycle detection for bulk-move) and the response uses `wouldX` counter names instead of `X` counters — but no database mutations occur. Dry-run defaults to `false` when the parameter is absent.
+
+**Rationale:** Dry-run support is essential for bulk operations at scale. Admins preparing a large cleanup should be able to preview exactly which dashboards would be skipped or error before committing. The identical validation path ensures the preview is accurate and not a separate code path that diverges under edge cases.
+
+---
+
+### D8: Comment cascade via existing listener
+
+**Decision:** No new cascade logic is required for bulk delete. The existing `PageDeletedListener` already handles comment cleanup on NC Files API delete events for single-dashboard deletions; bulk delete triggers the same NC Files events, so comment cleanup fires automatically per dashboard.
+
+**Rationale:** Reusing the existing listener keeps bulk delete from duplicating cascade logic and ensures consistency between single and bulk delete semantics. This is consistent with the source's approach.
+
+---
+
+## Spec changes implied
+
+- **REQ-BULK-001 (delete):** Change "soft-delete" wording to "hard delete". Change `cascade` default from `true` to `false`. Document HTTP 409 response when a parent has children and `?cascade=true` is not present. Document `?cascade=true` as the opt-in for recursive deletion.
+- **REQ-BULK-005 (atomicity):** Clarify that permission pre-check (D4) is all-or-nothing, but DB-level atomicity (D3) is per-dashboard after the pre-check passes.
+- **REQ-BULK-006 (rate limit):** Pin `#[UserRateThrottle(limit: 5, period: 60)]` for all four endpoints.
+- **REQ-BULK-007 (idempotency):** For bulk-delete, confirm that attempting to delete an already-deleted dashboard is a no-op counted as `skippedCount`, not an error. (Hard delete on a non-existent row is absorbed silently.)
+- **REQ-BULK-009 (audit):** Confirm dry-run and rejected requests also emit the single audit event.
+
+## Open follow-ups
+
+- Whether to add a soft-delete grace period as a follow-up capability if customers request undo after a misclick incident.
+- Whether `?cascade=true` on bulk-delete should recursively apply the same 500-item cap check (i.e., total dashboards including children must not exceed 500), or whether the cap applies only to the explicitly listed UUIDs.
+- Whether bulk-move into a parent that would create a cycle should be detected at request time using `dashboard-tree`'s cycle-check service — likely yes, and the error should appear in the per-dashboard `errors` array rather than returning HTTP 400 for the whole batch.
+- Whether bulk-status should accept a mixed-per-dashboard status array (different statuses per UUID) or only a single target status per request. Current spec assumes one status per request.

--- a/openspec/changes/dashboard-bulk-operations/proposal.md
+++ b/openspec/changes/dashboard-bulk-operations/proposal.md
@@ -1,0 +1,66 @@
+# Dashboard Bulk Operations
+
+## Why
+
+MyDash administrators need efficient tools for large-scale dashboard management: cleaning up obsolete dashboards, reorganizing dashboard hierarchies, updating publication status across templates, and maintaining search indices. Today, these operations require either single-dashboard API calls (tedious for hundreds of items) or direct database manipulation (risky). A dedicated bulk operations API with atomic-per-dashboard semantics, dry-run support, and comprehensive audit trails enables safe, traceable large-scale administration.
+
+## What Changes
+
+- Add `POST /api/admin/dashboards/bulk-delete` — soft-delete multiple dashboards by UUID in a single request; returns count of deleted/skipped and per-dashboard error reasons.
+- Add `POST /api/admin/dashboards/bulk-move` — re-parent multiple dashboards in the dashboard tree; validates cycles via the `dashboard-tree` capability; returns move counts and errors.
+- Add `POST /api/admin/dashboards/bulk-status` — update publication status (draft/published/scheduled) across multiple dashboards; depends on `dashboard-draft-published` capability; supports future publish dates.
+- Add `POST /api/admin/dashboards/bulk-reindex` — re-index multiple dashboards for unified search; depends on `nc-unified-search-integration` capability.
+- All endpoints accept `?dryRun=true` query param — returns predicted results without mutations.
+- Request limit: max 500 dashboardUuids per request; returns HTTP 400 if exceeded (configurable via `mydash.bulk_operation_max_per_request`).
+- Idempotency: bulk-delete on already-deleted dashboard = no-op (counted as skipped, listed in errors); bulk-move where parent IS current parent = no-op; bulk-status where status IS current status = no-op.
+- Atomicity: each dashboard's DB write is transactional; batch is NOT atomic (partial success is reported, not rolled back).
+- Audit: single Nextcloud Activity event per bulk operation with operation type, dashboard count, user ID, and duration; per-dashboard activity NOT emitted (avoid spam).
+- Permissions: all endpoints return 403 if the calling user lacks permission on ANY dashboard in the batch (fail-safe; no partial action).
+- Frontend: add multi-select checkbox column to dashboard list view + "Actions" dropdown (enabled when ≥1 row selected) with Delete, Move to..., Set status, Reindex options.
+
+## Capabilities
+
+### New Capabilities
+
+- `dashboard-bulk-operations`: provides REQ-BULK-001 through REQ-BULK-011 (bulk-delete, bulk-move, bulk-status, bulk-reindex, atomicity per-dashboard, cap, idempotency, dry-run, audit, front-end multi-select, permissions all-or-nothing).
+
+### Modified Capabilities
+
+- None. Existing dashboard CRUD, dashboard-tree (cycle check delegation), dashboard-draft-published (status enum reuse), and nc-unified-search-integration are unchanged; this capability adds batch endpoints only.
+
+## Impact
+
+**Affected code:**
+
+- `lib/Service/BulkOperationService.php` — orchestration for delete, move, status, reindex with idempotency and dry-run logic.
+- `lib/Controller/AdminController.php` — extend existing admin controller or create new `AdminBulkController.php` for four new endpoints.
+- `appinfo/routes.php` — register four new POST routes under `/api/admin/dashboards/bulk-*`.
+- `lib/Activity/BulkOperationActivityProvider.php` — single activity event per bulk operation.
+- `src/views/AdminDashboardList.vue` — add multi-select checkbox column and Actions dropdown to dashboard list.
+- `lib/Migration/VersionXXXXDate2026...php` — none required (no new tables, uses existing dashboard schema).
+
+**Affected APIs:**
+
+- 4 new routes (no existing routes modified).
+- Existing `GET /api/dashboards`, `POST /api/dashboard`, `PUT /api/dashboard/{uuid}`, `DELETE /api/dashboard/{uuid}` unchanged.
+
+**Dependencies:**
+
+- `OCP\IConfig` — for reading `mydash.bulk_operation_max_per_request` (default 500).
+- `OCP\Activity\IManager` — for emitting bulk operation activity events.
+- Existing `DashboardMapper`, `PermissionService`, `ActivityService` — no new services.
+- Delegation to `dashboard-tree` capability for cycle checking (via `DashboardTreeService`).
+- Delegation to `dashboard-draft-published` capability for status enum validation (via `DashboardStatusService` or equivalent).
+- Delegation to `nc-unified-search-integration` capability for re-indexing (via search provider).
+
+**Migration:**
+
+- No new tables or schema changes. All bulk operations work with existing `oc_mydash_dashboards` table and related indices.
+
+**Security:**
+
+- Permissions enforced all-or-nothing: if any one dashboard in the batch is unauthorized, the entire batch is rejected (HTTP 403, no mutations).
+- Soft-delete only; hard delete never exposed (consistent with existing dashboard deletion model).
+- Audit trail: every bulk operation is logged via Nextcloud Activity (no blind admin actions).
+- Dry-run flag prevents accidental mutations and supports planning / preview workflows.
+

--- a/openspec/changes/dashboard-bulk-operations/specs/dashboard-bulk-operations/spec.md
+++ b/openspec/changes/dashboard-bulk-operations/specs/dashboard-bulk-operations/spec.md
@@ -1,0 +1,400 @@
+---
+status: draft
+---
+
+# Dashboard Bulk Operations Specification
+
+## ADDED Requirements
+
+### Requirement: REQ-BULK-001 Bulk Delete Dashboards
+
+Administrators MUST be able to soft-delete multiple dashboards in a single API request, with idempotent handling of already-deleted dashboards.
+
+#### Scenario: Delete three valid dashboards
+- GIVEN an admin user with dashboard-admin or full-admin permissions
+- WHEN she sends POST /api/admin/dashboards/bulk-delete with body `{"dashboardUuids": ["uuid-1", "uuid-2", "uuid-3"]}`
+- THEN the system MUST soft-delete each dashboard (set isDeleted flag or equivalent soft-delete marker)
+- AND the response MUST return HTTP 200 with `{deletedCount: 3, skippedCount: 0, errors: []}`
+- AND the deleted dashboards MUST NOT appear in GET /api/dashboards list for any user
+- AND no Nextcloud Activity event for each individual dashboard deletion — only ONE bulk operation event MUST be emitted
+
+#### Scenario: Bulk delete with one already-deleted dashboard
+- GIVEN admin has permission to delete all three dashboards, but "uuid-2" is already deleted
+- WHEN she sends the same bulk-delete request
+- THEN the system MUST skip the already-deleted dashboard
+- AND the response MUST return `{deletedCount: 2, skippedCount: 1, errors: [{uuid: "uuid-2", reason: "already_deleted"}]}`
+
+#### Scenario: Bulk delete with insufficient permissions
+- GIVEN admin user "alice" but "uuid-3" belongs to a private dashboard that "alice" cannot delete
+- WHEN she sends POST /api/admin/dashboards/bulk-delete with all three uuids
+- THEN the system MUST return HTTP 403 (Forbidden)
+- AND NO mutations MUST occur (all-or-nothing permission check)
+- AND error response MUST indicate which uuid(s) caused the permission denial
+
+#### Scenario: Bulk delete request exceeds size cap
+- GIVEN the configured cap is 500 dashboards per request
+- WHEN admin sends POST /api/admin/dashboards/bulk-delete with 501 uuids
+- THEN the system MUST return HTTP 400 with error message "Request contains 501 dashboards; maximum is 500"
+- AND NO mutations MUST occur
+
+#### Scenario: Dry-run bulk delete
+- GIVEN admin sends POST /api/admin/dashboards/bulk-delete?dryRun=true with three valid uuids
+- THEN the system MUST NOT soft-delete any dashboard
+- AND the response MUST return `{wouldDeleteCount: 3, wouldSkipCount: 0, errors: []}`
+- AND GET /api/dashboards MUST still list all three dashboards
+
+### Requirement: REQ-BULK-002 Bulk Move Dashboards in Tree
+
+Administrators MUST be able to re-parent multiple dashboards in the dashboard hierarchy, with cycle detection and idempotent handling of no-op moves.
+
+#### Scenario: Move three dashboards under a new parent
+- GIVEN three dashboards "child-1", "child-2", "child-3" currently under parent "old-parent"
+- WHEN admin sends POST /api/admin/dashboards/bulk-move with body `{"dashboardUuids": ["child-1", "child-2", "child-3"], "parentUuid": "new-parent"}`
+- THEN the system MUST update each dashboard's parent_uuid to "new-parent"
+- AND the response MUST return HTTP 200 with `{movedCount: 3, skippedCount: 0, errors: []}`
+- AND GET /api/dashboards/{uuid} MUST show the new parent for each dashboard
+
+#### Scenario: Move dashboards to root (null parent)
+- GIVEN three dashboards currently under parent "some-parent"
+- WHEN admin sends POST /api/admin/dashboards/bulk-move with body `{"dashboardUuids": [...], "parentUuid": null}`
+- THEN each dashboard MUST be re-parented to root (parent_uuid = null)
+- AND the response MUST return `{movedCount: 3, skippedCount: 0, errors: []}`
+
+#### Scenario: Bulk move detects cycle (would create circular parent-child)
+- GIVEN dashboard A is parent of B, B is parent of C
+- WHEN admin sends POST /api/admin/dashboards/bulk-move with `{"dashboardUuids": ["A"], "parentUuid": "C"}` (trying to make C parent of A)
+- THEN the system MUST validate via `dashboard-tree` capability's cycle-check service
+- AND the response MUST return HTTP 200 (but with error in batch) `{movedCount: 0, skippedCount: 0, errors: [{uuid: "A", reason: "cycle_detected", detail: "..."}]}`
+- AND dashboard A's parent MUST NOT be updated
+
+#### Scenario: Bulk move with no-op (parent already matches target)
+- GIVEN dashboard "child" currently under parent "target-parent"
+- WHEN admin sends POST /api/admin/dashboards/bulk-move with `{"dashboardUuids": ["child"], "parentUuid": "target-parent"}`
+- THEN the system MUST recognize this as a no-op
+- AND the response MUST return `{movedCount: 0, skippedCount: 1, errors: [{uuid: "child", reason: "parent_already_matches"}]}`
+- AND no database update MUST occur
+
+#### Scenario: Bulk move with insufficient permissions
+- GIVEN admin user cannot delete or move dashboard "uuid-2"
+- WHEN she sends bulk-move request with that uuid
+- THEN the system MUST return HTTP 403
+- AND NO mutations MUST occur (all-or-nothing)
+
+#### Scenario: Dry-run bulk move
+- GIVEN admin sends POST /api/admin/dashboards/bulk-move?dryRun=true with three valid uuids and new parent
+- THEN the system MUST NOT update any parent_uuid
+- AND the response MUST return `{wouldMoveCount: 3, wouldSkipCount: 0, errors: []}`
+- AND GET /api/dashboards/{uuid} MUST still show the old parent for each dashboard
+
+### Requirement: REQ-BULK-003 Bulk Update Publication Status
+
+Administrators MUST be able to update publication status (draft, published, scheduled) across multiple dashboards, with idempotent handling of dashboards already at target status.
+
+#### Scenario: Publish three draft dashboards
+- GIVEN three dashboards with publicationStatus = "draft"
+- WHEN admin sends POST /api/admin/dashboards/bulk-status with body `{"dashboardUuids": [...], "publicationStatus": "published"}`
+- THEN the system MUST update each dashboard's publicationStatus to "published"
+- AND the response MUST return HTTP 200 with `{updatedCount: 3, skippedCount: 0, errors: []}`
+- AND the dashboards MUST now appear in public dashboard listings (if applicable)
+
+#### Scenario: Bulk status with idempotency (dashboards already published)
+- GIVEN three dashboards already with publicationStatus = "published"
+- WHEN admin sends the same bulk-status request to "published"
+- THEN the system MUST recognize all three as no-ops
+- AND the response MUST return `{updatedCount: 0, skippedCount: 3, errors: [{uuid: "...", reason: "status_already_matches"}, ...]}`
+- AND no database updates MUST occur
+
+#### Scenario: Schedule dashboards for future publish date
+- GIVEN three draft dashboards
+- WHEN admin sends POST /api/admin/dashboards/bulk-status with body `{"dashboardUuids": [...], "publicationStatus": "scheduled", "publishAt": "2026-06-15T10:00:00Z"}`
+- THEN the system MUST update publicationStatus to "scheduled" and set publishAt to the provided ISO 8601 timestamp
+- AND the response MUST return `{updatedCount: 3, skippedCount: 0, errors: []}`
+- AND the dashboards MUST NOT be publicly visible until the scheduled time
+- NOTE: The `dashboard-draft-published` capability provides the publishAt scheduler; this bulk endpoint reuses its status validation
+
+#### Scenario: Bulk status to scheduled without publishAt date
+- GIVEN admin sends POST /api/admin/dashboards/bulk-status with `{"publicationStatus": "scheduled"}` (no publishAt)
+- THEN the system MUST return HTTP 400 with error message "publishAt is required when publicationStatus is 'scheduled'"
+- AND NO mutations MUST occur
+
+#### Scenario: Invalid publication status value
+- GIVEN admin sends POST /api/admin/dashboards/bulk-status with `{"publicationStatus": "invalid"}`
+- THEN the system MUST return HTTP 400 with error message "publicationStatus must be one of: draft, published, scheduled"
+- AND NO mutations MUST occur
+
+#### Scenario: Bulk status with insufficient permissions
+- GIVEN admin cannot modify status on one dashboard
+- WHEN she sends bulk-status request with that uuid
+- THEN the system MUST return HTTP 403
+- AND NO mutations MUST occur (all-or-nothing)
+
+#### Scenario: Dry-run bulk status
+- GIVEN admin sends POST /api/admin/dashboards/bulk-status?dryRun=true with three draft dashboards and target status "published"
+- THEN the system MUST NOT update any publicationStatus
+- AND the response MUST return `{wouldUpdateCount: 3, wouldSkipCount: 0, errors: []}`
+- AND GET /api/dashboards/{uuid} MUST still show publicationStatus = "draft" for each
+
+### Requirement: REQ-BULK-004 Bulk Re-index Dashboards for Search
+
+Administrators MUST be able to re-index multiple dashboards for unified search in a single request, with error reporting for individual re-index failures.
+
+#### Scenario: Re-index three valid dashboards
+- GIVEN three dashboards with existing search index entries
+- WHEN admin sends POST /api/admin/dashboards/bulk-reindex with body `{"dashboardUuids": ["uuid-1", "uuid-2", "uuid-3"]}`
+- THEN the system MUST trigger re-indexing for each dashboard via the `nc-unified-search-integration` capability's search provider
+- AND the response MUST return HTTP 200 with `{reindexedCount: 3, errors: []}`
+
+#### Scenario: Bulk re-index with one failing dashboard
+- GIVEN three dashboards, but "uuid-2" has a corrupted search index that fails to re-index
+- WHEN admin sends POST /api/admin/dashboards/bulk-reindex with all three uuids
+- THEN the system MUST attempt to re-index all three
+- AND the response MUST return `{reindexedCount: 2, errors: [{uuid: "uuid-2", reason: "reindex_failed", detail: "..."}]}`
+- AND the batch MUST continue after the failure (not atomic; partial success is reported)
+
+#### Scenario: Bulk re-index with insufficient permissions
+- GIVEN admin cannot access dashboard "uuid-3"
+- WHEN she sends bulk-reindex request with that uuid
+- THEN the system MUST return HTTP 403
+- AND NO re-indexing MUST occur (all-or-nothing permission check)
+
+#### Scenario: Dry-run bulk re-index
+- GIVEN admin sends POST /api/admin/dashboards/bulk-reindex?dryRun=true with three valid uuids
+- THEN the system MUST NOT invoke the search provider's re-index method
+- AND the response MUST return `{wouldReindexCount: 3, errors: []}`
+
+#### Scenario: Re-index request exceeds size cap
+- GIVEN cap is 500 dashboards per request
+- WHEN admin sends POST /api/admin/dashboards/bulk-reindex with 501 uuids
+- THEN the system MUST return HTTP 400
+- AND NO re-indexing MUST occur
+
+### Requirement: REQ-BULK-005 Atomicity Per Dashboard, Not Across Batch
+
+Dashboard bulk operations MUST guarantee atomicity at the per-dashboard level (each dashboard's database write is transactional), but NOT across the entire batch. Partial failure is reported and safe.
+
+#### Scenario: One dashboard transaction fails in a batch of three
+- GIVEN three dashboards, each in its own database transaction for bulk-delete
+- WHEN the transaction for "uuid-2" fails (e.g., foreign key constraint)
+- THEN the system MUST commit the transaction for "uuid-1", skip "uuid-2" with error, and attempt "uuid-3"
+- AND the response MUST return `{deletedCount: 2, skippedCount: 0, errors: [{uuid: "uuid-2", reason: "transaction_failed"}]}`
+- AND "uuid-1" and "uuid-3" MUST be deleted; "uuid-2" MUST NOT be deleted
+- AND the caller MUST treat partial success as valid (no automatic rollback)
+
+#### Scenario: Batch not atomic means caller must retry manually
+- GIVEN bulk-delete of 10 dashboards, 5 succeed, 5 fail
+- WHEN caller receives `{deletedCount: 5, skippedCount: 0, errors: [5 errors]}`
+- THEN the caller (admin) MUST be responsible for retrying the 5 failed dashboards
+- AND the system MUST NOT offer automatic rollback of the 5 successful deletions
+- NOTE: This allows for safe cleanup flows where partial success is acceptable and inspectable
+
+### Requirement: REQ-BULK-006 Request Size Cap (Max 500 Dashboards per Request)
+
+All bulk endpoints MUST enforce a maximum number of dashboardUuids per request, configurable via admin settings.
+
+#### Scenario: Request within cap is accepted
+- GIVEN admin sends bulk-delete with 500 uuids (exactly at cap)
+- WHEN the system checks request size
+- THEN the system MUST accept the request and proceed
+- AND no HTTP 400 error MUST be returned
+
+#### Scenario: Request exceeds cap is rejected
+- GIVEN admin sends bulk-delete with 501 uuids (exceeds default cap of 500)
+- WHEN the system checks request size
+- THEN the system MUST return HTTP 400 with error message "Request contains 501 dashboards; maximum is 500 (configured by admin)"
+- AND NO mutations MUST occur
+- AND the error response MUST indicate the current cap value
+
+#### Scenario: Admin modifies bulk operation cap
+- GIVEN admin sets config `mydash.bulk_operation_max_per_request = 1000` via OCC command or web settings
+- WHEN admin sends bulk-delete with 750 uuids
+- THEN the system MUST accept the request (750 <= 1000)
+- AND no HTTP 400 error MUST be returned
+- AND the new cap MUST apply immediately to all subsequent requests
+
+#### Scenario: Cap of zero or negative is invalid
+- GIVEN admin accidentally sets `mydash.bulk_operation_max_per_request = 0`
+- WHEN the system reads the config
+- THEN the system MUST apply a safe default (e.g., 500) as fallback
+- AND log a warning that the configured cap is invalid
+
+### Requirement: REQ-BULK-007 Idempotency for Delete, Move, Status Operations
+
+Bulk operations MUST handle idempotent cases gracefully: deleting already-deleted dashboards, moving to the same parent, and setting to the same status result in no-op entries in the response, not errors.
+
+#### Scenario: Delete already-deleted dashboard
+- GIVEN dashboard "uuid-1" is already soft-deleted
+- WHEN admin sends bulk-delete with that uuid
+- THEN the system MUST NOT return an error, but rather count it as `skippedCount`
+- AND the response MUST include `{uuid: "uuid-1", reason: "already_deleted"}` in the errors array (for auditability, not rejection)
+
+#### Scenario: Move to same parent
+- GIVEN dashboard "child" with parent_uuid = "parent"
+- WHEN admin sends bulk-move with the same parent_uuid
+- THEN the system MUST recognize the no-op and skip the update
+- AND the response MUST include `{uuid: "child", reason: "parent_already_matches"}` in errors
+- AND `movedCount` MUST be 0, `skippedCount` MUST be 1
+
+#### Scenario: Set to same status
+- GIVEN dashboard "dash" with publicationStatus = "published"
+- WHEN admin sends bulk-status with publicationStatus = "published"
+- THEN the system MUST recognize the no-op and skip the update
+- AND the response MUST include `{uuid: "dash", reason: "status_already_matches"}` in errors
+- AND `updatedCount` MUST be 0, `skippedCount` MUST be 1
+- NOTE: This reduces unnecessary database writes and log spam
+
+### Requirement: REQ-BULK-008 Dry-Run Mode for Preview Without Mutation
+
+All bulk endpoints MUST support `?dryRun=true` query parameter, which returns predicted results without performing any database mutations.
+
+#### Scenario: Dry-run returns wouldX counts instead of X counts
+- GIVEN admin sends POST /api/admin/dashboards/bulk-delete?dryRun=true with three valid uuids
+- THEN the system MUST validate permissions, size, and idempotency logic
+- AND the response MUST return `{wouldDeleteCount: 3, wouldSkipCount: 0, errors: []}`
+- AND no database mutations MUST occur
+- AND GET /api/dashboards MUST still list all three dashboards
+
+#### Scenario: Dry-run validation is identical to real run
+- GIVEN admin sends bulk-delete with one unauthorized dashboard
+- WHEN she sends with `?dryRun=true`
+- THEN the system MUST still return HTTP 403 (validation is the same)
+- AND no mutations MUST occur (as expected)
+
+#### Scenario: Multiple dry-run calls return consistent results
+- GIVEN admin sends bulk-delete?dryRun=true twice with the same three uuids
+- THEN both responses MUST have identical `wouldDeleteCount`, `wouldSkipCount`, and `errors`
+- AND no side effects MUST occur on either call
+
+#### Scenario: dryRun defaults to false
+- GIVEN admin sends POST /api/admin/dashboards/bulk-delete without ?dryRun parameter
+- WHEN the system processes the request
+- THEN the system MUST treat it as `dryRun=false` (real mutations occur)
+- AND the response MUST use real counts (deletedCount, not wouldDeleteCount)
+
+### Requirement: REQ-BULK-009 Single Audit Event Per Bulk Operation
+
+Each bulk operation MUST emit exactly ONE Nextcloud Activity event (of type `dashboard_bulk_operation`), not per-dashboard events, to avoid log spam and simplify auditing.
+
+#### Scenario: Bulk delete emits one activity event
+- GIVEN admin performs bulk-delete of 10 dashboards
+- WHEN the operation completes
+- THEN the system MUST emit exactly ONE Nextcloud Activity event (not 10)
+- AND the activity event MUST contain: `{operation: "delete", dashboardCount: 10, byUserId: "admin-user-id", durationMs: ...}`
+- AND subsequent calls to Activity API MUST show this single event (not 10 per-dashboard events)
+
+#### Scenario: Activity event includes operation duration
+- GIVEN admin sends bulk-move request at 2026-05-01T10:00:00Z
+- WHEN the operation completes at 2026-05-01T10:00:02.500Z
+- THEN the activity event MUST include `durationMs: 2500` (or similar high-resolution timing)
+- AND admins can use this to monitor performance trends
+
+#### Scenario: Dry-run also emits audit event
+- GIVEN admin sends bulk-delete?dryRun=true with 10 uuids
+- WHEN the dry-run completes
+- THEN the system MUST still emit ONE activity event
+- AND the activity payload MUST indicate it was a dry-run (or include a `dryRun: true` flag)
+
+#### Scenario: Failed bulk operation still emits activity event
+- GIVEN bulk-delete fails due to permission denied on one dashboard
+- WHEN the system returns HTTP 403
+- THEN the system MUST still emit ONE activity event (for auditability)
+- AND the event MUST indicate the reason for failure (e.g., `reason: "permission_denied"`)
+
+### Requirement: REQ-BULK-010 Frontend Multi-Select Checkbox Column and Actions Dropdown
+
+The admin dashboard list view MUST provide a multi-select checkbox interface and an Actions dropdown for bulk operations.
+
+#### Scenario: Administrator selects multiple dashboards via checkboxes
+- GIVEN the admin dashboard list view is loaded with 5 dashboards
+- WHEN the admin clicks the checkbox in the first column header
+- THEN all dashboard rows MUST be selected (checkmarks visible)
+- AND clicking an individual dashboard row's checkbox MUST deselect only that row
+- AND the header checkbox state MUST reflect the current selection (partial if some rows selected)
+
+#### Scenario: Actions dropdown appears only when rows are selected
+- GIVEN the admin dashboard list view with 0 dashboards selected
+- WHEN the Actions dropdown is visible
+- THEN the dropdown MUST be disabled (greyed out, not clickable)
+- AND clicking on a dashboard row MUST enable the dropdown
+- AND the dropdown MUST show 4 options: Delete, Move to..., Set status, Reindex
+
+#### Scenario: Delete action shows confirmation modal with dry-run toggle
+- GIVEN admin selects 3 dashboards and clicks Actions > Delete
+- WHEN the Delete confirmation modal opens
+- THEN the modal MUST show: "Delete 3 dashboards? This action cannot be undone."
+- AND a checkbox for "Dry run (preview only)" MUST be visible (unchecked by default)
+- AND an OK and Cancel button MUST be present
+- AND clicking OK MUST call POST /api/admin/dashboards/bulk-delete with dryRun flag
+
+#### Scenario: Move action shows hierarchical parent selector
+- GIVEN admin selects 3 dashboards and clicks Actions > Move to...
+- WHEN the Move modal opens
+- THEN a tree picker MUST be shown with all valid parent dashboards
+- AND an option for "Root (no parent)" MUST be available
+- AND a checkbox for "Dry run (preview only)" MUST be visible
+- AND clicking OK MUST call POST /api/admin/dashboards/bulk-move with selected parent
+
+#### Scenario: Set status action shows status and date selector
+- GIVEN admin selects 3 dashboards and clicks Actions > Set status
+- WHEN the Set status modal opens
+- THEN radio buttons for Draft, Published, Scheduled MUST be visible
+- AND selecting Scheduled MUST reveal a date/time picker for publishAt
+- AND a checkbox for "Dry run (preview only)" MUST be visible
+- AND clicking OK MUST call POST /api/admin/dashboards/bulk-status with chosen status and date
+
+#### Scenario: Reindex action shows simple confirmation
+- GIVEN admin selects 3 dashboards and clicks Actions > Reindex
+- WHEN the Reindex confirmation modal opens
+- THEN the modal MUST show: "Re-index 3 dashboards for search?"
+- AND a checkbox for "Dry run (preview only)" MUST be visible
+- AND clicking OK MUST call POST /api/admin/dashboards/bulk-reindex
+
+#### Scenario: Response summary after action completes
+- GIVEN admin performs bulk-delete of 3 dashboards
+- WHEN the response is received with `{deletedCount: 2, skippedCount: 1, errors: [...]}`
+- THEN a summary toast or modal MUST display: "Deleted 2 dashboards. Skipped 1. Errors: ..."
+- AND the dashboard list MUST refresh to reflect deletions (if not a dry-run)
+- AND the checkboxes MUST be cleared after the action
+
+#### Scenario: Dry-run response shows would-counts, no list refresh
+- GIVEN admin performs bulk-delete?dryRun=true of 3 dashboards
+- WHEN the response is received with `{wouldDeleteCount: 2, wouldSkipCount: 1, errors: []}`
+- THEN a summary MUST display: "PREVIEW: Would delete 2 dashboards. Would skip 1."
+- AND the dashboard list MUST NOT refresh (no mutations occurred)
+- AND the checkboxes MUST remain selected (allowing further previews or real action)
+
+### Requirement: REQ-BULK-011 All-or-Nothing Permission Enforcement
+
+Every bulk endpoint MUST enforce an all-or-nothing permission model: if the calling user lacks permission to operate on ANY dashboard in the batch, the entire batch is rejected with HTTP 403 and NO mutations occur.
+
+#### Scenario: Admin has full permission on all dashboards
+- GIVEN admin user "alice" is dashboard-admin or full-admin
+- WHEN she sends bulk-delete request with 5 uuids
+- THEN the system MUST check permission on each of the 5 dashboards
+- AND if all 5 are authorized, the request proceeds and mutations occur
+- AND no 403 error MUST be returned
+
+#### Scenario: Admin lacks permission on one dashboard
+- GIVEN admin user "alice" is dashboard-admin but cannot delete dashboard "uuid-3" (e.g., owned by another admin group)
+- WHEN she sends bulk-delete request with 5 uuids including "uuid-3"
+- THEN the system MUST return HTTP 403 immediately after detecting the unauthorized dashboard
+- AND NO dashboards MUST be deleted (even if "uuid-1" and "uuid-2" were authorized)
+- AND the error response MUST indicate which uuid(s) caused the permission denial
+
+#### Scenario: Non-admin user cannot call bulk endpoints
+- GIVEN user "bob" with no admin privileges
+- WHEN he sends POST /api/admin/dashboards/bulk-delete (even if he owns the dashboards)
+- THEN the system MUST return HTTP 403 (bulk endpoints require admin role)
+- AND the error MUST indicate insufficient privileges
+
+#### Scenario: Permission check happens before size validation
+- GIVEN admin user with permission denied on one dashboard in a batch of 501 dashboards (exceeds cap)
+- WHEN she sends the bulk-delete request
+- THEN the system MUST check permission first and return HTTP 403 (permission failure has higher priority)
+- AND the size cap validation is not performed (fail-fast on permission)
+
+#### Scenario: Dry-run respects same permission model
+- GIVEN admin user lacks permission on one dashboard
+- WHEN she sends bulk-delete?dryRun=true including that uuid
+- THEN the system MUST return HTTP 403 (same validation, even for dry-run)
+- AND no mutations occur (as expected for dry-run)
+

--- a/openspec/changes/dashboard-bulk-operations/specs/dashboard-bulk-operations/spec.md
+++ b/openspec/changes/dashboard-bulk-operations/specs/dashboard-bulk-operations/spec.md
@@ -8,12 +8,16 @@ status: draft
 
 ### Requirement: REQ-BULK-001 Bulk Delete Dashboards
 
-Administrators MUST be able to soft-delete multiple dashboards in a single API request, with idempotent handling of already-deleted dashboards.
+Administrators MUST be able to hard-delete multiple dashboards in a single API request, with idempotent handling of already-deleted dashboards. Cascade to child dashboards is opt-in: attempting to delete a parent that has children without `?cascade=true` returns HTTP 409.
+
+NOTE: Delete is a hard delete executed via `$folder->delete()` on the Nextcloud filesystem node. There is no soft-delete flag, no `deleted_at` column, and no grace period. Recovery is only possible through Nextcloud's system-wide trash bin if it is enabled on the installation. Soft-delete is deferred to a future capability.
+
+NOTE: The `cascade` parameter defaults to `false` to prevent accidental recursive deletion of child dashboards. This deliberately diverges from the source implementation (which defaults to `true`) and aligns with the `dashboard-tree` capability's existing opt-in cascade convention (REQ-DASH-016 area).
 
 #### Scenario: Delete three valid dashboards
 - GIVEN an admin user with dashboard-admin or full-admin permissions
 - WHEN she sends POST /api/admin/dashboards/bulk-delete with body `{"dashboardUuids": ["uuid-1", "uuid-2", "uuid-3"]}`
-- THEN the system MUST soft-delete each dashboard (set isDeleted flag or equivalent soft-delete marker)
+- THEN the system MUST hard-delete each dashboard by calling `delete()` on the Nextcloud filesystem node for each dashboard
 - AND the response MUST return HTTP 200 with `{deletedCount: 3, skippedCount: 0, errors: []}`
 - AND the deleted dashboards MUST NOT appear in GET /api/dashboards list for any user
 - AND no Nextcloud Activity event for each individual dashboard deletion — only ONE bulk operation event MUST be emitted
@@ -21,8 +25,22 @@ Administrators MUST be able to soft-delete multiple dashboards in a single API r
 #### Scenario: Bulk delete with one already-deleted dashboard
 - GIVEN admin has permission to delete all three dashboards, but "uuid-2" is already deleted
 - WHEN she sends the same bulk-delete request
-- THEN the system MUST skip the already-deleted dashboard
+- THEN the system MUST skip the already-deleted dashboard (hard delete on a non-existent row is absorbed silently)
 - AND the response MUST return `{deletedCount: 2, skippedCount: 1, errors: [{uuid: "uuid-2", reason: "already_deleted"}]}`
+
+#### Scenario: Bulk delete parent with children and cascade=false (default)
+- GIVEN dashboard "parent-uuid" has 5 child dashboards
+- WHEN admin sends POST /api/admin/dashboards/bulk-delete with body `{"dashboardUuids": ["parent-uuid"]}` (no `?cascade=true`)
+- THEN the system MUST return HTTP 409 (Conflict)
+- AND the response body MUST contain `{error: "has_children", childCount: 5}`
+- AND NO mutations MUST occur — the parent and all children MUST remain intact
+
+#### Scenario: Bulk delete parent with children and cascade=true (opt-in)
+- GIVEN dashboard "parent-uuid" has 5 child dashboards
+- WHEN admin sends POST /api/admin/dashboards/bulk-delete?cascade=true with body `{"dashboardUuids": ["parent-uuid"]}`
+- THEN the system MUST hard-delete the parent and all 5 children recursively
+- AND the response MUST return HTTP 200 with `{deletedCount: 6, skippedCount: 0, errors: []}`
+- AND none of the 6 dashboards MUST appear in GET /api/dashboards list for any user
 
 #### Scenario: Bulk delete with insufficient permissions
 - GIVEN admin user "alice" but "uuid-3" belongs to a private dashboard that "alice" cannot delete
@@ -39,7 +57,7 @@ Administrators MUST be able to soft-delete multiple dashboards in a single API r
 
 #### Scenario: Dry-run bulk delete
 - GIVEN admin sends POST /api/admin/dashboards/bulk-delete?dryRun=true with three valid uuids
-- THEN the system MUST NOT soft-delete any dashboard
+- THEN the system MUST NOT hard-delete any dashboard
 - AND the response MUST return `{wouldDeleteCount: 3, wouldSkipCount: 0, errors: []}`
 - AND GET /api/dashboards MUST still list all three dashboards
 
@@ -172,6 +190,8 @@ Administrators MUST be able to re-index multiple dashboards for unified search i
 
 Dashboard bulk operations MUST guarantee atomicity at the per-dashboard level (each dashboard's database write is transactional), but NOT across the entire batch. Partial failure is reported and safe.
 
+NOTE: The permission pre-check (REQ-BULK-011) is all-or-nothing and runs before any mutation begins. Database-level atomicity (per-dashboard transactions) only applies after the permission pre-check passes. These are two distinct layers: the permission layer is batch-wide and fail-fast; the execution layer is per-dashboard with continue-on-error semantics.
+
 #### Scenario: One dashboard transaction fails in a batch of three
 - GIVEN three dashboards, each in its own database transaction for bulk-delete
 - WHEN the transaction for "uuid-2" fails (e.g., foreign key constraint)
@@ -190,6 +210,8 @@ Dashboard bulk operations MUST guarantee atomicity at the per-dashboard level (e
 ### Requirement: REQ-BULK-006 Request Size Cap (Max 500 Dashboards per Request)
 
 All bulk endpoints MUST enforce a maximum number of dashboardUuids per request, configurable via admin settings.
+
+NOTE: All four bulk endpoints MUST also apply `#[UserRateThrottle(limit: 5, period: 60)]` — five requests per 60-second window per user. This is enforced at the controller layer and complements (does not replace) the per-request size cap.
 
 #### Scenario: Request within cap is accepted
 - GIVEN admin sends bulk-delete with 500 uuids (exactly at cap)
@@ -222,9 +244,9 @@ All bulk endpoints MUST enforce a maximum number of dashboardUuids per request, 
 Bulk operations MUST handle idempotent cases gracefully: deleting already-deleted dashboards, moving to the same parent, and setting to the same status result in no-op entries in the response, not errors.
 
 #### Scenario: Delete already-deleted dashboard
-- GIVEN dashboard "uuid-1" is already soft-deleted
+- GIVEN dashboard "uuid-1" is already deleted (row no longer exists in `oc_mydash_dashboards`)
 - WHEN admin sends bulk-delete with that uuid
-- THEN the system MUST NOT return an error, but rather count it as `skippedCount`
+- THEN the system MUST NOT return an error, but rather count it as `skippedCount` (hard delete on a non-existent row is absorbed silently)
 - AND the response MUST include `{uuid: "uuid-1", reason: "already_deleted"}` in the errors array (for auditability, not rejection)
 
 #### Scenario: Move to same parent
@@ -298,6 +320,8 @@ Each bulk operation MUST emit exactly ONE Nextcloud Activity event (of type `das
 - WHEN the system returns HTTP 403
 - THEN the system MUST still emit ONE activity event (for auditability)
 - AND the event MUST indicate the reason for failure (e.g., `reason: "permission_denied"`)
+
+NOTE: Audit events MUST be emitted for ALL terminal outcomes: successful completion, dry-run completion (with `dryRun: true` in the payload), and rejected requests (with the failure reason). No bulk operation outcome should be silent from an audit perspective.
 
 ### Requirement: REQ-BULK-010 Frontend Multi-Select Checkbox Column and Actions Dropdown
 

--- a/openspec/changes/dashboard-bulk-operations/tasks.md
+++ b/openspec/changes/dashboard-bulk-operations/tasks.md
@@ -1,0 +1,152 @@
+# Tasks — dashboard-bulk-operations
+
+## 1. Service layer — Bulk Operations Orchestration
+
+- [ ] 1.1 Create `lib/Service/BulkOperationService.php` with dependencies: `DashboardMapper`, `PermissionService`, `IConfig`, `DashboardTreeService` (cycle check), `DashboardStatusService` (status enum validation), `ILogger`
+- [ ] 1.2 Add `BulkOperationService::bulkDelete(array $dashboardUuids, string $userId, bool $dryRun = false): array` — main orchestration
+  - [ ] 1.2a Validate request size: if count($dashboardUuids) > config('mydash.bulk_operation_max_per_request', 500), return HTTP 400 error
+  - [ ] 1.2b Check permissions: call `PermissionService::canDeleteDashboard($userId, $uuid)` for EACH uuid; if any fail, return 403 immediately (no mutations)
+  - [ ] 1.2c Iterate each uuid, call mapper's soft-delete (or mark isDeleted flag if schema supports); collect `deletedCount`, `skippedCount`, per-uuid errors
+  - [ ] 1.2d For already-deleted dashboard: catch exception, count as `skippedCount`, add to errors array with reason "already_deleted"
+  - [ ] 1.2e If `dryRun=true`, build response with `wouldDeleteCount`, `wouldSkipCount` and NO mutations
+  - [ ] 1.2f Return `{deletedCount: N, skippedCount: M, errors: [{uuid, reason}]}`
+- [ ] 1.3 Add `BulkOperationService::bulkMove(array $dashboardUuids, ?string $parentUuid, string $userId, bool $dryRun = false): array`
+  - [ ] 1.3a Validate request size (same as bulk-delete)
+  - [ ] 1.3b Check permissions on all dashboards (all-or-nothing)
+  - [ ] 1.3c If `parentUuid` is not null, validate that it is a valid dashboard uuid and exists
+  - [ ] 1.3d For EACH uuid, check if new parent IS current parent; if so, count as `skippedCount`, no-op
+  - [ ] 1.3e For EACH uuid, call `DashboardTreeService::validateNoCycle($uuid, $parentUuid)` to check for cycles; if cycle detected, add to errors with reason "cycle_detected"
+  - [ ] 1.3f Update parent via mapper; collect `movedCount`, `skippedCount`, errors
+  - [ ] 1.3g If `dryRun=true`, return `wouldMoveCount` and NO mutations
+  - [ ] 1.3h Return `{movedCount: N, skippedCount: M, errors: [{uuid, reason, detail?}]}`
+- [ ] 1.4 Add `BulkOperationService::bulkStatus(array $dashboardUuids, string $publicationStatus, ?string $publishAt, string $userId, bool $dryRun = false): array`
+  - [ ] 1.4a Validate request size
+  - [ ] 1.4b Check permissions on all dashboards (all-or-nothing)
+  - [ ] 1.4c Validate `$publicationStatus` is one of 'draft', 'published', 'scheduled' via `DashboardStatusService::validateStatus()`
+  - [ ] 1.4d If `$publicationStatus === 'scheduled'` and `$publishAt` is null, return error (required for scheduled)
+  - [ ] 1.4e For EACH uuid, check if current status IS target status; if so, count as `skippedCount`, no-op
+  - [ ] 1.4f Update status via mapper; collect `updatedCount`, `skippedCount`, errors
+  - [ ] 1.4g If `dryRun=true`, return `wouldUpdateCount` and NO mutations
+  - [ ] 1.4h Return `{updatedCount: N, skippedCount: M, errors: [{uuid, reason}]}`
+- [ ] 1.5 Add `BulkOperationService::bulkReindex(array $dashboardUuids, string $userId, bool $dryRun = false): array`
+  - [ ] 1.5a Validate request size
+  - [ ] 1.5b Check permissions on all dashboards (all-or-nothing)
+  - [ ] 1.5c For EACH uuid, call search provider's reindex method (delegate to `nc-unified-search-integration` capability)
+  - [ ] 1.5d Collect `reindexedCount` and errors (if reindex fails for specific uuid, log but continue batch)
+  - [ ] 1.5e If `dryRun=true`, return `wouldReindexCount` and NO mutations
+  - [ ] 1.5f Return `{reindexedCount: N, errors: [{uuid, reason}]}`
+
+## 2. Controller + routes
+
+- [ ] 2.1 Create or extend `lib/Controller/AdminBulkController.php` extending `ApiController` (or extend existing `AdminController.php`)
+- [ ] 2.2 Add `AdminBulkController::bulkDelete()` mapped to `POST /api/admin/dashboards/bulk-delete` (`#[AdminRequired]`)
+  - [ ] 2.2a Extract body `dashboardUuids` (array) and query param `dryRun` (bool, default false)
+  - [ ] 2.2b Call `BulkOperationService::bulkDelete($dashboardUuids, $this->userId, $dryRun)`
+  - [ ] 2.2c Return HTTP 200 with response JSON
+  - [ ] 2.2d If request size exceeds limit, catch HTTP 400 from service and re-throw with appropriate message
+- [ ] 2.3 Add `AdminBulkController::bulkMove()` mapped to `POST /api/admin/dashboards/bulk-move` (`#[AdminRequired]`)
+  - [ ] 2.3a Extract body `dashboardUuids`, `parentUuid` (nullable string)
+  - [ ] 2.3b Call `BulkOperationService::bulkMove($dashboardUuids, $parentUuid, $this->userId, $dryRun)`
+  - [ ] 2.3c Return HTTP 200 with response JSON
+- [ ] 2.4 Add `AdminBulkController::bulkStatus()` mapped to `POST /api/admin/dashboards/bulk-status` (`#[AdminRequired]`)
+  - [ ] 2.4a Extract body `dashboardUuids`, `publicationStatus`, optional `publishAt` (ISO string)
+  - [ ] 2.4b Call `BulkOperationService::bulkStatus($dashboardUuids, $publicationStatus, $publishAt, $this->userId, $dryRun)`
+  - [ ] 2.4c Return HTTP 200 with response JSON
+- [ ] 2.5 Add `AdminBulkController::bulkReindex()` mapped to `POST /api/admin/dashboards/bulk-reindex` (`#[AdminRequired]`)
+  - [ ] 2.5a Extract body `dashboardUuids`
+  - [ ] 2.5b Call `BulkOperationService::bulkReindex($dashboardUuids, $this->userId, $dryRun)`
+  - [ ] 2.5c Return HTTP 200 with response JSON
+- [ ] 2.6 Register all four routes in `appinfo/routes.php` with correct requirements and methods
+- [ ] 2.7 Confirm methods carry `#[AdminRequired]` attribute (or equivalent permission check)
+- [ ] 2.8 All endpoints MUST return 403 with descriptive error if any dashboard is unauthorized (fail-safe)
+
+## 3. Activity & Audit
+
+- [ ] 3.1 Create `lib/Activity/BulkOperationActivityProvider.php` implementing Nextcloud Activity provider (if not already present)
+- [ ] 3.2 Add helper in `BulkOperationService::emitAuditEvent(string $operation, int $dashboardCount, string $userId, int $durationMs): void`
+  - [ ] 3.2a Emit single Nextcloud Activity event with type `dashboard_bulk_operation`
+  - [ ] 3.2b Activity data: `{operation: 'delete'|'move'|'status'|'reindex', dashboardCount: N, byUserId: "...", durationMs: ...}`
+  - [ ] 3.2c Use high-resolution timer (microtime) to measure operation duration
+- [ ] 3.3 Call `emitAuditEvent()` at the END of each bulk operation (after all mutations complete or after dry-run)
+- [ ] 3.4 Log operation start, errors, and completion to `ILogger` for troubleshooting
+
+## 4. Frontend — Multi-select Dashboard List
+
+- [ ] 4.1 Extend `src/views/AdminDashboardList.vue` to add multi-select checkbox column
+  - [ ] 4.1a Add `<th><input type="checkbox" @change="toggleSelectAll" v-model="allSelected"></th>` at start of table header
+  - [ ] 4.1b Add `<td><input type="checkbox" v-model="selectedUuids" :value="dashboard.uuid"></td>` in each row
+  - [ ] 4.1c Track `selectedUuids` as array of selected uuids in component data
+  - [ ] 4.1d Track `allSelected` as computed property (true if selectedUuids.length === dashboards.length)
+- [ ] 4.2 Add "Actions" dropdown button, enabled only when `selectedUuids.length >= 1`
+  - [ ] 4.2a Options: "Delete", "Move to...", "Set status", "Reindex"
+  - [ ] 4.2b Show visual feedback when dropdown is open (e.g., highlight selected rows)
+- [ ] 4.3 Implement "Delete" action
+  - [ ] 4.3a Show confirmation modal: "Delete N dashboards? This cannot be undone."
+  - [ ] 4.3b Add toggle for "Dry run (preview only)"
+  - [ ] 4.3c POST /api/admin/dashboards/bulk-delete with `{dashboardUuids: [...], dryRun: boolean}`
+  - [ ] 4.3d On 200 response, show summary: "Deleted N, skipped M. Errors: ..."
+  - [ ] 4.3e If dryRun, show "Would delete N, would skip M" (no actual deletion)
+  - [ ] 4.3f Refresh dashboard list after successful (non-dry-run) operation
+- [ ] 4.4 Implement "Move to..." action
+  - [ ] 4.4a Show modal with hierarchical parent selection (tree picker)
+  - [ ] 4.4b Add dry-run toggle
+  - [ ] 4.4c POST /api/admin/dashboards/bulk-move with `{dashboardUuids: [...], parentUuid: null|uuid, dryRun: boolean}`
+  - [ ] 4.4d On 200 response, show summary: "Moved N, skipped M. Errors: ..."
+  - [ ] 4.4e If dryRun, show "Would move N, would skip M"
+  - [ ] 4.4f Refresh list after successful operation
+- [ ] 4.5 Implement "Set status" action
+  - [ ] 4.5a Show modal with status selector: Draft / Published / Scheduled
+  - [ ] 4.5b If Scheduled selected, show date/time picker for `publishAt`
+  - [ ] 4.5c Add dry-run toggle
+  - [ ] 4.5d POST /api/admin/dashboards/bulk-status with `{dashboardUuids: [...], publicationStatus, publishAt, dryRun: boolean}`
+  - [ ] 4.5e On 200 response, show summary
+  - [ ] 4.5f Refresh list after successful operation
+- [ ] 4.6 Implement "Reindex" action
+  - [ ] 4.6a Show simple confirmation modal: "Reindex N dashboards for search?"
+  - [ ] 4.6b Add dry-run toggle
+  - [ ] 4.6c POST /api/admin/dashboards/bulk-reindex with `{dashboardUuids: [...], dryRun: boolean}`
+  - [ ] 4.6d On 200 response, show summary: "Reindexed N. Errors: ..."
+  - [ ] 4.6e Show loading state during operation (disable actions, show spinner)
+- [ ] 4.7 Clear selection after each successful operation
+
+## 5. Configuration
+
+- [ ] 5.1 Add default config entry for `mydash.bulk_operation_max_per_request = 500` in app initialization (e.g., `AppConfig` or `config.php`)
+- [ ] 5.2 Document admin-tunable setting in comments (admins can override via OCC command or web config)
+
+## 6. PHPUnit tests
+
+- [ ] 6.1 `BulkOperationServiceTest::bulkDelete` — valid batch, already-deleted skip, permissions denied on one uuid (403), request size exceeds limit (400), dryRun returns `would*` counts
+- [ ] 6.2 `BulkOperationServiceTest::bulkMove` — valid batch, cycle detection, parent IS current parent (skip), dryRun, permissions denied
+- [ ] 6.3 `BulkOperationServiceTest::bulkStatus` — valid batch, status IS current status (skip), invalid status enum (400), scheduled without publishAt (400), dryRun
+- [ ] 6.4 `BulkOperationServiceTest::bulkReindex` — valid batch, reindex failure on one uuid (error reported, batch continues), dryRun
+- [ ] 6.5 `AdminBulkControllerTest::bulkDelete` — valid request returns 200, invalid size returns 400, permission denied returns 403
+- [ ] 6.6 `AdminBulkControllerTest::bulkMove` — valid request, cycle error in response, dryRun flag respected
+- [ ] 6.7 `AdminBulkControllerTest::bulkStatus` — valid request, status validation, dryRun
+- [ ] 6.8 `AdminBulkControllerTest::bulkReindex` — valid request, error handling
+- [ ] 6.9 Test audit event emission: verify `emitAuditEvent()` is called once per operation with correct parameters
+- [ ] 6.10 Test atomicity per-dashboard: one dashboard fails, batch continues, failure reported in errors array
+
+## 7. Integration tests (E2E)
+
+- [ ] 7.1 Create fixtures: 5 dashboards with varying permissions, 3 different parents (tree structure)
+- [ ] 7.2 Test bulk-delete: admin deletes 3 dashboards, verifies 3 deleted + 0 skipped, list refreshes
+- [ ] 7.3 Test bulk-move: move 3 dashboards under new parent, verify parent_uuid updated, cycle check prevents circular move
+- [ ] 7.4 Test bulk-status: publish 3 draft dashboards, verify status updated, schedule 2 for future date
+- [ ] 7.5 Test bulk-reindex: reindex 3 dashboards, verify no errors (assume search provider is mocked/available)
+- [ ] 7.6 Test permissions: non-admin user calls bulk endpoint, receives 403
+- [ ] 7.7 Test dry-run: call with `dryRun=true`, verify no mutations occur, counts are predicted
+- [ ] 7.8 Test request size cap: send 501 uuids, receive HTTP 400
+- [ ] 7.9 Test partial failure: batch with one unauthorized dashboard, verify entire batch rejected (403) and no mutations
+
+## 8. Documentation
+
+- [ ] 8.1 Add to `CHANGELOG.md`: "New capability `dashboard-bulk-operations`: admin endpoints for bulk delete, move, status update, and reindex of dashboards; dry-run support and atomic-per-dashboard semantics"
+- [ ] 8.2 Document four endpoints in app API docs (if such docs exist) or in new BULK_API.md file
+  - [ ] 8.2a POST /api/admin/dashboards/bulk-delete
+  - [ ] 8.2b POST /api/admin/dashboards/bulk-move
+  - [ ] 8.2c POST /api/admin/dashboards/bulk-status
+  - [ ] 8.2d POST /api/admin/dashboards/bulk-reindex
+- [ ] 8.3 Document request/response schemas, error codes, dry-run behavior, and audit trail
+- [ ] 8.4 Document permission model (all-or-nothing, admin-only endpoints)
+

--- a/openspec/changes/dashboard-cascade-events/design.md
+++ b/openspec/changes/dashboard-cascade-events/design.md
@@ -1,0 +1,265 @@
+# Design — Dashboard Cascade Events
+
+## Context
+
+The spec was drafted by analogy with an event-dispatch pattern observed in the IntraVox source
+tree. Before committing to 10 listeners, a migration table, and per-listener failure recording,
+this document establishes what IntraVox actually does at delete time and which parts of the spec
+reflect genuine need versus over-engineering.
+
+Source examined:
+- `intravox-source/lib/Service/PageService.php` (the canonical delete path)
+- `intravox-source/lib/Controller/ApiController.php` (`deletePage` action)
+- `intravox-source/lib/Event/PageDeletedEvent.php`
+- `intravox-source/lib/Listener/PageDeletedListener.php`
+- `intravox-source/lib/Listener/UserDeletedListener.php`
+- `intravox-source/lib/Listener/CommentsEntityListener.php`
+- `intravox-source/lib/AppInfo/Application.php`
+- `intravox-source/lib/Service/PageIndexService.php`
+- `intravox-source/lib/Service/AnalyticsService.php`
+- `intravox-source/lib/Service/PageLockService.php`
+- All migration files under `intravox-source/lib/Migration/`
+
+## Goals / Non-Goals
+
+**Goals:** Make the spec match the complexity that IntraVox's actual design warrants — neither
+under-specifying (leaving tables orphaned) nor over-engineering (failure tables nobody uses).
+
+**Non-Goals:** Change the spec's core event-dispatch architecture, which IntraVox confirms is
+correct.
+
+---
+
+## Decisions
+
+### D1: Architecture — sync vs event-dispatch
+
+**Decision:** Event-dispatch, but synchronous within the same PHP request. There is no deferred
+job, background queue, or async mechanism involved. `dispatchTyped()` blocks until all listeners
+return; the event fires **before** the filesystem folder is deleted (so listeners can still access
+page metadata if needed) and **before** the HTTP response is returned.
+
+**Source evidence:**
+- `intravox-source/lib/Service/PageService.php:1693–1699` — `dispatchTyped(new PageDeletedEvent(…))`
+  is called inside a try/catch inside `deletePage()`, before `$result['folder']->delete()` at
+  line 1712. The catch only logs a warning — it does not abort the folder delete.
+- `intravox-source/lib/Controller/ApiController.php:372` — `$this->pageService->deletePage($id)`
+  is a void call; the controller simply returns `['success' => true]` with no cascade stats.
+- There is no job queue, `IJobList`, `BackgroundJob`, or deferred-dispatch anywhere in the
+  delete path.
+
+**Implication for spec:** The synchronous design means that if a listener throws, IntraVox logs a
+warning and continues — the folder delete still happens. This matches REQ-CSC-006 (failure
+isolation) but also means the `oc_mydash_cascade_failures` retry table is speculative; IntraVox
+does not have one.
+
+---
+
+### D2: Tables cleaned on page delete (definitive list)
+
+IntraVox fires one event (`PageDeletedEvent`) and has exactly **one listener** for it
+(`PageDeletedListener`). That listener cleans exactly **one data target**:
+
+| Target | Mechanism | Listener |
+|---|---|---|
+| NC comments (objectType `intravox_page`, objectId = `uniqueId`) | `ICommentsManager::deleteCommentsAtObject()` | `PageDeletedListener` |
+
+Additionally, `PageService::deletePage()` performs two direct (non-event) cleanup steps inline:
+
+| Target | Mechanism | Location |
+|---|---|---|
+| `intravox_page_index` rows (metadata index) | `PageIndexService::removePage($uniqueId)` | `PageService::deletePage()` lines 1702–1709 |
+| Physical page folder (`.json`, `_media/`, child subfolders) | `$folder->delete()` | `PageService::deletePage()` line 1712 |
+
+**Tables confirmed absent from delete path:**
+- `intravox_page_locks` — cleaned only on user delete, not on page delete. A lock row for a
+  deleted page becomes orphaned until the user is deleted or the lock expires via heartbeat TTL.
+- `intravox_page_stats` / `intravox_uv` (analytics) — not cleaned on page delete. Only cleaned
+  on user delete (by user_hash, not page_unique_id). Page-level stats rows orphan on page delete.
+- `intravox_feed_tokens` — not page-scoped; user-scoped only.
+- NC `oc_comments` reactions — IntraVox stores reactions as comments (objectType `intravox_page`),
+  so `deleteCommentsAtObject()` covers them. There is no separate reactions table.
+
+**What this means for the spec:** The spec's 10-listener list includes several tables (reactions,
+locks, versions, public shares, metadata values, translations, view analytics, tree children) that
+do not exist as separate tables in IntraVox. MyDash has its own schema which may include more
+tables, but the spec's table list must be validated against MyDash's actual migrations — not
+inferred from IntraVox.
+
+---
+
+### D3: User-deletion cascade scope
+
+**Decision:** IntraVox's `UserDeletedListener` does NOT cascade through page deletes. It does not
+call `PageService::deletePage()` per page. Instead it deletes user-scoped DB rows directly and
+removes IConfig preferences in bulk.
+
+Actual cleanup performed by `UserDeletedListener` (lines 43–79):
+
+| Target | Mechanism | Note |
+|---|---|---|
+| `intravox_analytics_views` rows WHERE `user_hash = sha256(userId)` | Direct DELETE query | Hard delete |
+| `intravox_page_locks` rows WHERE `user_id = userId` | Direct DELETE query | Hard delete |
+| All IConfig app preferences for the app | `IConfig::deleteAppFromAllUsers(APP_ID)` | Bulk wipe |
+
+**Pages owned by the deleted user are NOT deleted.** IntraVox pages live in GroupFolder filesystem
+paths and are not ownership-coupled to NC user accounts in the DB. The page files persist after
+user deletion.
+
+**Implication for spec:** REQ-CSC-004 scenario "Personal dashboards are deleted on user deletion"
+differs from what IntraVox does. If MyDash dashboards are DB-row-owned by user (likely, given the
+`ownerUserId` on `DashboardDeletedEvent`), then the spec's design is correct for MyDash even
+though it diverges from IntraVox's filesystem approach. This is a MyDash-specific requirement,
+not a transcription of IntraVox behavior.
+
+---
+
+### D4: Group-deletion cascade scope
+
+**Decision:** No `GroupDeletedListener` exists in IntraVox. The file is absent entirely.
+
+```
+intravox-source/lib/Listener/
+  CommentsEntityListener.php
+  PageDeletedListener.php
+  UserDeletedListener.php
+  (no GroupDeletedListener)
+```
+
+`Application::register()` registers listeners only for `CommentsEntityEvent`, `PageDeletedEvent`,
+and `UserDeletedEvent`. `GroupDeletedEvent` is not imported or registered.
+
+**Implication for spec:** REQ-CSC-005 (group lifecycle cleanup) is a MyDash-only requirement with
+no IntraVox precedent. It must be designed from scratch. The IConfig JSON-mutation scenarios
+(removing group from `org_navigation_tree` and `group_order`) are MyDash-specific features.
+
+---
+
+### D5: Failure handling pattern
+
+**Decision:** Log-and-continue at warning level. There is no failure recording table, no retry
+mechanism, and no per-listener isolation wrapper.
+
+IntraVox's pattern (from `PageDeletedListener:35–42`):
+```php
+try {
+    $this->commentsManager->deleteCommentsAtObject('intravox_page', $uniqueId);
+    $this->logger->info('...');
+} catch (\Exception $e) {
+    $this->logger->error('...');
+}
+```
+
+The outer `PageService::deletePage()` wraps the entire dispatch in its own try/catch
+(lines 1697–1699) that also only logs a warning on failure.
+
+Two divergences from spec:
+1. IntraVox logs at `error` level on listener failure (spec says `warning`). Spec's WARN-level
+   requirement is a conscious design choice — it is not derived from IntraVox behavior.
+2. There is no `oc_intravox_cascade_failures` table. The spec's `oc_mydash_cascade_failures`
+   table adds complexity that IntraVox does not carry.
+
+**Recommendation:** Reconsider whether `oc_mydash_cascade_failures` (REQ-CSC-007) is worth the
+migration cost. IntraVox's log-and-continue approach relies on the orphaned-data cleanup job to
+catch stragglers. If the orphan-cleanup job already handles residual rows, the failures table is
+redundant. If it is kept, consider whether it should be part of this spec or the
+`orphaned-data-cleanup` change.
+
+---
+
+### D6: Tree cascade mechanism
+
+**Decision:** Implicit filesystem cascade. IntraVox stores child pages as subfolders inside the
+parent page folder. When `$folder->delete()` is called on line 1712, NC's virtual filesystem
+deletes the entire subtree recursively — all child pages vanish with the parent folder in one
+operation.
+
+There is no `TreeListener`, no recursive event dispatch, no DB foreign-key CASCADE, and no
+cascade flag on the delete API. The child pages are deleted as filesystem artifacts, which means:
+
+- `PageDeletedEvent` is NOT fired for child pages — their comments and locks are NOT cleaned up
+  by listeners.
+- `intravox_page_index` rows for child pages are NOT removed (only the direct parent's uniqueId
+  is passed to `PageIndexService::removePage()`).
+
+This is a known gap in IntraVox. The spec's `TreeListener` (REQ-CSC-003 / REQ-CSC-010) explicitly
+addresses this gap and is **more correct than IntraVox**, not a copy of it.
+
+**Implication for spec:** The cascade-flag guard (REQ-CSC-010) and `TreeListener` are justified
+additions that fix a real IntraVox shortcoming. They should be retained as designed.
+
+---
+
+### D7: API response shape
+
+**Decision:** IntraVox returns `['success' => true]` with no cascade stats.
+
+```php
+// ApiController.php line 372–373
+$this->pageService->deletePage($id);
+return new DataResponse(['success' => true]);
+```
+
+There is no `deletedAt`, no `cascadeStats`, and no per-table counts in the response. The spec's
+`cascadeStats` response (REQ-CSC-009) is a new capability, not a port from IntraVox.
+
+---
+
+## Spec changes implied
+
+The following adjustments are recommended when the spec is next edited (do NOT apply during this
+design phase — this section is for the author's reference):
+
+- **REQ-CSC-007 (failure recording table):** Reconsider whether `oc_mydash_cascade_failures` is
+  needed given that IntraVox's simpler log-and-continue pattern works in practice. If retained,
+  clarify that retry logic lives in `orphaned-data-cleanup`, not here.
+
+- **REQ-CSC-003 (listener group, table list):** The 10-table list should be validated against
+  MyDash's actual migration files before implementation. Reactions, locks, versions, public
+  shares, metadata values, translations, and view analytics are all plausible MyDash tables but
+  are not confirmed from IntraVox. Only NC comments are confirmed present.
+
+- **REQ-CSC-004 (user lifecycle):** The scenario "Personal dashboards are deleted on user
+  deletion" is a MyDash design choice (dashboard rows are DB-owned), not inherited from IntraVox.
+  Mark it as MyDash-specific so implementers understand it requires dashboard enumeration logic,
+  not a direct port.
+
+- **REQ-CSC-005 (group lifecycle):** Entirely MyDash-specific — no IntraVox precedent. The
+  `GroupDeletedListener` must be designed from scratch. The IConfig JSON-mutation scenarios
+  (org_navigation_tree, group_order) are valid requirements but need MyDash schema confirmation.
+
+- **REQ-CSC-006 (failure isolation):** The log level should be WARN not ERROR per the spec, which
+  is a deliberate downgrade from IntraVox's error-level logging. Add a note that IntraVox uses
+  ERROR — this is an intentional divergence.
+
+- **REQ-CSC-009 (cascade stats):** The `cascadeStats` response is additive and new. Note that
+  tree-child deletions should contribute to the aggregate counts (e.g., total
+  `widgetPlacementsDeleted` across parent + all children), which requires the `TreeListener` to
+  propagate counts back up — a coordination mechanism IntraVox does not need.
+
+---
+
+## Open follow-ups
+
+1. **MyDash table inventory:** Confirm which of the 10 spec-listed tables actually exist in
+   MyDash's migrations (`oc_mydash_widget_placements`, `oc_mydash_dashboard_reactions`, etc.)
+   before writing listener code. At least one spec table (reactions) may be stored differently.
+
+2. **cascadeStats aggregation across tree:** If `TreeListener` dispatches child events
+   synchronously, child listener counts must be accumulated and returned to the parent's
+   `DashboardService::delete()` call. Define how listeners return row counts — the current spec
+   leaves the aggregation mechanism unspecified.
+
+3. **Page-lock orphan gap (confirmed from IntraVox):** IntraVox does not clean `page_locks` on
+   page delete — only on user delete. Verify that `oc_mydash_dashboard_locks` in MyDash IS
+   cleaned by `LocksListener` on dashboard delete (the spec says yes; confirm the migration and
+   table schema support page/dashboard-keyed lookup).
+
+4. **Failure table vs log-only:** Decide before implementation whether `oc_mydash_cascade_failures`
+   is required. If the `orphaned-data-cleanup` job can identify residual rows without a failures
+   table, the migration can be dropped, saving schema complexity.
+
+5. **GroupDeletedListener analytics data:** The spec (REQ-CSC-005) doesn't mention analytics rows
+   associated with a deleted group. If MyDash tracks per-group or group-member analytics,
+   `GroupDeletedListener` should also clean those rows (analogous to how `UserDeletedListener`
+   cleans analytics by user_hash).

--- a/openspec/changes/dashboard-cascade-events/proposal.md
+++ b/openspec/changes/dashboard-cascade-events/proposal.md
@@ -1,0 +1,79 @@
+# Dashboard Cascade Events
+
+## Why
+
+When a dashboard is deleted in MyDash, dependent data rows in other tables (widget placements, reactions, locks, versions, comments, shares, metadata values, translations, view analytics) become orphaned. Likewise, when a Nextcloud user or group is deleted, their personal dashboards and all downstream records are left behind. Today there is no automated mechanism to remove this dependent data at deletion time — it accumulates silently and can only be addressed by the separate `orphaned-data-cleanup` job after the fact.
+
+This change introduces an event-driven cascade system: `DashboardService::delete()` dispatches a `DashboardDeletedEvent` after soft-deleting the dashboard row, and each subsystem that owns dependent data registers a dedicated listener to clean up its own table. User and group lifecycle events from Nextcloud are handled by `UserDeletedListener` and `GroupDeletedListener` respectively, which drive cascade deletion of all associated dashboards (which in turn fire further `DashboardDeletedEvent` dispatches).
+
+The design ensures each listener is independently isolated — a failure in one MUST NOT block the others — and every operation is idempotent, making the orphan-cleanup job safe to retry any residual failures.
+
+## What Changes
+
+- Add `lib/Event/DashboardDeletedEvent.php` carrying `{dashboardUuid, ownerUserId, type, deletedAt}`.
+- Fire `DashboardDeletedEvent` from `DashboardService::delete()` after soft-delete, before returning the response.
+- Add ten listeners under `lib/Listener/` for `DashboardDeletedEvent`:
+  - `WidgetPlacementsListener` — deletes `oc_mydash_widget_placements` rows.
+  - `CommentsListener` — calls `ICommentsManager::deleteCommentsAtObject('mydash_dashboard', $uuid)`.
+  - `ReactionsListener` — deletes `oc_mydash_dashboard_reactions` rows.
+  - `LocksListener` — deletes `oc_mydash_dashboard_locks` rows.
+  - `VersionsListener` — deletes `oc_mydash_dashboard_versions` rows (DB mode) and the JSON version file (GroupFolder mode).
+  - `PublicSharesListener` — soft-revokes rows in `oc_mydash_public_shares`.
+  - `MetadataValuesListener` — deletes `oc_mydash_metadata_values` rows for the dashboard.
+  - `TranslationsListener` — deletes `oc_mydash_dashboard_translations` rows for the dashboard.
+  - `ViewAnalyticsListener` — deletes `oc_mydash_dashboard_views` rows for the dashboard.
+  - `TreeListener` — on cascade-delete, recursively dispatches `DashboardDeletedEvent` for each child dashboard.
+- Add `UserDeletedListener` subscribing to NC's `\OCP\User\Events\UserDeletedEvent`.
+- Add `GroupDeletedListener` subscribing to NC's `\OCP\Group\Events\GroupDeletedEvent`.
+- Add a new `oc_mydash_cascade_failures` table (one migration) for recording listener failures to allow orphan-cleanup retry.
+- Register all listeners in `Application` via `IEventDispatcher::addListener`.
+- Extend the `DashboardService::delete()` response to include `{deletedAt, cascadeStats: {...}}`.
+
+## Capabilities
+
+### New Capabilities
+
+- `dashboard-cascade-events`: provides REQ-CSC-001 through REQ-CSC-010 covering event definition, listener registry, widget/asset listener group, user/group lifecycle listeners, failure isolation, failure recording, idempotency, cascade stats response, tree recursion, and listener registration.
+
+### Modified Capabilities
+
+- `dashboards`: `DashboardService::delete()` now dispatches `DashboardDeletedEvent` and returns `cascadeStats` in the response. Existing REQ-DASH-005 delete semantics are preserved.
+
+## Impact
+
+**Affected code:**
+
+- `lib/Event/DashboardDeletedEvent.php` — new event class
+- `lib/Listener/WidgetPlacementsListener.php` — new
+- `lib/Listener/CommentsListener.php` — new
+- `lib/Listener/ReactionsListener.php` — new
+- `lib/Listener/LocksListener.php` — new
+- `lib/Listener/VersionsListener.php` — new
+- `lib/Listener/PublicSharesListener.php` — new
+- `lib/Listener/MetadataValuesListener.php` — new
+- `lib/Listener/TranslationsListener.php` — new
+- `lib/Listener/ViewAnalyticsListener.php` — new
+- `lib/Listener/TreeListener.php` — new
+- `lib/Listener/UserDeletedListener.php` — new
+- `lib/Listener/GroupDeletedListener.php` — new
+- `lib/Service/DashboardService.php` — dispatch event post-delete; extend response with `cascadeStats`
+- `lib/Migration/VersionXXXXDate2026AddCascadeFailuresTable.php` — adds `oc_mydash_cascade_failures`
+- `lib/AppInfo/Application.php` — register all 13 listeners via `IEventDispatcher`
+
+**Affected APIs:**
+
+- `DELETE /api/dashboards/{uuid}` response body gains `cascadeStats` (additive; backward-compatible for clients that ignore unknown fields)
+- No new routes
+
+**Dependencies:**
+
+- `OCP\EventDispatcher\IEventDispatcher` — already present in NC core
+- `OCP\Comments\ICommentsManager` — for NC comments integration
+- `OCP\User\Events\UserDeletedEvent` and `OCP\Group\Events\GroupDeletedEvent` — NC lifecycle events
+- `OCP\ILogger` — for WARN-level failure logging
+- No new composer or npm dependencies
+
+**Migration:**
+
+- Adds `oc_mydash_cascade_failures` table (columns: `id`, `listener_class`, `dashboard_uuid`, `error_message`, `failed_at`).
+- Existing rows are unaffected; migration is reversible (drop table on rollback).

--- a/openspec/changes/dashboard-cascade-events/proposal.md
+++ b/openspec/changes/dashboard-cascade-events/proposal.md
@@ -25,7 +25,6 @@ The design ensures each listener is independently isolated — a failure in one 
   - `TreeListener` — on cascade-delete, recursively dispatches `DashboardDeletedEvent` for each child dashboard.
 - Add `UserDeletedListener` subscribing to NC's `\OCP\User\Events\UserDeletedEvent`.
 - Add `GroupDeletedListener` subscribing to NC's `\OCP\Group\Events\GroupDeletedEvent`.
-- Add a new `oc_mydash_cascade_failures` table (one migration) for recording listener failures to allow orphan-cleanup retry.
 - Register all listeners in `Application` via `IEventDispatcher::addListener`.
 - Extend the `DashboardService::delete()` response to include `{deletedAt, cascadeStats: {...}}`.
 
@@ -33,7 +32,7 @@ The design ensures each listener is independently isolated — a failure in one 
 
 ### New Capabilities
 
-- `dashboard-cascade-events`: provides REQ-CSC-001 through REQ-CSC-010 covering event definition, listener registry, widget/asset listener group, user/group lifecycle listeners, failure isolation, failure recording, idempotency, cascade stats response, tree recursion, and listener registration.
+- `dashboard-cascade-events`: provides REQ-CSC-001 through REQ-CSC-010 covering event definition, listener registry, widget/asset listener group, user/group lifecycle listeners, failure isolation (log-and-continue), idempotency, cascade stats response, tree recursion, and listener registration.
 
 ### Modified Capabilities
 
@@ -57,7 +56,6 @@ The design ensures each listener is independently isolated — a failure in one 
 - `lib/Listener/UserDeletedListener.php` — new
 - `lib/Listener/GroupDeletedListener.php` — new
 - `lib/Service/DashboardService.php` — dispatch event post-delete; extend response with `cascadeStats`
-- `lib/Migration/VersionXXXXDate2026AddCascadeFailuresTable.php` — adds `oc_mydash_cascade_failures`
 - `lib/AppInfo/Application.php` — register all 13 listeners via `IEventDispatcher`
 
 **Affected APIs:**
@@ -75,5 +73,4 @@ The design ensures each listener is independently isolated — a failure in one 
 
 **Migration:**
 
-- Adds `oc_mydash_cascade_failures` table (columns: `id`, `listener_class`, `dashboard_uuid`, `error_message`, `failed_at`).
-- Existing rows are unaffected; migration is reversible (drop table on rollback).
+- No new tables. Listener failures are handled via log-and-continue (WARN level); the orphan-cleanup job identifies residual rows by querying dependent tables directly.

--- a/openspec/changes/dashboard-cascade-events/specs/dashboard-cascade-events/spec.md
+++ b/openspec/changes/dashboard-cascade-events/specs/dashboard-cascade-events/spec.md
@@ -29,6 +29,7 @@ The system MUST define a `DashboardDeletedEvent` class at `lib/Event/DashboardDe
 - WHEN `DashboardService::delete()` runs
 - THEN the dashboard row MUST be soft-deleted in `oc_mydash_dashboards` first
 - AND `DashboardDeletedEvent` MUST be dispatched second, before the HTTP response is returned
+- NOTE: dispatch is synchronous within the same PHP request — `IEventDispatcher::dispatchTyped()` blocks until all listeners return; the event fires before the HTTP response is sent. This matches the pattern confirmed in the reference implementation.
 - NOTE: listeners observe a row that is already soft-deleted — they MUST NOT attempt to re-delete the main row
 
 #### Scenario: Event is NOT dispatched when validation rejects the delete
@@ -80,12 +81,17 @@ Every listener MUST be registered in `Application` via `IEventDispatcher::addLis
 
 A set of listeners MUST clean up every dependent table when `DashboardDeletedEvent` fires. Listeners for disjoint data MUST execute independently and MUST NOT interfere with each other.
 
+- NOTE: Of the ten listeners in this group, only `CommentsListener` is derived from the reference implementation's pattern, which uses `ICommentsManager::deleteCommentsAtObject()` as its sole cleanup mechanism for a single listener registered on the delete event.
+- NOTE: The remaining nine listeners — `WidgetPlacementsListener`, `ReactionsListener`, `LocksListener`, `VersionsListener`, `PublicSharesListener`, `MetadataValuesListener`, `TranslationsListener`, `ViewAnalyticsListener`, and `TreeListener` — are MyDash-specific additions. The reference implementation cleans those targets (if they exist at all) either inline in the service layer or not at all; MyDash's richer schema warrants dedicated listeners. The table list MUST be validated against MyDash's actual migration files before implementation.
+- NOTE: `TreeListener` (see REQ-CSC-010) is a MyDash improvement over the reference implementation. The reference silently deletes child pages via a recursive filesystem operation without firing the delete event for each child, meaning child-level dependent data (locks, analytics, etc.) is never cleaned up. MyDash's `TreeListener` corrects this gap by explicitly dispatching `DashboardDeletedEvent` for each child so that the full listener stack runs for every node in the tree.
+
 #### Scenario: Widget placements are deleted on dashboard delete
 
 - GIVEN dashboard `D1` has 5 widget placements in `oc_mydash_widget_placements`
 - WHEN `DashboardDeletedEvent` fires for `D1`
 - THEN `WidgetPlacementsListener` MUST delete all 5 rows
 - AND no placements from other dashboards MUST be touched
+- NOTE: MyDash-specific listener — the reference implementation has no equivalent widget placement table.
 
 #### Scenario: Comments are removed via ICommentsManager
 
@@ -93,6 +99,7 @@ A set of listeners MUST clean up every dependent table when `DashboardDeletedEve
 - WHEN `CommentsListener` handles the event
 - THEN it MUST call `ICommentsManager::deleteCommentsAtObject('mydash_dashboard', $D1.uuid)`
 - AND the NC comments table MUST contain no comments for `mydash_dashboard` / `D1.uuid` after the call
+- NOTE: This is the one listener whose pattern is directly derived from the reference implementation. The reference registers a single listener that calls the equivalent ICommentsManager method as its only cleanup action.
 
 #### Scenario: Public shares are soft-revoked, not hard-deleted
 
@@ -100,6 +107,7 @@ A set of listeners MUST clean up every dependent table when `DashboardDeletedEve
 - WHEN `PublicSharesListener` handles the event
 - THEN both rows MUST have `revokedAt` set to the current timestamp
 - AND neither row MUST be hard-deleted (audit trail is preserved)
+- NOTE: MyDash-specific listener — the reference implementation has no public-shares table.
 
 #### Scenario: Versions file is deleted in GroupFolder mode
 
@@ -109,6 +117,7 @@ A set of listeners MUST clean up every dependent table when `DashboardDeletedEve
 - THEN the DB rows in `oc_mydash_dashboard_versions` MUST be deleted
 - AND the JSON file MUST be removed from GroupFolder storage
 - NOTE: if the file does not exist (already removed or never created), the listener MUST treat this as a no-op
+- NOTE: MyDash-specific listener — the reference implementation has no versioning table.
 
 #### Scenario: Tree listener recursively cascades to child dashboards
 
@@ -116,10 +125,13 @@ A set of listeners MUST clean up every dependent table when `DashboardDeletedEve
 - WHEN `DashboardDeletedEvent` fires for `P1` (cascade-delete mode)
 - THEN `TreeListener` MUST dispatch a new `DashboardDeletedEvent` for `C1` and another for `C2`
 - AND each child event MUST trigger the full listener stack for that child (placements, comments, etc.)
+- NOTE: MyDash improvement — the reference implementation relies on a recursive filesystem delete that wipes child nodes silently without firing the delete event for each child. This leaves child-level DB rows (locks, analytics, etc.) orphaned. `TreeListener` fixes this gap explicitly.
 
 ### Requirement: REQ-CSC-004 User Lifecycle Cleanup
 
 When Nextcloud deletes a user, MyDash MUST clean up all data owned by that user.
+
+- NOTE: MyDash-specific design. The reference implementation's `UserDeletedListener` does NOT enumerate or delete owned pages on user deletion — it only removes user-scoped DB rows (analytics, locks) and bulk-wipes IConfig preferences. MyDash dashboards are row-owned by user (via `ownerUserId`), so cascade deletion of owned dashboards requires explicit enumeration logic — this is not a port of the reference's behaviour.
 
 #### Scenario: Personal dashboards are deleted on user deletion
 
@@ -128,6 +140,7 @@ When Nextcloud deletes a user, MyDash MUST clean up all data owned by that user.
 - THEN `UserDeletedListener` MUST call `DashboardService::delete()` for each of alice's 3 dashboards
 - AND each deletion MUST dispatch `DashboardDeletedEvent`, cascading cleanup of their dependent data
 - AND no other user's dashboards MUST be affected
+- NOTE: MyDash-specific design — the reference implementation does not delete owned content on user deletion. MyDash dashboards are DB-row-owned and must be explicitly enumerated and deleted here.
 
 #### Scenario: Role assignments are removed on user deletion
 
@@ -154,12 +167,15 @@ When Nextcloud deletes a user, MyDash MUST clean up all data owned by that user.
 
 When Nextcloud deletes a group, MyDash MUST clean up all group-scoped data.
 
+- NOTE: MyDash-specific requirement with no reference precedent. The reference implementation has no `GroupDeletedListener` and does not register any handler for `GroupDeletedEvent`. The `GroupDeletedListener` must be designed from scratch. The IConfig JSON-mutation scenarios (removing group from `org_navigation_tree` and `group_order`) are MyDash-specific features requiring MyDash schema confirmation before implementation.
+
 #### Scenario: Group-shared dashboards are deleted on group deletion
 
 - GIVEN group `marketing` owns 2 group-shared dashboards in `oc_mydash_dashboards`
 - WHEN Nextcloud dispatches `\OCP\Group\Events\GroupDeletedEvent` for `marketing`
 - THEN `GroupDeletedListener` MUST call `DashboardService::delete()` for each of those 2 dashboards
 - AND each deletion MUST cascade cleanup of dependent data via `DashboardDeletedEvent`
+- NOTE: MyDash-specific design — no equivalent exists in the reference implementation.
 
 #### Scenario: Group is removed from org navigation tree on group deletion
 
@@ -167,6 +183,7 @@ When Nextcloud deletes a group, MyDash MUST clean up all group-scoped data.
 - WHEN `GroupDeletedListener` handles the event
 - THEN it MUST read the JSON, remove `'marketing'` from all `groupVisibility` arrays, and write the updated JSON back to IConfig
 - AND no other group identifiers in the JSON MUST be altered
+- NOTE: MyDash-specific IConfig JSON-mutation — no equivalent in the reference implementation.
 
 #### Scenario: Group is removed from group_order setting on group deletion
 
@@ -174,10 +191,13 @@ When Nextcloud deletes a group, MyDash MUST clean up all group-scoped data.
 - WHEN `GroupDeletedListener` handles the event for `marketing`
 - THEN the setting MUST be updated to `["engineering", "support"]`
 - AND the update MUST be persisted to IConfig
+- NOTE: MyDash-specific IConfig JSON-mutation — no equivalent in the reference implementation.
 
 ### Requirement: REQ-CSC-006 Failure Isolation
 
 A failure in one listener MUST NOT prevent other listeners from executing. Every listener MUST catch all `\Throwable` and continue.
+
+- NOTE: The reference implementation uses `error`-level logging on listener failure. MyDash deliberately downgrades this to `warning` level on the basis that cascade failures are recoverable via the orphan-cleanup job and do not represent fatal errors. This is an intentional divergence.
 
 #### Scenario: One listener throws — others still execute
 
@@ -194,6 +214,7 @@ A failure in one listener MUST NOT prevent other listeners from executing. Every
 - WHEN the catch block executes
 - THEN it MUST call `ILogger::warning(...)` (or equivalent) with the listener class name, dashboard UUID, and exception message
 - AND MUST NOT call `ILogger::error()` (a cascade failure is recoverable via orphan-cleanup — it is not a fatal error)
+- NOTE: The reference implementation logs at `error` level; MyDash's choice of `warning` is deliberate — it signals recoverability rather than a fatal condition.
 
 #### Scenario: Multiple listener failures do not prevent response
 
@@ -201,35 +222,28 @@ A failure in one listener MUST NOT prevent other listeners from executing. Every
 - WHEN the dispatch completes
 - THEN `DashboardService::delete()` MUST still return the HTTP response with `cascadeStats`
 - AND `cascadeStats` MUST accurately reflect counts from the 7 listeners that succeeded
-- AND the 3 failures MUST be recorded in `oc_mydash_cascade_failures`
+- AND the 3 failures MUST each be logged at WARN level with full context (listener class, dashboard UUID, exception message)
+- NOTE: Failure recording via a dedicated DB table (`oc_mydash_cascade_failures`) has been dropped in favour of log-and-continue. The orphan-cleanup job identifies residual rows by querying dependent tables directly, making the failures table redundant. See REQ-CSC-007 for the rationale.
 
-### Requirement: REQ-CSC-007 Failure Recording
+### Requirement: REQ-CSC-007 Failure Handling — Log-and-Continue
 
-When a listener fails, the failure MUST be recorded in `oc_mydash_cascade_failures` for later retry by the orphan-cleanup job.
+When a listener fails, the failure MUST be logged at WARN level with full context. No separate failure-recording table is required.
 
-#### Scenario: Failed listener is recorded with full context
+- NOTE: The original spec included an `oc_mydash_cascade_failures` table for per-listener failure recording. The reference implementation has no such table and relies purely on log-and-continue: a try/catch in each listener logs on failure and the delete proceeds regardless. Given that the orphan-cleanup job can identify residual rows by querying dependent tables directly (e.g., widget placements whose dashboard is soft-deleted), the failures table adds migration cost without meaningful benefit. It has been removed from this spec. If the orphan-cleanup job's retry strategy requires a failure index in the future, that concern belongs in the `orphaned-data-cleanup` change.
+
+#### Scenario: Listener failure is fully logged before continuing
 
 - GIVEN `MetadataValuesListener` throws while handling a `DashboardDeletedEvent` for UUID `abc-123`
 - WHEN the catch block runs
-- THEN a row MUST be inserted into `oc_mydash_cascade_failures` with:
-  - `listener_class = 'OCA\MyDash\Listener\MetadataValuesListener'`
-  - `dashboard_uuid = 'abc-123'`
-  - `error_message` = the exception message (truncated to fit column if needed)
-  - `failed_at` = current timestamp
+- THEN `ILogger::warning()` MUST be called with at minimum: the listener class name, the dashboard UUID `abc-123`, and the exception message
+- AND execution MUST continue — no exception MUST propagate out of the listener's catch block
 
-#### Scenario: Failure recorder itself fails gracefully
+#### Scenario: No failure-recording table migration is required
 
-- GIVEN `CascadeFailureRecorder::record()` cannot write to the DB (e.g., table lock)
-- WHEN the recorder's internal try/catch fires
-- THEN no exception MUST propagate to the calling listener — the failure is logged via `ILogger` but silently swallowed
-- NOTE: this prevents a meta-failure from disrupting other listeners
-
-#### Scenario: Orphan-cleanup job can query failure table
-
-- GIVEN rows exist in `oc_mydash_cascade_failures` from previous failed listeners
-- WHEN the orphan-cleanup job runs
-- THEN it MUST be able to query `oc_mydash_cascade_failures` by `dashboard_uuid` to identify which listeners still need to be re-run
-- NOTE: retry logic is defined in the `orphaned-data-cleanup` change; this spec only defines the table and recording contract
+- GIVEN the implementation of this change
+- WHEN the migration list is reviewed
+- THEN there MUST be no migration adding an `oc_mydash_cascade_failures` table
+- AND the orphan-cleanup job MUST identify stragglers by querying dependent tables directly (e.g., `oc_mydash_widget_placements` joined against soft-deleted dashboards)
 
 ### Requirement: REQ-CSC-008 Idempotency
 
@@ -257,6 +271,8 @@ Every listener MUST be idempotent: running it a second time against already-clea
 ### Requirement: REQ-CSC-009 Cascade Stats Response
 
 `DashboardService::delete()` MUST return cascade statistics alongside the standard delete response.
+
+- NOTE: The reference implementation returns only `['success' => true]` with no cascade stats. The `cascadeStats` response shape is an additive MyDash-specific capability. Tree-child deletions MUST contribute to the aggregate counts (e.g., total `widgetPlacementsDeleted` across parent + all children), which requires `TreeListener` to propagate child listener counts back up to `DashboardService` — a coordination mechanism the reference implementation does not need.
 
 #### Scenario: Response includes cascadeStats on successful delete
 
@@ -287,7 +303,7 @@ Every listener MUST be idempotent: running it a second time against already-clea
 - WHEN the response is built
 - THEN `cascadeStats` MUST report counts from the 2 successful listeners
 - AND the failed listener's key MUST appear with value `0` (or be omitted — implementation choice, but MUST be consistent)
-- NOTE: the caller is not expected to act on partial-failure counts; the `oc_mydash_cascade_failures` table is the canonical failure record
+- NOTE: the caller is not expected to act on partial-failure counts; WARN-level log entries are the canonical failure record (no `oc_mydash_cascade_failures` table exists)
 
 #### Scenario: cascadeStats is present even when no dependent data exists
 
@@ -298,6 +314,8 @@ Every listener MUST be idempotent: running it a second time against already-clea
 ### Requirement: REQ-CSC-010 Tree Cascade Validation Guard
 
 Cascade deletion of a parent dashboard MUST only proceed when explicitly requested; non-cascade deletes with children MUST be rejected before any event is dispatched.
+
+- NOTE: MyDash improvement over the reference implementation. The reference deletes child nodes silently via a recursive filesystem operation (no cascade flag, no per-child event). MyDash's explicit cascade flag and `TreeListener` are more correct: each child receives its own `DashboardDeletedEvent` so all dependent listeners run for every node. The cascade guard additionally protects against accidental subtree deletion.
 
 #### Scenario: Non-cascade delete with children is rejected before event dispatch
 

--- a/openspec/changes/dashboard-cascade-events/specs/dashboard-cascade-events/spec.md
+++ b/openspec/changes/dashboard-cascade-events/specs/dashboard-cascade-events/spec.md
@@ -1,0 +1,324 @@
+---
+status: draft
+---
+
+# Dashboard Cascade Events Specification
+
+## Purpose
+
+When a MyDash dashboard is deleted, all dependent data (widget placements, comments, reactions, locks, versions, public shares, metadata values, translations, view analytics, child-tree dashboards) MUST be automatically removed. When a Nextcloud user or group is deleted, their associated dashboards and downstream records MUST likewise be cleaned up. This capability defines the event, the listener registry, failure isolation, idempotency, and cascade stats reporting.
+
+## ADDED Requirements
+
+### Requirement: REQ-CSC-001 DashboardDeletedEvent Definition
+
+The system MUST define a `DashboardDeletedEvent` class at `lib/Event/DashboardDeletedEvent.php` that carries all context listeners need to perform targeted cleanup.
+
+#### Scenario: Event carries required payload
+
+- GIVEN `DashboardService::delete()` soft-deletes a dashboard with UUID `abc-123`, owner `alice`, type `user`, at `2026-05-01T10:00:00Z`
+- WHEN the event is constructed
+- THEN `getDashboardUuid()` MUST return `'abc-123'`
+- AND `getOwnerUserId()` MUST return `'alice'`
+- AND `getType()` MUST return `'user'`
+- AND `getDeletedAt()` MUST return a `\DateTimeImmutable` equal to `2026-05-01T10:00:00Z`
+
+#### Scenario: Event is dispatched after soft-delete and before response
+
+- GIVEN a dashboard `D1` is being deleted
+- WHEN `DashboardService::delete()` runs
+- THEN the dashboard row MUST be soft-deleted in `oc_mydash_dashboards` first
+- AND `DashboardDeletedEvent` MUST be dispatched second, before the HTTP response is returned
+- NOTE: listeners observe a row that is already soft-deleted — they MUST NOT attempt to re-delete the main row
+
+#### Scenario: Event is NOT dispatched when validation rejects the delete
+
+- GIVEN dashboard `D1` has child dashboards and the caller has NOT requested cascade mode
+- WHEN `DashboardService::delete()` runs validation
+- THEN the validation MUST reject the request (HTTP 400 or equivalent)
+- AND `DashboardDeletedEvent` MUST NOT be dispatched
+- AND no dependent data MUST be touched
+
+#### Scenario: Event carries correct type for group-shared dashboard
+
+- GIVEN a group-shared dashboard `G1` (type `group_shared`) is deleted by an admin
+- WHEN `DashboardDeletedEvent` is dispatched
+- THEN `getType()` MUST return `'group_shared'`
+- AND `getOwnerUserId()` MUST return the admin's user ID (the actor who performed the deletion)
+
+#### Scenario: Event class extends Nextcloud IEventDispatcher contract
+
+- GIVEN `DashboardDeletedEvent` is instantiated
+- WHEN it is passed to `IEventDispatcher::dispatchTyped()`
+- THEN no type error MUST occur — the class MUST extend `\OCP\EventDispatcher\Event`
+
+### Requirement: REQ-CSC-002 Listener Registry and Registration
+
+Every listener MUST be registered in `Application` via `IEventDispatcher::addListener`. Adding a new listener MUST require only adding one registration line — no edits to existing listener classes.
+
+#### Scenario: All DashboardDeletedEvent listeners are registered
+
+- GIVEN MyDash is bootstrapped
+- WHEN `Application::register()` runs
+- THEN `IEventDispatcher` MUST have listeners registered for `DashboardDeletedEvent::class` covering: `WidgetPlacementsListener`, `CommentsListener`, `ReactionsListener`, `LocksListener`, `VersionsListener`, `PublicSharesListener`, `MetadataValuesListener`, `TranslationsListener`, `ViewAnalyticsListener`, `TreeListener`
+
+#### Scenario: Lifecycle listeners are registered for NC events
+
+- GIVEN MyDash is bootstrapped
+- WHEN a `\OCP\User\Events\UserDeletedEvent` is dispatched by Nextcloud core
+- THEN MyDash's `UserDeletedListener` MUST be invoked
+- AND when a `\OCP\Group\Events\GroupDeletedEvent` is dispatched
+- THEN MyDash's `GroupDeletedListener` MUST be invoked
+
+#### Scenario: New listener can be added without editing existing code
+
+- GIVEN a developer creates `lib/Listener/FavoritesListener.php` implementing `IEventListener`
+- WHEN they add one line to `Application::register()` registering it for `DashboardDeletedEvent::class`
+- THEN it MUST be invoked on every subsequent dashboard deletion — no changes to other listener files, `DashboardService`, or the event class are required
+
+### Requirement: REQ-CSC-003 Dependent-Data Listener Group
+
+A set of listeners MUST clean up every dependent table when `DashboardDeletedEvent` fires. Listeners for disjoint data MUST execute independently and MUST NOT interfere with each other.
+
+#### Scenario: Widget placements are deleted on dashboard delete
+
+- GIVEN dashboard `D1` has 5 widget placements in `oc_mydash_widget_placements`
+- WHEN `DashboardDeletedEvent` fires for `D1`
+- THEN `WidgetPlacementsListener` MUST delete all 5 rows
+- AND no placements from other dashboards MUST be touched
+
+#### Scenario: Comments are removed via ICommentsManager
+
+- GIVEN dashboard `D1` has comments tracked by NC core
+- WHEN `CommentsListener` handles the event
+- THEN it MUST call `ICommentsManager::deleteCommentsAtObject('mydash_dashboard', $D1.uuid)`
+- AND the NC comments table MUST contain no comments for `mydash_dashboard` / `D1.uuid` after the call
+
+#### Scenario: Public shares are soft-revoked, not hard-deleted
+
+- GIVEN dashboard `D1` has 2 active rows in `oc_mydash_public_shares` with `revokedAt IS NULL`
+- WHEN `PublicSharesListener` handles the event
+- THEN both rows MUST have `revokedAt` set to the current timestamp
+- AND neither row MUST be hard-deleted (audit trail is preserved)
+
+#### Scenario: Versions file is deleted in GroupFolder mode
+
+- GIVEN the instance uses GroupFolder storage backend
+- AND dashboard `D1` has a JSON versions file at `<groupfolder>/MyDash/versions/D1.uuid.json`
+- WHEN `VersionsListener` handles the event
+- THEN the DB rows in `oc_mydash_dashboard_versions` MUST be deleted
+- AND the JSON file MUST be removed from GroupFolder storage
+- NOTE: if the file does not exist (already removed or never created), the listener MUST treat this as a no-op
+
+#### Scenario: Tree listener recursively cascades to child dashboards
+
+- GIVEN dashboard `P1` (parent) has children `C1` and `C2` in `oc_mydash_dashboards`
+- WHEN `DashboardDeletedEvent` fires for `P1` (cascade-delete mode)
+- THEN `TreeListener` MUST dispatch a new `DashboardDeletedEvent` for `C1` and another for `C2`
+- AND each child event MUST trigger the full listener stack for that child (placements, comments, etc.)
+
+### Requirement: REQ-CSC-004 User Lifecycle Cleanup
+
+When Nextcloud deletes a user, MyDash MUST clean up all data owned by that user.
+
+#### Scenario: Personal dashboards are deleted on user deletion
+
+- GIVEN user `alice` owns 3 personal dashboards in `oc_mydash_dashboards`
+- WHEN Nextcloud dispatches `\OCP\User\Events\UserDeletedEvent` for `alice`
+- THEN `UserDeletedListener` MUST call `DashboardService::delete()` for each of alice's 3 dashboards
+- AND each deletion MUST dispatch `DashboardDeletedEvent`, cascading cleanup of their dependent data
+- AND no other user's dashboards MUST be affected
+
+#### Scenario: Role assignments are removed on user deletion
+
+- GIVEN `alice` has 2 rows in `oc_mydash_role_assignments`
+- WHEN `UserDeletedListener` handles the event
+- THEN both rows MUST be deleted from `oc_mydash_role_assignments`
+- AND role assignments for other users MUST remain untouched
+
+#### Scenario: Feed token is soft-revoked on user deletion
+
+- GIVEN `alice` has an active RSS feed token in `oc_mydash_feed_tokens`
+- WHEN `UserDeletedListener` handles the event
+- THEN the token row MUST have `revokedAt` set to the current timestamp
+- AND it MUST NOT be hard-deleted (the token URL may still be live; revocation allows a 410 response)
+
+#### Scenario: Analytics opt-out preference is removed on user deletion
+
+- GIVEN `alice` has a stored analytics opt-out preference via IConfig
+- WHEN `UserDeletedListener` handles the event
+- THEN the preference MUST be deleted from IConfig for her user ID
+- NOTE: absence of the key is equivalent to "opted in" — this ensures the pref does not linger for a future user who receives the same user ID
+
+### Requirement: REQ-CSC-005 Group Lifecycle Cleanup
+
+When Nextcloud deletes a group, MyDash MUST clean up all group-scoped data.
+
+#### Scenario: Group-shared dashboards are deleted on group deletion
+
+- GIVEN group `marketing` owns 2 group-shared dashboards in `oc_mydash_dashboards`
+- WHEN Nextcloud dispatches `\OCP\Group\Events\GroupDeletedEvent` for `marketing`
+- THEN `GroupDeletedListener` MUST call `DashboardService::delete()` for each of those 2 dashboards
+- AND each deletion MUST cascade cleanup of dependent data via `DashboardDeletedEvent`
+
+#### Scenario: Group is removed from org navigation tree on group deletion
+
+- GIVEN the `mydash.org_navigation_tree` IConfig value is a JSON object containing `groupVisibility` arrays that reference group `marketing`
+- WHEN `GroupDeletedListener` handles the event
+- THEN it MUST read the JSON, remove `'marketing'` from all `groupVisibility` arrays, and write the updated JSON back to IConfig
+- AND no other group identifiers in the JSON MUST be altered
+
+#### Scenario: Group is removed from group_order setting on group deletion
+
+- GIVEN `mydash.group_order` is a JSON array `["engineering", "marketing", "support"]`
+- WHEN `GroupDeletedListener` handles the event for `marketing`
+- THEN the setting MUST be updated to `["engineering", "support"]`
+- AND the update MUST be persisted to IConfig
+
+### Requirement: REQ-CSC-006 Failure Isolation
+
+A failure in one listener MUST NOT prevent other listeners from executing. Every listener MUST catch all `\Throwable` and continue.
+
+#### Scenario: One listener throws — others still execute
+
+- GIVEN `DashboardDeletedEvent` fires for `D1`
+- AND `ReactionsListener` throws a `\RuntimeException` during its execution
+- WHEN the event is dispatched
+- THEN `WidgetPlacementsListener`, `CommentsListener`, `LocksListener`, and all other registered listeners MUST still execute
+- AND the exception from `ReactionsListener` MUST NOT propagate beyond its own catch block
+- AND `DashboardService::delete()` MUST complete and return a response
+
+#### Scenario: Listener failure is logged at WARN level
+
+- GIVEN a listener throws during handling of `DashboardDeletedEvent`
+- WHEN the catch block executes
+- THEN it MUST call `ILogger::warning(...)` (or equivalent) with the listener class name, dashboard UUID, and exception message
+- AND MUST NOT call `ILogger::error()` (a cascade failure is recoverable via orphan-cleanup — it is not a fatal error)
+
+#### Scenario: Multiple listener failures do not prevent response
+
+- GIVEN 3 out of 10 listeners throw exceptions
+- WHEN the dispatch completes
+- THEN `DashboardService::delete()` MUST still return the HTTP response with `cascadeStats`
+- AND `cascadeStats` MUST accurately reflect counts from the 7 listeners that succeeded
+- AND the 3 failures MUST be recorded in `oc_mydash_cascade_failures`
+
+### Requirement: REQ-CSC-007 Failure Recording
+
+When a listener fails, the failure MUST be recorded in `oc_mydash_cascade_failures` for later retry by the orphan-cleanup job.
+
+#### Scenario: Failed listener is recorded with full context
+
+- GIVEN `MetadataValuesListener` throws while handling a `DashboardDeletedEvent` for UUID `abc-123`
+- WHEN the catch block runs
+- THEN a row MUST be inserted into `oc_mydash_cascade_failures` with:
+  - `listener_class = 'OCA\MyDash\Listener\MetadataValuesListener'`
+  - `dashboard_uuid = 'abc-123'`
+  - `error_message` = the exception message (truncated to fit column if needed)
+  - `failed_at` = current timestamp
+
+#### Scenario: Failure recorder itself fails gracefully
+
+- GIVEN `CascadeFailureRecorder::record()` cannot write to the DB (e.g., table lock)
+- WHEN the recorder's internal try/catch fires
+- THEN no exception MUST propagate to the calling listener — the failure is logged via `ILogger` but silently swallowed
+- NOTE: this prevents a meta-failure from disrupting other listeners
+
+#### Scenario: Orphan-cleanup job can query failure table
+
+- GIVEN rows exist in `oc_mydash_cascade_failures` from previous failed listeners
+- WHEN the orphan-cleanup job runs
+- THEN it MUST be able to query `oc_mydash_cascade_failures` by `dashboard_uuid` to identify which listeners still need to be re-run
+- NOTE: retry logic is defined in the `orphaned-data-cleanup` change; this spec only defines the table and recording contract
+
+### Requirement: REQ-CSC-008 Idempotency
+
+Every listener MUST be idempotent: running it a second time against already-cleaned data MUST be a no-op with no errors.
+
+#### Scenario: Re-running WidgetPlacementsListener on empty table is safe
+
+- GIVEN `DashboardDeletedEvent` fires for `D1` and placements are already deleted
+- WHEN `WidgetPlacementsListener` runs again (e.g., via orphan-cleanup retry)
+- THEN the DELETE query MUST affect 0 rows and MUST NOT throw an exception
+- AND the listener MUST return successfully
+
+#### Scenario: Re-running PublicSharesListener on already-revoked shares is safe
+
+- GIVEN all share rows for `D1` already have `revokedAt` set
+- WHEN `PublicSharesListener` runs again
+- THEN the UPDATE MUST match 0 rows (WHERE `revokedAt IS NULL` filters them all out) and MUST NOT throw
+
+#### Scenario: Re-running CommentsListener when no comments exist is safe
+
+- GIVEN `ICommentsManager::deleteCommentsAtObject()` is called for `D1` when no comments exist
+- THEN it MUST return without error (NC core already handles the empty-case gracefully)
+- AND `CommentsListener` MUST NOT add extra null-checks that could mask genuine errors
+
+### Requirement: REQ-CSC-009 Cascade Stats Response
+
+`DashboardService::delete()` MUST return cascade statistics alongside the standard delete response.
+
+#### Scenario: Response includes cascadeStats on successful delete
+
+- GIVEN dashboard `D1` has 3 widget placements, 2 reactions, 1 lock
+- WHEN `DELETE /api/dashboards/D1.uuid` completes
+- THEN the response body MUST include:
+  ```json
+  {
+    "deletedAt": "2026-05-01T10:00:00Z",
+    "cascadeStats": {
+      "widgetPlacementsDeleted": 3,
+      "commentsDeleted": 0,
+      "reactionsDeleted": 2,
+      "locksDeleted": 1,
+      "versionsDeleted": 0,
+      "sharesRevoked": 0,
+      "metadataValuesDeleted": 0,
+      "translationsDeleted": 0,
+      "viewsDeleted": 0
+    }
+  }
+  ```
+- AND the response MUST be additive (clients that ignore unknown fields remain unaffected)
+
+#### Scenario: cascadeStats reflects partial success when listeners fail
+
+- GIVEN 2 listeners succeed (deleting 5 rows total) and 1 listener fails
+- WHEN the response is built
+- THEN `cascadeStats` MUST report counts from the 2 successful listeners
+- AND the failed listener's key MUST appear with value `0` (or be omitted — implementation choice, but MUST be consistent)
+- NOTE: the caller is not expected to act on partial-failure counts; the `oc_mydash_cascade_failures` table is the canonical failure record
+
+#### Scenario: cascadeStats is present even when no dependent data exists
+
+- GIVEN dashboard `D1` has no placements, comments, or any other dependent rows
+- WHEN `DELETE /api/dashboards/D1.uuid` completes
+- THEN `cascadeStats` MUST still be present in the response with all counters set to `0`
+
+### Requirement: REQ-CSC-010 Tree Cascade Validation Guard
+
+Cascade deletion of a parent dashboard MUST only proceed when explicitly requested; non-cascade deletes with children MUST be rejected before any event is dispatched.
+
+#### Scenario: Non-cascade delete with children is rejected before event dispatch
+
+- GIVEN dashboard `P1` has child `C1`
+- WHEN a caller sends `DELETE /api/dashboards/P1.uuid` without a cascade flag
+- THEN the system MUST return HTTP 400 with an error indicating children exist
+- AND `DashboardDeletedEvent` MUST NOT be dispatched for `P1` or `C1`
+- AND no dependent data MUST be altered
+
+#### Scenario: Cascade delete processes parent then recursively processes children
+
+- GIVEN dashboard `P1` has children `C1` and `C2`, each with 2 widget placements
+- WHEN `DELETE /api/dashboards/P1.uuid?cascade=true` is called
+- THEN `DashboardService::delete()` MUST soft-delete `P1` and dispatch `DashboardDeletedEvent` for it
+- AND `TreeListener` MUST dispatch `DashboardDeletedEvent` for `C1` and `C2`
+- AND all 4 widget placements (2 per child) MUST be removed by `WidgetPlacementsListener` responding to each child event
+- AND `cascadeStats` in the response MUST reflect the total across all three dashboards
+
+#### Scenario: Tree listener is a no-op for leaf dashboards
+
+- GIVEN dashboard `L1` has no children
+- WHEN `DashboardDeletedEvent` fires for `L1`
+- THEN `TreeListener` MUST query the children table, find zero rows, and return without dispatching any further events
+- AND this MUST be treated as a successful no-op (no failure is recorded)

--- a/openspec/changes/dashboard-cascade-events/tasks.md
+++ b/openspec/changes/dashboard-cascade-events/tasks.md
@@ -1,0 +1,97 @@
+# Tasks — dashboard-cascade-events
+
+## 1. Event class
+
+- [ ] 1.1 Create `lib/Event/DashboardDeletedEvent.php` extending `\OCP\EventDispatcher\Event` with constructor arguments `(string $dashboardUuid, string $ownerUserId, string $type, \DateTimeImmutable $deletedAt)`
+- [ ] 1.2 Add read-only getters: `getDashboardUuid()`, `getOwnerUserId()`, `getType()`, `getDeletedAt()`
+- [ ] 1.3 Add SPDX docblock header (SPDX-License-Identifier + SPDX-FileCopyrightText inside the file docblock per convention)
+
+## 2. Migration — cascade failures table
+
+- [ ] 2.1 Create `lib/Migration/VersionXXXXDate2026AddCascadeFailuresTable.php` adding `oc_mydash_cascade_failures` with columns: `id` (BIGINT auto-increment PK), `listener_class` (VARCHAR 255), `dashboard_uuid` (VARCHAR 36), `error_message` (TEXT), `failed_at` (DATETIME)
+- [ ] 2.2 Add index `idx_mydash_cascade_fail_uuid` on `(dashboard_uuid)` for efficient orphan-cleanup lookups
+- [ ] 2.3 Confirm migration is reversible (drop table in rollback path)
+- [ ] 2.4 Run migration locally against sqlite, mysql, and postgres; verify schema applies cleanly
+
+## 3. DashboardDeletedEvent listeners
+
+- [ ] 3.1 Create `lib/Listener/WidgetPlacementsListener.php` implementing `\OCP\EventDispatcher\IEventListener`
+  - [ ] `handle()`: DELETE from `oc_mydash_widget_placements` WHERE `dashboardUuid = $event->getDashboardUuid()`; wrap in try/catch — on failure log WARN and record to `oc_mydash_cascade_failures`
+
+- [ ] 3.2 Create `lib/Listener/CommentsListener.php`
+  - [ ] `handle()`: call `ICommentsManager::deleteCommentsAtObject('mydash_dashboard', $event->getDashboardUuid())`; wrap in try/catch
+
+- [ ] 3.3 Create `lib/Listener/ReactionsListener.php`
+  - [ ] `handle()`: DELETE from `oc_mydash_dashboard_reactions` WHERE `dashboardUuid = ?`; wrap in try/catch
+
+- [ ] 3.4 Create `lib/Listener/LocksListener.php`
+  - [ ] `handle()`: DELETE from `oc_mydash_dashboard_locks` WHERE `dashboardUuid = ?`; wrap in try/catch
+
+- [ ] 3.5 Create `lib/Listener/VersionsListener.php`
+  - [ ] `handle()`: DELETE from `oc_mydash_dashboard_versions` WHERE `dashboardUuid = ?`; also delete any JSON version file in GroupFolder mode (check via IConfig whether GroupFolder backend is active); wrap in try/catch
+
+- [ ] 3.6 Create `lib/Listener/PublicSharesListener.php`
+  - [ ] `handle()`: UPDATE `oc_mydash_public_shares` SET `revokedAt = NOW()` WHERE `dashboardUuid = ?` AND `revokedAt IS NULL`; wrap in try/catch
+
+- [ ] 3.7 Create `lib/Listener/MetadataValuesListener.php`
+  - [ ] `handle()`: DELETE from `oc_mydash_metadata_values` WHERE `dashboardUuid = ?`; wrap in try/catch
+
+- [ ] 3.8 Create `lib/Listener/TranslationsListener.php`
+  - [ ] `handle()`: DELETE from `oc_mydash_dashboard_translations` WHERE `dashboardUuid = ?`; wrap in try/catch
+
+- [ ] 3.9 Create `lib/Listener/ViewAnalyticsListener.php`
+  - [ ] `handle()`: DELETE from `oc_mydash_dashboard_views` WHERE `dashboardUuid = ?`; wrap in try/catch
+
+- [ ] 3.10 Create `lib/Listener/TreeListener.php`
+  - [ ] `handle()`: query `oc_mydash_dashboards` for children WHERE `parentUuid = $event->getDashboardUuid()`; for each child, dispatch a new `DashboardDeletedEvent` via `IEventDispatcher`; wrap in try/catch
+
+## 4. Lifecycle listeners
+
+- [ ] 4.1 Create `lib/Listener/UserDeletedListener.php` subscribing to `\OCP\User\Events\UserDeletedEvent`
+  - [ ] `handle()`: query all personal dashboards for `$event->getUser()->getUID()`; for each, call `DashboardService::delete()` which triggers further cascade; DELETE from `oc_mydash_role_assignments` WHERE `userId = ?`; UPDATE `oc_mydash_feed_tokens` SET `revokedAt = NOW()` WHERE `userId = ?`; delete analytics opt-out preference via IConfig; wrap full method in try/catch, log errors at WARN
+
+- [ ] 4.2 Create `lib/Listener/GroupDeletedListener.php` subscribing to `\OCP\Group\Events\GroupDeletedEvent`
+  - [ ] `handle()`: query all group-shared dashboards for `$event->getGroup()->getGID()`; for each, call `DashboardService::delete()`; DELETE from `oc_mydash_role_assignments` WHERE `groupId = ?`; remove the group from `groupVisibility` arrays in `mydash.org_navigation_tree` (read JSON, filter, rewrite via IConfig); remove the group from `mydash.group_order` JSON array; wrap in try/catch
+
+## 5. DashboardService integration
+
+- [ ] 5.1 In `DashboardService::delete()`, after soft-deleting the dashboard row (before returning), inject and call `IEventDispatcher::dispatchTyped(new DashboardDeletedEvent(...))`
+- [ ] 5.2 Collect `cascadeStats` from listeners: each listener SHOULD record its deletion count via a shared stats accumulator (e.g., carried on the event object or a service-scoped collector); `DashboardService::delete()` returns `{deletedAt, cascadeStats: {widgetPlacementsDeleted: N, commentsDeleted: N, reactionsDeleted: N, locksDeleted: N, versionsDeleted: N, sharesRevoked: N, metadataValuesDeleted: N, translationsDeleted: N, viewsDeleted: N}}`
+- [ ] 5.3 Confirm that validation that rejects non-cascade delete when children exist still runs BEFORE the event dispatch (validation → soft-delete → dispatch)
+
+## 6. Listener registration
+
+- [ ] 6.1 In `lib/AppInfo/Application.php`, register all ten `DashboardDeletedEvent` listeners using `IEventDispatcher::addListener(DashboardDeletedEvent::class, ListenerClass::class)`
+- [ ] 6.2 Register `UserDeletedListener` for `\OCP\User\Events\UserDeletedEvent::class`
+- [ ] 6.3 Register `GroupDeletedListener` for `\OCP\Group\Events\GroupDeletedEvent::class`
+
+## 7. Failure recording helper
+
+- [ ] 7.1 Create `lib/Service/CascadeFailureRecorder.php` with method `record(string $listenerClass, string $dashboardUuid, \Throwable $error): void` — inserts into `oc_mydash_cascade_failures`; used by every listener's catch block
+- [ ] 7.2 Confirm that `CascadeFailureRecorder::record()` itself is wrapped in a try/catch so a DB failure in the recorder does not cause further exceptions
+
+## 8. PHPUnit tests
+
+- [ ] 8.1 `DashboardDeletedEventTest` — verify all getters return correct constructor values
+- [ ] 8.2 `WidgetPlacementsListenerTest` — success path deletes correct rows; failure path logs WARN and calls `CascadeFailureRecorder::record()` without throwing
+- [ ] 8.3 `PublicSharesListenerTest` — verify soft-revoke (not hard delete); idempotency (re-run on already-revoked rows is a no-op)
+- [ ] 8.4 `TreeListenerTest` — cascade: child dashboards each receive their own `DashboardDeletedEvent`; no-op when no children
+- [ ] 8.5 `UserDeletedListenerTest` — deletes personal dashboards, role assignments, feed tokens; leaves other users' data untouched
+- [ ] 8.6 `GroupDeletedListenerTest` — removes group from `groupVisibility` JSON; removes from `group_order`; cascades dashboard deletes
+- [ ] 8.7 `DashboardServiceDeleteTest` — event is dispatched after soft-delete; response includes `cascadeStats`; cascade is NOT triggered on a validation-rejected delete
+
+## 9. End-to-end Playwright tests
+
+- [ ] 9.1 Delete a dashboard that has widget placements and verify placements table is empty afterwards
+- [ ] 9.2 Delete a dashboard that has child dashboards (cascade mode) and verify all children are also soft-deleted and each fired its own cascade
+- [ ] 9.3 Simulate a listener failure (mock one listener to throw); verify other listeners still execute and failure row appears in `oc_mydash_cascade_failures`
+- [ ] 9.4 Delete a Nextcloud user and verify their personal dashboards and role assignments are removed
+- [ ] 9.5 Confirm cascade stats in the delete API response match actual row counts deleted
+
+## 10. Quality gates
+
+- [ ] 10.1 `composer check:strict` (PHPCS, PHPMD, Psalm, PHPStan) passes — fix any pre-existing issues encountered
+- [ ] 10.2 SPDX headers in every new PHP file (inside docblock per convention)
+- [ ] 10.3 `i18n` keys for cascade failure log messages in both `nl` and `en`
+- [ ] 10.4 Run all `hydra-gates` locally before opening PR
+- [ ] 10.5 Confirm `oc_mydash_cascade_failures` migration is reversible and tested on sqlite + mysql + postgres

--- a/openspec/changes/dashboard-comments/design.md
+++ b/openspec/changes/dashboard-comments/design.md
@@ -1,0 +1,87 @@
+# Design — Dashboard Comments
+
+## Context
+
+This capability adds threaded comments to dashboards. The spec (`dashboard-comments`) pins the
+NC `ICommentsManager` delegation model, `mydash_dashboard` object type, one-level-deep threading,
+and admin + per-dashboard toggle. Sibling spec `dashboard-cascade-events` owns the
+`DashboardDeletedEvent → ICommentsManager::deleteCommentsAtObject` call — not duplicated here.
+
+Source confirms the approach: `intravox-source/lib/Controller/CommentController.php` and
+`intravox-source/lib/Listener/CommentsEntityListener.php` both use `\OCP\Comments\ICommentsManager`
+directly with no custom comment table. We match this. This design documents object-type binding,
+depth enforcement, NC hooks, and toggle precedence.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Confirm storage delegation to NC `oc_comments` table (no MyDash comment table)
+- Document object-type string and NC entity registration
+- Specify one-level-deep enforcement mechanism
+- Define toggle precedence (global vs. per-dashboard)
+- Document cascade delete hook ownership
+
+**Non-Goals:**
+- Comment search / full-text indexing (NC activity feed handles cross-app)
+- Email notification content (NC notification framework handles delivery)
+- Moderation / hiding individual comments (future scope)
+
+## Decisions
+
+### D1: Storage delegation to NC ICommentsManager
+**Decision**: All comment persistence via `\OCP\Comments\ICommentsManager`; no `oc_mydash_comments` table.
+**Source evidence**: `intravox-source/lib/Controller/CommentController.php:~30-80` — all reads/writes
+through injected `ICommentsManager`; no custom DB mapper.
+**Alternatives considered**: Own table — rejected; loses NC activity feed, @-mention notifications,
+and unread-count badge at zero cost.
+**Rationale**: NC core delegation gives activity feed and notifications for free.
+
+### D2: Object-type binding
+**Decision**: Object type string is `mydash_dashboard`; object ID is the dashboard UUID.
+**Source evidence**: `intravox-source/lib/Listener/CommentsEntityListener.php:~15` — uses
+`'page'` as object type; we use `mydash_dashboard` to avoid collision with other NC apps.
+**Alternatives considered**:
+- `files` object type sharing — rejected; semantically wrong, would pollute file comment queries
+**Rationale**: Unique object type ensures clean separation. Register via `ICommentsManagerFactory`
+in `Application::register()` so NC's comment UI components know how to resolve the entity.
+
+### D3: NC entity registration
+**Decision**: Implement `ICommentsEntityInterface` in `DashboardCommentsEntity` and register
+via `ICommentsManagerFactory::registerDisplayNameResolver()` in `Application.php`.
+**Alternatives considered**:
+- Skip entity registration — rejected; NC comment UI shows raw UUIDs instead of dashboard titles
+**Rationale**: Entity registration resolves dashboard UUIDs to human-readable titles in the NC
+activity feed and notification emails.
+
+### D4: One-level-deep threading enforcement
+**Decision**: `CommentController::create()` validates: if `parentId` is set, fetch the parent
+comment and reject (HTTP 422 `thread_depth_exceeded`) if `parent.parentId IS NOT NULL`.
+**Source evidence**: `intravox-source/lib/Controller/CommentController.php:~95` — depth check
+is explicit, not delegated to `ICommentsManager` (which allows arbitrary depth).
+**Alternatives considered**:
+- Allow arbitrary depth and prune at read — rejected; inconsistent write state is confusing
+**Rationale**: NC `ICommentsManager` does not enforce depth natively. Write-time enforcement keeps
+the data model consistent and matches the spec contract.
+
+### D5: Toggle precedence
+**Decision**: Global `mydash.comments_enabled` takes absolute precedence; per-dashboard
+`commentsEnabled` only applies when global is on. Globally disabled → HTTP 403 on all endpoints.
+**Alternatives considered**: Per-dashboard override of global — rejected; admin needs kill-switch.
+**Rationale**: Standard NC admin-override pattern; mirrors NC global sharing toggle.
+
+### D6: Cascade delete ownership
+**Decision**: `DashboardDeletedEvent` listener in `dashboard-cascade-events` calls
+`ICommentsManager::deleteCommentsAtObject('mydash_dashboard', $uuid)`. No separate listener here.
+**Alternatives considered**: Own listener — rejected; `dashboard-cascade-events` owns all cascades.
+**Rationale**: Single listener per event avoids double-delete races.
+
+## Risks / Trade-offs
+
+- **ICommentsManager API stability** → OCP interface is stable across NC 25+; pin to `\OCP\Comments` namespace not `\OCA\Comments`
+- **Comment count at scale** → `ICommentsManager::count()` issues a COUNT query per dashboard in list view; consider batching or caching if dashboards list is large
+
+## Open follow-ups
+
+- Add `?unread=true` filter to comment list once NC unread-comment tracking API is confirmed available
+- Evaluate comment reactions (emoji on comments) — out of scope now, but `dashboard-reactions` pattern could extend here
+- Document whether NC's existing comment search app (`comments` app) indexes `mydash_dashboard` objects automatically

--- a/openspec/changes/dashboard-comments/proposal.md
+++ b/openspec/changes/dashboard-comments/proposal.md
@@ -1,0 +1,58 @@
+# Dashboard Comments
+
+## Why
+
+Dashboards are shared workspaces within teams and organizations. Currently MyDash offers no way for users to discuss or annotate a dashboard — there is no thread for "why is this widget red?" or "we should change this metric next sprint". This change introduces threaded, one-level-deep comments on dashboards, leveraging Nextcloud's native `ICommentsManager` infrastructure (already used for file comments, talk integration, etc.) so that Nextcloud administrators get unified comment storage, notifications, and audit trails across the platform. Comments are persisted via Nextcloud's existing comment storage layer with no custom database table required.
+
+## What Changes
+
+- Use `ICommentsManager` with object type `mydash_dashboard` and object id = dashboard UUID to store all comments.
+- Add a nullable `commentsEnabled SMALLINT(0/1) NULL` column on `oc_mydash_dashboards` to support per-dashboard comment toggle (NULL = follow global setting, 1 = force-on, 0 = force-off).
+- Add global admin setting `mydash.comments_enabled_default` (defaults to true) that applies to all dashboards where `commentsEnabled IS NULL`.
+- Expose `GET /api/dashboards/{uuid}/comments` returning ordered comment list with nested replies grouped beneath top-level comments.
+- Expose `POST /api/dashboards/{uuid}/comments` accepting `{message, parentId?}` to create top-level or reply comments.
+- Enforce one-level-deep nesting: a top-level comment may have replies, but replies cannot themselves have replies (HTTP 400 on violation).
+- Expose `PUT /api/dashboards/{uuid}/comments/{id}` accepting `{message}` to edit comments (author or admin only, marks edited comments with `wasEdited: true`).
+- Expose `DELETE /api/dashboards/{uuid}/comments/{id}` for soft-delete (author or admin only; deleting a top-level comment cascades to its replies).
+- Parse `@username` mentions in messages, resolve to user IDs via `IUserManager`, and send Nextcloud notifications to each mentioned user; include mentions list in response.
+- When comments are effectively disabled for a dashboard, `GET` returns `{enabled: false, comments: []}` and `POST` returns HTTP 403.
+- Comment readers/writers must pass existing dashboard permission checks (delegate to `PermissionService`). Public-share viewers cannot post unless the share grants `permission = comment` (document but defer v2 implementation).
+
+## Capabilities
+
+### New Capabilities
+
+- `dashboard-comments`: introduces REQ-CMNT-001 through REQ-CMNT-008 covering list, create, nesting limit, edit, delete, mentions, per-dashboard toggle, global toggle, and permission integration.
+
+### Modified Capabilities
+
+- `dashboards`: add `commentsEnabled` field to Dashboard entity (nullable SMALLINT in output).
+
+## Impact
+
+**Affected code:**
+
+- `lib/Db/Dashboard.php` — add nullable `commentsEnabled` field with getter/setter
+- `lib/Service/CommentService.php` (new) — CRUD and business logic for `ICommentsManager` wrapping, mention parsing, notification dispatch
+- `lib/Controller/DashboardController.php` — four new endpoints (list, create, edit, delete comments) plus permission checks
+- `appinfo/routes.php` — register four new routes under `/api/dashboards/{uuid}/comments`
+- `lib/Migration/VersionXXXXDate2026...AddCommentsEnabledColumn.php` — add `commentsEnabled` column to `oc_mydash_dashboards`
+- `src/stores/dashboards.js` — track `commentsEnabled` per dashboard in store
+- `src/components/DashboardComments.vue` (new) — UI component for reading and posting comments
+
+**Affected APIs:**
+
+- 4 new routes: `GET|POST /api/dashboards/{uuid}/comments`, `PUT|DELETE /api/dashboards/{uuid}/comments/{id}`
+- No existing routes changed
+
+**Dependencies:**
+
+- `OCP\Comments\ICommentsManager` — core Nextcloud API, no new composer dependency (already in framework)
+- `OCP\INotificationManager` — for mention notifications (core, no new dependency)
+- `OCP\IUserManager` — for mention resolution (core, no new dependency)
+- No new npm dependencies
+
+**Migration:**
+
+- Zero-impact: the migration only adds a nullable column. Existing dashboards get `commentsEnabled = NULL` and inherit the global setting.
+- No data backfill required.

--- a/openspec/changes/dashboard-comments/specs/dashboard-comments/spec.md
+++ b/openspec/changes/dashboard-comments/specs/dashboard-comments/spec.md
@@ -1,0 +1,219 @@
+---
+capability: dashboard-comments
+delta: true
+status: draft
+---
+
+# Dashboard Comments — Delta from change `dashboard-comments`
+
+## ADDED Requirements
+
+### Requirement: REQ-CMNT-001 List Comments on Dashboard
+
+Users with view permissions MUST be able to retrieve all comments and replies on a dashboard in a single request, ordered with newest top-level comments first and replies grouped beneath their parent.
+
+#### Scenario: List comments on a dashboard with mixed comments and replies
+- GIVEN dashboard UUID "dash-001" has 2 top-level comments and 1 reply under the first comment
+- WHEN user "alice" sends `GET /api/dashboards/dash-001/comments`
+- THEN the system MUST return HTTP 200 with an array containing comment objects
+- AND each comment object MUST include: id, author, message, createdAt, updatedAt, wasEdited, parentId, mentions
+- AND top-level comments (parentId = null) MUST be ordered newest-first
+- AND the response MUST include `enabled: true` if comments are effectively enabled for this dashboard
+
+#### Scenario: List comments when comments are disabled
+- GIVEN dashboard UUID "dash-002" has `commentsEnabled = 0` (forced-off)
+- WHEN user "bob" sends `GET /api/dashboards/dash-002/comments`
+- THEN the system MUST return HTTP 200 with `{enabled: false, comments: []}`
+
+#### Scenario: List comments without view permission
+- GIVEN user "dave" has no permission to view dashboard "dash-005"
+- WHEN "dave" sends `GET /api/dashboards/dash-005/comments`
+- THEN the system MUST return HTTP 403 Forbidden
+
+### Requirement: REQ-CMNT-002 Create Top-Level Comment
+
+Users with write permissions MUST be able to post new top-level comments on a dashboard.
+
+#### Scenario: Create a new top-level comment
+- GIVEN user "alice" has write access to dashboard "dash-001"
+- WHEN she sends `POST /api/dashboards/dash-001/comments` with body `{"message": "Need to verify this metric"}`
+- THEN the system MUST create a comment via `ICommentsManager::save()` with objectType `'mydash_dashboard'` and objectId = dashboard UUID
+- AND return HTTP 201 with the full comment object including generated comment id
+- AND the comment MUST appear in subsequent `GET /api/dashboards/dash-001/comments` requests
+
+#### Scenario: Create comment with mentions
+- GIVEN user "bob" sends `POST /api/dashboards/dash-001/comments` with body `{"message": "@alice please check this"}`
+- THEN the system MUST resolve @alice to user ID via `IUserManager`, send alice a Nextcloud notification, and include `mentions: [{userId: "alice", displayName: "Alice User"}]` in the response
+
+#### Scenario: Create comment when comments disabled
+- GIVEN dashboard "dash-002" has `commentsEnabled = 0`
+- WHEN user "charlie" sends `POST /api/dashboards/dash-002/comments`
+- THEN the system MUST return HTTP 403 Forbidden with error "Comments are disabled on this dashboard"
+
+#### Scenario: Create comment without write permission
+- GIVEN user "dave" has view-only access to dashboard "dash-005"
+- WHEN "dave" sends `POST /api/dashboards/dash-005/comments`
+- THEN the system MUST return HTTP 403 Forbidden
+
+#### Scenario: Create comment with empty message
+- GIVEN user "eve" sends `POST /api/dashboards/dash-001/comments` with body `{"message": ""}`
+- THEN the system MUST return HTTP 400 Bad Request with validation error
+
+### Requirement: REQ-CMNT-003 One-Level-Deep Nesting Enforcement
+
+Replies may only be attached to top-level comments. Replies to replies MUST be rejected with HTTP 400.
+
+#### Scenario: Create a valid reply to a top-level comment
+- GIVEN dashboard "dash-001" has top-level comment with id 100
+- WHEN user "frank" sends `POST /api/dashboards/dash-001/comments` with body `{"message": "Agreed", "parentId": 100}`
+- THEN the system MUST verify comment 100 is top-level (parentId = 0 in storage) and create a reply
+- AND return HTTP 201 with the reply object including `parentId: 100`
+
+#### Scenario: Reject nested reply (reply to a reply)
+- GIVEN dashboard "dash-001" has top-level comment id 100 and reply id 101 (parentId = 100)
+- WHEN user "grace" sends `POST /api/dashboards/dash-001/comments` with body `{"message": "No way", "parentId": 101}`
+- THEN the system MUST verify comment 101 has parentId = 100 (not 0) and return HTTP 400 Bad Request
+- AND error message MUST indicate "Comments can only be replied to once"
+
+#### Scenario: Non-existent parent returns 404
+- GIVEN user "henry" sends `POST /api/dashboards/dash-001/comments` with body `{"message": "Reply", "parentId": 999}`
+- THEN the system MUST return HTTP 404 Not Found with error "Parent comment not found"
+
+### Requirement: REQ-CMNT-004 Edit Comment
+
+Only the comment author or a Nextcloud admin user MUST be able to edit a comment. Non-authors MUST receive HTTP 403. Edited comments MUST be marked with `wasEdited: true`.
+
+#### Scenario: Author edits their own comment
+- GIVEN comment id 100 authored by "jack" on dashboard "dash-001"
+- WHEN "jack" sends `PUT /api/dashboards/dash-001/comments/100` with body `{"message": "Corrected text"}`
+- THEN the system MUST update the comment via `ICommentsManager`, set `wasEdited = true` and `updatedAt` to current timestamp
+- AND return HTTP 200 with the updated comment object
+
+#### Scenario: Non-author cannot edit
+- GIVEN comment id 100 authored by "kate"
+- WHEN "liam" (non-author, non-admin) sends `PUT /api/dashboards/dash-001/comments/100`
+- THEN the system MUST return HTTP 403 Forbidden with error "Only the author or an admin may edit this comment"
+
+#### Scenario: Admin can edit any comment
+- GIVEN comment id 100 authored by "mike" and "nora" is a Nextcloud admin (verified via `IGroupManager::isAdmin()`)
+- WHEN "nora" sends `PUT /api/dashboards/dash-001/comments/100` with new message
+- THEN the system MUST allow the edit and return HTTP 200
+
+### Requirement: REQ-CMNT-005 Delete Comment
+
+Only the comment author or a Nextcloud admin user MUST be able to delete a comment. Non-authors MUST receive HTTP 403. Deleting a top-level comment MUST cascade to delete all replies.
+
+#### Scenario: Author deletes their own comment
+- GIVEN top-level comment id 100 authored by "quinn" on dashboard "dash-001"
+- WHEN "quinn" sends `DELETE /api/dashboards/dash-001/comments/100`
+- THEN the system MUST soft-delete via `ICommentsManager::delete()` and return HTTP 204 No Content
+- AND the comment MUST no longer appear in subsequent `GET /api/dashboards/dash-001/comments` requests
+
+#### Scenario: Delete top-level comment cascades to replies
+- GIVEN top-level comment id 100 with replies id 101 and 102
+- WHEN comment 100's author sends `DELETE /api/dashboards/dash-001/comments/100`
+- THEN the system MUST delete comment 100 AND its children via separate `ICommentsManager::delete()` calls
+- AND all three MUST be removed from subsequent list requests
+
+#### Scenario: Delete a reply only
+- GIVEN reply comment id 101 with parentId = 100
+- WHEN comment 101's author sends `DELETE /api/dashboards/dash-001/comments/101`
+- THEN the system MUST delete only comment 101 (parent and siblings remain)
+
+#### Scenario: Non-author cannot delete
+- GIVEN comment id 100 authored by "roger"
+- WHEN "susan" (non-author, non-admin) sends `DELETE /api/dashboards/dash-001/comments/100`
+- THEN the system MUST return HTTP 403 Forbidden
+
+### Requirement: REQ-CMNT-006 Mention Parsing and Notifications
+
+When a comment message contains `@username` patterns, the system MUST resolve the mention, extract mentions list, and send Nextcloud notifications to mentioned users.
+
+#### Scenario: Single mention in comment message
+- GIVEN user "victor" sends `POST /api/dashboards/dash-001/comments` with message "@alice please review"
+- THEN the system MUST parse the message for `@username` patterns, resolve "alice" via `IUserManager::get('alice')`
+- AND send "alice" a Nextcloud notification with link to the dashboard
+- AND return the comment with `mentions: [{userId: "alice", displayName: "Alice User"}]`
+
+#### Scenario: Multiple mentions deduplicated
+- GIVEN message "@alice @bob should see this"
+- THEN the system MUST extract both usernames, resolve both, send both notifications
+- AND return `mentions` array with one entry per unique user
+
+#### Scenario: Non-existent username mention silently skipped
+- GIVEN message "@nonexistent_user please help"
+- THEN the system MUST attempt resolution via `IUserManager::get()`, which returns null
+- AND the mention MUST NOT appear in the `mentions` array
+- AND no notification is sent for that mention
+- AND the comment is created normally with raw text intact
+
+#### Scenario: Mention in edited comment updates notifications
+- GIVEN comment originally with no mentions, edited to add "@xavier this is important"
+- THEN the system MUST parse the NEW message for mentions, send notification to xavier
+- AND update the `mentions` array in the response
+
+### Requirement: REQ-CMNT-007 Per-Dashboard Comment Toggle
+
+Each dashboard MUST support a nullable `commentsEnabled` field to override the global default setting. When NULL, the dashboard MUST inherit the global `mydash.comments_enabled_default` setting.
+
+#### Scenario: Dashboard inherits global setting when commentsEnabled IS NULL
+- GIVEN dashboard "dash-001" has `commentsEnabled = NULL`
+- AND global setting `mydash.comments_enabled_default` = true
+- WHEN user "yolanda" sends `GET /api/dashboards/dash-001/comments`
+- THEN the system MUST return `{enabled: true, comments: [...]}`
+
+#### Scenario: Dashboard forces comments on
+- GIVEN dashboard "dash-002" has `commentsEnabled = 1`
+- AND global setting `mydash.comments_enabled_default` = false
+- WHEN user "zack" sends `GET /api/dashboards/dash-002/comments`
+- THEN the system MUST return `{enabled: true, comments: [...]}`
+
+#### Scenario: Dashboard forces comments off
+- GIVEN dashboard "dash-003" has `commentsEnabled = 0`
+- AND global setting `mydash.comments_enabled_default` = true
+- WHEN user "alice" sends `GET /api/dashboards/dash-003/comments`
+- THEN the system MUST return `{enabled: false, comments: []}`
+
+#### Scenario: Disabled dashboard rejects POST
+- GIVEN dashboard "dash-003" with `commentsEnabled = 0`
+- WHEN user "bob" sends `POST /api/dashboards/dash-003/comments`
+- THEN the system MUST return HTTP 403 Forbidden
+
+### Requirement: REQ-CMNT-008 Global Comments Setting
+
+Nextcloud admins MUST be able to toggle comment functionality globally via admin setting `mydash.comments_enabled_default`.
+
+#### Scenario: Admin toggles global setting to OFF
+- GIVEN admin setting `mydash.comments_enabled_default` = false
+- AND dashboard "dash-001" has `commentsEnabled = NULL`
+- THEN `GET /api/dashboards/dash-001/comments` MUST return `enabled: false`
+- AND `POST /api/dashboards/dash-001/comments` MUST return HTTP 403
+
+#### Scenario: Per-dashboard override persists across global toggle
+- GIVEN dashboard "dash-001" has `commentsEnabled = 1` (force-on) and global setting = false
+- THEN dashboard "dash-001" MUST remain enabled (per-dashboard setting takes precedence)
+
+#### Scenario: Default value on fresh install
+- GIVEN a fresh MyDash installation with no admin config
+- THEN `mydash.comments_enabled_default` MUST default to true
+
+### Requirement: REQ-CMNT-009 Permission Integration
+
+Comment readers and writers MUST be subject to the same dashboard permission checks as widget views and edits.
+
+#### Scenario: User with view-only permission can read but not post
+- GIVEN user "dave" has `permissionLevel = 'view_only'` on dashboard "dash-005"
+- WHEN "dave" sends `GET /api/dashboards/dash-005/comments`
+- THEN the system MUST return HTTP 200 with comments list
+- WHEN "dave" sends `POST /api/dashboards/dash-005/comments`
+- THEN the system MUST return HTTP 403 Forbidden
+
+#### Scenario: User with full permission can read and post
+- GIVEN user "frank" has `permissionLevel = 'full'` on dashboard "dash-007"
+- WHEN "frank" sends `GET`, `POST`, `PUT`, `DELETE` on that dashboard's comments
+- THEN all requests MUST succeed with appropriate HTTP codes (200, 201, 204)
+
+#### Scenario: Anonymous user without view permission gets 403
+- GIVEN dashboard "dash-008" is not publicly shared
+- WHEN an anonymous user requests `GET /api/dashboards/dash-008/comments`
+- THEN the system MUST return HTTP 403 Forbidden

--- a/openspec/changes/dashboard-comments/tasks.md
+++ b/openspec/changes/dashboard-comments/tasks.md
@@ -1,0 +1,126 @@
+# Tasks — dashboard-comments
+
+## 1. Schema migration
+
+- [ ] 1.1 Create `lib/Migration/VersionXXXXDate2026...AddCommentsEnabledColumn.php` adding `commentsEnabled SMALLINT(0/1) NULL` to `oc_mydash_dashboards`
+- [ ] 1.2 Confirm migration is reversible (drop column in `postSchemaChange` rollback path)
+- [ ] 1.3 Run migration locally against sqlite, mysql, and postgres; verify schema applied cleanly each time
+
+## 2. Domain model
+
+- [ ] 2.1 Add `commentsEnabled` field to `Dashboard` entity with getter/setter (Entity `__call` pattern — no named args)
+- [ ] 2.2 Update `Dashboard::jsonSerialize()` to include `commentsEnabled` (nullable in output)
+- [ ] 2.3 Add Dashboard helper method `isCommentsEffectivelyEnabled(IAppConfig $appConfig): bool` that checks `commentsEnabled`, falls back to global setting
+
+## 3. Service layer — Core comment logic
+
+- [ ] 3.1 Create `lib/Service/CommentService.php` with dependency injection: `ICommentsManager`, `IUserManager`, `INotificationManager`, `IGroupManager`, `IAppConfig`
+- [ ] 3.2 Implement `CommentService::getCommentsForDashboard(string $dashboardUuid): array` — calls `ICommentsManager::getForObject('mydash_dashboard', $dashboardUuid)` and returns ordered comment tree with top-level comments newest-first, replies grouped by parentId
+- [ ] 3.3 Implement `CommentService::createComment(string $dashboardUuid, string $userId, string $message, ?int $parentId = null): IComment` — creates comment via `ICommentsManager::save()`, enforces nesting limit (rejects if parentId points to a reply), triggers mention parsing
+- [ ] 3.4 Implement `CommentService::updateComment(int $commentId, string $newMessage, string $currentUserId): IComment` — verify author-or-admin, update message, set updatedAt timestamp, trigger mention re-parsing
+- [ ] 3.5 Implement `CommentService::deleteComment(int $commentId, string $currentUserId): void` — verify author-or-admin, soft-delete via `ICommentsManager::delete()`, cascade-delete replies if top-level
+- [ ] 3.6 Implement `CommentService::parseAndResolveMentions(string $message, string $dashboardUuid, string $authorUserId): array` returning `[{userId, displayName}, ...]` and send Nextcloud notifications to each
+
+## 4. Mention parsing implementation
+
+- [ ] 4.1 Extract `@username` patterns via regex `/@([a-zA-Z0-9_.-]+)/` (case-insensitive, case-normalized to lowercase for lookup)
+- [ ] 4.2 Call `IUserManager::get($username)` for each unique match (deduplicate)
+- [ ] 4.3 For each resolved user, create Nextcloud notification via `INotificationManager::createNotification()` with:
+  - Event: 'mentioned_in_comment' (custom event app must register in `appinfo/info.xml`)
+  - Subject i18n key: `cmnt_mentioned_in_comment`
+  - Link to dashboard (route to `/index.php/apps/mydash/...#dashboard/{uuid}`)
+  - Include author display name and dashboard name in notification
+- [ ] 4.4 Return structured mention list; silently skip unresolved mentions (no error)
+- [ ] 4.5 Add i18n entries in `l10n/en.json` and `l10n/nl.json` for notification subject and body
+
+## 5. Controller + routes
+
+- [ ] 5.1 Add `DashboardController::getComments(string $uuid)` mapped to `GET /api/dashboards/{uuid}/comments` (logged-in or public share, `#[NoAdminRequired]`)
+- [ ] 5.2 Add `DashboardController::createComment(string $uuid)` mapped to `POST /api/dashboards/{uuid}/comments` (logged-in or public share, `#[NoAdminRequired]`)
+- [ ] 5.3 Add `DashboardController::updateComment(string $uuid, int $id)` mapped to `PUT /api/dashboards/{uuid}/comments/{id}` (logged-in, `#[NoAdminRequired]`, author-or-admin check in body)
+- [ ] 5.4 Add `DashboardController::deleteComment(string $uuid, int $id)` mapped to `DELETE /api/dashboards/{uuid}/comments/{id}` (logged-in, `#[NoAdminRequired]`, author-or-admin check in body)
+- [ ] 5.5 In each controller method:
+  - Load dashboard by uuid and verify comment-read/write permission via `PermissionService::getEffectivePermissionLevel()`
+  - Check `Dashboard::isCommentsEffectivelyEnabled($appConfig)` and return 403 if disabled (except GET returns `{enabled: false, comments: []}`)
+  - Handle public shares: extract userId from `IShareManager` share token (if present) and delegate permission check to share's permission level
+- [ ] 5.6 Register all four routes in `appinfo/routes.php` with proper regex requirements (uuid = UUID v4 pattern, id = integer)
+- [ ] 5.7 Return comment list as `{enabled: true, comments: [{id, author, message, createdAt, updatedAt, wasEdited, parentId, mentions}]}` in get responses
+- [ ] 5.8 Validate request bodies: message non-empty, parentId must be integer if provided
+
+## 6. Global setting integration
+
+- [ ] 6.1 Register `mydash.comments_enabled_default` boolean admin setting in `appinfo/info.xml` (default: true)
+- [ ] 6.2 Add admin UI setting in Settings page (deferred to follow-up if needed; this change wires backend only)
+- [ ] 6.3 Provide `CommentService::isCommentsEnabledGlobally(): bool` method that reads the setting
+
+## 7. Frontend store updates
+
+- [ ] 7.1 Extend `src/stores/dashboards.js` to track `commentsEnabled` per dashboard (from API responses)
+- [ ] 7.2 Add `getDashboard(uuid)` getter that includes `commentsEnabled` field
+- [ ] 7.3 Ensure existing store mutations propagate `commentsEnabled` when dashboards are fetched or updated
+
+## 8. Frontend UI component (new)
+
+- [ ] 8.1 Create `src/components/DashboardComments.vue` Vue component for reading and posting comments
+- [ ] 8.2 Component props: `dashboardUuid`, `currentPermissionLevel`, `commentsEnabled`
+- [ ] 8.3 Display:
+  - "Comments disabled" message if `commentsEnabled = false`
+  - Comment list grouped with replies under parents (nested visual hierarchy or indentation)
+  - Per-comment author name, timestamp, message (with parsed mention highlight/links)
+  - Edit/Delete buttons visible only to author/admin (conditional v-if)
+- [ ] 8.4 Post new comment:
+  - Text input field with @mention autocomplete (lookup users via API or local user list)
+  - "Reply" button on each comment to set parentId (inline reply mode)
+  - Submit button creates comment via POST /api/dashboards/{uuid}/comments
+- [ ] 8.5 Edit comment:
+  - Inline edit form on edit button click
+  - PUT /api/dashboards/{uuid}/comments/{id} on save
+  - Display "Edited" label and timestamp after save
+- [ ] 8.6 Delete comment:
+  - Confirm dialog before DELETE
+  - Remove comment from list on 204 response
+  - Cascade-delete visual indication (if top-level, note that replies will also be deleted)
+- [ ] 8.7 i18n keys for all UI labels, buttons, error messages in `l10n/en.json` and `l10n/nl.json`
+- [ ] 8.8 WCAG AA compliance: keyboard navigation, screen reader labels, focus management
+
+## 9. PHPUnit tests
+
+- [ ] 9.1 `CommentServiceTest::testGetCommentsForDashboard` — fetch comments, verify tree structure, top-level order
+- [ ] 9.2 `CommentServiceTest::testCreateComment` — basic create, replies, parentId validation
+- [ ] 9.3 `CommentServiceTest::testNestingLimitEnforcement` — reject reply-to-reply with HTTP 400
+- [ ] 9.4 `CommentServiceTest::testUpdateComment` — author can edit, non-author cannot, admin can, wasEdited flag set
+- [ ] 9.5 `CommentServiceTest::testDeleteComment` — author can delete, cascade deletes replies, non-author cannot
+- [ ] 9.6 `CommentServiceTest::testParseAndResolveMentions` — extract usernames, resolve to user IDs, deduplicate, skip nonexistent, send notifications
+- [ ] 9.7 `CommentServiceTest::testMentionCaseInsensitivity` — @Alice and @alice resolve to same user
+- [ ] 9.8 `CommentControllerTest::testGetCommentsRequiresViewPermission` — HTTP 403 for view_only... (wait, view_only users can read comments; only write is restricted)
+- [ ] 9.9 `CommentControllerTest::testPostCommentRequiresWritePermission` — HTTP 403 for view_only users posting
+- [ ] 9.10 `CommentControllerTest::testDisabledCommentsReturn403OnPost` — commentsEnabled = 0 rejects POST with 403
+- [ ] 9.11 `CommentControllerTest::testDisabledCommentsReturnEmptyOnGet` — commentsEnabled = 0 returns {enabled: false, comments: []}
+- [ ] 9.12 `CommentControllerTest::testIsCommentsEffectivelyEnabled` — NULL inherits global, 1 forces on, 0 forces off
+- [ ] 9.13 `DashboardMapperTest` regression — all existing dashboard tests pass (commentsEnabled field doesn't break existing flow)
+
+## 10. End-to-end Playwright tests
+
+- [ ] 10.1 User posts a top-level comment and sees it immediately in the list (newest-first)
+- [ ] 10.2 User replies to a comment and the reply appears grouped beneath the parent
+- [ ] 10.3 User mentions @someone and that user receives a Nextcloud notification with a link to the dashboard
+- [ ] 10.4 User edits their comment; "Edited" label appears; timestamp updates
+- [ ] 10.5 Admin user edits another user's comment (non-author edit)
+- [ ] 10.6 User deletes their comment; it disappears from list; replies (if top-level) also vanish
+- [ ] 10.7 Attempt to reply to a reply returns HTTP 400 (nesting limit)
+- [ ] 10.8 Disabled dashboard shows "Comments disabled" message; POST returns 403
+- [ ] 10.9 View-only user can read comments but "Post" button is disabled (or returns 403 on attempt)
+- [ ] 10.10 Admin toggles per-dashboard `commentsEnabled` setting and comments enable/disable accordingly
+
+## 11. Quality gates
+
+- [ ] 11.1 `composer check:strict` (PHPCS, PHPMD, Psalm, PHPStan) passes — fix any pre-existing issues encountered along the way
+- [ ] 11.2 ESLint + Stylelint clean on all Vue/JS files
+- [ ] 11.3 SPDX headers on every new PHP file (inside the docblock per the SPDX-in-docblock convention)
+- [ ] 11.4 i18n keys defined in `l10n/en.json` and `l10n/nl.json` for:
+  - Notification subject: `cmnt_mentioned_in_comment`
+  - UI labels: `cmnt_comments`, `cmnt_post_comment`, `cmnt_edit`, `cmnt_delete`, `cmnt_reply`, `cmnt_edited`, `cmnt_disabled_message`
+  - Error messages: `cmnt_empty_message`, `cmnt_nested_reply_error`, `cmnt_permission_denied`, `cmnt_disabled_error`
+- [ ] 11.5 Register custom notification event in `appinfo/info.xml`: activity/notificationTypes section
+- [ ] 11.6 Update generated OpenAPI spec so API consumers see the four new endpoints
+- [ ] 11.7 Run all 10 `hydra-gates` locally before opening PR

--- a/openspec/changes/dashboard-draft-published/design.md
+++ b/openspec/changes/dashboard-draft-published/design.md
@@ -1,0 +1,179 @@
+# Design — Dashboard draft / published / scheduled
+
+## Context
+
+The `dashboard-draft-published` change adds a three-state publication workflow
+(`draft` / `published` / `scheduled`) to MyDash dashboards. Before this change,
+every dashboard was implicitly visible to its intended audience as soon as it
+existed. After the change, dashboards begin life as `draft`, are promoted to
+`published` explicitly (or scheduled for automatic promotion), and are hidden from
+non-owners until published.
+
+The reference source implements the same concept for pages: a new index table
+(`intravox_page_index`) carries a `status` column, pages without a `status` key in
+their JSON resolve to `'published'` at index time, and new template copies are
+seeded as `'draft'`. This design.md confirms where MyDash follows that pattern
+exactly, where it diverges intentionally (column-as-source-of-truth vs.
+JSON-plus-index-table), and what implementation traps to avoid.
+
+The MyDash spec (REQ-DASH-019 through REQ-DASH-025) was drafted after reviewing the
+source. Most source choices are confirmed below. One meaningful divergence exists in
+the backfill strategy (see D1), which the spec must clarify.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Confirm the source's lazy-backfill approach (no explicit UPDATE statement) is
+  appropriate for MyDash and matches the spec's intent for REQ-DASH-025.
+- Pin the authoritative storage location for `publicationStatus` as a typed column
+  on `oc_mydash_dashboards`, not embedded in widgetTree JSON.
+- Confirm template-spawned copies must default to `'draft'` (REQ-DASH-021 /
+  REQ-DASH-022 area).
+- Record that scheduled-as-published resolution is a read-time contract, not a
+  background-job contract (REQ-DASH-024).
+- Prevent a naming collision with a same-named service in the source that does
+  something entirely different.
+
+**Non-Goals:**
+- Re-specifying REQ-DASH-019 through REQ-DASH-025 (spec.md owns that).
+- Designing the optional background materialisation job beyond what the spec
+  already captures.
+- Any UI work (deferred to `dashboard-publication-ui`).
+
+## Decisions
+
+### D1: Backfill default — `published`, applied lazily via column DEFAULT
+
+**Decision:** The migration adds `publicationStatus` with `DEFAULT 'published'` (not
+`DEFAULT 'draft'`). No separate `UPDATE` backfill statement is needed. Existing
+dashboard rows acquire `'published'` automatically when the column is materialised
+by the database engine. New dashboards created after the migration default to
+`'draft'` via application logic in `DashboardService::createDashboard()`, not via
+the column default.
+
+**Source evidence:**
+- `intravox-source/lib/Migration/Version001300Date20260420000000.php:43-47` — the
+  `intravox_page_index.status` column is declared with `default: 'published'`. The
+  table itself is new in that migration, so there are no pre-existing rows requiring
+  an UPDATE; existing pages are picked up on the next incremental re-index.
+- `intravox-source/lib/Service/PageIndexService.php:39, 57` — when indexing a page,
+  status is read as `$pageData['status'] ?? 'published'`; pages without a status
+  key in their JSON are treated as published at index time.
+
+**Rationale:** MyDash already has rows in `oc_mydash_dashboards` that must become
+`'published'` after migration. Using `DEFAULT 'published'` on the migration column
+achieves exactly that in one DDL step with no risk of partial-update failures.
+Application code then overrides the default to `'draft'` for every new dashboard
+created post-migration. This is the same effect as an explicit backfill UPDATE but
+with fewer moving parts and no risk of locking a large table during migration.
+
+**Spec note:** REQ-DASH-025's scenario currently reads `DEFAULT 'draft'` plus an
+explicit `UPDATE … SET publicationStatus = 'published'`. The scenario is correct in
+_outcome_ (pre-existing dashboards end up `'published'`) but wrong in _mechanism_.
+The spec scenario should be updated to reflect `DEFAULT 'published'` on the column
+with no backfill UPDATE statement. (See "Spec changes implied" below.)
+
+---
+
+### D2: New dashboards default to `draft`; template copies seeded as `draft`
+
+**Decision:** `DashboardService::createDashboard()` MUST explicitly set
+`publicationStatus = 'draft'` on every new dashboard object before persisting,
+overriding the database column default of `'published'`. Template-spawned copies
+created via the `basedOnTemplate` flow (in `TemplateService::createDashboardFromTemplate()`)
+MUST also receive `publicationStatus = 'draft'` before first save.
+
+**Source evidence:**
+- `intravox-source/lib/Service/PageService.php:6029` — template copies are seeded as
+  `'draft'` via `$pageData['status'] = 'draft'` before any persistence call.
+- `intravox-source/lib/Service/PageService.php:2056-2057` — the service validates
+  that `status` is one of `'draft'` or `'published'` at write time; `'scheduled'` is
+  a MyDash addition not present in the source.
+
+**Rationale:** The "create now, share later" contract (proposal.md line 26) requires
+that new content is private by default. Seeding template copies as `'draft'` rather
+than `'published'` also prevents a template distribution event from immediately
+exposing a dashboard the admin has not yet reviewed for the target user's context.
+
+---
+
+### D3: Status canonical home — column on `oc_mydash_dashboards`, not in widgetTree JSON
+
+**Decision:** `publicationStatus` (and `publishAt` / `publishedAt`) live as typed
+columns on the dashboards table and are the exclusive source of truth. No duplication
+into widgetTree JSON is required or permitted.
+
+**Alternatives considered:**
+- _Status in widgetTree JSON (mirrors source's page-JSON + index-table pattern)_:
+  rejected. The source duplicates status because its index table is a separate
+  read-optimised projection of a JSON document store. MyDash stores dashboards in a
+  conventional relational table where a typed column is already the primary read
+  path, so duplicating into JSON adds complexity with no benefit and would create
+  divergence risk between the two copies.
+
+**Source evidence:**
+- `intravox-source/lib/Service/PageIndexService.php:39, 57` — source explicitly
+  syncs status from JSON into the index table on each index run, confirming this is
+  a workaround for a document-store architecture.
+
+**Rationale:** A typed column enables indexed `WHERE` queries on publication status
+(required for the composite index `idx_mydash_dash_user_pubstatus` in REQ-DASH-019
+and for any future bulk-status endpoint). It also eliminates desync risk.
+
+---
+
+### D4: Scheduled-as-published lazy resolution
+
+**Decision:** A scheduled dashboard whose `publishAt <= now()` MUST be treated as
+published on every read, regardless of whether a background job has run. The optional
+background job that eagerly flips the column to `'published'` is for audit-log
+cleanliness only, not for correctness. Any code path that checks visibility MUST
+implement the `publishAt <= now()` comparison — it cannot rely solely on the stored
+`publicationStatus` value.
+
+**Rationale:** Background jobs can be delayed, disabled, or miss a run. Making
+read-time materialisation the contractual guarantee means there is no window during
+which a scheduled dashboard appears unpublished to viewers after its due time. The
+eager flip (REQ-DASH-024 optional scenario) is a cosmetic optimisation: it keeps the
+stored column consistent with the logical state so that audit queries on the raw
+table are not misleading.
+
+---
+
+### D5: Naming hygiene — do not name the new MyDash service `PublicationSettingsService`
+
+**Decision:** The MyDash service that owns publish / unpublish / schedule transitions
+MUST NOT be named `PublicationSettingsService`. Suggested names:
+`DashboardPublicationService` or `PublicationStateService`.
+
+**Source evidence:**
+- `intravox-source/lib/Service/PublicationSettingsService.php` — this class manages
+  MetaVox field names used by the news-widget date-filtering import path. It has no
+  connection to draft/published page state.
+
+**Rationale:** When developers cross-reference MyDash code against the source for
+implementation patterns, a class named identically to a source class in the same
+conceptual area (publication) but with completely different responsibilities would
+cause serious confusion. Using a distinct name eliminates that risk upfront.
+
+## Spec changes implied
+
+- **REQ-DASH-025 scenario "Existing dashboards default to published after migration"**:
+  Change `DEFAULT 'draft'` to `DEFAULT 'published'`; remove the line requiring an
+  explicit `UPDATE … SET publicationStatus = 'published'` backfill statement. The
+  outcome sentence ("all existing dashboard rows backfilled to `'published'`") remains
+  correct, only the mechanism differs.
+- Optionally add a NOTE to REQ-DASH-025 clarifying that new dashboards default to
+  `'draft'` via application logic in `DashboardService`, not via the column default.
+
+## Open follow-ups
+
+- Confirm whether `DashboardMapper::findVisibleToUser()` should materialise the
+  scheduled→published transition inline in SQL (`WHERE publishAt <= NOW()`) or in
+  PHP post-fetch; SQL is preferred for the index to be effective.
+- Verify that the `TemplateService::createDashboardFromTemplate()` call site (the
+  `basedOnTemplate` flow) is the only place template copies are created — there may
+  be an admin bulk-distribute path that also needs the `'draft'` seed.
+- Decide whether `scheduledAt` (time the schedule action was called) should be
+  persisted separately from `publishAt` (time publication will occur); currently not
+  in scope but may be useful for audit logs.

--- a/openspec/changes/dashboard-draft-published/proposal.md
+++ b/openspec/changes/dashboard-draft-published/proposal.md
@@ -1,0 +1,66 @@
+# Dashboard publication workflow
+
+## Why
+
+Today MyDash dashboards are either in an unpublished (draft, invisible) or published (shared) state. There is no notion of scheduling a dashboard for future publication, or of preserving audit history when a dashboard transitions from draft to published. This change introduces a publication-state workflow (`draft` / `published` / `scheduled`) so users can:
+
+- Create dashboards and keep them private until ready (draft state)
+- Publish dashboards to their intended audience (published state)
+- Schedule dashboards for automatic publication at a future date/time (scheduled state)
+- Unpublish dashboards back to draft if needed
+
+The change preserves backward compatibility: existing dashboards are backfilled to `published` state on migration to maintain current visibility behaviour.
+
+## What Changes
+
+- Add `publicationStatus ENUM('draft','published','scheduled') NOT NULL DEFAULT 'draft'` column on `oc_mydash_dashboards`.
+- Add `publishAt TIMESTAMP NULL` — required when `publicationStatus = 'scheduled'`; ignored otherwise.
+- Add `publishedAt TIMESTAMP NULL` — set automatically when transitioning to `published`; preserved when unpublishing.
+- A dashboard in `draft` state is visible ONLY to its owner and to Nextcloud admins, never in `GET /api/dashboards/visible` for other viewers.
+- A dashboard in `published` state is visible to its normal audience (per existing dashboard visibility rules and shares).
+- A dashboard in `scheduled` state behaves as `draft` until `publishAt <= now()`, then is treated as `published`. The transition is detectable on every read (lazy materialisation).
+- Expose `POST /api/dashboards/{uuid}/publish` — set status to `published`, set `publishedAt = now()`. Owner-or-admin only.
+- Expose `POST /api/dashboards/{uuid}/unpublish` — set status to `draft`, preserve `publishedAt` historical. Owner-or-admin only.
+- Expose `POST /api/dashboards/{uuid}/schedule` with body `{publishAt: ISO-8601}` — set status to `scheduled`, validate `publishAt > now()`, return 400 if past.
+- Status transitions are audit-logged via Nextcloud activity: `dashboard_published`, `dashboard_unpublished`, `dashboard_scheduled`.
+- New dashboards created via `POST /api/dashboard` MUST default to `publicationStatus = 'draft'` to preserve a "create now, share later" workflow.
+- Background job (optional, sibling `background-job-feed-refresh` is unrelated): periodically (every 5 minutes) eagerly flip past-due `scheduled` rows to `published` for cleaner audit logs.
+
+## Capabilities
+
+### New Capabilities
+
+(none — the feature folds into the existing `dashboards` capability as a delta)
+
+### Modified Capabilities
+
+- `dashboards`: adds REQ-DASH-019 (schema: publication-state columns), REQ-DASH-020 (draft visibility rules), REQ-DASH-021 (publish action), REQ-DASH-022 (unpublish action), REQ-DASH-023 (schedule action), REQ-DASH-024 (lazy resolution of scheduled-as-published), REQ-DASH-025 (migration backfill to published). Existing REQ-DASH-001..018 are untouched.
+
+## Impact
+
+**Affected code:**
+
+- `lib/Db/Dashboard.php` — extend entity with `publicationStatus`, `publishAt`, `publishedAt` fields and getters/setters
+- `lib/Db/DashboardMapper.php` — add `findVisibleToUser()` method that filters by publication state and applies lazy materialisation for scheduled dashboards; update `findByUserId()` result set processing to handle scheduled-as-published logic
+- `lib/Service/DashboardService.php` — add `publish()`, `unpublish()`, `schedule()` methods; update `createDashboard()` to default new dashboards to `publicationStatus = 'draft'`
+- `lib/Service/ActivityService.php` or similar — log activity for `dashboard_published`, `dashboard_unpublished`, `dashboard_scheduled`
+- `lib/Controller/DashboardController.php` — three new POST endpoints: `/api/dashboards/{uuid}/publish`, `/api/dashboards/{uuid}/unpublish`, `/api/dashboards/{uuid}/schedule`
+- `appinfo/routes.php` — register the three new routes
+- `lib/Migration/VersionXXXXDate2026...AddPublicationState.php` — schema migration adding three columns + index on `(userId, publicationStatus)` for fast visible-dashboard queries; backfill existing rows to `publicationStatus = 'published'`
+- `src/stores/dashboards.js` — track `publicationStatus`, `publishAt`, `publishedAt` in store; update `/api/dashboards/visible` filtering logic on client side to respect publication state
+- `src/views/DashboardDetail.vue` — UI for publish/unpublish/schedule actions (deferred to a follow-up `dashboard-publication-ui` change; this change only ships the backend + store wiring)
+
+**Affected APIs:**
+
+- 3 new routes (no existing routes changed)
+- Existing `GET /api/dashboards` and `GET /api/dashboards/visible` filtering must now respect publication state
+
+**Dependencies:**
+
+- `OCP\Activity\IManager` — for audit logging (already used elsewhere in MyDash)
+- No new composer or npm dependencies
+
+**Migration:**
+
+- Non-breaking: the migration adds three nullable/defaulted columns. All existing dashboard rows are backfilled to `publicationStatus = 'published'` so visibility behaviour is preserved immediately after migration.
+- No data loss.

--- a/openspec/changes/dashboard-draft-published/specs/dashboards/spec.md
+++ b/openspec/changes/dashboard-draft-published/specs/dashboards/spec.md
@@ -1,0 +1,279 @@
+---
+capability: dashboards
+delta: true
+status: draft
+---
+
+# Dashboards — Delta from change `dashboard-draft-published`
+
+## ADDED Requirements
+
+### Requirement: REQ-DASH-019 Publication-state schema
+
+The system MUST track dashboard publication state via three new database columns: `publicationStatus` (enumerated), `publishAt` (nullable timestamp), and `publishedAt` (nullable timestamp). These columns enable the draft → published → scheduled workflow.
+
+#### Scenario: Schema addition and migration backfill
+
+- GIVEN a MyDash instance with existing dashboards before the publication-state migration
+- WHEN the migration `VersionXXXXDate2026...AddPublicationState.php` is applied
+- THEN the schema MUST add three columns to `oc_mydash_dashboards`:
+  - `publicationStatus ENUM('draft','published','scheduled') NOT NULL DEFAULT 'draft'`
+  - `publishAt TIMESTAMP NULL`
+  - `publishedAt TIMESTAMP NULL`
+- AND all existing dashboard rows MUST be backfilled with `publicationStatus = 'published'` to preserve visibility behaviour
+- AND a composite index `idx_mydash_dash_user_pubstatus` on `(userId, publicationStatus)` MUST be created
+- AND the migration MUST be reversible via `postSchemaChange` rollback
+
+#### Scenario: Timestamp formats
+
+- GIVEN a dashboard with `publishAt` or `publishedAt` set
+- WHEN the dashboard is serialized to JSON
+- THEN both timestamps MUST be in ISO-8601 format (e.g., "2026-03-20T14:30:00Z")
+- AND null timestamps MUST be included in the JSON with null values
+
+#### Scenario: Invariants on field population
+
+- GIVEN a dashboard in `draft` state
+- THEN both `publishAt` and `publishedAt` MUST be null (not set)
+- AND the database MUST enforce this invariant via application logic (nullable columns allow storage, but service layer prevents misuse)
+
+#### Scenario: Scheduled state requires publishAt
+
+- GIVEN a dashboard with `publicationStatus = 'scheduled'`
+- THEN `publishAt` MUST be set (a non-null timestamp in the future)
+- AND attempting to schedule a dashboard with a past or null `publishAt` MUST fail
+
+#### Scenario: Published state may have publishedAt
+
+- GIVEN a dashboard with `publicationStatus = 'published'`
+- THEN `publishedAt` MAY be set (records when it was first published) or null (for pre-existing dashboards from backfill)
+- AND `publishAt` MUST be null (ignored for published state)
+
+### Requirement: REQ-DASH-020 Draft visibility restrictions
+
+A dashboard in `draft` state MUST be visible only to its owner and to Nextcloud administrators. Draft dashboards MUST NOT appear in any visible-dashboard listing for other users.
+
+#### Scenario: Draft dashboard hidden from other users
+
+- GIVEN user "alice" has created a draft dashboard "My Private Analysis"
+- WHEN user "bob" calls `GET /api/dashboards/visible`
+- THEN the draft dashboard "My Private Analysis" MUST NOT be included in the response
+- AND bob has no way to discover or access the draft dashboard via the API
+
+#### Scenario: Draft dashboard visible to owner
+
+- GIVEN user "alice" has created a draft dashboard "My Private Analysis"
+- WHEN alice calls `GET /api/dashboards/visible`
+- THEN the response MUST include "My Private Analysis"
+- AND it MUST carry `publicationStatus: 'draft'`
+
+#### Scenario: Admin can see draft dashboards of other users
+
+- GIVEN user "alice" has created a draft dashboard "My Private Analysis"
+- AND user "root" is a Nextcloud administrator
+- WHEN root calls `GET /api/dashboards/visible` or queries directly via admin endpoints
+- THEN the dashboard MUST be visible to root (for administrative purposes)
+
+#### Scenario: GET /api/dashboard (active) respects draft state
+
+- GIVEN user "alice" has set her active dashboard to a draft state
+- WHEN alice calls `GET /api/dashboard` (fetch her active dashboard)
+- THEN the response MUST return the draft dashboard with `publicationStatus: 'draft'`
+- AND the same dashboard MUST NOT appear in `GET /api/dashboards/visible` for other users
+
+#### Scenario: Draft dashboards excluded from search/listing filters
+
+- GIVEN user "alice" has draft dashboard "D1" and published dashboard "D2"
+- WHEN any API or frontend logic iterates over visible dashboards
+- THEN draft "D1" MUST be filtered out for all non-owner callers
+- NOTE: Filtering happens at the mapper layer (`findVisibleToUser()` method)
+
+### Requirement: REQ-DASH-021 Publish action
+
+The system MUST expose an action to transition a dashboard from draft or scheduled state to published state, recording the publication timestamp.
+
+#### Scenario: Publish a draft dashboard
+
+- GIVEN user "alice" has a draft dashboard with `uuid: "d123"`
+- WHEN alice sends `POST /api/dashboards/d123/publish`
+- THEN the system MUST transition the dashboard to `publicationStatus = 'published'`
+- AND set `publishedAt = now()` (if not already set)
+- AND set `publishAt = null` (clear any scheduled-publication time)
+- AND return HTTP 200 with the updated dashboard object
+
+#### Scenario: Publish is idempotent
+
+- GIVEN user "alice" has a published dashboard with `publishedAt = '2026-03-20T14:30:00Z'`
+- WHEN alice sends `POST /api/dashboards/{uuid}/publish` again
+- THEN the system MUST return HTTP 200 (success, not 409 conflict)
+- AND `publishedAt` MUST remain '2026-03-20T14:30:00Z' (unchanged, not updated to current time)
+- AND the dashboard MUST remain published
+
+#### Scenario: Only owner or admin can publish
+
+- GIVEN user "alice" has a draft dashboard
+- WHEN user "bob" sends `POST /api/dashboards/{alice's-uuid}/publish`
+- THEN the system MUST return HTTP 403
+- AND the dashboard MUST remain draft
+- AND admin "root" CAN publish alice's dashboard
+
+#### Scenario: Publish a scheduled dashboard
+
+- GIVEN user "alice" has a scheduled dashboard with `publishAt = '2026-04-01T10:00:00Z'`
+- WHEN alice sends `POST /api/dashboards/{uuid}/publish` before the scheduled time
+- THEN the system MUST transition to `publicationStatus = 'published'`
+- AND set `publishedAt = now()` (immediate publication, not the scheduled time)
+- AND the dashboard MUST be visible to other users immediately
+
+#### Scenario: Activity log records publication
+
+- GIVEN user "alice" publishes a draft dashboard named "Q1 Reports"
+- WHEN the publish action completes
+- THEN the system MUST log activity with type `dashboard_published` and subject containing the dashboard name
+- AND the activity MUST be visible in the Nextcloud activity stream
+
+### Requirement: REQ-DASH-022 Unpublish action
+
+The system MUST expose an action to revert a published or scheduled dashboard back to draft state, preserving the publication history.
+
+#### Scenario: Unpublish a published dashboard
+
+- GIVEN user "alice" has a published dashboard with `uuid: "d123"` and `publishedAt = '2026-03-20T14:30:00Z'`
+- WHEN alice sends `POST /api/dashboards/d123/unpublish`
+- THEN the system MUST transition to `publicationStatus = 'draft'`
+- AND `publishedAt` MUST remain '2026-03-20T14:30:00Z' (preserved for audit history)
+- AND `publishAt` MUST be null
+- AND return HTTP 200 with the updated dashboard
+
+#### Scenario: Unpublish hides dashboard from non-owners
+
+- GIVEN user "alice" publishes a dashboard
+- AND user "bob" is viewing the dashboard
+- WHEN alice unpublishes the dashboard via `POST /api/dashboards/{uuid}/unpublish`
+- THEN the dashboard MUST NOT appear in bob's next `GET /api/dashboards/visible` response
+- AND bob cannot access the dashboard via direct API call (HTTP 403 or 404)
+
+#### Scenario: Only owner or admin can unpublish
+
+- GIVEN user "alice" has a published dashboard
+- WHEN user "bob" sends `POST /api/dashboards/{alice's-uuid}/unpublish`
+- THEN the system MUST return HTTP 403
+- AND the dashboard MUST remain published
+
+#### Scenario: Unpublish is idempotent
+
+- GIVEN user "alice" has a draft dashboard
+- WHEN alice sends `POST /api/dashboards/{uuid}/unpublish` (already draft)
+- THEN the system MUST return HTTP 200
+- AND the dashboard MUST remain draft
+- AND no state change occurs
+
+#### Scenario: Activity log records unpublication
+
+- GIVEN user "alice" unpublishes a published dashboard named "Q1 Reports"
+- WHEN the unpublish action completes
+- THEN the system MUST log activity with type `dashboard_unpublished` and subject containing the dashboard name
+
+### Requirement: REQ-DASH-023 Schedule action
+
+The system MUST expose an action to schedule a dashboard for automatic publication at a future date and time.
+
+#### Scenario: Schedule a draft dashboard
+
+- GIVEN user "alice" has a draft dashboard with `uuid: "d123"`
+- AND the current time is "2026-03-20T10:00:00Z"
+- WHEN alice sends `POST /api/dashboards/d123/schedule` with body `{"publishAt": "2026-04-01T10:00:00Z"}`
+- THEN the system MUST transition to `publicationStatus = 'scheduled'`
+- AND set `publishAt = '2026-04-01T10:00:00Z'`
+- AND return HTTP 200 with the updated dashboard
+
+#### Scenario: Cannot schedule with past date
+
+- GIVEN the current time is "2026-03-20T10:00:00Z"
+- WHEN user "alice" sends `POST /api/dashboards/{uuid}/schedule` with body `{"publishAt": "2026-03-19T10:00:00Z"}`
+- THEN the system MUST return HTTP 400 with error message containing "future" or "scheduled time"
+- AND the dashboard state MUST NOT change
+- AND the error message MUST be available in both Dutch and English
+
+#### Scenario: Scheduled dashboard behaves as draft until publishAt
+
+- GIVEN user "alice" has scheduled a dashboard for "2026-04-01T10:00:00Z"
+- AND the current time is "2026-03-20T10:00:00Z"
+- WHEN user "bob" calls `GET /api/dashboards/visible`
+- THEN the scheduled dashboard MUST NOT appear in bob's response (behaves as draft)
+- AND bob cannot access it
+
+#### Scenario: Only owner or admin can schedule
+
+- GIVEN user "alice" has a draft dashboard
+- WHEN user "bob" sends `POST /api/dashboards/{alice's-uuid}/schedule` with a future date
+- THEN the system MUST return HTTP 403
+- AND the dashboard state MUST NOT change
+
+#### Scenario: Activity log records scheduling
+
+- GIVEN user "alice" schedules a dashboard named "Q2 Planning" for "2026-04-01T10:00:00Z"
+- WHEN the schedule action completes
+- THEN the system MUST log activity with type `dashboard_scheduled` with timestamp in the subject
+
+### Requirement: REQ-DASH-024 Lazy materialisation of scheduled dashboards
+
+The system MUST treat a scheduled dashboard as published when `publishAt <= now()`, without requiring an explicit external trigger. This materialisation happens on every read operation, ensuring correctness even if a background job fails.
+
+#### Scenario: Scheduled dashboard becomes visible when publishAt passes
+
+- GIVEN user "alice" has scheduled a dashboard for "2026-03-20T14:30:00Z"
+- AND the current server time is "2026-03-20T14:35:00Z" (after the scheduled publication time)
+- WHEN user "bob" calls `GET /api/dashboards/visible`
+- THEN the dashboard MUST appear in the response
+- AND bob MUST be able to view it (materialised as published)
+
+#### Scenario: Lazy materialisation does not update database immediately
+
+- GIVEN user "alice" has scheduled a dashboard for "2026-03-20T14:30:00Z"
+- AND the current server time is "2026-03-20T14:35:00Z"
+- WHEN bob reads the dashboard via `GET /api/dashboards/{uuid}`
+- THEN the response MUST show `publicationStatus: 'published'` (client sees it as published)
+- AND the database row MAY still contain `publicationStatus: 'scheduled'` (lazy materialisation, not eager)
+
+#### Scenario: Scheduled dashboard transitions instantly at the second it becomes due
+
+- GIVEN a scheduled dashboard with `publishAt = '2026-03-20T14:30:00Z'`
+- AND the server clock at that instant has just reached "2026-03-20T14:30:00Z"
+- WHEN any user (owner or not) queries for visible dashboards
+- THEN the dashboard MUST appear (materialised as published)
+- AND there is no grace period or delay
+
+#### Scenario: Optional background job can eagerly materialise
+
+- GIVEN `lib/Cron/PublicationMaterialisation.php` is optionally enabled in `appinfo/info.xml`
+- WHEN the cron job runs every 5 minutes
+- THEN it MAY find all `publicationStatus = 'scheduled'` rows with `publishAt <= now()` and update them to `published`
+- AND set `publishedAt = now()` for cleaner audit logs
+- NOTE: This is optional for correctness; lazy materialisation at read time is sufficient
+
+### Requirement: REQ-DASH-025 Migration backfill to published state
+
+The system MUST ensure that all dashboards created before this change are treated as published, preserving existing visibility behaviour.
+
+#### Scenario: Existing dashboards default to published after migration
+
+- GIVEN a MyDash instance with 100 existing dashboards before the migration
+- WHEN the migration `VersionXXXXDate2026...AddPublicationState.php` is applied
+- THEN the `publicationStatus` column MUST be added with `DEFAULT 'draft'`
+- AND the migration MUST backfill ALL existing rows with `publicationStatus = 'published'` via explicit UPDATE statement
+- AND existing visibility rules MUST be preserved (all pre-existing dashboards remain visible to their intended audience)
+
+#### Scenario: Backfill only affects pre-existing rows
+
+- GIVEN a dashboard created before the migration has `publicationStatus = 'published'` after backfill
+- WHEN a new dashboard is created after the migration via `POST /api/dashboard`
+- THEN the new dashboard MUST default to `publicationStatus = 'draft'` (not 'published')
+- AND the old and new dashboards have different initial states
+
+#### Scenario: Visibility semantics unchanged for pre-migration dashboards
+
+- GIVEN user "alice" shared a dashboard with user "bob" before this change
+- WHEN the migration runs and backfills alice's dashboard to `publicationStatus = 'published'`
+- THEN bob MUST continue to see the dashboard (same visibility as before)
+- AND the share relationship is unaffected

--- a/openspec/changes/dashboard-draft-published/specs/dashboards/spec.md
+++ b/openspec/changes/dashboard-draft-published/specs/dashboards/spec.md
@@ -17,10 +17,11 @@ The system MUST track dashboard publication state via three new database columns
 - GIVEN a MyDash instance with existing dashboards before the publication-state migration
 - WHEN the migration `VersionXXXXDate2026...AddPublicationState.php` is applied
 - THEN the schema MUST add three columns to `oc_mydash_dashboards`:
-  - `publicationStatus ENUM('draft','published','scheduled') NOT NULL DEFAULT 'draft'`
+  - `publicationStatus ENUM('draft','published','scheduled') NOT NULL DEFAULT 'published'`
   - `publishAt TIMESTAMP NULL`
   - `publishedAt TIMESTAMP NULL`
 - AND all existing dashboard rows MUST be backfilled with `publicationStatus = 'published'` to preserve visibility behaviour
+- NOTE: The column default is `'published'` (not `'draft'`). Existing rows acquire `'published'` automatically from the column default when the column is materialised — no explicit UPDATE backfill statement is needed. New dashboards created after the migration default to `'draft'` via application logic in `DashboardService::createDashboard()`, not via the column default.
 - AND a composite index `idx_mydash_dash_user_pubstatus` on `(userId, publicationStatus)` MUST be created
 - AND the migration MUST be reversible via `postSchemaChange` rollback
 
@@ -260,9 +261,9 @@ The system MUST ensure that all dashboards created before this change are treate
 
 - GIVEN a MyDash instance with 100 existing dashboards before the migration
 - WHEN the migration `VersionXXXXDate2026...AddPublicationState.php` is applied
-- THEN the `publicationStatus` column MUST be added with `DEFAULT 'draft'`
-- AND the migration MUST backfill ALL existing rows with `publicationStatus = 'published'` via explicit UPDATE statement
+- THEN the `publicationStatus` column MUST be added with `DEFAULT 'published'`
 - AND existing visibility rules MUST be preserved (all pre-existing dashboards remain visible to their intended audience)
+- NOTE: No explicit `UPDATE … SET publicationStatus = 'published'` backfill statement is required. The `DEFAULT 'published'` on the column causes the database engine to materialise existing rows as `'published'` automatically, eliminating partial-update risk on large tables. New dashboards created after migration receive `publicationStatus = 'draft'` via application logic in `DashboardService::createDashboard()` — not via the column default.
 
 #### Scenario: Backfill only affects pre-existing rows
 

--- a/openspec/changes/dashboard-draft-published/tasks.md
+++ b/openspec/changes/dashboard-draft-published/tasks.md
@@ -1,0 +1,89 @@
+# Tasks — dashboard-draft-published
+
+## 1. Schema migration
+
+- [ ] 1.1 Create `lib/Migration/VersionXXXXDate2026...AddPublicationState.php` adding three columns to `oc_mydash_dashboards`:
+  - `publicationStatus ENUM('draft','published','scheduled') NOT NULL DEFAULT 'draft'`
+  - `publishAt TIMESTAMP NULL`
+  - `publishedAt TIMESTAMP NULL`
+- [ ] 1.2 Same migration adds composite index `idx_mydash_dash_user_pubstatus` on `(userId, publicationStatus)` for fast filtering in `findVisibleToUser()`
+- [ ] 1.3 Backfill existing rows: `UPDATE oc_mydash_dashboards SET publicationStatus = 'published' WHERE publicationStatus IS NULL` to preserve current visibility behaviour
+- [ ] 1.4 Confirm migration is reversible (drop columns + index in `postSchemaChange` rollback path)
+- [ ] 1.5 Run migration locally against sqlite, mysql, and postgres; verify schema applied cleanly each time
+
+## 2. Domain model
+
+- [ ] 2.1 Add `Dashboard::STATUS_DRAFT = 'draft'`, `STATUS_PUBLISHED = 'published'`, `STATUS_SCHEDULED = 'scheduled'` constants
+- [ ] 2.2 Add `publicationStatus`, `publishAt`, `publishedAt` fields to `Dashboard` entity with getter/setter (Entity `__call` pattern — no named args)
+- [ ] 2.3 Update `Dashboard::jsonSerialize()` to include all three fields (nulls are included)
+
+## 3. Mapper layer
+
+- [ ] 3.1 Add `DashboardMapper::findVisibleToUser(string $userId): array` — applies publication-state filtering and lazy-materialisation of scheduled dashboards
+  - Fetches dashboards where `(userId = ? AND publicationStatus IN ('published', 'scheduled'))` OR `(userId = ? AND publicationStatus = 'draft' AND userId = currentUser)` logic
+  - For each `scheduled` dashboard with `publishAt <= now()`, materializes it as published (lazy resolution without DB write)
+  - Returns array of Dashboard objects ready for API response
+- [ ] 3.2 Update `DashboardMapper::findByUserId()` to respect publication-state filtering (draft dashboards visible only to owner, scheduled treated as published if `publishAt <= now()`)
+- [ ] 3.3 Add PHPUnit test covering: draft visible only to owner, published visible to owner, scheduled-with-past-publishAt treated as published, scheduled-with-future-publishAt behaves as draft for non-owner
+
+## 4. Service layer
+
+- [ ] 4.1 Update `DashboardFactory::create()` — new dashboards MUST default to `publicationStatus = 'draft'`
+- [ ] 4.2 Add `DashboardService::publish(string $uuid, string $userId): Dashboard` — set `publicationStatus = 'published'`, set `publishedAt = now()` if not already set, owner-or-admin guard
+- [ ] 4.3 Add `DashboardService::unpublish(string $uuid, string $userId): Dashboard` — set `publicationStatus = 'draft'`, preserve `publishedAt` (don't clear it), owner-or-admin guard
+- [ ] 4.4 Add `DashboardService::schedule(string $uuid, string $publishAt, string $userId): Dashboard` — set `publicationStatus = 'scheduled'`, set `publishAt` to provided timestamp, validate `publishAt > now()` and return 400 if past, owner-or-admin guard
+- [ ] 4.5 Add `DashboardService::materialiseScheduledDashboards(): void` (optional background-job entry point) — finds all `publicationStatus = 'scheduled'` rows with `publishAt <= now()`, updates them to `published`, sets `publishedAt = now()`
+
+## 5. Activity logging
+
+- [ ] 5.1 Integrate with `OCP\Activity\IManager` or MyDash's existing activity service
+- [ ] 5.2 Log activity type `dashboard_published` with subject `{dashboard.name}` when publish action fires
+- [ ] 5.3 Log activity type `dashboard_unpublished` with subject `{dashboard.name}` when unpublish action fires
+- [ ] 5.4 Log activity type `dashboard_scheduled` with subject `{dashboard.name}` when schedule action fires
+
+## 6. Controller + routes
+
+- [ ] 6.1 Add `DashboardController::publish(string $uuid)` mapped to `POST /api/dashboards/{uuid}/publish` (logged-in owner or admin)
+- [ ] 6.2 Add `DashboardController::unpublish(string $uuid)` mapped to `POST /api/dashboards/{uuid}/unpublish` (logged-in owner or admin)
+- [ ] 6.3 Add `DashboardController::schedule(string $uuid)` mapped to `POST /api/dashboards/{uuid}/schedule` with request body parsing (logged-in owner or admin, requires `publishAt` ISO-8601 field)
+- [ ] 6.4 Each endpoint MUST return HTTP 400 if `publishAt` is in the past (for schedule action), with error message in both `nl` and `en`
+- [ ] 6.5 Each endpoint MUST return HTTP 403 if caller is neither owner nor admin
+- [ ] 6.6 Register all three routes in `appinfo/routes.php` with proper UUID requirements
+- [ ] 6.7 Confirm every new method carries the correct Nextcloud auth attribute (`#[NoAdminRequired]`) and performs runtime owner/admin checks
+
+## 7. Frontend store
+
+- [ ] 7.1 Extend `src/stores/dashboards.js` with `publicationStatus`, `publishAt`, `publishedAt` fields in dashboard objects
+- [ ] 7.2 Add computed property or method to apply lazy-materialisation of `scheduled` dashboards (check `publishAt <= now()` client-side for instant UI feedback)
+- [ ] 7.3 Update `GET /api/dashboards/visible` filtering logic to respect publication state (draft dashboards excluded unless caller is owner)
+
+## 8. PHPUnit tests
+
+- [ ] 8.1 `DashboardMapperTest::findVisibleToUser` — draft visible only to owner; published visible to owner; scheduled-with-past-publishAt treated as published
+- [ ] 8.2 `DashboardServiceTest::testPublish` — transition to published, set publishedAt on first publish, idempotent on subsequent publish calls
+- [ ] 8.3 `DashboardServiceTest::testUnpublish` — transition to draft, preserve publishedAt
+- [ ] 8.4 `DashboardServiceTest::testSchedule` — valid future date accepted, past date rejected with 400
+- [ ] 8.5 `DashboardControllerTest::testPublishOwnerCanPublish` — owner can publish own dashboard
+- [ ] 8.6 `DashboardControllerTest::testPublishAdminCanPublish` — admin can publish other user's dashboard
+- [ ] 8.7 `DashboardControllerTest::testPublishNonOwnerCannotPublish` — non-owner gets 403
+- [ ] 8.8 `DashboardControllerTest::testScheduleInvalidDate` — publishAt in past returns 400 with i18n error message
+- [ ] 8.9 `DashboardFactoryTest::testNewDashboardDefaultsToDraft` — new dashboards default to `publicationStatus = 'draft'`
+- [ ] 8.10 Test all transitions (draft → published → draft → scheduled → published) round-trip correctly
+
+## 9. End-to-end Playwright tests
+
+- [ ] 9.1 User creates a dashboard via API (defaults to draft), verifies it is not visible in `/api/dashboards/visible` for other users
+- [ ] 9.2 Owner publishes the dashboard via `POST /api/dashboards/{uuid}/publish`, verifies it appears in `/api/dashboards/visible` for other users
+- [ ] 9.3 Owner schedules the dashboard via `POST /api/dashboards/{uuid}/schedule` with future date, verifies it behaves as draft for non-owner until scheduled time
+- [ ] 9.4 Owner unpublishes a published dashboard via `POST /api/dashboards/{uuid}/unpublish`, verifies it disappears from `/api/dashboards/visible` for non-owners
+- [ ] 9.5 Admin can publish/unpublish/schedule any user's dashboard (admin-override behavior)
+
+## 10. Quality gates
+
+- [ ] 10.1 `composer check:strict` (PHPCS, PHPMD, Psalm, PHPStan) passes — fix any pre-existing issues encountered along the way
+- [ ] 10.2 ESLint + Stylelint clean on all touched Vue/JS files
+- [ ] 10.3 Update generated OpenAPI spec / Postman collection so external API consumers see the three new endpoints
+- [ ] 10.4 `i18n` keys for all new error messages (`Cannot schedule dashboard with past date`, etc.) in both `nl` and `en` per the i18n requirement
+- [ ] 10.5 SPDX headers on every new PHP file (inside the docblock per the SPDX-in-docblock convention) — gate-spdx must pass
+- [ ] 10.6 Run all 10 `hydra-gates` locally before opening PR
+- [ ] 10.7 Background job (optional): create `lib/Cron/PublicationMaterialisation.php` and register in `appinfo/info.xml` if the eager materialisation is desired (5-minute schedule)

--- a/openspec/changes/dashboard-export-import/design.md
+++ b/openspec/changes/dashboard-export-import/design.md
@@ -1,0 +1,99 @@
+# Design — Dashboard Export / Import
+
+## Context
+
+Operators need to move dashboards between installations — e.g. shipping a demo configuration to
+a customer, migrating between environments, or backing up a curated layout before a major
+upgrade. Today there is no export path; dashboards must be recreated by hand.
+
+The feature must handle arbitrarily large exports (a site-wide export with many widgets and
+embedded assets). Loading the entire archive into PHP memory is not viable; the implementation
+must stream the ZIP on the fly using the platform's file API. Import faces the symmetric
+problem: the uploaded file may be large, and collision handling (two dashboards with the same
+slug) must be declared upfront so the operation is predictable.
+
+Both directions are user-facing operations, but they have different permission models. Export is
+always scoped to what the requester can read — it cannot escalate privilege. Import writes to the
+requester's personal dashboards by default; an admin-only query parameter can redirect the
+import target for provisioning workflows.
+
+## Goals / Non-Goals
+
+**Goals:**
+- ZIP export of a single dashboard or the full site (all dashboards the requester can see).
+- Streaming export — never buffer the full archive in memory.
+- ZIP import with configurable collision handling.
+- Dry-run mode that previews what would be imported without persisting.
+- Admin-controlled import target.
+
+**Non-Goals:**
+- Incremental / delta export (only changed dashboards since last export).
+- Scheduled / automated export jobs (handled by a separate background-job spec).
+- Export of platform configuration or user account data.
+
+## Decisions
+
+### D1: Archive format
+**Decision:** A ZIP file containing `manifest.json`, one `dashboards/<uuid>.json` per dashboard,
+one `widgets/<placement-id>.json` per widget, and an `assets/` directory for referenced files.
+**Alternatives considered:** JSON-LD bundle (single file); tar.gz.
+**Rationale:** ZIP is natively supported by the platform's file helpers and is universally
+readable without specialist tooling. Splitting dashboards and widgets into separate files allows
+partial inspection and future partial-import without parsing a monolith.
+
+### D2: Manifest schema
+**Decision:** `manifest.json` has shape `{schemaVersion: 1, exportedAt: <ISO8601>,
+exportedBy: <userId>, dashboards: [{uuid, title, file}]}`. The `schemaVersion` field gates
+import compatibility checks.
+**Alternatives considered:** Embedding all metadata inside each dashboard file; no manifest.
+**Rationale:** A top-level manifest lets the importer validate compatibility and enumerate
+contents before opening any dashboard file, enabling the dry-run summary without full
+deserialization.
+
+### D3: Streaming export
+**Decision:** Use the platform `\OCP\Files\IRootFolder` write stream + a streaming ZIP library
+to append files on-the-fly. The HTTP response streams chunks as they are produced.
+**Alternatives considered:** Temp-file ZIP then stream; hold everything in memory.
+**Rationale:** Gigabyte-scale exports are a stated requirement; streaming is the only approach
+that does not impose a size ceiling.
+
+### D4: Import collision handling
+**Decision:** `?onCollision=rename|replace|skip` (default `rename`). `rename` appends ` (2)`,
+` (3)` to the title; `replace` overwrites in-place; `skip` leaves the existing record and notes
+the skip in the response.
+**Alternatives considered:** Always rename; require manual pre-delete.
+**Rationale:** Three strategies map cleanly to the three real workflows: safe demo import,
+environment sync, and idempotent provisioning.
+
+### D5: Permission scoping
+**Decision:** Export respects `canViewDashboard($userId, $dashboard)` per dashboard. Import
+writes to the requester's personal dashboards unless an admin supplies `?importTarget=<userId>`.
+**Alternatives considered:** Export always requires admin.
+**Rationale:** Scoped export lets regular users share their own dashboards without privilege
+escalation.
+
+### D6: Dry-run support
+**Decision:** `?dryRun=true` runs full validation and returns a summary JSON without persisting.
+**Alternatives considered:** A separate `/import/preview` endpoint.
+**Rationale:** One endpoint, one code path — dry-run exercises exactly the same logic as the
+live import up to the persistence call.
+
+### D7: Schema version gating
+**Decision:** A `schemaVersion` higher than the app's supported maximum causes HTTP 422 rejection
+with a descriptive error message.
+**Alternatives considered:** Best-effort import with unknown-field warnings.
+**Rationale:** Silent imports of future schema versions risk data loss; explicit rejection is
+safer and easier to debug.
+
+## Risks / Trade-offs
+
+- Streaming ZIP generation ties up a PHP worker thread for the export duration; large exports
+  risk gateway timeouts — operators should be warned.
+- Asset deduplication across dashboards is not handled in v1; the same image may appear twice.
+- Import does not validate asset MIME types beyond the platform's existing upload restrictions.
+
+## Open follow-ups
+
+- Add `?dashboardUuids[]=` filter to export a subset of dashboards.
+- Evaluate resumable/chunked upload once field file sizes are better understood.
+- Consider a `mydash:export` CLI command for automated backup workflows.

--- a/openspec/changes/dashboard-export-import/proposal.md
+++ b/openspec/changes/dashboard-export-import/proposal.md
@@ -1,0 +1,70 @@
+# Dashboard Export & Import
+
+## Why
+
+MyDash administrators and end-users need to back up dashboards, share dashboard templates across instances, and author reusable dashboard layouts as artifacts. Today, dashboards exist only within their source Nextcloud instance; there is no standardized way to export a dashboard configuration, widgets, metadata fields, and associated assets, or to re-import them on the same or a different instance. This change introduces a versioned ZIP export format and corresponding import endpoints that allow administrators to export individual dashboards or entire site inventories and re-import them with collision handling, asset preservation, and atomic per-dashboard transactions.
+
+## What Changes
+
+- Define a versioned ZIP container format `mydash-export-v1.zip` containing:
+  - `manifest.json` at root with schema version, export timestamp, scope (dashboard or site), dashboard count, and included asset types
+  - `dashboards/<uuid>.json` — one JSON file per dashboard with full widget tree, grid config, metadata field references, and per-language descriptions
+  - `assets/icons/` — dashboard icon files uploaded to Nextcloud
+  - `assets/widgets/<placement-uuid>/` — user-uploaded files referenced by widgets (e.g., image-widget PNG)
+  - `metadata-fields.json` — field definitions (name, type, key, etc.) used by exported dashboards
+- Expose `POST /api/admin/export` with query parameters `scope` (dashboard|site) and `dashboardUuid` (required if scope=dashboard) — streams a ZIP archive. Nextcloud-admin or Dashboard-Admin only.
+- Expose `POST /api/admin/import` (multipart) accepting a `file` field — validates manifest, imports dashboards, creates missing metadata fields, handles UUID collisions. Nextcloud-admin only.
+- UUID collision handling: by default, imported dashboards receive fresh UUIDs (safe re-import on the same instance); optional query param `preserveUuids=true` keeps original UUIDs and fails with HTTP 409 on collision.
+- Metadata field collision handling: if an imported field's `key` exists in the target, reuse the existing field's ID and remap dashboard references. Fail the affected dashboard if the existing field's `type` differs.
+- Asset collision handling: rename imported files with `-imported-<timestamp>` suffix on collision.
+- Validation: reject ZIP if manifest is missing or schema version is unsupported (HTTP 400). Per-dashboard JSON is validated; invalid records are skipped and listed in import response errors.
+- CLI commands: `php occ mydash:export --scope=site --output=/tmp/mydash-backup.zip` and `php occ mydash:import --file=/tmp/mydash-backup.zip [--preserve-uuids]`.
+- Memory-efficient streaming: site exports with 1K+ dashboards stream ZIP writes rather than building in memory.
+- Atomic-ish import: each dashboard import wraps in a DB transaction; partial failure (corrupt widget tree) skips just that dashboard, not the batch.
+
+## Capabilities
+
+### New Capabilities
+
+- `dashboard-export-import`: exposes export/import API endpoints, CLI commands, and validation for the versioned ZIP format and collision handling semantics.
+
+### Modified Capabilities
+
+- (none — `dashboards` and `metadata-fields` capabilities remain unchanged)
+
+## Impact
+
+**Affected code:**
+
+- `lib/Controller/AdminController.php` — add `export()` and `import()` methods
+- `lib/Service/ExportService.php` (new) — build and stream ZIP, validate manifest, call mapper/service methods
+- `lib/Service/ImportService.php` (new) — parse ZIP, validate, create/remap dashboards and metadata fields
+- `lib/Db/MetadataFieldMapper.php` — extend with `findByKey()` to support collision detection
+- `appinfo/routes.php` — register `POST /api/admin/export` and `POST /api/admin/import`
+- `lib/Command/ExportCommand.php` (new) — CLI for `php occ mydash:export`
+- `lib/Command/ImportCommand.php` (new) — CLI for `php occ mydash:import`
+- No schema migration — uses existing tables only
+
+**Affected APIs:**
+
+- `POST /api/admin/export?scope=dashboard&dashboardUuid=<uuid>` (streams ZIP)
+- `POST /api/admin/export?scope=site` (streams ZIP)
+- `POST /api/admin/import` (multipart, returns `{importedDashboardCount, skippedDashboardCount, errors: [...]}`)
+- `php occ mydash:export --scope=site --output=/tmp/mydash-backup.zip`
+- `php occ mydash:import --file=/tmp/mydash-backup.zip [--preserve-uuids]`
+
+**Dependencies:**
+
+- `ZipArchive` (standard library) — for ZIP reading/writing
+- `OCP\Files\IRootFolder` — to access Nextcloud storage for asset export
+- No new composer or npm dependencies
+
+**Backward compatibility:**
+
+- Zero-impact. No existing endpoints or data models change.
+
+## References
+
+- `openspec/specs/dashboards/spec.md` — dashboard structure and lifecycle
+- `openspec/specs/admin-settings/spec.md` — admin authorization patterns
+- `openspec/specs/metadata-fields/spec.md` — metadata field definition and assignment (assumed to exist)

--- a/openspec/changes/dashboard-export-import/specs/dashboard-export-import/spec.md
+++ b/openspec/changes/dashboard-export-import/specs/dashboard-export-import/spec.md
@@ -1,0 +1,500 @@
+---
+capability: dashboard-export-import
+delta: true
+status: draft
+---
+
+# Dashboard Export & Import — New Capability
+
+## Purpose
+
+Dashboard export and import allow MyDash administrators to create versioned snapshots of dashboard configurations, widgets, metadata fields, and associated assets. Snapshots are portable across Nextcloud instances, enabling backup, disaster recovery, template authoring, and cross-instance sharing. This capability defines a standardized ZIP container format, collision handling semantics, and API/CLI endpoints for end-to-end export-import workflows.
+
+## Data Model
+
+### ZIP Container Format: `mydash-export-v1.zip`
+
+The export container is a ZIP archive with the following structure:
+
+```
+mydash-export-v1.zip
+├── manifest.json
+├── dashboards/
+│   ├── <uuid-1>.json
+│   ├── <uuid-2>.json
+│   └── ...
+├── assets/
+│   ├── icons/
+│   │   ├── dashboard-icon-1.png
+│   │   ├── dashboard-icon-2.svg
+│   │   └── ...
+│   └── widgets/
+│       ├── <placement-uuid-1>/
+│       │   ├── image.png
+│       │   └── ...
+│       └── <placement-uuid-2>/
+│           └── ...
+└── metadata-fields.json
+```
+
+### manifest.json
+
+```json
+{
+  "schemaVersion": 1,
+  "exportedAt": "2026-05-01T14:32:00Z",
+  "exportedBy": "admin",
+  "mydashVersion": "1.0.0",
+  "scope": "site",
+  "dashboardCount": 42,
+  "includedAssets": ["icons", "widgetUploads", "metadataFields"]
+}
+```
+
+**Fields:**
+- `schemaVersion` (integer): Currently `1`. Required for forward compatibility and migration planning.
+- `exportedAt` (ISO 8601 string): UTC timestamp of export creation.
+- `exportedBy` (string): Nextcloud user ID of the exporting admin.
+- `mydashVersion` (string): MyDash app version at time of export (informational, not enforced on import).
+- `scope` (string): Either `"dashboard"` (single dashboard) or `"site"` (all dashboards in instance).
+- `dashboardCount` (integer): Number of dashboards included.
+- `includedAssets` (array of strings): Types of assets packaged (`"icons"`, `"widgetUploads"`, `"metadataFields"`). Informs importer what to expect.
+
+### dashboards/<uuid>.json
+
+Each dashboard is a JSON object with complete state:
+
+```json
+{
+  "uuid": "<uuid>",
+  "userId": "alice",
+  "name": "Sales Dashboard",
+  "description": "Q2 sales pipeline",
+  "type": "user",
+  "basedOnTemplate": null,
+  "gridColumns": 12,
+  "permissionLevel": "full",
+  "targetGroups": [],
+  "isDefault": 0,
+  "isActive": 1,
+  "createdAt": "2026-01-15 10:30:00",
+  "updatedAt": "2026-05-01 14:00:00",
+  "widgets": [
+    {
+      "uuid": "<placement-uuid>",
+      "widgetType": "image-widget",
+      "row": 0,
+      "column": 0,
+      "width": 6,
+      "height": 5,
+      "config": {
+        "imageUrl": "assets/widgets/<placement-uuid>/sales-chart.png",
+        "alt": "Sales chart"
+      },
+      "showTitle": 1,
+      "isVisible": 1,
+      "sortOrder": 1
+    }
+  ],
+  "metadataFieldAssignments": [
+    {
+      "fieldKey": "department",
+      "fieldValue": "sales"
+    }
+  ]
+}
+```
+
+### metadata-fields.json
+
+```json
+[
+  {
+    "id": 42,
+    "key": "department",
+    "name": "Department",
+    "type": "string",
+    "required": false,
+    "default": null,
+    "pattern": null,
+    "createdAt": "2026-01-10 08:00:00"
+  }
+]
+```
+
+## ADDED Requirements
+
+### Requirement: REQ-EXIM-001 ZIP Format Definition
+
+The export output MUST be a ZIP container with a versioned schema that includes manifest, dashboards, assets, and metadata field definitions. The container MUST be self-describing and machine-parseable.
+
+#### Scenario: Single-dashboard export contains all required files
+- GIVEN an admin exports a single dashboard via `POST /api/admin/export?scope=dashboard&dashboardUuid=<uuid>`
+- WHEN the export completes
+- THEN the response MUST be a ZIP archive with:
+  - `manifest.json` at the root
+  - `dashboards/<uuid>.json` containing the exported dashboard state
+  - `metadata-fields.json` containing any metadata fields referenced by the dashboard
+  - `assets/icons/` directory (if dashboard has an icon)
+  - `assets/widgets/` directory (if dashboard widgets have uploaded files)
+- AND the manifest MUST declare `scope: "dashboard"` and `dashboardCount: 1`
+- AND all file paths inside the ZIP MUST be relative (no leading `/`)
+
+#### Scenario: Site export includes all dashboards
+- GIVEN an admin exports the entire site via `POST /api/admin/export?scope=site`
+- WHEN the export completes
+- THEN the ZIP MUST contain one JSON file per dashboard in `dashboards/` (personal, admin_template, group_shared)
+- AND the manifest MUST declare `scope: "site"` and `dashboardCount: N` matching the actual count
+- AND a single `metadata-fields.json` MUST be present listing all metadata field definitions in the instance
+
+#### Scenario: Manifest schema version enforces forward compatibility
+- GIVEN the export ZIP is created with `manifest.json`
+- WHEN the manifest is written
+- THEN `schemaVersion` MUST be set to `1`
+- AND the importer MUST reject any ZIP with unsupported schemaVersion (e.g., 2, 0) with HTTP 400
+
+#### Scenario: Asset paths are normalized in dashboard JSON
+- GIVEN a dashboard contains an icon and a widget with an uploaded image
+- WHEN the dashboard is serialized to `dashboards/<uuid>.json`
+- THEN all file references MUST use relative asset paths (e.g., `"assets/icons/dashboard-icon.png"` or `"assets/widgets/<placement-uuid>/image.png"`)
+- AND these paths MUST correspond to actual files in the ZIP archive
+
+### Requirement: REQ-EXIM-002 Dashboard Scope Export
+
+An admin MUST be able to export a single dashboard with all its configuration, widgets, and associated assets. The export MUST include only the selected dashboard and its dependencies (metadata fields and assets).
+
+#### Scenario: Export single dashboard with widgets
+- GIVEN a dashboard with 3 widgets and 2 metadata field assignments
+- WHEN admin calls `POST /api/admin/export?scope=dashboard&dashboardUuid=<uuid>`
+- THEN the response MUST be HTTP 200 with Content-Type `application/zip`
+- AND the ZIP MUST contain exactly one dashboard JSON file
+- AND the dashboards JSON MUST include all 3 widgets with their full config (row, column, width, height, config object)
+- AND the metadata-fields.json MUST include only the 2 fields referenced by the dashboard (not unrelated instance metadata)
+
+#### Scenario: Export non-existent dashboard
+- GIVEN an admin calls `POST /api/admin/export?scope=dashboard&dashboardUuid=00000000-0000-0000-0000-000000000000`
+- AND that UUID does not exist in the instance
+- THEN the system MUST return HTTP 404
+
+#### Scenario: Invalid UUID format rejected
+- GIVEN an admin calls `POST /api/admin/export?scope=dashboard&dashboardUuid=invalid-uuid-format`
+- THEN the system MUST return HTTP 400 with error message `"Invalid dashboard UUID format"`
+
+#### Scenario: dashboardUuid parameter required for scope=dashboard
+- GIVEN an admin calls `POST /api/admin/export?scope=dashboard` (missing dashboardUuid)
+- THEN the system MUST return HTTP 400 with error message `"dashboardUuid parameter is required when scope=dashboard"`
+
+### Requirement: REQ-EXIM-003 Site Scope Export
+
+An admin MUST be able to export all dashboards in the instance in a single operation. The export MUST include all personal, admin_template, and group_shared dashboards, plus all metadata field definitions and assets.
+
+#### Scenario: Site export includes all dashboard types
+- GIVEN the instance contains 5 personal dashboards, 2 admin templates, and 1 group_shared dashboard
+- WHEN a Nextcloud admin calls `POST /api/admin/export?scope=site`
+- THEN the response MUST be HTTP 200 with a ZIP containing all 8 `dashboards/<uuid>.json` files
+- AND the manifest `dashboardCount` MUST be `8`
+- AND the `metadata-fields.json` MUST contain all metadata field definitions used across all 8 dashboards (deduplicated by key)
+
+#### Scenario: Empty instance site export
+- GIVEN an instance with no dashboards
+- WHEN an admin calls `POST /api/admin/export?scope=site`
+- THEN the system MUST return HTTP 200 with a valid ZIP
+- AND the manifest MUST declare `dashboardCount: 0`
+- AND the `dashboards/` directory MUST be empty (or absent)
+
+#### Scenario: Memory efficiency for large site exports
+- GIVEN an instance with 1000+ dashboards
+- WHEN an admin calls `POST /api/admin/export?scope=site`
+- THEN the system MUST NOT buffer the entire ZIP in memory
+- AND the system MUST stream the ZIP data to the response body
+- AND peak memory usage MUST NOT exceed 100 MB (independent of dashboard count)
+- NOTE: Implementation MUST use streaming writes via ZipArchive or equivalent
+
+### Requirement: REQ-EXIM-004 Import Endpoint
+
+An admin MUST be able to import a previously exported ZIP archive into the same or a different MyDash instance. The import process MUST validate the ZIP structure, create or update dashboards, handle collisions, and return a summary of imported/skipped records.
+
+#### Scenario: Import valid ZIP creates new dashboards
+- GIVEN a valid `mydash-export-v1.zip` with 3 dashboards
+- WHEN an admin calls `POST /api/admin/import` with the ZIP file (multipart/form-data, file field)
+- THEN the system MUST return HTTP 200 with JSON response:
+  ```json
+  {
+    "importedDashboardCount": 3,
+    "skippedDashboardCount": 0,
+    "errors": []
+  }
+  ```
+- AND all 3 dashboards MUST be created in the instance with fresh UUIDs (by default)
+
+#### Scenario: Missing manifest.json fails import
+- GIVEN a ZIP archive without manifest.json
+- WHEN an admin calls `POST /api/admin/import` with the ZIP
+- THEN the system MUST return HTTP 400 with error message `"manifest.json not found in archive"`
+- AND no dashboards MUST be imported
+
+#### Scenario: Invalid JSON in dashboard file skips that dashboard
+- GIVEN a ZIP with 3 dashboards, one of which has corrupt `dashboards/<uuid>.json`
+- WHEN admin imports the ZIP
+- THEN the system MUST return HTTP 200 (partial success)
+- AND the response MUST include `importedDashboardCount: 2, skippedDashboardCount: 1`
+- AND the `errors` array MUST contain an error message identifying the corrupt dashboard
+- AND the other 2 valid dashboards MUST be imported
+
+#### Scenario: Import multipart file upload
+- GIVEN an admin prepares multipart/form-data POST with `file` field set to the ZIP archive
+- WHEN they send `POST /api/admin/import` with Content-Type `multipart/form-data`
+- THEN the system MUST extract the file from the multipart data
+- AND proceed with ZIP validation and import
+
+### Requirement: REQ-EXIM-005 UUID Collision Handling on Import
+
+When importing dashboards with preserved UUIDs, the system MUST detect and report UUID collisions. By default, imported dashboards receive fresh UUIDs; an optional query parameter allows collision-aware imports to fail on conflict.
+
+#### Scenario: Fresh UUIDs by default (safe re-import)
+- GIVEN a ZIP from a previous export of the same instance, containing dashboard with uuid `abc-123`
+- AND that dashboard uuid already exists in the instance
+- WHEN admin calls `POST /api/admin/import?preserveUuids=false` (or omits the parameter)
+- THEN the system MUST assign a new UUID to the imported dashboard
+- AND the import MUST succeed with `importedDashboardCount: 1`
+- AND the instance now has both: the original `abc-123` dashboard and the newly imported dashboard with a different UUID
+
+#### Scenario: Preserve UUIDs with collision detection
+- GIVEN a ZIP with dashboard uuid `abc-123`
+- AND that uuid already exists in the instance
+- WHEN admin calls `POST /api/admin/import?preserveUuids=true`
+- THEN the system MUST return HTTP 409 Conflict with JSON:
+  ```json
+  {
+    "importedDashboardCount": 0,
+    "skippedDashboardCount": 0,
+    "errors": [
+      {
+        "type": "uuidCollision",
+        "dashboard": "abc-123",
+        "message": "Dashboard with UUID abc-123 already exists. Use preserveUuids=false to assign new UUIDs."
+      }
+    ]
+  }
+  ```
+- AND no dashboards MUST be imported
+
+#### Scenario: Multiple UUID collisions reported together
+- GIVEN a ZIP with 5 dashboards, 3 of which have UUIDs that exist in the instance
+- WHEN admin calls `POST /api/admin/import?preserveUuids=true`
+- THEN the system MUST return HTTP 409 with all 3 collisions listed in `errors`
+- AND no dashboards MUST be imported (all-or-nothing on collision)
+
+#### Scenario: preserveUuids parameter default is false
+- GIVEN an admin calls `POST /api/admin/import` without specifying `preserveUuids`
+- WHEN the import includes dashboards with existing UUIDs
+- THEN the system MUST behave as if `preserveUuids=false` (assign fresh UUIDs)
+
+### Requirement: REQ-EXIM-006 Metadata Field Collision Handling
+
+When importing dashboards that reference metadata fields, the system MUST detect field collisions by key. If a collision occurs with the same field type, reuse the existing field; if types differ, skip the affected dashboard and report the mismatch.
+
+#### Scenario: Reuse existing field on key collision (same type)
+- GIVEN the instance has a metadata field `{key: "department", type: "string"}`
+- AND the imported ZIP contains a dashboard that references `{fieldKey: "department", type: "string"}`
+- WHEN import processes the ZIP
+- THEN the system MUST NOT create a duplicate field
+- AND the dashboard MUST be updated to reference the existing field's ID (not the imported field ID)
+- AND import MUST succeed with that dashboard counted in `importedDashboardCount`
+
+#### Scenario: Skip dashboard on field type mismatch
+- GIVEN the instance has a metadata field `{key: "priority", type: "string", id: 5}`
+- AND the imported ZIP contains a dashboard that references `{fieldKey: "priority", type: "number"}`
+- WHEN admin imports the ZIP
+- THEN the system MUST NOT create a duplicate field
+- AND the dashboard MUST be skipped (field type mismatch cannot be auto-resolved)
+- AND the `errors` array MUST include: `{type: "metadataFieldTypeMismatch", field: "priority", message: "Field 'priority' exists as type 'string' but import requires type 'number'"}`
+- AND the dashboard count MUST be in `skippedDashboardCount`
+
+#### Scenario: New fields created if not present
+- GIVEN the imported ZIP contains a dashboard that references `{fieldKey: "custom_field", type: "string"}`
+- AND `custom_field` does NOT exist in the instance
+- WHEN admin imports the ZIP
+- THEN the system MUST create the new field via `MetadataFieldService::create()`
+- AND the dashboard MUST reference the newly created field
+- AND import MUST succeed
+
+#### Scenario: Field remapping preserves dashboard integrity
+- GIVEN a ZIP with 2 dashboards both referencing field `{key: "team", type: "string", id: 42}`
+- WHEN the ZIP is imported into an instance that already has `{key: "team", type: "string", id: 99}`
+- THEN the system MUST update both dashboards' field references to use ID `99`
+- AND both dashboards MUST be imported with correct field bindings
+
+### Requirement: REQ-EXIM-007 Asset Import and Collision Handling
+
+When importing dashboards with asset references (icons, widget uploads), the system MUST extract and restore those assets to Nextcloud storage. On filename collision, assets MUST be renamed with a collision-suffix rather than overwriting existing files.
+
+#### Scenario: Icons imported to Nextcloud storage
+- GIVEN a ZIP with an icon file `assets/icons/dashboard-logo.png`
+- AND the dashboard JSON references `"iconPath": "assets/icons/dashboard-logo.png"`
+- WHEN admin imports the ZIP
+- THEN the system MUST extract the PNG file from the ZIP
+- AND write it to Nextcloud storage at the original path (e.g., `/admin/dashboard-icons/dashboard-logo.png` or equivalent)
+- AND update the dashboard JSON to reference the new Nextcloud path
+
+#### Scenario: Widget uploads imported to storage
+- GIVEN a ZIP with widget upload `assets/widgets/<placement-uuid>/chart-data.csv`
+- WHEN admin imports
+- THEN the system MUST extract the CSV and write it to Nextcloud storage
+- AND the dashboard's widget config MUST reference the new Nextcloud path
+
+#### Scenario: Asset filename collision triggers rename
+- GIVEN a ZIP with icon file `assets/icons/logo.png`
+- AND an existing Nextcloud file already at `/admin/dashboard-icons/logo.png`
+- WHEN admin imports the ZIP
+- THEN the system MUST NOT overwrite the existing file
+- AND instead write the imported asset to `/admin/dashboard-icons/logo-imported-20260501T143200Z.png` (or similar collision-suffix pattern)
+- AND update the dashboard JSON to reference the renamed path
+
+#### Scenario: Missing asset in ZIP does not block dashboard import
+- GIVEN a ZIP with a dashboard that references `assets/icons/missing-icon.png`
+- AND that file does NOT exist in the ZIP
+- WHEN admin imports
+- THEN the system MUST log a warning: `"Asset not found in ZIP: assets/icons/missing-icon.png"`
+- AND the dashboard MUST still be imported with the asset path left as-is (importer cannot resolve the reference, but dashboard structure is preserved)
+- AND import MUST succeed (not treated as an error)
+
+### Requirement: REQ-EXIM-008 Manifest and ZIP Validation
+
+The import process MUST validate the ZIP structure, manifest schema, and per-dashboard JSON before committing any changes. Invalid or unsupported archives MUST be rejected with clear error messages.
+
+#### Scenario: Reject unsupported schema version
+- GIVEN a ZIP with `manifest.json` containing `schemaVersion: 2`
+- WHEN admin calls `POST /api/admin/import`
+- THEN the system MUST return HTTP 400 with error message `"Unsupported manifest schema version: 2. Only version 1 is supported."`
+- AND no dashboards MUST be imported
+
+#### Scenario: Reject manifest with invalid JSON
+- GIVEN a ZIP with malformed `manifest.json`
+- WHEN admin imports
+- THEN the system MUST return HTTP 400 with error message `"manifest.json is not valid JSON"`
+
+#### Scenario: Reject ZIP missing required manifest fields
+- GIVEN a ZIP with `manifest.json` missing `schemaVersion` or `scope` field
+- WHEN admin imports
+- THEN the system MUST return HTTP 400 listing which required field(s) are missing
+
+#### Scenario: Dashboard JSON missing required fields
+- GIVEN a ZIP with a `dashboards/<uuid>.json` missing the `name` or `uuid` field
+- WHEN admin imports
+- THEN the system MUST skip that dashboard
+- AND report in `errors` array: `{type: "invalidDashboard", uuid: "<uuid>", message: "Missing required field: name"}`
+- AND other valid dashboards in the batch MUST still be imported
+
+#### Scenario: ZIP file is not a valid ZIP archive
+- GIVEN an admin uploads a file that is NOT a valid ZIP (e.g., a text file)
+- WHEN `POST /api/admin/import` processes the file
+- THEN the system MUST return HTTP 400 with error message `"Uploaded file is not a valid ZIP archive"`
+
+### Requirement: REQ-EXIM-009 Schema Versioning and Migration Path
+
+The export format MUST support forward-compatible versioning. Only `schemaVersion: 1` is implemented now; the spec MUST document migration semantics for future versions.
+
+#### Scenario: Current version is schemaVersion 1
+- GIVEN an export created by the current MyDash version
+- WHEN the export ZIP is generated
+- THEN the manifest MUST contain `schemaVersion: 1`
+
+#### Scenario: Version 2 migration path documented
+- GIVEN that a future version of MyDash might export `schemaVersion: 2`
+- WHEN the specification is updated
+- THEN the migration process MUST be documented in a future ADR or spec change (e.g., `ADR-XXX: Dashboard Export Schema v2`)
+- AND the importer MUST refuse `schemaVersion: 2` on v1-only instances with HTTP 400
+- AND migration tooling (if needed) MUST be provided in a separate change proposal
+
+#### Scenario: Version mismatch does not corrupt existing data
+- GIVEN an instance running export/import for `schemaVersion: 1`
+- WHEN an unsupported `schemaVersion: 2` ZIP is encountered
+- THEN the import MUST fail cleanly (HTTP 400)
+- AND the instance database MUST remain unchanged
+- AND the user MUST be instructed to upgrade MyDash if they need to import v2 archives
+
+### Requirement: REQ-EXIM-010 CLI Commands for Export and Import
+
+Administrators MUST be able to export and import dashboards via command-line interface for automation, backup scripting, and disaster recovery workflows.
+
+#### Scenario: Export all dashboards via CLI
+- GIVEN an admin runs `php occ mydash:export --scope=site --output=/tmp/mydash-backup.zip`
+- THEN the command MUST create a ZIP archive at `/tmp/mydash-backup.zip`
+- AND the command output MUST display: `"Exported N dashboards to /tmp/mydash-backup.zip"`
+- AND the command exit code MUST be `0` (success)
+
+#### Scenario: Export single dashboard via CLI
+- GIVEN an admin runs `php occ mydash:export --scope=dashboard --dashboard-uuid=<uuid> --output=/tmp/single-dashboard.zip`
+- THEN the command MUST create a ZIP with that single dashboard
+- AND the output MUST display: `"Exported 1 dashboard to /tmp/single-dashboard.zip"`
+
+#### Scenario: CLI export missing required parameters
+- GIVEN an admin runs `php occ mydash:export --scope=site` (missing --output)
+- THEN the command MUST return exit code `1` (error)
+- AND the command output MUST display: `"--output parameter is required"`
+
+#### Scenario: Import via CLI with default settings
+- GIVEN an admin runs `php occ mydash:import --file=/tmp/mydash-backup.zip`
+- THEN the command MUST import the ZIP with `preserveUuids=false` (default)
+- AND the output MUST display: `"Imported N dashboards, skipped M, errors: E"`
+
+#### Scenario: Import via CLI with UUID preservation
+- GIVEN an admin runs `php occ mydash:import --file=/tmp/mydash-backup.zip --preserve-uuids`
+- THEN the command MUST import with `preserveUuids=true`
+- AND if collisions are detected, the output MUST list them: `"UUID collision: abc-123. Use --no-preserve-uuids to assign new UUIDs."`
+
+#### Scenario: CLI import file not found
+- GIVEN an admin runs `php occ mydash:import --file=/nonexistent/file.zip`
+- THEN the command MUST return exit code `1`
+- AND the output MUST display: `"File not found: /nonexistent/file.zip"`
+
+### Requirement: REQ-EXIM-011 Atomic Import Transactions and Memory Efficiency
+
+Each dashboard import MUST be wrapped in a database transaction to ensure consistency. Site exports with 1K+ dashboards MUST use streaming to avoid memory exhaustion.
+
+#### Scenario: Dashboard import is transaction-wrapped
+- GIVEN the import process is importing a single dashboard with 5 widgets
+- WHEN a widget save fails mid-transaction
+- THEN the system MUST roll back the entire dashboard (widgets, metadata field assignments, etc.)
+- AND the dashboard MUST NOT partially exist in the database
+- AND the error MUST be reported in the `errors` array
+
+#### Scenario: Partial import on multi-dashboard failure
+- GIVEN a ZIP with 10 dashboards, where dashboard #5 has corrupt widget JSON
+- WHEN import processes the batch
+- THEN dashboards #1-4 and #6-10 MUST be successfully imported (within their own transactions)
+- AND dashboard #5 MUST be skipped with an error message
+- AND the final response MUST show `importedDashboardCount: 9, skippedDashboardCount: 1`
+
+#### Scenario: Site export with 1000+ dashboards uses streaming
+- GIVEN the instance contains 1000 dashboards
+- WHEN an admin calls `POST /api/admin/export?scope=site`
+- THEN the system MUST NOT build the entire ZIP in memory
+- AND the ZIP output MUST be streamed to the HTTP response in chunks
+- AND peak memory usage MUST remain under 100 MB
+
+#### Scenario: Streaming preserves response stream integrity
+- GIVEN an export of 500 dashboards is being streamed
+- WHEN the response body is transmitted to the client
+- THEN the resulting ZIP file on disk MUST be valid and extractable
+- AND the manifest and all dashboard files MUST be intact
+
+## Non-Functional Requirements
+
+- **Performance**: Single dashboard export MUST complete within 5s; site export of 100 dashboards within 30s (excluding I/O). Import of the same 100 dashboards within 60s.
+- **Memory**: Site export of 1K+ dashboards MUST stream and keep peak memory below 100 MB (independent of dashboard count).
+- **Security**: Export/import endpoints MUST require Nextcloud admin (`IGroupManager::isAdmin()`) authentication. ZIP parsing MUST validate paths to prevent directory traversal attacks (e.g., `../../../etc/passwd`).
+- **Atomicity**: Each dashboard import MUST be transaction-wrapped. Partial failure of one dashboard MUST NOT affect others in the batch.
+- **Validation**: Manifest schema MUST be validated before any database mutations. Per-dashboard JSON MUST be validated; invalid records skipped and reported.
+- **Compatibility**: Only `schemaVersion: 1` supported on v1.x of MyDash. Future versions MUST provide migration tooling for schema updates.
+- **Localization**: All error messages MUST be translatable and support English and Dutch per i18n requirements.
+
+## Standards & References
+
+- ZIP format: [PKWARE ZIP specification](https://www.loc.gov/preservation/digital/formats/fdd/fdd000354.shtml)
+- UUID v4: [RFC 4122](https://tools.ietf.org/html/rfc4122)
+- ISO 8601 timestamps: [RFC 3339](https://tools.ietf.org/html/rfc3339)
+- Nextcloud Admin API: `OCP\IGroupManager::isAdmin()`
+- Nextcloud Files API: `OCP\Files\IRootFolder`
+- PHP ZipArchive: [PHP documentation](https://www.php.net/manual/en/class.ziparchive.php)

--- a/openspec/changes/dashboard-export-import/tasks.md
+++ b/openspec/changes/dashboard-export-import/tasks.md
@@ -1,0 +1,108 @@
+# Tasks — dashboard-export-import
+
+## 1. Service layer: export
+
+- [ ] 1.1 Create `lib/Service/ExportService.php` with public method `exportDashboard(string $dashboardUuid, string $currentUserId): StreamResponse` — fetches dashboard by UUID, checks admin/owner permission, builds ZIP in a temporary stream
+- [ ] 1.2 Add `exportSite(string $currentUserId): StreamResponse` — Nextcloud-admin only; exports all dashboards (personal, admin_template, group_shared). Streams ZIP to avoid memory exhaustion on 1K+ dashboards
+- [ ] 1.3 Add private `buildManifest(string $scope, int $dashboardCount, array $includedAssets): array` — returns manifest data structure with `schemaVersion: 1`, `exportedAt: ISO 8601`, `exportedBy: userId`, `mydashVersion: string`, `scope`, `dashboardCount`, `includedAssets` list
+- [ ] 1.4 Add private `serializeDashboard(Dashboard $dashboard): array` — returns dashboard as JSON object with full widget tree, grid config, metadata field refs, all fields (name, description, type, gridColumns, permissionLevel, widgets, etc.)
+- [ ] 1.5 Add private `collectAssets(array $dashboards): array` — scans all widget configurations and metadata field definitions; returns `{icons: [...], widgetUploads: {...}, metadataFields: [...]}` mapping paths to collect
+- [ ] 1.6 Add private `writeZip(string $tempFile, array $manifest, array $dashboards, array $assets): void` — uses `ZipArchive` to write manifest.json, dashboards/<uuid>.json, assets/, and metadata-fields.json to the temporary file
+- [ ] 1.7 Add private `streamZipResponse(string $zipPath, string $filename): StreamResponse` — reads ZIP from disk, sets Content-Type and Content-Disposition headers, streams to response body, deletes temp file
+
+## 2. Service layer: import
+
+- [ ] 2.1 Create `lib/Service/ImportService.php` with public method `import(UploadedFile $file, bool $preserveUuids, string $currentUserId): array` — returns `{importedDashboardCount: int, skippedDashboardCount: int, errors: [...]}`
+- [ ] 2.2 Add private `validateZipStructure(ZipArchive $zip): array` — extracts and validates manifest.json; throws `\InvalidArgumentException` if missing or `schemaVersion !== 1`; returns parsed manifest
+- [ ] 2.3 Add private `remapUuids(array $dashboards, bool $preserveUuids): array` — if `preserveUuids=false`, replaces all UUIDs in dashboard and widget placement records with fresh v4 UUIDs. Returns modified dashboard array and UUID mapping
+- [ ] 2.4 Add private `importMetadataFields(array $importedFields, string $currentUserId): array` — for each imported field, lookup by `key` in target instance via `MetadataFieldMapper::findByKey()`; if exists, check `type` match (fail dashboard on mismatch); if not, create new via `MetadataFieldService::create()`. Returns `{oldId => newId}` mapping and `{oldId => error message}` for mismatches
+- [ ] 2.5 Add private `remapMetadataFieldIds(array $dashboards, array $fieldMapping): array` — updates all dashboard metadata field references using the import mapping (e.g., field assignments in dashboard config)
+- [ ] 2.6 Add private `importAssets(ZipArchive $zip, array $dashboards): array` — extracts `assets/icons/` and `assets/widgets/` from ZIP; for each, attempt to write to Nextcloud via `IRootFolder`; on collision, append `-imported-<timestamp>` to filename; updates dashboard references to new paths; returns `{skippedAssets: [...], renamedAssets: {...}}`
+- [ ] 2.7 Add private `importDashboardBatch(array $dashboards, array $fieldMapping, string $currentUserId): array` — for each dashboard, wrap in a DB transaction: validate JSON, call `DashboardService::create()` (or update if preserveUuids=true and exists), commit/rollback. Collect errors per-dashboard. Returns `{success: int, skipped: int, errors: {...}}`
+- [ ] 2.8 Add private `resolvePermissionLevel(Dashboard $imported, string $currentUserId): string` — if the imported dashboard is `type='user'` and current user is not admin, force the effective permission level from admin settings. Otherwise use the imported permission level.
+
+## 3. Mapper layer
+
+- [ ] 3.1 Extend `lib/Db/MetadataFieldMapper.php` with method `findByKey(string $key): ?MetadataField` — returns a single row by unique key, or null if not found
+
+## 4. Controller
+
+- [ ] 4.1 Add methods to `lib/Controller/AdminController.php`:
+  - `export(string $scope, ?string $dashboardUuid, IRequest $request): StreamResponse` — validates query params, calls `ExportService::exportDashboard()` or `ExportService::exportSite()`, returns streamed ZIP
+  - `import(IRequest $request): DataResponse` — multipart, calls `ImportService::import()` with file, `preserveUuids` query param, returns JSON response
+- [ ] 4.2 Both methods check admin-only via `IGroupManager::isAdmin($currentUserId)` (semantic auth, since the controller has `#[NoAdminRequired]`)
+- [ ] 4.3 Validate `scope` param; reject unsupported scope with HTTP 400
+- [ ] 4.4 Validate `dashboardUuid` is UUID v4 format and exists when scope=dashboard; return HTTP 400 on invalid format or 404 on not found
+- [ ] 4.5 Return 409 Conflict with `{collisions: [...]}` if import fails due to UUID collision and `preserveUuids=true`
+
+## 5. Routes
+
+- [ ] 5.1 Register `POST /api/admin/export` in `appinfo/routes.php` mapped to `AdminController::export()`
+- [ ] 5.2 Register `POST /api/admin/import` in `appinfo/routes.php` mapped to `AdminController::import()`
+
+## 6. CLI commands
+
+- [ ] 6.1 Create `lib/Command/ExportCommand.php` implementing `Command` interface with:
+  - `--scope=site|dashboard` (required)
+  - `--dashboard-uuid=<uuid>` (required if scope=dashboard)
+  - `--output=/path/to/file.zip` (required)
+  - Calls `ExportService` and writes ZIP to output path
+  - Displays progress message: "Exported X dashboards to /path/to/file.zip"
+- [ ] 6.2 Create `lib/Command/ImportCommand.php` implementing `Command` interface with:
+  - `--file=/path/to/file.zip` (required)
+  - `--preserve-uuids` (optional boolean flag, defaults false)
+  - Calls `ImportService` and displays summary: "Imported X dashboards, skipped Y, encountered Z errors"
+  - List any errors to the console
+
+## 7. ZIP format validation & versioning
+
+- [ ] 7.1 Document the ZIP schema in `README.md` or spec:
+  - `manifest.json` structure with required fields (schemaVersion, exportedAt, exportedBy, scope, dashboardCount, includedAssets)
+  - `dashboards/<uuid>.json` expected fields
+  - `assets/icons/<filename>`, `assets/widgets/<placement-uuid>/<filename>` directory structure
+  - `metadata-fields.json` array of field objects
+- [ ] 7.2 Add validation in `ImportService` to reject schema versions other than 1 (future-proof for v2 migration)
+- [ ] 7.3 Per-dashboard JSON validation: reject if missing `uuid`, `name`, or `widgets` key; log and skip with error message
+
+## 8. Memory & streaming
+
+- [ ] 8.1 Use `ZipArchive::addStream()` or equivalent to stream large dashboards rather than buffering in memory
+- [ ] 8.2 Test export of 1K+ dashboards locally to confirm peak memory stays below 100 MB
+- [ ] 8.3 Use temporary file on disk (`/tmp/mydash-*.zip`) rather than buffering ZIP in memory
+
+## 9. PHPUnit tests
+
+- [ ] 9.1 `ExportServiceTest::testExportDashboard` — single dashboard exports correctly with all fields and assets
+- [ ] 9.2 `ExportServiceTest::testExportSite` — site export includes all dashboards (personal, template, group_shared); manifest counts correct
+- [ ] 9.3 `ExportServiceTest::testManifestStructure` — manifest has schemaVersion: 1, ISO timestamp, correct scope, asset list
+- [ ] 9.4 `ImportServiceTest::testImportDashboardPreservingUuids` — reimport same ZIP with preserveUuids=true on same instance fails with 409
+- [ ] 9.5 `ImportServiceTest::testImportDashboardFreshUuids` — reimport same ZIP with preserveUuids=false succeeds, new UUIDs generated
+- [ ] 9.6 `ImportServiceTest::testMetadataFieldCollisionSameType` — imported field with existing key and same type reuses existing field ID
+- [ ] 9.7 `ImportServiceTest::testMetadataFieldCollisionTypeMismatch` — imported field with existing key but different type fails that dashboard with error message
+- [ ] 9.8 `ImportServiceTest::testAssetCollisionRename` — icon/widget file on collision renamed to `-imported-<timestamp>`
+- [ ] 9.9 `ImportServiceTest::testInvalidZip` — missing manifest.json rejected with HTTP 400
+- [ ] 9.10 `ImportServiceTest::testUnsupportedSchemaVersion` — manifest with schemaVersion: 2 rejected with HTTP 400
+- [ ] 9.11 `ImportServiceTest::testPartialFailure` — one dashboard's widget JSON is corrupt; import succeeds with that dashboard skipped and listed in errors
+- [ ] 9.12 `AdminControllerTest::testExportNonAdminForbidden` — non-admin user calling POST /api/admin/export returns 403
+- [ ] 9.13 `AdminControllerTest::testImportNonAdminForbidden` — non-admin user calling POST /api/admin/import returns 403
+
+## 10. End-to-end Playwright tests
+
+- [ ] 10.1 Admin API call to `POST /api/admin/export?scope=dashboard&dashboardUuid=<uuid>` returns HTTP 200 with ZIP content-type; file can be extracted and contains manifest.json
+- [ ] 10.2 Admin API call to `POST /api/admin/export?scope=site` returns ZIP with all dashboards from the test instance
+- [ ] 10.3 Admin API call to `POST /api/admin/import` with valid ZIP succeeds with importedDashboardCount > 0
+- [ ] 10.4 Non-admin API call to export/import returns 403
+
+## 11. Quality gates
+
+- [ ] 11.1 `composer check:strict` (PHPCS, PHPMD, Psalm, PHPStan) passes — fix any pre-existing issues
+- [ ] 11.2 SPDX headers on every new PHP file inside docblock
+- [ ] 11.3 i18n keys for all error messages (`"Invalid ZIP manifest"`, `"Metadata field type mismatch"`, etc.) in both `nl` and `en`
+- [ ] 11.4 Run all Hydra gates locally before opening PR
+- [ ] 11.5 CLI help text documented in `php occ mydash:export --help` and `php occ mydash:import --help` with examples
+
+## 12. Documentation
+
+- [ ] 12.1 Update `README.md` with export/import section: use cases (backup, migration, template authoring), scope differences (dashboard vs site), collision handling strategy
+- [ ] 12.2 Document the ZIP format schema and manifest structure
+- [ ] 12.3 Add example CLI commands and API curl snippets

--- a/openspec/changes/dashboard-language-content/design.md
+++ b/openspec/changes/dashboard-language-content/design.md
@@ -1,0 +1,137 @@
+# Design — Per-language dashboard content
+
+## Context
+
+The `dashboard-language-content` change adds per-language content variants to MyDash dashboards.
+The open design question was: how does the reference intranet app partition per-language content —
+directories, JSON keys, or database rows — and does that evidence validate or challenge the
+proposed `oc_mydash_dashboard_translations` table?
+
+Source analysis covered:
+- `intravox-source/lib/Command/MigrateToLanguageStructureCommand.php`
+- `intravox-source/lib/Command/CreateLanguageHomepagesCommand.php`
+- `intravox-source/lib/Command/CopyNavigationCommand.php`
+- `intravox-source/lib/Service/PageService.php`
+- `intravox-source/lib/Service/NavigationService.php`
+- `intravox-source/lib/Service/FooterService.php`
+- `intravox-source/lib/Service/FeedService.php`
+- `intravox-source/lib/Search/PageSearchProvider.php`
+- `intravox-source/lib/Controller/PageController.php`
+- `intravox-source/lib/Migration/Version001300Date20260420000000.php` (and three earlier migrations)
+
+## Goals / Non-Goals
+
+**Goals:**
+- Confirm the storage layout (option a/b/c/d) from primary source evidence.
+- Pin the exact locale-resolution chain used in practice.
+- Identify any mismatch between the proposed spec and the reference implementation's idioms.
+- Enumerate spec scenarios that need adjustment.
+
+**Non-Goals:**
+- Copying the reference implementation's directory-based model into MyDash (domains differ).
+- Re-evaluating REQ-DASH-028..031 (create/update/delete/promote) — those are independent of storage layout.
+
+## Decisions
+
+### D1: Storage layout — separate row per language (option c) is correct
+
+**Decision**: The spec's `oc_mydash_dashboard_translations` table with one row per `(dashboardUuid, languageCode)` is the right-sized approach for MyDash. Option (a), per-language directories in a GroupFolder, is the actual mechanism used by the source app, but it is **filesystem-bound** and specific to an intranet wiki architecture — it is not a model MyDash should copy.
+
+**Alternatives considered:**
+
+- **(a) Per-language GroupFolder directories** (`IntraVox/nl/`, `IntraVox/en/`, …). This is what the source app uses. The `MigrateToLanguageStructureCommand` moves all existing flat content into a `<targetLang>/` subdirectory and creates empty sibling language folders. The `CreateLanguageHomepagesCommand` then writes `home.json` into each `<lang>/` folder. Content is a JSON file per page, stored on the Nextcloud filesystem. This approach is wholly inappropriate for MyDash, which stores dashboard widget trees in a relational database, not as GroupFolder files.
+
+- **(b) Per-language keys inside one JSON blob** (e.g. `{"content": {"en": "…", "nl": "…"}}`). Not used anywhere in the source app. JSON is used inside each page file but as a flat content document, not as a multilingual container.
+
+- **(c) Separate row per language** — the spec's proposed design. Matches MyDash's existing relational storage style; enables indexed lookups by `(dashboardUuid, languageCode)` without JSON parsing.
+
+- **(d) Other**: The source app has a secondary `intravox_page_index` DB table (migration `Version001300Date20260420000000`) with a `language VARCHAR(8)` column and a `(unique_id, language)` unique index, plus `(language)` and `(language, status)` plain indexes. This is a *metadata index* over the filesystem tree — one index row per page per language. MyDash does not have a filesystem layer, so the index serves as confirmation that a `(entityId, languageCode)` composite key is the natural DB shape for multi-language data in this ecosystem.
+
+**Rationale**: The source app moved away from flat storage to language directories because its content unit is a filesystem file. MyDash's content unit is already a DB row. The right analogy is the source app's `intravox_page_index` table schema — one row per `(entityId, language)` with a composite unique index — not the GroupFolder directory tree. The spec's proposed table matches that shape exactly.
+
+**Source evidence:**
+- `intravox-source/lib/Command/MigrateToLanguageStructureCommand.php:17,67–149` — migrates flat `IntraVox/` content INTO `IntraVox/<lang>/` subdirectories; proves option (a) is the source architecture but is filesystem-specific.
+- `intravox-source/lib/Command/CreateLanguageHomepagesCommand.php:47–69` — creates `IntraVox/<lang>/home.json` per language; confirms the source app's unit of language partitioning is a directory, not a DB column.
+- `intravox-source/lib/Migration/Version001300Date20260420000000.php:28–76` — `intravox_page_index` table: `language VARCHAR(8)`, `UNIQUE(unique_id, language)`, `INDEX(language)`, `INDEX(language, status)`. Confirms the DB idiom for multi-language indexing is a `(entityId, language)` composite key.
+- `intravox-source/lib/Service/PageIndexService.php:27–66` — `indexPage($pageData, $language, $path)` writes one row per `(uniqueId, language)` pair; confirms the composite-key shape.
+
+---
+
+### D2: Locale resolution chain — two-step truncation, not three-tier prefix matching
+
+**Decision**: The locale resolution used in practice is **two-step, not three-tier**:
+
+1. Read `IConfig::getUserValue($userId, 'core', 'lang', 'en')` (or `IL10N::getLanguageCode()` in services wired with `IL10N`).
+2. Truncate to the 2-character base code immediately: `explode('_', $lang)[0]` (or `substr($lang, 0, 2)`), discarding the regional variant.
+3. Check if the base code is in `SUPPORTED_LANGUAGES = ['nl', 'en', 'de', 'fr']`; if not, fall back to `'en'` (PageService, FooterService, FeedService) or to `'nl'` (NavigationService).
+
+The spec's three-tier matching — exact match → language-prefix match → primary fallback — conflates two distinct steps. The source app never stores `nl-BE`-style codes anywhere; it always truncates to two characters before the first lookup. The "language-part match" tier exists only to handle the format difference between what Nextcloud stores (`nl_NL` with underscore) and what the directory is named (`nl`).
+
+**What this means for MyDash**: The `languageCode` column in `oc_mydash_dashboard_translations` should store the truncated 2-character code (`nl`, `en`, `de`, `fr`) — never a full BCP-47 locale like `nl-BE`. If MyDash wants to store `nl-BE` variants for customers who have them, that is a genuine product decision not validated by the source app, and needs an explicit spec decision.
+
+**Resolution divergences discovered:**
+
+| Context | Method | Default |
+|---|---|---|
+| `PageService::getUserLanguage()` | `IConfig::getUserValue($uid, 'core', 'lang', 'en')` + `explode('_', …)[0]` | `'en'` |
+| `FooterService::getUserLanguage()` | Same call + 2-char truncation | `'en'` |
+| `FeedService::getUserLanguage()` | Same call + `substr(…, 0, 2)` | `'en'` |
+| `NavigationService::getCurrentLanguage()` | `IL10N::getLanguageCode()` + `substr(…, 0, 2)` | `'nl'` |
+| `PageSearchProvider` | `IConfig::getUserValue($uid, 'core', 'lang', 'en')` (no truncation — passes full locale string to index query) | `'en'` |
+
+Note: `PageSearchProvider` passes the raw value (e.g. `nl_NL`) directly to the `intravox_page_index` search without truncation — this is likely a latent bug in the source app, not intentional.
+
+**Source evidence:**
+- `intravox-source/lib/Service/PageService.php:350–356` — canonical resolution with `explode('_', $lang)[0]`.
+- `intravox-source/lib/Service/NavigationService.php:239–246` — uses `IL10N` instead of `IConfig`; truncates via `substr(…, 0, 2)`. Default falls back to `'nl'`, not `'en'`.
+- `intravox-source/lib/Service/FeedService.php:594–599` — same pattern as PageService, default `'en'`.
+- `intravox-source/lib/Search/PageSearchProvider.php:68` — raw locale string passed without truncation (inconsistency).
+
+---
+
+### D3: Closed set of supported languages — not open-ended
+
+**Decision**: The source app uses a **closed static list** `['nl', 'en', 'de', 'fr']`, hardcoded as a constant in every service. New languages require a code change. The spec should explicitly decide whether MyDash's translation table is open-ended (any BCP-47 code) or closed (admin-configured set).
+
+**Rationale**: The spec's current `languageCode VARCHAR(16)` column and API are open-ended (any code can be posted). The source app is the opposite. MyDash is a generic dashboard tool, so open-ended is likely correct — but this should be an explicit spec decision, not an accidental omission. The `isPrimary` fallback mechanism compensates for open-ended by ensuring an unknown locale always has a safe landing.
+
+**Source evidence:**
+- `intravox-source/lib/Service/PageService.php:40` — `private const SUPPORTED_LANGUAGES = ['nl', 'en', 'de', 'fr'];`
+- `intravox-source/lib/Command/MigrateToLanguageStructureCommand.php:17` — `private const LANGUAGE_FOLDERS = ['nl', 'en', 'de', 'fr'];`
+- `intravox-source/lib/Service/NavigationService.php:20` — same constant repeated.
+
+---
+
+### D4: GroupFolder-based sharing has no analogue in MyDash
+
+**Decision**: The source app uses a dedicated Nextcloud system user (`intravox`) and a GroupFolder (`IntraVox/`) as the content store, with per-language subdirectories inside. Nextcloud's GroupFolder ACL controls who can see which language tree. MyDash uses its own relational tables; there is no GroupFolder involved. The spec correctly does not attempt to mirror the GroupFolder pattern.
+
+The `PageController::languagePage()` route (`/en/home`, `/nl/home`) is purely a Vue.js client-side routing shim — it returns the same template for all languages. Language resolution for actual content happens inside the API (PageService/NavigationService), not at the routing layer.
+
+**Source evidence:**
+- `intravox-source/lib/Controller/PageController.php:387–397` — `languagePage()` returns the same `TemplateResponse` as `index()` with no language-specific logic.
+- `intravox-source/lib/Command/MigrateToLanguageStructureCommand.php:15–16` — hardcoded system user `'intravox'` and folder `'IntraVox'`.
+
+## Spec changes implied
+
+The following adjustments are needed in `specs/dashboards/spec.md` — do NOT edit the spec now; these are tracked for the next spec revision:
+
+1. **REQ-DASH-026, locale resolution in backfill**: The scenario says `languageCode` is set to `getUserValue($userId, 'core', 'lang')`. Add a clarification that the raw value must be truncated to the base language code (`explode('_', $raw)[0]`) before storing. `nl_NL` → `nl`, not `nl-NL`. Otherwise the backfill writes a code the three-tier lookup will never match exactly.
+
+2. **REQ-DASH-027, three-tier matching**: The "language-part match" scenario currently shows `nl-BE → nl` using a hyphen separator. The actual Nextcloud storage format is `nl_NL` (underscore). The scenario should note that both underscore and hyphen variants must be handled (Nextcloud uses underscore; HTTP Accept-Language uses hyphen; the resolution must normalise both to a 2-char base before matching stored codes).
+
+3. **REQ-DASH-027, explicit `?lang=` strict mode**: The current spec stores `nl-BE`-style codes in translation rows (from the scenario in REQ-DASH-028). If language codes in the DB are always 2-character base codes (as validated here), the `?lang=de-DE` query parameter would need to be normalized before lookup. The spec should state whether `?lang=` accepts full BCP-47 and normalises, or only accepts stored codes exactly.
+
+4. **REQ-DASH-026, `languageCode` format note**: Add a note to the translation schema scenario specifying that `languageCode` values stored in the DB are always the 2-character ISO 639-1 base code (e.g. `nl`, `en`, `de`, `fr`), not full locale strings. Rationale: aligns with how the source app resolves and stores language, and avoids duplicate rows for `nl` vs `nl-NL` vs `nl_NL`.
+
+5. **REQ-DASH-032, backfill locale note**: The scenario says "dashboard owner's Nextcloud locale at migration time". Clarify this means the truncated 2-char base code from `getUserValue($userId, 'core', 'lang')` — not the raw value.
+
+## Open follow-ups
+
+- **NavigationService default mismatch**: `NavigationService::getCurrentLanguage()` defaults to `'nl'` while all other services default to `'en'`. MyDash should pick one canonical fallback and document it. Source evidence suggests `'en'` is the majority convention, and the spec already uses `'en'` as the primary fallback — confirm this is the intended MyDash default.
+
+- **Open vs closed language set**: The spec is silent on whether admins can define arbitrary language codes or only a fixed set. This should be decided before implementation to avoid schema drift (e.g. someone storing `zh-Hans` which is 7 characters; the current `VARCHAR(16)` accommodates it, but the resolution logic needs to be defined).
+
+- **`?lang=` normalisation**: If the `?lang` query parameter accepts `nl-BE` and the DB stores only `nl`, the controller must normalise before the lookup — otherwise the "strict" 404 path in REQ-DASH-027 fires incorrectly for a code that does exist in a normalised form. Decide and spec this explicitly.
+
+- **`PageSearchProvider` raw-locale bug**: The source app's search provider passes the raw `nl_NL` string to the page index without truncation. If MyDash adopts `IL10N`-based resolution anywhere, verify consistency with the `IConfig` path to avoid similar silent mismatches.

--- a/openspec/changes/dashboard-language-content/proposal.md
+++ b/openspec/changes/dashboard-language-content/proposal.md
@@ -1,0 +1,54 @@
+# Dashboard Language Content
+
+## Why
+
+Today MyDash dashboards store a single widget tree, name, and description per dashboard. Organisations operating in multi-language environments cannot provide locale-specific content variants without manually maintaining separate dashboards per language. This change introduces per-language content variants, allowing a single dashboard to carry multiple localised widget trees, names, and descriptions, with automatic detection of the viewer's Nextcloud locale.
+
+## What Changes
+
+- Add a new table `oc_mydash_dashboard_translations` to store per-language variants of a dashboard's widget tree, name, and description.
+- Each dashboard MUST have exactly one variant marked as the primary (`isPrimary = 1`), serving as the fallback when no locale match is found and as the seed for newly-created variants.
+- On dashboard creation, a primary translation is auto-created in the owner's current Nextcloud locale (`\OCP\IConfig::getUserValue($uid, 'core', 'lang')`).
+- Add locale matching with three-tier precedence: exact match first, then language-part match (e.g. `nl-BE` → `nl`), then fallback to primary.
+- Add translation management endpoints: `POST /api/dashboards/{uuid}/translations` to create a variant, `PUT /api/dashboards/{uuid}/translations/{lang}` to update, `DELETE /api/dashboards/{uuid}/translations/{lang}` to remove.
+- Add `GET /api/dashboards/{uuid}?lang=<code>` explicit language override.
+- Ensure backwards compatibility: existing dashboards with no translation rows are treated as having a single primary variant from the existing widget tree; migration backfills primary translation rows from existing data.
+
+## Capabilities
+
+### New Capabilities
+
+(none — the feature folds into the existing `dashboards` capability)
+
+### Modified Capabilities
+
+- `dashboards`: adds REQ-DASH-026 (translation schema), REQ-DASH-027 (locale resolution and primary fallback), REQ-DASH-028 (create variant), REQ-DASH-029 (update variant), REQ-DASH-030 (delete variant), REQ-DASH-031 (promote primary), REQ-DASH-032 (backwards-compat migration). Existing REQ-DASH-001..025 are untouched.
+
+## Impact
+
+**Affected code:**
+
+- `lib/Db/DashboardTranslation.php` — new entity for translation records
+- `lib/Db/DashboardTranslationMapper.php` — CRUD for translation variants
+- `lib/Db/Dashboard.php` — no breaking changes; existing fields remain
+- `lib/Service/DashboardService.php` — locale resolution logic; translation creation/update/deletion with variant seeding
+- `lib/Controller/DashboardController.php` — five new endpoints for translation management; GET /api/dashboards/{uuid} enhanced to include availableLanguages and currentLanguage
+- `appinfo/routes.php` — register five new translation routes
+- `lib/Migration/VersionXXXXDate2026...php` — schema migration adding `oc_mydash_dashboard_translations` table + migration backfill for primary variants from existing widget trees
+
+**Affected APIs:**
+
+- 5 new routes: `POST|PUT|DELETE /api/dashboards/{uuid}/translations/{lang}`, `POST /api/dashboards/{uuid}/translations`, `POST /api/dashboards/{uuid}/translations/{lang}/set-primary`
+- Enhanced `GET /api/dashboards/{uuid}` to return `availableLanguages`, `currentLanguage`, `isFallback` fields
+- New `GET /api/dashboards/{uuid}?lang=<code>` query parameter for explicit override
+
+**Dependencies:**
+
+- `OCP\IConfig::getUserValue()` — already available in Nextcloud; used to auto-detect creation locale
+- No new composer or npm dependencies
+
+**Migration:**
+
+- Zero-impact schema: adds a new table with no constraints on the existing `oc_mydash_dashboards` table.
+- Backfill: For every dashboard, a primary translation row is created with the dashboard's existing `widgetTreeJson` from the parent table, in the owner's locale if available (else 'en' fallback).
+- Existing widget tree data is NOT removed from `oc_mydash_dashboards` initially (kept for backwards compat during a transition period); this is tracked separately for future deprecation.

--- a/openspec/changes/dashboard-language-content/specs/dashboards/spec.md
+++ b/openspec/changes/dashboard-language-content/specs/dashboards/spec.md
@@ -1,0 +1,299 @@
+---
+capability: dashboards
+delta: true
+status: draft
+---
+
+# Dashboards — Delta from change `dashboard-language-content`
+
+## ADDED Requirements
+
+### Requirement: REQ-DASH-026 Translation Schema
+
+The system MUST store per-language content variants for a dashboard in a dedicated `oc_mydash_dashboard_translations` table. Each variant holds a localised widget tree, name, and description, with exactly one row per (dashboard, language) pair.
+
+#### Scenario: Translation table structure
+
+- GIVEN the schema migration is applied
+- THEN the `oc_mydash_dashboard_translations` table MUST exist with columns: `id` (auto-increment primary key), `dashboardUuid VARCHAR(36)`, `languageCode VARCHAR(16)`, `name VARCHAR(255)`, `description LONGTEXT`, `widgetTreeJson MEDIUMTEXT`, `isPrimary SMALLINT(0/1)`, `createdAt DATETIME`, `updatedAt DATETIME`
+- AND a composite unique constraint MUST exist on `(dashboardUuid, languageCode)` to prevent duplicate language variants per dashboard
+
+#### Scenario: Primary variant enforcement
+
+- GIVEN any dashboard record
+- THEN exactly ONE row MUST have `isPrimary = 1` for that dashboard's UUID
+- AND the database MUST guarantee this invariant (enforced by service layer, not by constraint)
+
+#### Scenario: Backwards-compatible backfill
+
+- GIVEN an existing dashboard with widget tree data in `oc_mydash_dashboards`
+- WHEN the schema migration runs
+- THEN the system MUST auto-create a primary translation row with the dashboard's existing `widgetTreeJson`, `name`, `description`, and `languageCode` set to the dashboard owner's Nextcloud locale (`\OCP\IConfig::getUserValue($userId, 'core', 'lang')`, fallback to 'en' if not set)
+- AND the existing widget tree MUST remain in `oc_mydash_dashboards` during the transition period (marked for future deprecation)
+
+#### Scenario: Variant isolation from dashboard record
+
+- GIVEN a dashboard and its translation records
+- THEN updates to the dashboard's `name`, `description`, or `widgetTreeJson` fields in `oc_mydash_dashboards` MUST NOT affect the translation records
+- AND all subsequent reads MUST fetch content from the translation table, not the dashboard record
+
+### Requirement: REQ-DASH-027 Locale Resolution and Primary Fallback
+
+The system MUST resolve the appropriate translation variant for a requesting user using a three-tier matching strategy: exact language match first, then language-part match, then primary variant fallback.
+
+#### Scenario: Exact language match
+
+- GIVEN a dashboard has variants for 'en', 'nl', 'de-DE'
+- AND the user's Nextcloud locale is set to 'de-DE'
+- WHEN `GET /api/dashboards/{uuid}` is called (no ?lang param)
+- THEN the system MUST return the 'de-DE' variant
+- AND the response MUST include `currentLanguage: 'de-DE'`, `isFallback: false`
+
+#### Scenario: Language-part match (prefix fallback)
+
+- GIVEN a dashboard has variants for 'en' and 'nl' (no 'nl-BE')
+- AND the user's Nextcloud locale is 'nl-BE'
+- WHEN `GET /api/dashboards/{uuid}` is called (no ?lang param)
+- THEN the system MUST match the 'nl' variant by language prefix
+- AND the response MUST include `currentLanguage: 'nl'`, `isFallback: false`
+
+#### Scenario: Primary fallback when no locale match
+
+- GIVEN a dashboard has primary variant in 'en', and secondary variants in 'nl', 'de'
+- AND the user's Nextcloud locale is 'fr' (no French variant exists)
+- WHEN `GET /api/dashboards/{uuid}` is called (no ?lang param)
+- THEN the system MUST return the primary ('en') variant
+- AND the response MUST include `currentLanguage: 'en'`, `isFallback: true`
+
+#### Scenario: Explicit language override via query parameter
+
+- GIVEN a dashboard has variants for 'en', 'nl', 'de'
+- AND the user's Nextcloud locale is 'en'
+- WHEN `GET /api/dashboards/{uuid}?lang=de` is called
+- THEN the system MUST return the 'de' variant, ignoring the user's locale
+- AND the response MUST include `currentLanguage: 'de'`, `isFallback: false`
+
+#### Scenario: Explicit lang parameter with no matching variant returns 404
+
+- GIVEN a dashboard has only 'en' and 'nl' variants
+- WHEN `GET /api/dashboards/{uuid}?lang=ja` is called
+- THEN the system MUST return HTTP 404
+- AND MUST NOT fall back to the primary variant (explicit lang param is strict)
+
+#### Scenario: Available languages list
+
+- GIVEN a dashboard has variants for 'en', 'nl', 'de-DE', 'fr'
+- WHEN `GET /api/dashboards/{uuid}` is called
+- THEN the response MUST include `availableLanguages: ['de-DE', 'en', 'fr', 'nl']` (sorted alphabetically)
+
+### Requirement: REQ-DASH-028 Create Translation Variant
+
+Users MUST be able to create new language variants for a dashboard, optionally seeding the new variant from an existing variant or the primary.
+
+#### Scenario: Create a new translation variant
+
+- GIVEN user "alice" owns a dashboard with a primary 'en' variant
+- WHEN she sends `POST /api/dashboards/{uuid}/translations` with body `{"languageCode": "nl", "name": "Mijn Dashboard", "description": "Beschrijving", "copyFrom": "primary"}`
+- THEN the system MUST create a new translation row with `languageCode='nl'`, `name='Mijn Dashboard'`, `description='Beschrijving'`, `widgetTreeJson` copied from the primary variant, and `isPrimary=0`
+- AND the response MUST return HTTP 201 with the created translation object
+
+#### Scenario: Create variant without copyFrom (defaults to primary)
+
+- GIVEN user "alice" owns a dashboard with primary 'en' variant
+- WHEN she sends `POST /api/dashboards/{uuid}/translations` with body `{"languageCode": "de"}` (no name, description, copyFrom)
+- THEN the system MUST create a variant seeded from the primary: `widgetTreeJson`, `name`, `description` all copied from primary, `isPrimary=0`
+- AND the `name` and `description` MAY be overridden in the same request (optional fields)
+
+#### Scenario: Create variant by copying from non-primary variant
+
+- GIVEN a dashboard has 'en' (primary) and 'nl' (secondary) variants
+- WHEN user "alice" sends `POST /api/dashboards/{uuid}/translations` with body `{"languageCode": "de", "copyFrom": "nl"}`
+- THEN the system MUST seed the 'de' variant from the 'nl' variant's data, not primary
+- AND the response MUST return HTTP 201
+
+#### Scenario: Duplicate language returns conflict error
+
+- GIVEN a dashboard has an 'en' variant
+- WHEN user "alice" sends `POST /api/dashboards/{uuid}/translations` with body `{"languageCode": "en"}`
+- THEN the system MUST return HTTP 409
+- AND the response body MUST include an error message (localized to 'nl' or 'en' based on user locale)
+
+#### Scenario: Cross-user access is rejected
+
+- GIVEN user "alice" owns a dashboard
+- WHEN user "bob" sends `POST /api/dashboards/{uuid}/translations`
+- THEN the system MUST return HTTP 403
+- AND no variant MUST be created
+
+### Requirement: REQ-DASH-029 Update Translation Variant
+
+Users MUST be able to update a translation variant's name, description, and widget tree.
+
+#### Scenario: Update translation name and description
+
+- GIVEN user "alice" owns a dashboard with an 'nl' variant
+- WHEN she sends `PUT /api/dashboards/{uuid}/translations/nl` with body `{"name": "Updated Name", "description": "Updated desc"}`
+- THEN the system MUST update the 'nl' variant's `name` and `description` fields
+- AND set `updatedAt` to the current timestamp
+- AND return HTTP 200 with the updated translation object
+
+#### Scenario: Update translation widget tree
+
+- GIVEN user "alice" owns a dashboard with an 'en' variant
+- WHEN she sends `PUT /api/dashboards/{uuid}/translations/en` with body `{"widgetTreeJson": "{...new tree...}"}`
+- THEN the system MUST replace the entire widget tree
+- AND return HTTP 200
+
+#### Scenario: Cross-user update is rejected
+
+- GIVEN user "alice" owns a dashboard
+- WHEN user "bob" sends `PUT /api/dashboards/{uuid}/translations/en`
+- THEN the system MUST return HTTP 403
+
+#### Scenario: Update non-existent variant returns 404
+
+- GIVEN a dashboard has only 'en' and 'nl' variants
+- WHEN user "alice" sends `PUT /api/dashboards/{uuid}/translations/de`
+- THEN the system MUST return HTTP 404
+
+#### Scenario: Partial updates are supported
+
+- GIVEN a dashboard's 'nl' variant has name='Original Name', description='Original desc', widgetTreeJson='{...}'
+- WHEN user "alice" sends `PUT /api/dashboards/{uuid}/translations/nl` with body `{"name": "New Name"}` (description and widgetTreeJson omitted)
+- THEN the system MUST update only the `name` field
+- AND `description` and `widgetTreeJson` MUST remain unchanged
+
+### Requirement: REQ-DASH-030 Delete Translation Variant
+
+Users MUST be able to delete language variants, with a guard against deleting the only remaining variant.
+
+#### Scenario: Delete a non-primary variant
+
+- GIVEN user "alice" owns a dashboard with 'en' (primary) and 'nl' (secondary) variants
+- WHEN she sends `DELETE /api/dashboards/{uuid}/translations/nl`
+- THEN the system MUST delete the 'nl' variant row
+- AND the response MUST return HTTP 200
+
+#### Scenario: Delete when multiple variants remain
+
+- GIVEN a dashboard has 'en' (primary), 'nl', and 'de' variants
+- WHEN user "alice" sends `DELETE /api/dashboards/{uuid}/translations/nl`
+- THEN the system MUST allow the deletion (other variants remain)
+- AND the dashboard's primary variant MUST still be accessible
+
+#### Scenario: Cannot delete the only remaining variant
+
+- GIVEN user "alice" owns a dashboard with only one variant ('en', primary)
+- WHEN she sends `DELETE /api/dashboards/{uuid}/translations/en`
+- THEN the system MUST return HTTP 400
+- AND the response MUST include an error message: "Cannot delete the only language variant. Promote another variant to primary first."
+- AND the variant MUST NOT be deleted
+
+#### Scenario: Delete primary variant when others exist
+
+- GIVEN a dashboard has 'en' (primary), 'nl', and 'de' variants
+- WHEN user "alice" sends `DELETE /api/dashboards/{uuid}/translations/en`
+- THEN the system MUST return HTTP 400 (primary cannot be directly deleted)
+- AND the error message MUST indicate: "Cannot delete the primary variant. Use POST /api/dashboards/{uuid}/translations/{lang}/set-primary to promote another variant first."
+- AND the variant MUST NOT be deleted
+
+#### Scenario: Cross-user delete is rejected
+
+- GIVEN user "alice" owns a dashboard
+- WHEN user "bob" sends `DELETE /api/dashboards/{uuid}/translations/nl`
+- THEN the system MUST return HTTP 403
+
+### Requirement: REQ-DASH-031 Promote Variant to Primary
+
+Users MUST be able to promote a non-primary variant to become the new primary, downgrading the current primary.
+
+#### Scenario: Promote a secondary variant
+
+- GIVEN user "alice" owns a dashboard with 'en' (primary, isPrimary=1) and 'nl' (secondary, isPrimary=0)
+- WHEN she sends `POST /api/dashboards/{uuid}/translations/nl/set-primary`
+- THEN the system MUST set 'nl' variant's `isPrimary=1`
+- AND set 'en' variant's `isPrimary=0`
+- AND return HTTP 200 with the promoted translation object
+
+#### Scenario: Promote idempotent when already primary
+
+- GIVEN a dashboard's 'en' variant is already primary (isPrimary=1)
+- WHEN user "alice" sends `POST /api/dashboards/{uuid}/translations/en/set-primary`
+- THEN the system MUST return HTTP 200 (idempotent operation)
+- AND the variant MUST remain primary
+- AND no other variant MUST be affected
+
+#### Scenario: Only one variant can be primary
+
+- GIVEN a dashboard has 'en' (primary), 'nl', and 'de' variants
+- WHEN user "alice" sends `POST /api/dashboards/{uuid}/translations/de/set-primary`
+- THEN the system MUST set 'de' `isPrimary=1`
+- AND set 'en' `isPrimary=0`
+- AND ensure 'nl' remains `isPrimary=0`
+- AND return HTTP 200
+
+#### Scenario: Cross-user promotion is rejected
+
+- GIVEN user "alice" owns a dashboard
+- WHEN user "bob" sends `POST /api/dashboards/{uuid}/translations/nl/set-primary`
+- THEN the system MUST return HTTP 403
+
+#### Scenario: Promote non-existent variant returns 404
+
+- GIVEN a dashboard has only 'en' variant
+- WHEN user "alice" sends `POST /api/dashboards/{uuid}/translations/ja/set-primary`
+- THEN the system MUST return HTTP 404
+
+### Requirement: REQ-DASH-032 Backwards Compatibility and Dashboard Deletion
+
+Existing dashboards without translation rows MUST continue to function as before. Deleting a dashboard MUST cascade-delete all its translation variants.
+
+#### Scenario: Pre-migration dashboard behaves as single-variant
+
+- GIVEN a dashboard was created before the translation schema was deployed
+- AND no migration has run yet (no translation rows exist)
+- WHEN `GET /api/dashboards/{uuid}` is called
+- THEN the system MUST treat the dashboard's existing `widgetTreeJson`, `name`, `description` as the primary variant
+- AND the response MUST include `availableLanguages: ['en']` (or the owner's locale if available)
+- AND MUST be indistinguishable from a post-migration dashboard with one primary variant
+
+#### Scenario: Post-migration, dashboard has backfilled primary translation
+
+- GIVEN the migration has run on a pre-existing dashboard
+- WHEN a query is issued for the dashboard's translations
+- THEN exactly one translation row MUST exist with `isPrimary=1`
+- AND the row's `languageCode` MUST match the dashboard owner's Nextcloud locale at migration time (or 'en' fallback)
+
+#### Scenario: Dashboard deletion cascades to translations
+
+- GIVEN user "alice" owns a dashboard with 3 translation variants
+- WHEN she sends `DELETE /api/dashboard/{id}` (dashboard deletion endpoint)
+- THEN the system MUST delete the dashboard record
+- AND all 3 translation rows MUST be cascade-deleted via `DashboardTranslationMapper::deleteByDashboardUuid()`
+- AND subsequent queries for the dashboard's translations MUST return empty results
+
+#### Scenario: Admin template dashboard with translations
+
+- GIVEN an admin template dashboard has 'en' and 'de' variants
+- WHEN a user copies the template via the existing template distribution flow
+- THEN the system MUST create a personal dashboard copy with its own primary variant in the user's locale
+- AND the copied variant's widget tree, name, description MUST be seeded from the template's primary variant
+- AND the copied dashboard MUST be independent from the template (translation updates to the template do NOT affect the copy)
+
+#### Scenario: Migration rollback removes translation table
+
+- GIVEN the migration has been applied and translation data exists
+- WHEN the migration is rolled back via `postSchemaChange()` in reverse
+- THEN the `oc_mydash_dashboard_translations` table MUST be dropped
+- AND existing dashboard records MUST remain unaffected (the widget tree is still in `oc_mydash_dashboards`)
+
+## UPDATED Requirements
+
+(None — all existing REQ-DASH-001..025 remain unchanged in scope and implementation)
+
+## Non-Functional Requirements
+
+- **Performance**: Locale resolution (3-tier matching + database lookup) MUST complete in <100ms per request. `GET /api/dashboards/{uuid}` MUST return within 500ms including all translation metadata.
+- **Data integrity**: The invariant "exactly one primary variant per dashboard UUID" MUST be maintained even under concurrent requests. Delete guards MUST prevent orphaning dashboards with zero variants.
+- **Localization**: All new error messages MUST be translatable to Dutch and English per the i18n requirement.
+- **Backwards compatibility**: Dashboards created before the translation feature MUST continue to work without manual intervention; migration backfill MUST be transparent to users.

--- a/openspec/changes/dashboard-language-content/tasks.md
+++ b/openspec/changes/dashboard-language-content/tasks.md
@@ -1,0 +1,89 @@
+# Tasks — dashboard-language-content
+
+## 1. Schema migration
+
+- [ ] 1.1 Create `lib/Migration/VersionXXXXDate2026...AddDashboardTranslations.php` adding `oc_mydash_dashboard_translations` table with columns: `id`, `dashboardUuid`, `languageCode VARCHAR(16)`, `name`, `description TEXT`, `widgetTreeJson MEDIUMTEXT`, `isPrimary SMALLINT(0/1)`, `createdAt`, `updatedAt`
+- [ ] 1.2 Add composite unique index `(dashboardUuid, languageCode)` to enforce one row per language per dashboard
+- [ ] 1.3 Add backfill logic: for each row in `oc_mydash_dashboards`, query the owner's Nextcloud locale via `\OCP\IConfig::getUserValue($userId, 'core', 'lang')` (fallback to 'en' if not set), then insert a primary translation row with the existing widget tree, name, description
+- [ ] 1.4 Confirm migration is reversible (drop table in `postSchemaChange` rollback path)
+- [ ] 1.5 Run migration locally against sqlite, mysql, and postgres; verify schema applied cleanly and backfill row counts match dashboard count
+
+## 2. Domain model
+
+- [ ] 2.1 Create `DashboardTranslation` entity at `lib/Db/DashboardTranslation.php` with fields: `id`, `dashboardUuid`, `languageCode`, `name`, `description`, `widgetTreeJson`, `isPrimary`, `createdAt`, `updatedAt`
+- [ ] 2.2 Implement `__construct()` with Entity `__call` pattern (no named args on setters per user preference)
+- [ ] 2.3 Implement `jsonSerialize()` including all fields
+
+## 3. Mapper layer
+
+- [ ] 3.1 Create `DashboardTranslationMapper` at `lib/Db/DashboardTranslationMapper.php` extending `QBMapper`
+- [ ] 3.2 Add `findByDashboardUuid(string $dashboardUuid): array` — returns all variants for a dashboard
+- [ ] 3.3 Add `findByDashboardUuidAndLanguage(string $dashboardUuid, string $languageCode): ?DashboardTranslation` — returns single variant or null
+- [ ] 3.4 Add `findPrimaryByDashboardUuid(string $dashboardUuid): ?DashboardTranslation` — returns the `isPrimary = 1` row
+- [ ] 3.5 Add `findByDashboardUuidWithLocaleMatching(string $dashboardUuid, string $preferredLanguage): DashboardTranslation` — implements 3-tier matching (exact, language-part, primary fallback)
+- [ ] 3.6 Add `deleteByDashboardUuid(string $dashboardUuid)` for cascade delete when dashboard is deleted
+- [ ] 3.7 Add fixture-based PHPUnit test covering: exact match, language-part fallback (nl-BE → nl), primary fallback, missing primary guard
+
+## 4. Service layer
+
+- [ ] 4.1 Add `DashboardTranslationService::createVariant(string $dashboardUuid, string $languageCode, ?string $name, ?string $description, ?string $copyFromLanguage)` — create a new variant, optionally seeded from an existing variant or primary; throw 409 exception if language already exists
+- [ ] 4.2 Add `DashboardTranslationService::updateVariant(string $dashboardUuid, string $languageCode, array $patch)` — update `name`, `description`, `widgetTreeJson`; ensure primary variant cannot be deleted via this method (use set-primary instead)
+- [ ] 4.3 Add `DashboardTranslationService::deleteVariant(string $dashboardUuid, string $languageCode)` — delete one variant; throw exception if attempting to delete the only remaining variant (must promote another first)
+- [ ] 4.4 Add `DashboardTranslationService::promoteVariantToPrimary(string $dashboardUuid, string $languageCode)` — set the target variant's `isPrimary = 1` and downgrade the current primary to 0
+- [ ] 4.5 Integrate translation resolution into `DashboardService::getDashboard()` — call mapper's locale-matching method and return the matched translation's widget tree in the response
+- [ ] 4.6 Update `DashboardService::createDashboard()` to auto-create a primary translation in the owner's current Nextcloud locale
+
+## 5. Controller + routes
+
+- [ ] 5.1 Enhance `DashboardController::get(string $uuid)` (GET /api/dashboards/{uuid}) to accept optional `?lang=<code>` query param; add response fields `availableLanguages`, `currentLanguage`, `isFallback`
+- [ ] 5.2 Add `DashboardController::createTranslation(string $uuid)` mapped to `POST /api/dashboards/{uuid}/translations` (logged-in user, `#[NoAdminRequired]`); body `{languageCode, name?, description?, copyFrom?: 'primary'|<lang>}`
+- [ ] 5.3 Add `DashboardController::updateTranslation(string $uuid, string $lang)` mapped to `PUT /api/dashboards/{uuid}/translations/{lang}` (logged-in, `#[NoAdminRequired]`); body `{name?, description?, widgetTreeJson?}`
+- [ ] 5.4 Add `DashboardController::deleteTranslation(string $uuid, string $lang)` mapped to `DELETE /api/dashboards/{uuid}/translations/{lang}` (logged-in, `#[NoAdminRequired]`)
+- [ ] 5.5 Add `DashboardController::setTranslationPrimary(string $uuid, string $lang)` mapped to `POST /api/dashboards/{uuid}/translations/{lang}/set-primary` (logged-in, `#[NoAdminRequired]`)
+- [ ] 5.6 Register all five routes in `appinfo/routes.php`; {lang} route param should accept any VARCHAR(16) string (no special validation)
+- [ ] 5.7 Ownership checks: all mutation endpoints MUST verify that the dashboard belongs to the current user (reject 403 for cross-user attempts)
+
+## 6. Response envelope
+
+- [ ] 6.1 `GET /api/dashboards/{uuid}` response includes:
+  - All existing dashboard fields
+  - `widgetTreeJson` from the matched translation
+  - New fields: `availableLanguages: ['en','nl','de']`, `currentLanguage: 'nl'`, `isFallback: true|false`
+- [ ] 6.2 `POST /api/dashboards/{uuid}/translations` success (201) returns the created `DashboardTranslation` object
+- [ ] 6.3 `POST /api/dashboards/{uuid}/translations` conflict (409) when language already exists
+- [ ] 6.4 `DELETE /api/dashboards/{uuid}/translations/{lang}` with one variant remaining returns 400 (cannot delete last variant without promoting another first)
+
+## 7. PHPUnit tests
+
+- [ ] 7.1 `DashboardTranslationMapperTest::testFindByDashboardUuidAndLanguage` — exact match, null on missing
+- [ ] 7.2 `DashboardTranslationMapperTest::testFindByDashboardUuidWithLocaleMatching` — exact match, language-part fallback, primary fallback
+- [ ] 7.3 `DashboardTranslationMapperTest::testFindPrimaryByDashboardUuid` — returns primary, throws if no primary exists
+- [ ] 7.4 `DashboardTranslationServiceTest::testCreateVariant` — success, 409 on duplicate language, optional seed from primary or other variant
+- [ ] 7.5 `DashboardTranslationServiceTest::testDeleteVariant` — success, 400 when deleting only variant
+- [ ] 7.6 `DashboardTranslationServiceTest::testPromoteVariantToPrimary` — primary flag flipped, old primary downgraded
+- [ ] 7.7 `DashboardControllerTest::testGetDashboardWithLangParam` — explicit lang override via ?lang=<code>, 404 if no variant exists for that code
+- [ ] 7.8 `DashboardControllerTest::testGetDashboardAutoDetectLocale` — returns user's Nextcloud locale variant if available
+- [ ] 7.9 `DashboardControllerTest::testCreateTranslationOwnershipCheck` — non-owner gets 403
+- [ ] 7.10 `DashboardControllerTest::testDeleteTranslationLastVariantGuard` — 400 when deleting only variant
+- [ ] 7.11 Regression: existing dashboard tests (REQ-DASH-001..025) continue to pass unchanged
+
+## 8. Migration backfill verification
+
+- [ ] 8.1 Create a fixture with 3 dashboards (user alice, user bob, admin template) each with widget tree data
+- [ ] 8.2 Run migration; verify 3 translation rows created, each with correct `dashboardUuid`, `isPrimary=1`, language from owner's Nextcloud locale or 'en' fallback
+- [ ] 8.3 Verify `GET /api/dashboards/{uuid}` on a pre-existing dashboard returns the backfilled translation's data
+
+## 9. End-to-end Playwright tests
+
+- [ ] 9.1 User creates a dashboard; auto-created primary translation is in user's current Nextcloud locale
+- [ ] 9.2 User creates a new translation variant via API; `GET /api/dashboards/{uuid}` with explicit `?lang=<code>` returns that variant
+- [ ] 9.3 User without matching language variant falls back to primary on `GET /api/dashboards/{uuid}` (isFallback=true in response)
+- [ ] 9.4 User deletes a translation variant; attempt to delete the only remaining variant returns 400
+- [ ] 9.5 User promotes a non-primary variant to primary; subsequent `GET /api/dashboards/{uuid}` (no lang param) returns that new primary
+
+## 10. Quality gates
+
+- [ ] 10.1 `composer check:strict` (PHPCS, PHPMD, Psalm, PHPStan) passes — fix any pre-existing issues encountered along the way
+- [ ] 10.2 `i18n` keys for all new error messages (`Language variant already exists`, `Cannot delete the only language variant`, etc.) in both `nl` and `en` per the i18n requirement
+- [ ] 10.3 SPDX headers on every new PHP file (inside the docblock per the SPDX-in-docblock convention) — gate-spdx must pass
+- [ ] 10.4 Update generated OpenAPI spec / Postman collection so external API consumers see the new translation management endpoints

--- a/openspec/changes/dashboard-locking/design.md
+++ b/openspec/changes/dashboard-locking/design.md
@@ -1,0 +1,264 @@
+# Design — Dashboard editing lock
+
+## Context
+
+The `dashboard-locking` proposal was written with a heartbeat/lease model in mind, including a
+frontend-generated `clientId` per browser tab, a 5-minute TTL stored as an explicit `expiresAt`
+column, and a `/heartbeat` sub-resource endpoint. Before implementation began, it was flagged that
+the IntraVox app in the same monorepo already ships a working page-lock system whose design choices
+may differ significantly from those assumptions.
+
+A deep-read of the IntraVox source at tag 0.8.4 was performed to ground-truth the open question.
+The findings below drive the final design choices for the MyDash `DashboardLock` feature.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Align the MyDash lock model with the proven IntraVox approach where it is architecturally sound.
+- Resolve all six open sub-questions (clientId, expiresAt column, heartbeat endpoint, owner check, admin override, background sweeper) with a clear decision backed by source evidence.
+- Produce a spec-delta list so REQ-LOCK-001..008 can be updated in a single targeted edit pass.
+
+**Non-Goals:**
+- Porting the IntraVox lock system directly — MyDash locks dashboards (UUID-keyed), not wiki pages (uniqueId-keyed). The column names and routes differ.
+- Deciding the frontend implementation details beyond what the backend contract requires.
+
+## Decisions
+
+### D1: Lock model — server-side TTL via `updated_at` heartbeat, NOT an `expiresAt` column
+
+**Decision**: Use two timestamp columns — `created_at` (immutable, set on acquire) and `updated_at`
+(bumped on every heartbeat) — plus a server-side constant `LOCK_TIMEOUT_MINUTES`. A lock is
+considered active if `updated_at > now() - timeout`. There is no `expiresAt` column stored in the
+database.
+
+**Alternatives considered:**
+- Explicit `expiresAt` column (as written in the spec). Rejected by the IntraVox implementation
+  in favour of a rolling `updated_at` timestamp, which is simpler and avoids a field that must be
+  recalculated on every heartbeat write.
+
+**Rationale**: The `updated_at`-based model is self-healing: if the application TTL constant is
+adjusted, all existing rows in the database re-evaluate correctly against the new constant without a
+migration. The `expiresAt` model would require a backfill of every live lock row. Additionally, the
+`updated_at` approach produces a natural heartbeat record (last-seen timestamp) that doubles as
+diagnostic information.
+
+**Source evidence:**
+- `intravox-source/lib/Service/PageLockService.php:17` — `private const LOCK_TIMEOUT_MINUTES = 15;`
+- `intravox-source/lib/Service/PageLockService.php:171-180` — `cleanExpiredLock()` computes
+  `$expiry = new \DateTime(); $expiry->modify('-' . self::LOCK_TIMEOUT_MINUTES . ' minutes');`
+  and deletes rows where `updated_at < $expiry`, confirming there is no stored `expiresAt`.
+- `intravox-source/lib/Migration/Version001001Date20260307000000.php:54-60` — the CREATE TABLE
+  statement has columns `created_at` and `updated_at`, with NO `expires_at` column.
+
+**MyDash implication**: The `expiresAt` field in the spec's data model and scenario steps must be
+replaced with a `lastHeartbeat` field (= `updated_at`) plus an implicit expiry rule
+(`lastHeartbeat + TTL`). The TTL constant lives in `DashboardLockService`, not in the row.
+
+---
+
+### D2: clientId — absent from the lock table; owner check is by `userId` alone
+
+**Decision**: There is no `clientId` column in the lock table. Owner identity is determined solely
+by `userId`. The same user opening a second tab does NOT get a separate lock slot; the second
+`acquireLock` call for the same user on the same resource succeeds (re-entrant) and refreshes the
+existing lock rather than creating a conflict.
+
+**Alternatives considered:**
+- Frontend-generated `clientId` per tab (as written in the spec). Rejected by the IntraVox
+  implementation: no such column exists in the schema or in any query.
+- Server-generated token returned to the frontend. Not present in the IntraVox implementation.
+
+**Rationale**: Tab-level isolation creates usability friction (the spec itself acknowledges that
+tab-2 would be blocked by tab-1 for the same user). The re-entrant `userId`-only model is simpler
+and matches how users actually think: "I'm editing this page" regardless of how many tabs they have.
+The trade-off is that heartbeat authority cannot be scoped to a single tab, but in practice this
+edge case is negligible: any of the user's tabs can extend the lease.
+
+**Source evidence:**
+- `intravox-source/lib/Migration/Version001001Date20260307000000.php:39-65` — full column list:
+  `id`, `page_unique_id`, `user_id`, `display_name`, `created_at`, `updated_at`. No `client_id`.
+- `intravox-source/lib/Service/PageLockService.php:63-100` — `acquireLock()` checks
+  `if ($existing['userId'] === $userId) { $this->refreshLock(); return ['success' => true]; }`,
+  explicitly making same-user acquire re-entrant.
+- `intravox-source/lib/Service/PageLockService.php:106-113` — `refreshLock()` WHERE clause uses
+  only `page_unique_id` + `user_id`; no `client_id` predicate.
+- `intravox-source/lib/Controller/PageLockController.php:48-64` — `acquireLock()` passes only
+  `$user->getUID()` and `$user->getDisplayName()` to the service; no request body is parsed.
+
+**MyDash implication**: Remove the `clientId` column from the data model. Remove `clientId` from
+all request bodies (acquire, heartbeat, release). Update REQ-LOCK-001 scenario "Same user with two
+browser tabs" — tab-2's acquire MUST succeed (re-entrant refresh), not return 409. Remove
+REQ-LOCK-002 "Wrong clientId on alice's own lock" scenario. Update heartbeat and release to use
+`userId` as the sole ownership predicate.
+
+---
+
+### D3: Heartbeat endpoint — uses PUT on the same lock URL, cadence is 60 seconds
+
+**Decision**: The heartbeat is a `PUT /api/pages/{pageId}/lock` (same resource, different verb)
+rather than a dedicated `/heartbeat` sub-resource. The frontend fires this every 60 seconds.
+Returns 409 if the lock was lost; 200 on success.
+
+**Alternatives considered:**
+- Dedicated `POST /api/dashboards/{uuid}/lock/heartbeat` sub-resource (as written in the spec).
+  Rejected by the IntraVox implementation, which collapses acquire, heartbeat (refresh), and
+  release onto GET/POST/PUT/DELETE of a single resource URL.
+
+**Rationale**: Using the REST verb matrix on a single URL (GET=query, POST=acquire, PUT=refresh,
+DELETE=release) is clean and avoids route proliferation. The 60-second heartbeat against a
+15-minute TTL gives a 15× safety margin on transient network failures, which is generous.
+
+**Source evidence:**
+- `intravox-source/appinfo/routes.php:27-30` — the four verbs on `/api/pages/{pageId}/lock`:
+  GET=`getLock`, POST=`acquireLock`, PUT=`refreshLock`, DELETE=`releaseLock`.
+- `intravox-source/src/App.vue:777-792` — `setInterval(async () => { axios.put(url); }, 60 * 1000)`
+  — heartbeat every 60 seconds confirmed in a comment: `// Every 60 seconds`.
+- `intravox-source/src/App.vue:779-780` — PUT target is the same lock URL (no `/heartbeat` suffix).
+
+**MyDash implication**: Replace `POST /api/dashboards/{uuid}/lock/heartbeat` with
+`PUT /api/dashboards/{uuid}/lock`. Update REQ-LOCK-002 route reference. Update the proposal's
+endpoint table and `appinfo/routes.php` impact section accordingly. The heartbeat cadence note in
+REQ-LOCK-002 and the proposal should change from "every 3 minutes" to "every 60 seconds".
+
+---
+
+### D4: Admin override — force-release only (not force-acquire); no activity-log integration
+
+**Decision**: The admin action is `POST /api/pages/{pageId}/lock/force-release`, which deletes the
+lock regardless of owner, returning the dashboard to an unlocked state. There is no
+`force-acquire` variant (the spec's `POST /api/.../lock/force-acquire` that simultaneously steals
+the lock for the admin). Admin override is logged to the application logger only, not to the
+Nextcloud activity system.
+
+**Alternatives considered:**
+- `force-acquire` stealing the lock for the admin (as written in the spec). Not present in
+  IntraVox — admins release the lock but do not automatically enter edit mode.
+- Nextcloud `IManager` activity logging (as in the spec). Not present in IntraVox — the
+  `forceReleaseLock()` call uses `$this->logger->info(...)` (PSR logger) only.
+
+**Rationale**: Force-release is the appropriate admin action: the admin unlocks the dashboard so
+the user can retry or so the admin can then acquire it themselves in a separate step. This matches
+what an intranet admin expects ("unlock for maintenance") rather than a lock-stealing semantic.
+PSR logger is sufficient for audit in a single-instance deployment; `IActivity` integration can be
+added later if compliance requirements surface.
+
+**Source evidence:**
+- `intravox-source/appinfo/routes.php:31` — `'pageLock#forceReleaseLock'` at
+  `/api/pages/{pageId}/lock/force-release` (POST). No `force-acquire` route exists.
+- `intravox-source/lib/Controller/PageLockController.php:114-126` — `forceReleaseLock()` calls
+  `$this->lockService->forceReleaseLock($pageId, $user->getUID())` and checks
+  `$this->permissionService->isAdmin()` for the guard.
+- `intravox-source/lib/Service/PageLockService.php:137-153` — `forceReleaseLock()` deletes the
+  row and logs via `$this->logger->info(...)`. No `OCP\Activity\IManager` import in the file.
+- `intravox-source/src/App.vue:828-835` — frontend calls `axios.post(url)` to the
+  `force-release` endpoint; the admin then sees the lock indicator clear from the UI, after which
+  they may enter edit mode themselves via the normal acquire path.
+
+**MyDash implication**: Rename the admin endpoint from `force-acquire` to `force-release` in all
+spec scenarios, the proposal, and the routes impact list. Remove the scenario "Admin steals a lock"
+(simultaneous acquire) and replace with "Admin releases lock, then can acquire normally". Downgrade
+the `OCP\Activity\IManager` dependency to optional/future; use `LoggerInterface` only for the
+initial implementation. Remove REQ-LOCK-006's `dashboard_lock_override` activity event requirement
+(or mark it as a future enhancement).
+
+---
+
+### D5: Stale-lock cleanup — inline per-resource on every read/write, no background sweeper
+
+**Decision**: Expired locks are cleaned up inline (before every `getLock` and `acquireLock` call)
+via a `cleanExpiredLock(pageId)` helper that deletes only the row for the requested resource. There
+is no global background sweeper or Nextcloud background job.
+
+**Alternatives considered:**
+- A Nextcloud `IJob` background sweeper (not present in IntraVox, though an `updated_at` index
+  exists that would make such a sweep efficient).
+- Leaving stale rows in place and filtering them by timestamp on SELECT (hybrid — IntraVox does
+  clean them inline rather than relying on filter-only).
+
+**Rationale**: Inline cleanup is safe and predictable: the resource is clean by the time any user
+sees a response. It also prevents the table from growing unboundedly on pages that are locked and
+then crashed without release. The `updated_at` index ensures the DELETE is fast even if many
+stale rows accumulate between accesses.
+
+**Source evidence:**
+- `intravox-source/lib/Service/PageLockService.php:30-33` — `getLock()` calls
+  `$this->cleanExpiredLock($pageUniqueId)` as its first line.
+- `intravox-source/lib/Service/PageLockService.php:63-64` — `acquireLock()` also calls
+  `$this->cleanExpiredLock($pageUniqueId)` before checking for an existing lock.
+- `intravox-source/lib/Service/PageLockService.php:171-180` — `cleanExpiredLock()` issues a
+  targeted `DELETE WHERE page_unique_id = ? AND updated_at < ?` (not a full-table sweep).
+- `intravox-source/lib/Migration/Version001001Date20260307000000.php:65` — `addIndex(['updated_at'],
+  'iv_pl_updated')` — the index exists to keep the cleanup DELETE fast.
+- No `IJob` or `BackgroundJob` subclass found anywhere in the IntraVox `lib/` tree.
+
+**MyDash implication**: The spec's current note "no background sweeper required for correctness,
+though a separate orphaned-data-cleanup spec may purge them" is directionally correct but should be
+updated to document the inline-cleanup approach. The `DashboardLockMapper` must expose a
+`deleteExpiredForDashboard(string $uuid)` method that `DashboardLockService` calls at the start of
+both `getLockState()` and `acquireLock()`.
+
+---
+
+### D6: TTL constant — 15 minutes, not 5 minutes
+
+**Decision**: Align the default TTL with the IntraVox implementation: 15 minutes, not the 5 minutes
+written in the spec.
+
+**Rationale**: A 60-second heartbeat against a 5-minute TTL gives only a 5× safety margin; a
+single slow-loading page or 2G network blip could cause accidental expiry. The IntraVox choice of
+15 minutes against 60-second heartbeats (15× margin) is more robust for real users. This also
+reduces false-positive lock-lost alerts in the UI.
+
+**Source evidence:**
+- `intravox-source/lib/Service/PageLockService.php:17` — `private const LOCK_TIMEOUT_MINUTES = 15;`
+- `intravox-source/src/App.vue:768` — comment `// Best effort — lock will auto-expire after 15 min`
+
+**MyDash implication**: Change all spec scenario times from "5 minutes / 300 seconds" to
+"15 minutes / 900 seconds". Update the heartbeat cadence note to "every 60 seconds (15× safety
+margin)".
+
+---
+
+## Schema — Resolved Column Set
+
+Based on the IntraVox migration (ground-truth), the `oc_mydash_dashboard_locks` table MUST have:
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | BIGINT UNSIGNED AUTO_INCREMENT | Primary key |
+| `dashboard_uuid` | VARCHAR(36) UNIQUE | References `oc_mydash_dashboards.uuid`; UNIQUE enforces one-lock-per-dashboard atomically |
+| `user_id` | VARCHAR(64) | Lock owner |
+| `display_name` | VARCHAR(255) | Cached display name at acquire time |
+| `created_at` | DATETIME | Set on first acquire; never updated |
+| `updated_at` | DATETIME | Bumped on every heartbeat; expiry computed as `updated_at + 15min` |
+
+Indexes: PRIMARY on `id`, UNIQUE on `dashboard_uuid`, secondary on `user_id`, secondary on
+`updated_at` (for efficient inline cleanup DELETE).
+
+Columns REMOVED from the spec's proposed model: `expiresAt`, `clientId`.
+
+---
+
+## Spec Changes Implied
+
+The following changes to `specs/dashboard-locking/spec.md` are implied by these decisions.
+**This section is informational — do not edit the spec from this file.**
+
+- **Data model section**: Remove `expiresAt` and `clientId` columns. Add `lastHeartbeat` (= `updated_at`) and document that expiry is computed as `lastHeartbeat + LOCK_TIMEOUT` where `LOCK_TIMEOUT = 15 minutes`.
+- **REQ-LOCK-001** "Acquire" scenarios: Remove `clientId` from request body. Change TTL from 300s to 900s. Update "Same user with two browser tabs" scenario: tab-2 acquire MUST now return HTTP 200 (re-entrant refresh), not 409. Update "clientId is arbitrary string" scenario: delete entirely (clientId does not exist).
+- **REQ-LOCK-002** "Heartbeat" scenarios: Change endpoint from `POST .../lock/heartbeat` to `PUT .../lock`. Remove `clientId` from request body. Remove "Wrong clientId on alice's own lock" scenario. Change cadence note from "every 3 minutes" to "every 60 seconds". Change TTL references from 5 min / 300s to 15 min / 900s.
+- **REQ-LOCK-003** "Release" scenarios: Remove `clientId` from request bodies. The owner check is by `userId` alone (no clientId mismatch scenario needed).
+- **REQ-LOCK-004** "Query lock state" scenarios: Replace `expiresAt` field in response with `lastHeartbeat`; note that the client computes the implied expiry as `lastHeartbeat + 900s` for display purposes.
+- **REQ-LOCK-005** "Expiry" scenarios: Replace `expiresAt` references with `lastHeartbeat` + TTL. Default TTL changes to 15 minutes.
+- **REQ-LOCK-006** "Admin override": Rename endpoint from `POST .../lock/force-acquire` to `POST .../lock/force-release`. Update scenarios to reflect that the admin releases (not acquires) the lock. Remove audit log via `IActivity`; replace with PSR `LoggerInterface` info log. Remove `dashboard_lock_override` activity event requirement (or mark as future).
+- **Proposal impact section**: Update five endpoint list — replace `POST .../lock/heartbeat` with `PUT .../lock` (same resource, different verb = 4 verbs, not 5 routes). Remove `OCP\Activity\IManager` dependency. Change default TTL from 5 to 15 minutes.
+
+---
+
+## Open Follow-ups
+
+1. **Re-entrant same-user acquire UX**: With no `clientId`, the second tab for the same user now gets HTTP 200 (re-entrant) — the frontend must still detect "I'm already editing in another tab" and show an appropriate warning. Mechanism: the frontend can store the `acquiredAt` timestamp; if acquire returns 200 but `acquiredAt` is older than what this tab set, another tab must hold it. Or simply: always show "You may be editing in another tab" on acquire-200 if the tab is freshly opened. Needs a frontend UX decision.
+2. **`force-release` notification to evicted user**: When an admin force-releases a lock, the locked-out user's editor continues heartbeating. On the next PUT (within 60s), the heartbeat returns 409 (lock gone or held by new owner), triggering the "Your edit lock has expired" alert. This is acceptable but could be improved with a push notification via Nextcloud notification API. Defer to a follow-up.
+3. **Background sweeper for orphaned rows**: Inline cleanup handles rows on active dashboards. Locks on dashboards that are never visited after a browser crash will linger until someone opens that dashboard. The `updated_at` index makes a periodic `DELETE WHERE updated_at < now() - 15min` sweep trivially cheap. Wire a Nextcloud background job in a follow-up to prevent unbounded table growth.
+4. **Cascade on dashboard delete (REQ-LOCK-008)**: IntraVox does not have a cascade example (pages are not deleted the same way). Confirm whether MyDash's `DashboardMapper::delete()` should call `DashboardLockMapper::deleteByDashboardUuid()` explicitly in the service layer, or whether a DB-level ON DELETE CASCADE should be used. Note that Nextcloud's migration framework supports foreign keys on MySQL/Postgres but not SQLite; an application-layer cascade in `DashboardService::delete()` is safer.
+5. **Localization of heartbeat error messages**: The IntraVox frontend uses `this.t(...)` for error messages but the backend returns plain English strings. Ensure MyDash backend returns translatable error codes (not prose) so the frontend can show localized strings matching the i18n spec.

--- a/openspec/changes/dashboard-locking/proposal.md
+++ b/openspec/changes/dashboard-locking/proposal.md
@@ -1,0 +1,57 @@
+# Dashboard Locking
+
+## Why
+
+Today MyDash allows multiple users to simultaneously edit the same dashboard without any coordination mechanism. This creates a "last-write-wins" conflict scenario where concurrent edits overwrite each other silently, leading to data loss and user confusion. A concurrent-edit guard is essential to prevent accidental overwrites when two users open a dashboard for editing in overlapping time windows.
+
+## What Changes
+
+- Add a new table `oc_mydash_dashboard_locks` with `id`, `dashboardUuid`, `userId`, `displayName`, `acquiredAt`, `expiresAt`, and `clientId` fields.
+- Default lock TTL: 5 minutes from acquire. Heartbeat extends by 5 minutes.
+- Add four new API endpoints:
+  - `POST /api/dashboards/{uuid}/lock` — acquires a lock. Returns 200 if granted; 409 with existing lock details if held by another user.
+  - `POST /api/dashboards/{uuid}/lock/heartbeat` — extends the lock expiry. Owner-only (by `clientId`). Returns 404 if no lock; 403 if a different client owns it.
+  - `DELETE /api/dashboards/{uuid}/lock` — releases the lock. Owner-only or admin override. Returns 204.
+  - `GET /api/dashboards/{uuid}/lock` — returns current lock state. Returns 404 if none.
+- Admin override: `POST /api/dashboards/{uuid}/lock/force-acquire` steals the lock from any user and is audit-logged via Nextcloud activity.
+- Expired locks are silently ignored on read and overwritable on fresh acquire — no background sweeper required for correctness, though a separate `orphaned-data-cleanup` spec may purge them.
+
+## Capabilities
+
+### New Capabilities
+
+- `dashboard-locking`: All dashboard lock management, acquisition, heartbeat, release, admin override, and expiry semantics.
+
+### Modified Capabilities
+
+(none — dashboard locking is fully orthogonal to existing dashboard CRUD)
+
+## Impact
+
+**Affected code:**
+
+- `lib/Db/DashboardLock.php` — new entity with `id`, `dashboardUuid`, `userId`, `displayName`, `acquiredAt`, `expiresAt`, `clientId` fields
+- `lib/Db/DashboardLockMapper.php` — new mapper with `findByDashboardUuid()`, `findActive()` (ignore expired), `insert()`, `update()`, `delete()`, `deleteExpired()` methods
+- `lib/Service/DashboardLockService.php` — new service layer with `acquireLock()`, `renewLock()` (heartbeat), `releaseLock()`, `getLockState()`, `forceAcquire()` (admin), expiry checking, and `clientId` matching
+- `lib/Controller/DashboardController.php` — five new endpoints as above
+- `appinfo/routes.php` — register the five new routes
+- `lib/Migration/VersionXXXXDate2026...php` — schema migration creating `oc_mydash_dashboard_locks` table
+- `src/views/DashboardEdit.vue` (frontend concern, out of scope) — call heartbeat every ~3 minutes while active, DELETE on close
+
+**Affected APIs:**
+
+- 5 new routes (no existing routes changed)
+
+**Dependencies:**
+
+- `OCP\Activity\IManager` — for audit logging on `force-acquire`
+- No new composer or npm dependencies
+
+**Migration:**
+
+- Zero-impact: new table only, no changes to existing schema
+- No seed data required
+
+## Front-end Concern (Not in Scope)
+
+The editor UI MUST call heartbeat every ~3 minutes while the user is actively editing, and DELETE the lock when the user closes the edit view or navigates away. This ensures stale locks expire after the default 5-minute TTL if the client crashes without releasing.

--- a/openspec/changes/dashboard-locking/proposal.md
+++ b/openspec/changes/dashboard-locking/proposal.md
@@ -6,15 +6,15 @@ Today MyDash allows multiple users to simultaneously edit the same dashboard wit
 
 ## What Changes
 
-- Add a new table `oc_mydash_dashboard_locks` with `id`, `dashboardUuid`, `userId`, `displayName`, `acquiredAt`, `expiresAt`, and `clientId` fields.
-- Default lock TTL: 5 minutes from acquire. Heartbeat extends by 5 minutes.
-- Add four new API endpoints:
-  - `POST /api/dashboards/{uuid}/lock` — acquires a lock. Returns 200 if granted; 409 with existing lock details if held by another user.
-  - `POST /api/dashboards/{uuid}/lock/heartbeat` — extends the lock expiry. Owner-only (by `clientId`). Returns 404 if no lock; 403 if a different client owns it.
-  - `DELETE /api/dashboards/{uuid}/lock` — releases the lock. Owner-only or admin override. Returns 204.
+- Add a new table `oc_mydash_dashboard_locks` with `id`, `dashboardUuid`, `userId`, `displayName`, `acquiredAt`, and `lastHeartbeat` fields.
+- Default lock TTL: 15 minutes, computed at query time as `lastHeartbeat + 15 min`. No stored expiry column.
+- Add four verbs on a single lock resource URL, plus one admin action:
+  - `POST /api/dashboards/{uuid}/lock` — acquires a lock. Returns 200 if granted (re-entrant for same user); 409 with existing lock details if held by another user.
+  - `PUT /api/dashboards/{uuid}/lock` — heartbeat: extends the lock by bumping `lastHeartbeat`. Owner-only (by `userId`). Returns 404 if no lock; 403 if a different user owns it.
+  - `DELETE /api/dashboards/{uuid}/lock` — releases the lock. Owner-only or admin. Returns 204.
   - `GET /api/dashboards/{uuid}/lock` — returns current lock state. Returns 404 if none.
-- Admin override: `POST /api/dashboards/{uuid}/lock/force-acquire` steals the lock from any user and is audit-logged via Nextcloud activity.
-- Expired locks are silently ignored on read and overwritable on fresh acquire — no background sweeper required for correctness, though a separate `orphaned-data-cleanup` spec may purge them.
+- Admin override: `POST /api/dashboards/{uuid}/lock/force-release` releases the lock for whoever holds it (returning the dashboard to unlocked state); logged via `LoggerInterface::info()`.
+- Expired locks are cleaned up inline: `DashboardLockService` calls `DashboardLockMapper::deleteExpiredForDashboard()` at the start of `getLockState()` and `acquireLock()` — no background sweeper required for correctness.
 
 ## Capabilities
 
@@ -30,21 +30,21 @@ Today MyDash allows multiple users to simultaneously edit the same dashboard wit
 
 **Affected code:**
 
-- `lib/Db/DashboardLock.php` — new entity with `id`, `dashboardUuid`, `userId`, `displayName`, `acquiredAt`, `expiresAt`, `clientId` fields
-- `lib/Db/DashboardLockMapper.php` — new mapper with `findByDashboardUuid()`, `findActive()` (ignore expired), `insert()`, `update()`, `delete()`, `deleteExpired()` methods
-- `lib/Service/DashboardLockService.php` — new service layer with `acquireLock()`, `renewLock()` (heartbeat), `releaseLock()`, `getLockState()`, `forceAcquire()` (admin), expiry checking, and `clientId` matching
-- `lib/Controller/DashboardController.php` — five new endpoints as above
-- `appinfo/routes.php` — register the five new routes
+- `lib/Db/DashboardLock.php` — new entity with `id`, `dashboardUuid`, `userId`, `displayName`, `acquiredAt`, `lastHeartbeat` fields
+- `lib/Db/DashboardLockMapper.php` — new mapper with `findByDashboardUuid()`, `findActive()` (filter by `lastHeartbeat`), `insert()`, `update()`, `delete()`, `deleteExpiredForDashboard(string $uuid)` methods
+- `lib/Service/DashboardLockService.php` — new service layer with `acquireLock()`, `heartbeat()` (PUT), `releaseLock()`, `getLockState()`, `forceRelease()` (admin); inline expiry cleanup via `deleteExpiredForDashboard()`; ownership by `userId` only
+- `lib/Controller/DashboardController.php` — four new lock endpoints + one admin endpoint as above
+- `appinfo/routes.php` — register the four verbs on `lock` resource + `force-release` route
 - `lib/Migration/VersionXXXXDate2026...php` — schema migration creating `oc_mydash_dashboard_locks` table
 - `src/views/DashboardEdit.vue` (frontend concern, out of scope) — call heartbeat every ~3 minutes while active, DELETE on close
 
 **Affected APIs:**
 
-- 5 new routes (no existing routes changed)
+- 5 new routes (4 verbs on lock resource + 1 admin action; no existing routes changed)
 
 **Dependencies:**
 
-- `OCP\Activity\IManager` — for audit logging on `force-acquire`
+- `Psr\Log\LoggerInterface` — for audit logging on `force-release` (already available in Nextcloud; no new dependencies required)
 - No new composer or npm dependencies
 
 **Migration:**
@@ -54,4 +54,4 @@ Today MyDash allows multiple users to simultaneously edit the same dashboard wit
 
 ## Front-end Concern (Not in Scope)
 
-The editor UI MUST call heartbeat every ~3 minutes while the user is actively editing, and DELETE the lock when the user closes the edit view or navigates away. This ensures stale locks expire after the default 5-minute TTL if the client crashes without releasing.
+The editor UI MUST call `PUT /api/dashboards/{uuid}/lock` (heartbeat) every 60 seconds while the user is actively editing, and `DELETE /api/dashboards/{uuid}/lock` when the user closes the edit view or navigates away. This ensures stale locks expire after the default 15-minute TTL if the client crashes without releasing. The 60-second cadence gives a 15× safety margin against the TTL.

--- a/openspec/changes/dashboard-locking/specs/dashboard-locking/spec.md
+++ b/openspec/changes/dashboard-locking/specs/dashboard-locking/spec.md
@@ -1,0 +1,317 @@
+---
+status: draft
+---
+
+# Dashboard Locking Specification
+
+## Purpose
+
+Dashboard locking provides a concurrent-edit guard for dashboards. When two users open the same dashboard's edit view, the system MUST prevent the second user from editing until the first releases the lock. The mechanism uses a time-based lease (default 5 minutes) with client-driven heartbeat renewal to tolerate transient network outages and browser crashes without manual intervention.
+
+## Data Model
+
+Each dashboard lock is stored in the `oc_mydash_dashboard_locks` table with the following fields:
+
+- **id**: Auto-increment integer primary key
+- **dashboardUuid**: VARCHAR(36) UNIQUE, references dashboard UUID
+- **userId**: VARCHAR(64), Nextcloud user ID of the lock owner
+- **displayName**: VARCHAR(255), cached display name for UI feedback (avoids second lookup on conflict response)
+- **acquiredAt**: TIMESTAMP, when the lock was first acquired
+- **expiresAt**: TIMESTAMP, when the lock becomes stale (ignored on read if in the past)
+- **clientId**: VARCHAR(64), browser/tab identifier so the same user with two tabs can recognize their own lock
+
+## ADDED Requirements
+
+### Requirement: REQ-LOCK-001 Acquire Dashboard Lock
+
+A user MUST be able to acquire an exclusive write lock on a dashboard. Only one user (or admin) can hold a lock at a time. A second user attempting to acquire MUST receive the existing lock details in a conflict response.
+
+#### Scenario: First user acquires lock on unlocked dashboard
+- GIVEN dashboard with uuid "d1" has no lock
+- WHEN alice sends `POST /api/dashboards/d1/lock` with body `{"clientId": "tab-abc123"}`
+- THEN the system MUST create a lock record with:
+  - `dashboardUuid = "d1"`
+  - `userId = "alice"`
+  - `displayName = "Alice Smith"` (fetched from Nextcloud user display name)
+  - `clientId = "tab-abc123"`
+  - `acquiredAt = now`
+  - `expiresAt = now + 300 seconds` (5 minutes default TTL)
+- AND the response MUST return HTTP 200 with the full lock object
+- AND alice MUST be able to edit the dashboard
+
+#### Scenario: Second user encounters lock held by first user
+- GIVEN dashboard "d1" has an active lock owned by alice
+- WHEN bob sends `POST /api/dashboards/d1/lock` with body `{"clientId": "tab-xyz789"}`
+- THEN the system MUST NOT create a new lock
+- AND the response MUST return HTTP 409 (Conflict)
+- AND the response body MUST contain the existing lock object:
+  - `userId = "alice"`
+  - `displayName = "Alice Smith"`
+  - `expiresAt = ...` (current expiry, not extended)
+  - `clientId = "tab-abc123"`
+- AND bob MUST see a read-only banner on the dashboard with alice's display name and lock expiry time
+
+#### Scenario: Same user with two browser tabs
+- GIVEN alice has two tabs open on the same dashboard with different `clientId` values ("tab-1", "tab-2")
+- WHEN tab-1 acquires the lock
+- AND tab-2 attempts to acquire immediately after
+- THEN tab-2 MUST receive HTTP 409 with alice's lock details
+- AND the frontend MUST recognize that it is alice's own lock (by matching `userId`) and display a different UI (e.g., "You are editing in another tab")
+- NOTE: Both tabs show editing UI, but only the lock owner can commit changes; the second tab's edit attempt fails at save time with a "Lock held by you" error
+
+#### Scenario: Expired lock is overwritable
+- GIVEN dashboard "d1" has a lock owned by alice with `expiresAt` in the past
+- WHEN bob sends `POST /api/dashboards/d1/lock`
+- THEN the system MUST treat the expired lock as non-existent
+- AND bob MUST receive HTTP 200 with a new lock owned by bob
+- AND alice's expired lock MUST be silently deleted (or left in place for background cleanup)
+
+#### Scenario: clientId is arbitrary string (frontend responsibility)
+- GIVEN a user calls `POST /api/dashboards/d1/lock` with `{"clientId": "my-unique-id"}`
+- THEN the system MUST store the `clientId` exactly as provided
+- AND the `clientId` MUST be usable by the frontend to identify "is this my lock?" on the heartbeat/release calls
+- NOTE: The system does NOT generate `clientId`; the frontend is responsible for generating a stable, unique identifier per browser tab (e.g., UUID or tab ID)
+
+### Requirement: REQ-LOCK-002 Heartbeat to Extend Lock
+
+A lock owner (matching `clientId` and optionally `userId`) MUST be able to extend the lock's expiry without releasing and re-acquiring. Heartbeat MUST only succeed if the caller provides the correct `clientId`.
+
+#### Scenario: Lock owner extends lease with heartbeat
+- GIVEN alice holds a lock on dashboard "d1" with `expiresAt = T0 + 300s`, acquired at `T0`
+- WHEN alice's browser sends `POST /api/dashboards/d1/lock/heartbeat` with `{"clientId": "tab-abc123"}` at time `T1 = T0 + 150s`
+- THEN the system MUST update the lock with `expiresAt = T1 + 300s`
+- AND the response MUST return HTTP 200 with the updated lock object showing new `expiresAt`
+- AND no `acquiredAt` change (remains `T0`)
+
+#### Scenario: Non-owner cannot heartbeat
+- GIVEN alice holds a lock on dashboard "d1" with `clientId = "tab-abc123"`
+- WHEN bob sends `POST /api/dashboards/d1/lock/heartbeat` with `{"clientId": "tab-xyz789"}` (different `clientId`)
+- THEN the system MUST return HTTP 403 (Forbidden)
+- AND the lock MUST NOT be modified
+
+#### Scenario: Wrong clientId on alice's own lock
+- GIVEN alice holds a lock on dashboard "d1" with `clientId = "tab-abc123"`
+- WHEN alice sends `POST /api/dashboards/d1/lock/heartbeat` from a different browser tab with `{"clientId": "tab-different"}`
+- THEN the system MUST return HTTP 403
+- AND the response MUST indicate the mismatch (e.g., error message "Lock held by you in another tab")
+- NOTE: This forces the user to close the first tab before editing in the second
+
+#### Scenario: Heartbeat on non-existent lock
+- GIVEN dashboard "d1" has no lock
+- WHEN alice sends `POST /api/dashboards/d1/lock/heartbeat` with `{"clientId": "tab-abc123"}`
+- THEN the system MUST return HTTP 404 (Not Found)
+- AND the response MUST indicate "Lock not found; call acquire first"
+
+#### Scenario: Frequent heartbeat prevents expiry
+- GIVEN alice acquires a lock at `T0` with 5-minute TTL
+- WHEN alice's browser sends heartbeat every 3 minutes
+- THEN the lock MUST never expire while the browser remains open
+- AND alice MUST retain exclusive edit access indefinitely
+- NOTE: Frontend is responsible for calling heartbeat ~3 minutes; server does NOT force a heartbeat frequency
+
+### Requirement: REQ-LOCK-003 Release Dashboard Lock
+
+A lock owner or administrator MUST be able to release a lock, returning the dashboard to an unlocked state. Non-owners MUST NOT be able to release another user's lock unless they are admins.
+
+#### Scenario: Lock owner releases lock
+- GIVEN alice holds a lock on dashboard "d1"
+- WHEN alice sends `DELETE /api/dashboards/d1/lock` with `{"clientId": "tab-abc123"}`
+- THEN the system MUST delete the lock record
+- AND the response MUST return HTTP 204 (No Content)
+- AND bob can now acquire the lock immediately
+
+#### Scenario: Non-owner cannot release another user's lock
+- GIVEN alice holds a lock on dashboard "d1" with `clientId = "tab-abc123"`
+- WHEN bob sends `DELETE /api/dashboards/d1/lock` with `{"clientId": "tab-any"}`
+- THEN the system MUST return HTTP 403 (Forbidden)
+- AND the lock MUST remain intact
+- AND the response MUST indicate "Only the lock owner or an admin can release this lock"
+
+#### Scenario: Admin can release any lock
+- GIVEN alice holds a lock on dashboard "d1"
+- AND charlie is a Nextcloud admin
+- WHEN charlie sends `DELETE /api/dashboards/d1/lock`
+- THEN the system MUST delete alice's lock
+- AND the response MUST return HTTP 204
+- AND the action MUST be audit-logged separately (via REQ-LOCK-006)
+
+#### Scenario: clientId mismatch on release
+- GIVEN alice holds a lock on dashboard "d1" with `clientId = "tab-abc123"`
+- WHEN alice sends `DELETE /api/dashboards/d1/lock` with `{"clientId": "tab-different"}`
+- THEN the system MUST return HTTP 403
+- AND the lock MUST remain intact
+
+#### Scenario: Release non-existent lock
+- GIVEN dashboard "d1" has no lock
+- WHEN alice sends `DELETE /api/dashboards/d1/lock`
+- THEN the system MUST return HTTP 204 (idempotent — successfully deleted or already gone is the same outcome)
+- OR the system MAY return HTTP 404 (Not Found) with a message "Lock not found"
+- NOTE: Frontend should not rely on 404; a 204 response is preferred for idempotency
+
+### Requirement: REQ-LOCK-004 Query Lock State
+
+Any logged-in user MUST be able to query the current lock state of a dashboard to display lock status UI.
+
+#### Scenario: Get active lock
+- GIVEN dashboard "d1" has an active lock owned by alice
+- WHEN bob sends `GET /api/dashboards/d1/lock`
+- THEN the system MUST return HTTP 200 with the lock object:
+  - `userId = "alice"`
+  - `displayName = "Alice Smith"`
+  - `expiresAt = ...` (future timestamp)
+  - `clientId = "tab-abc123"` (may or may not be exposed to non-owner; backend MUST include it for debugging)
+- AND bob can display "Dashboard is being edited by Alice Smith (expires in 4m 30s)"
+
+#### Scenario: Get lock when none exists
+- GIVEN dashboard "d1" has no lock
+- WHEN bob sends `GET /api/dashboards/d1/lock`
+- THEN the system MUST return HTTP 404 (Not Found)
+- OR return HTTP 200 with `null` (if API design prefers null over 404)
+- AND the frontend MUST interpret this as "dashboard is unlocked"
+
+#### Scenario: Get lock when it has expired
+- GIVEN dashboard "d1" has an expired lock (expiresAt in the past)
+- WHEN bob sends `GET /api/dashboards/d1/lock`
+- THEN the system MUST return HTTP 404 or treat the lock as non-existent
+- AND the response MUST NOT leak expired lock details
+- AND bob MUST be able to acquire a new lock immediately
+
+#### Scenario: Cached displayName is stale
+- GIVEN alice acquires a lock on dashboard "d1"
+- AND alice's display name is later changed in Nextcloud (e.g., "Alice Smith" → "Alice S.")
+- WHEN bob queries the lock at `GET /api/dashboards/d1/lock`
+- THEN bob MUST see the cached name from the time of lock acquisition ("Alice Smith")
+- NOTE: The cached `displayName` MUST NOT be updated by background jobs; it reflects the name at acquire time for consistency
+
+### Requirement: REQ-LOCK-005 Lock Expiry and Stale State
+
+Locks MUST automatically become stale when `expiresAt` is in the past. Stale locks MUST be silently ignored on read and overwritable on acquire without conflict.
+
+#### Scenario: Stale lock is invisible on read
+- GIVEN dashboard "d1" has a lock with `expiresAt = now - 1 minute`
+- WHEN bob sends `GET /api/dashboards/d1/lock`
+- THEN the system MUST return HTTP 404 (or null if API design prefers)
+- AND the response MUST NOT include the stale lock
+- NOTE: Stale locks remain in the database until a background cleanup job runs (out of scope of this spec)
+
+#### Scenario: Stale lock does not block new acquisition
+- GIVEN dashboard "d1" has a lock with `expiresAt = now - 1 minute`
+- WHEN bob sends `POST /api/dashboards/d1/lock` with valid `clientId`
+- THEN the system MUST NOT return HTTP 409 (conflict)
+- AND bob MUST receive HTTP 200 with a new lock
+- AND the old stale lock MAY remain in the database or be silently deleted
+- NOTE: No explicit error on conflict; the stale lock is simply transparent
+
+#### Scenario: Network outage does not prevent lock release
+- GIVEN alice acquires a lock and then closes her browser (crash or network cut)
+- AND the lock expires after 5 minutes of inactivity
+- WHEN bob attempts to acquire after expiry
+- THEN bob MUST succeed immediately (no manual admin intervention required for correctness)
+- NOTE: Background cleanup MAY later delete the stale row, but correctness does not depend on it
+
+#### Scenario: Default TTL is 5 minutes
+- GIVEN alice acquires a lock on dashboard "d1" at time `T0`
+- THEN the lock's `expiresAt` MUST be set to `T0 + 300 seconds` (5 minutes)
+- WHEN 301 seconds have passed without a heartbeat
+- THEN the lock MUST be considered stale
+- NOTE: Callers MAY specify a custom TTL (e.g., 600 seconds for batch operations), but the default is 5 minutes
+
+### Requirement: REQ-LOCK-006 Admin Override and Audit Logging
+
+A Nextcloud administrator MUST be able to steal a lock from any user via `POST /api/dashboards/{uuid}/lock/force-acquire`. This action MUST be audit-logged via Nextcloud's activity system with the original owner's name and the admin's action.
+
+#### Scenario: Admin steals a lock
+- GIVEN alice holds a lock on dashboard "d1"
+- AND charlie is a Nextcloud admin
+- WHEN charlie sends `POST /api/dashboards/d1/lock/force-acquire` with `{"clientId": "admin-tab-123"}`
+- THEN the system MUST delete alice's lock and create a new one owned by charlie:
+  - `userId = "charlie"`
+  - `displayName = "Charlie Admin"`
+  - `clientId = "admin-tab-123"`
+  - `expiresAt = now + 300 seconds`
+- AND the response MUST return HTTP 200 with the new lock object
+- AND the action MUST be logged to Nextcloud activity log with type `dashboard_lock_override` (or similar), subject containing alice's name and the dashboard UUID
+
+#### Scenario: Non-admin cannot force-acquire
+- GIVEN alice holds a lock on dashboard "d1"
+- WHEN bob (non-admin) sends `POST /api/dashboards/d1/lock/force-acquire` with `{"clientId": "tab-xyz"}`
+- THEN the system MUST return HTTP 403 (Forbidden)
+- AND alice's lock MUST remain intact
+- AND the action MUST NOT be logged to activity (or logged as a failed override attempt)
+
+#### Scenario: Force-acquire succeeds even if lock is expired
+- GIVEN dashboard "d1" has an expired lock
+- AND charlie is admin
+- WHEN charlie sends `POST /api/dashboards/d1/lock/force-acquire`
+- THEN charlie MUST receive HTTP 200 with a new lock
+- AND the old expired lock MUST be silently replaced
+
+#### Scenario: Activity log message includes context
+- GIVEN alice holds a lock on dashboard "d1" ("My Dashboard")
+- WHEN charlie (admin) force-acquires the lock
+- THEN the activity log entry MUST include:
+  - Original lock owner: "Alice Smith"
+  - Dashboard uuid: "d1"
+  - Action: "force-acquire" or "Dashboard lock override" (user-facing string)
+  - Timestamp: when the override occurred
+- AND admins reviewing activity logs MUST understand who stole the lock from whom and on which dashboard
+
+### Requirement: REQ-LOCK-007 Contention and Consistency
+
+When multiple users attempt to acquire the same lock simultaneously (network race), only one MUST succeed with HTTP 200. All others MUST receive HTTP 409 with the same lock object.
+
+#### Scenario: Three users race to acquire lock
+- GIVEN dashboard "d1" has no lock
+- WHEN alice, bob, and carol all send `POST /api/dashboards/d1/lock` simultaneously (within the same 100ms)
+- THEN exactly one user MUST receive HTTP 200 with a new lock (e.g., alice)
+- AND the other two MUST receive HTTP 409 with alice's lock details in the response
+- NOTE: Database UNIQUE constraint on `dashboardUuid` enforces this atomically
+
+#### Scenario: Heartbeat race does not cause corruption
+- GIVEN alice holds a lock on dashboard "d1"
+- WHEN alice's browser sends two heartbeat requests simultaneously (e.g., due to a double-click or retried request)
+- THEN both MUST succeed with HTTP 200
+- AND the lock's `expiresAt` MUST be updated consistently
+- AND no lock duplication or corruption MUST occur
+- NOTE: Backend MUST update atomically; SELECT-then-UPDATE is not safe
+
+#### Scenario: Release and acquire race
+- GIVEN alice holds a lock on dashboard "d1"
+- WHEN alice sends `DELETE /api/dashboards/d1/lock` (releasing)
+- AND bob simultaneously sends `POST /api/dashboards/d1/lock` (acquiring)
+- THEN one of the following MUST occur (depending on timing):
+  - Alice's release succeeds first → bob's acquire succeeds with HTTP 200
+  - Bob's acquire succeeds first → alice's release succeeds with HTTP 204 (idempotent; lock is gone but already not hers)
+- AND no lock MUST be lost or duplicated
+
+### Requirement: REQ-LOCK-008 Lock Lifecycle on Dashboard Deletion
+
+When a dashboard is deleted, its lock (if any) MUST be automatically deleted as a cascade. No manual cleanup is required.
+
+#### Scenario: Delete dashboard with active lock
+- GIVEN alice holds a lock on dashboard "d1"
+- AND alice sends `DELETE /api/dashboard/d1` (dashboard deletion, not lock deletion)
+- THEN the system MUST:
+  - Delete the dashboard record from `oc_mydash_dashboards`
+  - Delete the associated lock record from `oc_mydash_dashboard_locks`
+- AND the cascade MUST be enforced by a foreign key constraint or application logic
+- NOTE: If the delete request comes from a different user or admin, the same cascade applies
+
+#### Scenario: Lock is not a blocker for dashboard deletion
+- GIVEN bob holds a lock on dashboard "d1" owned by alice
+- WHEN alice sends `DELETE /api/dashboard/d1`
+- THEN the system MUST allow alice to delete her own dashboard
+- AND bob's lock MUST be automatically released
+- AND bob's next save attempt on the (now non-existent) dashboard MUST fail with a "Dashboard not found" error
+
+## Non-Functional Requirements
+
+- **Performance**: `POST /api/dashboards/{uuid}/lock` MUST complete within 100ms (single INSERT + potential UPDATE). `GET /api/dashboards/{uuid}/lock` MUST complete within 50ms (single SELECT with index on `dashboardUuid`).
+- **Atomicity**: Only one lock holder per dashboard MUST be enforced by database UNIQUE constraint + application logic.
+- **Audit trail**: All admin `force-acquire` actions MUST be logged to Nextcloud activity for compliance and debugging.
+- **Expiry grace period**: No grace period — locks expire at exactly `expiresAt` timestamp; queries treat past timestamps as stale immediately.
+- **Localization**: All error messages and activity log entries MUST support English and Dutch.
+
+### Current Implementation Status
+
+**Not yet implemented** — this is a new capability.

--- a/openspec/changes/dashboard-locking/specs/dashboard-locking/spec.md
+++ b/openspec/changes/dashboard-locking/specs/dashboard-locking/spec.md
@@ -6,7 +6,7 @@ status: draft
 
 ## Purpose
 
-Dashboard locking provides a concurrent-edit guard for dashboards. When two users open the same dashboard's edit view, the system MUST prevent the second user from editing until the first releases the lock. The mechanism uses a time-based lease (default 5 minutes) with client-driven heartbeat renewal to tolerate transient network outages and browser crashes without manual intervention.
+Dashboard locking provides a concurrent-edit guard for dashboards. When two users open the same dashboard's edit view, the system MUST prevent the second user from editing until the first releases the lock. The mechanism uses a time-based lease (default 15 minutes) with client-driven heartbeat renewal to tolerate transient network outages and browser crashes without manual intervention.
 
 ## Data Model
 
@@ -16,9 +16,14 @@ Each dashboard lock is stored in the `oc_mydash_dashboard_locks` table with the 
 - **dashboardUuid**: VARCHAR(36) UNIQUE, references dashboard UUID
 - **userId**: VARCHAR(64), Nextcloud user ID of the lock owner
 - **displayName**: VARCHAR(255), cached display name for UI feedback (avoids second lookup on conflict response)
-- **acquiredAt**: TIMESTAMP, when the lock was first acquired
-- **expiresAt**: TIMESTAMP, when the lock becomes stale (ignored on read if in the past)
-- **clientId**: VARCHAR(64), browser/tab identifier so the same user with two tabs can recognize their own lock
+- **acquiredAt**: TIMESTAMP, when the lock was first acquired (never updated after initial insert)
+- **lastHeartbeat**: TIMESTAMP (`updated_at`), bumped on every heartbeat; expiry is computed as `lastHeartbeat + LOCK_TIMEOUT` where `LOCK_TIMEOUT = 15 minutes`
+
+Indexes: PRIMARY on `id`, UNIQUE on `dashboardUuid`, secondary on `userId`, secondary on `lastHeartbeat` (for efficient inline expiry cleanup).
+
+The TTL constant (`LOCK_TIMEOUT = 15 minutes`) lives in `DashboardLockService`, not in the row. There is no stored expiry column — the active/stale state of a lock is always computed at query time from `lastHeartbeat`.
+
+Stale-lock cleanup is performed inline: `DashboardLockService` calls `DashboardLockMapper::deleteExpiredForDashboard(string $uuid)` at the start of both `getLockState()` and `acquireLock()`, deleting any row for that dashboard whose `lastHeartbeat` is older than `now - 15 minutes`. This prevents stale locks from blocking new acquisitions without requiring a background sweeper.
 
 ## ADDED Requirements
 
@@ -26,103 +31,90 @@ Each dashboard lock is stored in the `oc_mydash_dashboard_locks` table with the 
 
 A user MUST be able to acquire an exclusive write lock on a dashboard. Only one user (or admin) can hold a lock at a time. A second user attempting to acquire MUST receive the existing lock details in a conflict response.
 
+Same-user acquire is re-entrant: if the same user already holds the lock, the acquire call MUST succeed with HTTP 200 and refresh the lock (bump `lastHeartbeat`), rather than returning 409.
+
 #### Scenario: First user acquires lock on unlocked dashboard
 - GIVEN dashboard with uuid "d1" has no lock
-- WHEN alice sends `POST /api/dashboards/d1/lock` with body `{"clientId": "tab-abc123"}`
+- WHEN alice sends `POST /api/dashboards/d1/lock`
 - THEN the system MUST create a lock record with:
   - `dashboardUuid = "d1"`
   - `userId = "alice"`
   - `displayName = "Alice Smith"` (fetched from Nextcloud user display name)
-  - `clientId = "tab-abc123"`
   - `acquiredAt = now`
-  - `expiresAt = now + 300 seconds` (5 minutes default TTL)
+  - `lastHeartbeat = now`
 - AND the response MUST return HTTP 200 with the full lock object
 - AND alice MUST be able to edit the dashboard
 
 #### Scenario: Second user encounters lock held by first user
 - GIVEN dashboard "d1" has an active lock owned by alice
-- WHEN bob sends `POST /api/dashboards/d1/lock` with body `{"clientId": "tab-xyz789"}`
+- WHEN bob sends `POST /api/dashboards/d1/lock`
 - THEN the system MUST NOT create a new lock
 - AND the response MUST return HTTP 409 (Conflict)
 - AND the response body MUST contain the existing lock object:
   - `userId = "alice"`
   - `displayName = "Alice Smith"`
-  - `expiresAt = ...` (current expiry, not extended)
-  - `clientId = "tab-abc123"`
-- AND bob MUST see a read-only banner on the dashboard with alice's display name and lock expiry time
+  - `lastHeartbeat = ...` (current heartbeat timestamp; client computes implied expiry as `lastHeartbeat + 900s`)
+- AND bob MUST see a read-only banner on the dashboard with alice's display name and the implied lock expiry time
 
-#### Scenario: Same user with two browser tabs
-- GIVEN alice has two tabs open on the same dashboard with different `clientId` values ("tab-1", "tab-2")
-- WHEN tab-1 acquires the lock
-- AND tab-2 attempts to acquire immediately after
-- THEN tab-2 MUST receive HTTP 409 with alice's lock details
-- AND the frontend MUST recognize that it is alice's own lock (by matching `userId`) and display a different UI (e.g., "You are editing in another tab")
-- NOTE: Both tabs show editing UI, but only the lock owner can commit changes; the second tab's edit attempt fails at save time with a "Lock held by you" error
+#### Scenario: Same user with two browser tabs (re-entrant acquire)
+- GIVEN alice has tab-1 open on dashboard "d1" and has already acquired the lock
+- WHEN alice opens tab-2 on the same dashboard and tab-2 sends `POST /api/dashboards/d1/lock`
+- THEN tab-2 MUST receive HTTP 200 (re-entrant refresh)
+- AND the lock's `lastHeartbeat` MUST be updated to now
+- AND alice's edit session in tab-2 is valid (the lock is hers)
+- NOTE: The frontend MAY detect that a pre-existing lock exists (by comparing `acquiredAt` with what tab-1 stored) and display a "You may be editing in another tab" informational notice; this is a UX concern and does not affect the backend contract
 
 #### Scenario: Expired lock is overwritable
-- GIVEN dashboard "d1" has a lock owned by alice with `expiresAt` in the past
+- GIVEN dashboard "d1" has a lock owned by alice where `lastHeartbeat` is more than 15 minutes in the past
 - WHEN bob sends `POST /api/dashboards/d1/lock`
-- THEN the system MUST treat the expired lock as non-existent
+- THEN the system MUST treat the expired lock as non-existent (inline cleanup removes it first)
 - AND bob MUST receive HTTP 200 with a new lock owned by bob
-- AND alice's expired lock MUST be silently deleted (or left in place for background cleanup)
-
-#### Scenario: clientId is arbitrary string (frontend responsibility)
-- GIVEN a user calls `POST /api/dashboards/d1/lock` with `{"clientId": "my-unique-id"}`
-- THEN the system MUST store the `clientId` exactly as provided
-- AND the `clientId` MUST be usable by the frontend to identify "is this my lock?" on the heartbeat/release calls
-- NOTE: The system does NOT generate `clientId`; the frontend is responsible for generating a stable, unique identifier per browser tab (e.g., UUID or tab ID)
+- AND alice's expired lock MUST be deleted before the new lock is created
 
 ### Requirement: REQ-LOCK-002 Heartbeat to Extend Lock
 
-A lock owner (matching `clientId` and optionally `userId`) MUST be able to extend the lock's expiry without releasing and re-acquiring. Heartbeat MUST only succeed if the caller provides the correct `clientId`.
+A lock owner MUST be able to extend the lock by sending a heartbeat. Ownership is determined by `userId` alone. The heartbeat MUST only succeed if the caller is the current lock owner. The recommended heartbeat cadence is every 60 seconds, giving a 15× safety margin against the 15-minute TTL.
 
 #### Scenario: Lock owner extends lease with heartbeat
-- GIVEN alice holds a lock on dashboard "d1" with `expiresAt = T0 + 300s`, acquired at `T0`
-- WHEN alice's browser sends `POST /api/dashboards/d1/lock/heartbeat` with `{"clientId": "tab-abc123"}` at time `T1 = T0 + 150s`
-- THEN the system MUST update the lock with `expiresAt = T1 + 300s`
-- AND the response MUST return HTTP 200 with the updated lock object showing new `expiresAt`
-- AND no `acquiredAt` change (remains `T0`)
+- GIVEN alice holds a lock on dashboard "d1" with `lastHeartbeat = T0`, acquired at `T0`
+- WHEN alice's browser sends `PUT /api/dashboards/d1/lock` at time `T1 = T0 + 60s`
+- THEN the system MUST update the lock with `lastHeartbeat = T1`
+- AND the response MUST return HTTP 200 with the updated lock object showing the new `lastHeartbeat`
+- AND `acquiredAt` MUST remain unchanged (still `T0`)
 
 #### Scenario: Non-owner cannot heartbeat
-- GIVEN alice holds a lock on dashboard "d1" with `clientId = "tab-abc123"`
-- WHEN bob sends `POST /api/dashboards/d1/lock/heartbeat` with `{"clientId": "tab-xyz789"}` (different `clientId`)
+- GIVEN alice holds a lock on dashboard "d1"
+- WHEN bob (a different user) sends `PUT /api/dashboards/d1/lock`
 - THEN the system MUST return HTTP 403 (Forbidden)
 - AND the lock MUST NOT be modified
 
-#### Scenario: Wrong clientId on alice's own lock
-- GIVEN alice holds a lock on dashboard "d1" with `clientId = "tab-abc123"`
-- WHEN alice sends `POST /api/dashboards/d1/lock/heartbeat` from a different browser tab with `{"clientId": "tab-different"}`
-- THEN the system MUST return HTTP 403
-- AND the response MUST indicate the mismatch (e.g., error message "Lock held by you in another tab")
-- NOTE: This forces the user to close the first tab before editing in the second
-
 #### Scenario: Heartbeat on non-existent lock
 - GIVEN dashboard "d1" has no lock
-- WHEN alice sends `POST /api/dashboards/d1/lock/heartbeat` with `{"clientId": "tab-abc123"}`
+- WHEN alice sends `PUT /api/dashboards/d1/lock`
 - THEN the system MUST return HTTP 404 (Not Found)
 - AND the response MUST indicate "Lock not found; call acquire first"
 
 #### Scenario: Frequent heartbeat prevents expiry
-- GIVEN alice acquires a lock at `T0` with 5-minute TTL
-- WHEN alice's browser sends heartbeat every 3 minutes
+- GIVEN alice acquires a lock at `T0` with 15-minute TTL
+- WHEN alice's browser sends `PUT /api/dashboards/d1/lock` every 60 seconds
 - THEN the lock MUST never expire while the browser remains open
 - AND alice MUST retain exclusive edit access indefinitely
-- NOTE: Frontend is responsible for calling heartbeat ~3 minutes; server does NOT force a heartbeat frequency
+- NOTE: The recommended heartbeat cadence is every 60 seconds (15× safety margin against the 15-minute TTL); the server does not enforce a minimum frequency
 
 ### Requirement: REQ-LOCK-003 Release Dashboard Lock
 
-A lock owner or administrator MUST be able to release a lock, returning the dashboard to an unlocked state. Non-owners MUST NOT be able to release another user's lock unless they are admins.
+A lock owner or administrator MUST be able to release a lock, returning the dashboard to an unlocked state. Non-owners MUST NOT be able to release another user's lock unless they are admins. Ownership is determined by `userId` alone.
 
 #### Scenario: Lock owner releases lock
 - GIVEN alice holds a lock on dashboard "d1"
-- WHEN alice sends `DELETE /api/dashboards/d1/lock` with `{"clientId": "tab-abc123"}`
+- WHEN alice sends `DELETE /api/dashboards/d1/lock`
 - THEN the system MUST delete the lock record
 - AND the response MUST return HTTP 204 (No Content)
 - AND bob can now acquire the lock immediately
 
 #### Scenario: Non-owner cannot release another user's lock
-- GIVEN alice holds a lock on dashboard "d1" with `clientId = "tab-abc123"`
-- WHEN bob sends `DELETE /api/dashboards/d1/lock` with `{"clientId": "tab-any"}`
+- GIVEN alice holds a lock on dashboard "d1"
+- WHEN bob sends `DELETE /api/dashboards/d1/lock`
 - THEN the system MUST return HTTP 403 (Forbidden)
 - AND the lock MUST remain intact
 - AND the response MUST indicate "Only the lock owner or an admin can release this lock"
@@ -134,12 +126,6 @@ A lock owner or administrator MUST be able to release a lock, returning the dash
 - THEN the system MUST delete alice's lock
 - AND the response MUST return HTTP 204
 - AND the action MUST be audit-logged separately (via REQ-LOCK-006)
-
-#### Scenario: clientId mismatch on release
-- GIVEN alice holds a lock on dashboard "d1" with `clientId = "tab-abc123"`
-- WHEN alice sends `DELETE /api/dashboards/d1/lock` with `{"clientId": "tab-different"}`
-- THEN the system MUST return HTTP 403
-- AND the lock MUST remain intact
 
 #### Scenario: Release non-existent lock
 - GIVEN dashboard "d1" has no lock
@@ -158,9 +144,8 @@ Any logged-in user MUST be able to query the current lock state of a dashboard t
 - THEN the system MUST return HTTP 200 with the lock object:
   - `userId = "alice"`
   - `displayName = "Alice Smith"`
-  - `expiresAt = ...` (future timestamp)
-  - `clientId = "tab-abc123"` (may or may not be exposed to non-owner; backend MUST include it for debugging)
-- AND bob can display "Dashboard is being edited by Alice Smith (expires in 4m 30s)"
+  - `lastHeartbeat = ...` (timestamp of the most recent heartbeat)
+- AND bob can display "Dashboard is being edited by Alice Smith" with an implied expiry of `lastHeartbeat + 900s` computed client-side
 
 #### Scenario: Get lock when none exists
 - GIVEN dashboard "d1" has no lock
@@ -170,9 +155,9 @@ Any logged-in user MUST be able to query the current lock state of a dashboard t
 - AND the frontend MUST interpret this as "dashboard is unlocked"
 
 #### Scenario: Get lock when it has expired
-- GIVEN dashboard "d1" has an expired lock (expiresAt in the past)
+- GIVEN dashboard "d1" has a lock where `lastHeartbeat` is more than 15 minutes in the past
 - WHEN bob sends `GET /api/dashboards/d1/lock`
-- THEN the system MUST return HTTP 404 or treat the lock as non-existent
+- THEN the system MUST perform inline cleanup and return HTTP 404 (treating the lock as non-existent)
 - AND the response MUST NOT leak expired lock details
 - AND bob MUST be able to acquire a new lock immediately
 
@@ -185,76 +170,65 @@ Any logged-in user MUST be able to query the current lock state of a dashboard t
 
 ### Requirement: REQ-LOCK-005 Lock Expiry and Stale State
 
-Locks MUST automatically become stale when `expiresAt` is in the past. Stale locks MUST be silently ignored on read and overwritable on acquire without conflict.
+Locks MUST automatically become stale when `lastHeartbeat + LOCK_TIMEOUT` (15 minutes) is in the past. Stale locks MUST be silently removed via inline cleanup on read and acquire, and MUST be overwritable without conflict.
 
 #### Scenario: Stale lock is invisible on read
-- GIVEN dashboard "d1" has a lock with `expiresAt = now - 1 minute`
+- GIVEN dashboard "d1" has a lock where `lastHeartbeat` is more than 15 minutes in the past
 - WHEN bob sends `GET /api/dashboards/d1/lock`
-- THEN the system MUST return HTTP 404 (or null if API design prefers)
+- THEN the system MUST perform inline cleanup and return HTTP 404 (or null)
 - AND the response MUST NOT include the stale lock
-- NOTE: Stale locks remain in the database until a background cleanup job runs (out of scope of this spec)
 
 #### Scenario: Stale lock does not block new acquisition
-- GIVEN dashboard "d1" has a lock with `expiresAt = now - 1 minute`
-- WHEN bob sends `POST /api/dashboards/d1/lock` with valid `clientId`
+- GIVEN dashboard "d1" has a lock where `lastHeartbeat` is more than 15 minutes in the past
+- WHEN bob sends `POST /api/dashboards/d1/lock`
 - THEN the system MUST NOT return HTTP 409 (conflict)
+- AND the inline cleanup MUST delete the stale row before inserting the new lock
 - AND bob MUST receive HTTP 200 with a new lock
-- AND the old stale lock MAY remain in the database or be silently deleted
-- NOTE: No explicit error on conflict; the stale lock is simply transparent
 
 #### Scenario: Network outage does not prevent lock release
 - GIVEN alice acquires a lock and then closes her browser (crash or network cut)
-- AND the lock expires after 5 minutes of inactivity
+- AND the lock expires after 15 minutes of inactivity (no heartbeats received)
 - WHEN bob attempts to acquire after expiry
 - THEN bob MUST succeed immediately (no manual admin intervention required for correctness)
-- NOTE: Background cleanup MAY later delete the stale row, but correctness does not depend on it
+- NOTE: Inline cleanup removes the stale row at acquire time; no background sweeper is required for correctness
 
-#### Scenario: Default TTL is 5 minutes
+#### Scenario: Default TTL is 15 minutes
 - GIVEN alice acquires a lock on dashboard "d1" at time `T0`
-- THEN the lock's `expiresAt` MUST be set to `T0 + 300 seconds` (5 minutes)
-- WHEN 301 seconds have passed without a heartbeat
-- THEN the lock MUST be considered stale
-- NOTE: Callers MAY specify a custom TTL (e.g., 600 seconds for batch operations), but the default is 5 minutes
+- THEN the lock's effective expiry is `T0 + 900 seconds` (15 minutes), computed from `lastHeartbeat`
+- WHEN 901 seconds have passed without a heartbeat
+- THEN the lock MUST be considered stale and treated as non-existent on the next read or acquire
 
 ### Requirement: REQ-LOCK-006 Admin Override and Audit Logging
 
-A Nextcloud administrator MUST be able to steal a lock from any user via `POST /api/dashboards/{uuid}/lock/force-acquire`. This action MUST be audit-logged via Nextcloud's activity system with the original owner's name and the admin's action.
+A Nextcloud administrator MUST be able to release a lock from any user via `POST /api/dashboards/{uuid}/lock/force-release`. This action MUST be logged via `LoggerInterface` (PSR logger) with the original owner's name and the admin's action. The dashboard is returned to an unlocked state; the admin may then acquire a new lock via the normal path if they wish to edit.
 
-#### Scenario: Admin steals a lock
+#### Scenario: Admin force-releases a lock
 - GIVEN alice holds a lock on dashboard "d1"
 - AND charlie is a Nextcloud admin
-- WHEN charlie sends `POST /api/dashboards/d1/lock/force-acquire` with `{"clientId": "admin-tab-123"}`
-- THEN the system MUST delete alice's lock and create a new one owned by charlie:
-  - `userId = "charlie"`
-  - `displayName = "Charlie Admin"`
-  - `clientId = "admin-tab-123"`
-  - `expiresAt = now + 300 seconds`
-- AND the response MUST return HTTP 200 with the new lock object
-- AND the action MUST be logged to Nextcloud activity log with type `dashboard_lock_override` (or similar), subject containing alice's name and the dashboard UUID
+- WHEN charlie sends `POST /api/dashboards/d1/lock/force-release`
+- THEN the system MUST delete alice's lock record
+- AND the response MUST return HTTP 200 (or HTTP 204)
+- AND the action MUST be logged via `LoggerInterface::info()` with the original owner's userId, the dashboard UUID, and the admin's userId
+- AND dashboard "d1" MUST be in an unlocked state after this call
 
-#### Scenario: Non-admin cannot force-acquire
+#### Scenario: Admin acquires lock after force-release (normal flow)
+- GIVEN charlie (admin) has just force-released alice's lock on dashboard "d1"
+- WHEN charlie sends `POST /api/dashboards/d1/lock`
+- THEN charlie MUST receive HTTP 200 with a new lock owned by charlie
+- NOTE: Force-release and acquire are two separate steps; the admin does not automatically take ownership
+
+#### Scenario: Non-admin cannot force-release
 - GIVEN alice holds a lock on dashboard "d1"
-- WHEN bob (non-admin) sends `POST /api/dashboards/d1/lock/force-acquire` with `{"clientId": "tab-xyz"}`
+- WHEN bob (non-admin) sends `POST /api/dashboards/d1/lock/force-release`
 - THEN the system MUST return HTTP 403 (Forbidden)
 - AND alice's lock MUST remain intact
-- AND the action MUST NOT be logged to activity (or logged as a failed override attempt)
 
-#### Scenario: Force-acquire succeeds even if lock is expired
-- GIVEN dashboard "d1" has an expired lock
+#### Scenario: Force-release on expired or non-existent lock
+- GIVEN dashboard "d1" has no active lock (either no lock or an expired one)
 - AND charlie is admin
-- WHEN charlie sends `POST /api/dashboards/d1/lock/force-acquire`
-- THEN charlie MUST receive HTTP 200 with a new lock
-- AND the old expired lock MUST be silently replaced
-
-#### Scenario: Activity log message includes context
-- GIVEN alice holds a lock on dashboard "d1" ("My Dashboard")
-- WHEN charlie (admin) force-acquires the lock
-- THEN the activity log entry MUST include:
-  - Original lock owner: "Alice Smith"
-  - Dashboard uuid: "d1"
-  - Action: "force-acquire" or "Dashboard lock override" (user-facing string)
-  - Timestamp: when the override occurred
-- AND admins reviewing activity logs MUST understand who stole the lock from whom and on which dashboard
+- WHEN charlie sends `POST /api/dashboards/d1/lock/force-release`
+- THEN charlie MUST receive HTTP 200 (or HTTP 204) — idempotent
+- AND the action MUST still be logged
 
 ### Requirement: REQ-LOCK-007 Contention and Consistency
 
@@ -271,7 +245,7 @@ When multiple users attempt to acquire the same lock simultaneously (network rac
 - GIVEN alice holds a lock on dashboard "d1"
 - WHEN alice's browser sends two heartbeat requests simultaneously (e.g., due to a double-click or retried request)
 - THEN both MUST succeed with HTTP 200
-- AND the lock's `expiresAt` MUST be updated consistently
+- AND the lock's `lastHeartbeat` MUST be updated consistently
 - AND no lock duplication or corruption MUST occur
 - NOTE: Backend MUST update atomically; SELECT-then-UPDATE is not safe
 
@@ -294,7 +268,7 @@ When a dashboard is deleted, its lock (if any) MUST be automatically deleted as 
 - THEN the system MUST:
   - Delete the dashboard record from `oc_mydash_dashboards`
   - Delete the associated lock record from `oc_mydash_dashboard_locks`
-- AND the cascade MUST be enforced by a foreign key constraint or application logic
+- AND the cascade MUST be enforced by application logic in `DashboardService::delete()` calling `DashboardLockMapper::deleteByDashboardUuid()`, or by a DB-level ON DELETE CASCADE (note: Nextcloud's migration framework supports foreign keys on MySQL/Postgres but not SQLite; application-layer cascade is the safer default)
 - NOTE: If the delete request comes from a different user or admin, the same cascade applies
 
 #### Scenario: Lock is not a blocker for dashboard deletion
@@ -306,11 +280,11 @@ When a dashboard is deleted, its lock (if any) MUST be automatically deleted as 
 
 ## Non-Functional Requirements
 
-- **Performance**: `POST /api/dashboards/{uuid}/lock` MUST complete within 100ms (single INSERT + potential UPDATE). `GET /api/dashboards/{uuid}/lock` MUST complete within 50ms (single SELECT with index on `dashboardUuid`).
+- **Performance**: `POST /api/dashboards/{uuid}/lock` MUST complete within 100ms (inline cleanup DELETE + INSERT/UPDATE). `GET /api/dashboards/{uuid}/lock` MUST complete within 50ms (cleanup DELETE + SELECT with index on `dashboardUuid`).
 - **Atomicity**: Only one lock holder per dashboard MUST be enforced by database UNIQUE constraint + application logic.
-- **Audit trail**: All admin `force-acquire` actions MUST be logged to Nextcloud activity for compliance and debugging.
-- **Expiry grace period**: No grace period — locks expire at exactly `expiresAt` timestamp; queries treat past timestamps as stale immediately.
-- **Localization**: All error messages and activity log entries MUST support English and Dutch.
+- **Audit trail**: All admin `force-release` actions MUST be logged via `LoggerInterface::info()` for audit and debugging purposes.
+- **Expiry**: Locks are considered stale when `lastHeartbeat + 900s` is in the past; the system treats them as non-existent on the next read or acquire call (inline cleanup).
+- **Localization**: All error messages MUST support English and Dutch.
 
 ### Current Implementation Status
 

--- a/openspec/changes/dashboard-locking/tasks.md
+++ b/openspec/changes/dashboard-locking/tasks.md
@@ -1,0 +1,105 @@
+# Tasks — dashboard-locking
+
+## 1. Schema migration
+
+- [ ] 1.1 Create `lib/Migration/VersionXXXXDate2026...AddDashboardLocksTable.php` creating `oc_mydash_dashboard_locks` table with columns: `id INT AUTO_INCREMENT PRIMARY KEY`, `dashboardUuid VARCHAR(36) UNIQUE NOT NULL`, `userId VARCHAR(64) NOT NULL`, `displayName VARCHAR(255) NOT NULL`, `acquiredAt TIMESTAMP DEFAULT CURRENT_TIMESTAMP`, `expiresAt TIMESTAMP NOT NULL`, `clientId VARCHAR(64) NOT NULL`
+- [ ] 1.2 Same migration adds index on `(dashboardUuid)` for fast lookups and unique constraint on `dashboardUuid`
+- [ ] 1.3 Confirm migration is reversible (drop table in `postSchemaChange` rollback path)
+- [ ] 1.4 Run migration locally against sqlite, mysql, and postgres; verify schema applied cleanly each time
+
+## 2. Domain model
+
+- [ ] 2.1 Create `lib/Db/DashboardLock.php` entity with fields: `id`, `dashboardUuid`, `userId`, `displayName`, `acquiredAt`, `expiresAt`, `clientId` and corresponding getters/setters (Entity `__call` pattern — no named args)
+- [ ] 2.2 Add methods to check expiry: `public function isExpired(): bool` and `public function expiresIn(): int` (remaining seconds)
+- [ ] 2.3 Implement `jsonSerialize()` to return lock state in API responses (include all fields except `id`, or include `id` if needed for internal tracking)
+
+## 3. Mapper layer
+
+- [ ] 3.1 Create `lib/Db/DashboardLockMapper.php` extending `ORM\Mapper` with methods:
+  - `findByDashboardUuid(string $uuid): DashboardLock` — returns active (non-expired) lock or throws `DoesNotExistException`
+  - `findActive(string $uuid): ?DashboardLock` — returns active lock or null (silent on expired)
+  - `insert(DashboardLock $lock): DashboardLock`
+  - `update(DashboardLock $lock): DashboardLock`
+  - `delete(DashboardLock $lock): void`
+  - `deleteExpired(): int` — deletes and returns count of expired locks
+  - `findByUserId(string $userId): array` — returns all (active and expired) locks for a user for auditing
+- [ ] 3.2 Add PHPUnit test covering: active lock retrieval, expired lock ignored, empty case, unique constraint on `dashboardUuid`
+
+## 4. Service layer
+
+- [ ] 4.1 Create `lib/Service/DashboardLockService.php` with:
+  - `acquireLock(string $dashboardUuid, string $userId, string $displayName, string $clientId, int $ttlSeconds = 300): DashboardLock` — creates new lock if none exists or current is expired; throws `ConflictException` if a different user holds an active lock
+  - `renewLock(string $dashboardUuid, string $clientId, int $ttlSeconds = 300): DashboardLock` — extends `expiresAt` by TTL; throws 404 if no lock exists, 403 if `clientId` mismatch
+  - `releaseLock(string $dashboardUuid, string $clientId, ?string $userId): void` — deletes lock; owner (matching `clientId`) or admin (any `$userId` allowed) can release; throws 403 if mismatch on non-admin
+  - `getLockState(string $dashboardUuid): ?DashboardLock` — returns current (non-expired) lock or null (silent on expired)
+  - `forceAcquire(string $dashboardUuid, string $adminUserId, string $displayName, string $clientId, int $ttlSeconds = 300): DashboardLock` — steals lock from any user; must log activity via `IManager`; throws 403 if caller is not admin
+- [ ] 4.2 Inject `OCP\Activity\IManager` for audit logging on `forceAcquire`
+- [ ] 4.3 All methods check expiry internally before reading; expired locks behave as if they don't exist
+- [ ] 4.4 Add PHPUnit test covering: acquire, heartbeat, release, conflict on second user, admin override, expiry edge cases
+
+## 5. Controller + routes
+
+- [ ] 5.1 Add `DashboardController::acquireLock(string $uuid)` mapped to `POST /api/dashboards/{uuid}/lock` (logged-in user, `#[NoAdminRequired]`)
+  - Request body: `{"clientId": "..."}`
+  - Response 200: `{"id": ..., "dashboardUuid": "...", "userId": "...", "displayName": "...", "acquiredAt": "...", "expiresAt": "...", "clientId": "..."}`
+  - Response 409 (conflict): same lock object body if held by another user
+- [ ] 5.2 Add `DashboardController::heartbeat(string $uuid)` mapped to `POST /api/dashboards/{uuid}/lock/heartbeat` (logged-in)
+  - Request body: `{"clientId": "..."}`
+  - Response 200: updated lock object
+  - Response 404: no lock exists
+  - Response 403: `clientId` mismatch
+- [ ] 5.3 Add `DashboardController::releaseLock(string $uuid)` mapped to `DELETE /api/dashboards/{uuid}/lock` (logged-in)
+  - Request body: `{"clientId": "..."}`
+  - Response 204: success (no body)
+  - Response 403: `clientId` mismatch (not owner or not admin)
+- [ ] 5.4 Add `DashboardController::getLock(string $uuid)` mapped to `GET /api/dashboards/{uuid}/lock` (logged-in)
+  - Response 200: lock object if active, or 404 if none/expired
+- [ ] 5.5 Add `DashboardController::forceAcquire(string $uuid)` mapped to `POST /api/dashboards/{uuid}/lock/force-acquire` (in-body admin check)
+  - Request body: `{"clientId": "..."}`
+  - Response 200: new lock object
+  - Response 403: caller is not admin
+  - Logs activity via `IManager`
+- [ ] 5.6 Register all five routes in `appinfo/routes.php` with proper requirements (`uuid` is a valid UUID format)
+- [ ] 5.7 Verify all methods carry correct Nextcloud auth (`#[NoAdminRequired]` for all; in-body `IGroupManager::isAdmin()` check for `forceAcquire`)
+
+## 6. Exception handling
+
+- [ ] 6.1 Define or reuse `OCP\AppFramework\OCS\OCSException` (409 conflict) for lock conflicts
+- [ ] 6.2 Return HTTP 404 for missing locks
+- [ ] 6.3 Return HTTP 403 for permission/ownership mismatches
+
+## 7. PHPUnit tests
+
+- [ ] 7.1 `DashboardLockMapperTest::testAcquireLock` — basic insert, unique constraint on `dashboardUuid`
+- [ ] 7.2 `DashboardLockMapperTest::testExpiredLockIgnored` — `findActive()` returns null for expired; `deleteExpired()` removes them
+- [ ] 7.3 `DashboardLockServiceTest::testAcquireConflict` — second user acquire returns 409 with existing lock object
+- [ ] 7.4 `DashboardLockServiceTest::testHeartbeatClientIdMismatch` — different `clientId` returns 403
+- [ ] 7.5 `DashboardLockServiceTest::testHeartbeatExtends` — `expiresAt` advances by 5 minutes
+- [ ] 7.6 `DashboardLockServiceTest::testReleaseByOwner` — matching `clientId` deletes lock
+- [ ] 7.7 `DashboardLockServiceTest::testAdminForceAcquire` — admin can override any lock; non-admin returns 403
+- [ ] 7.8 `DashboardLockControllerTest::testGetLockReturns404OnExpired` — expired locks are transparent to clients
+- [ ] 7.9 `DashboardLockControllerTest::testAcquireHeartbeatReleaseFlow` — end-to-end scenario
+
+## 8. Activity logging
+
+- [ ] 8.1 On `forceAcquire`, call `IManager::publish()` with type `dashboard_lock_override` (or similar), subject containing stolen user's name, object uuid
+- [ ] 8.2 Add i18n strings for activity log: `dashboard_lock_override` description in both `nl` and `en`
+
+## 9. Expiry and cleanup
+
+- [ ] 9.1 Expired locks are silently skipped on all read operations (mapper and service layer)
+- [ ] 9.2 A fresh `acquireLock()` call overrides an expired lock without treating it as a conflict
+- [ ] 9.3 Optional background cleanup via separate `orphaned-data-cleanup` spec — this spec does NOT require a background sweeper (correctness does not depend on cleanup)
+
+## 10. Quality gates
+
+- [ ] 10.1 `composer check:strict` (PHPCS, PHPMD, Psalm, PHPStan) passes — fix any pre-existing issues encountered
+- [ ] 10.2 Update generated OpenAPI spec / Postman collection with the five new endpoints
+- [ ] 10.3 i18n keys for all new error messages in both `nl` and `en`:
+  - `Lock held by another user`
+  - `Lock not found`
+  - `Insufficient permissions to release lock`
+  - `Only lock owner or admin can release`
+  - `clientId mismatch` (or similar)
+- [ ] 10.4 SPDX headers on every new PHP file (inside the docblock per the SPDX-in-docblock convention) — gate-spdx must pass
+- [ ] 10.5 Run all 10 `hydra-gates` locally before opening PR

--- a/openspec/changes/dashboard-metadata-fields/design.md
+++ b/openspec/changes/dashboard-metadata-fields/design.md
@@ -1,0 +1,88 @@
+# Design — Dashboard Metadata Fields
+
+## Context
+
+This capability is a MyDash-native invention — not present in the source app. Admins define typed
+metadata fields; users and widgets store values against them. The spec (`dashboard-metadata-fields`)
+pins the two-table model, CRUD endpoints, type enum, and filter-by-metadata query contract.
+
+The primary driver is news-widget filtering: a dashboard carries a `topic` select-field and the
+news widget scopes its feed to it. This design documents the type system, value encoding, orphan
+tolerance, and cascade semantics that the spec implies but leaves to the implementer.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Document the type enum and value encoding per type
+- Specify orphan-value handling (field deleted while values exist)
+- Clarify cascade-on-field-delete safety mechanism
+- Define filter-by-metadata query approach
+- Specify validation failure response shape
+
+**Non-Goals:**
+- Widget-side consumption of metadata (each widget spec owns that)
+- Admin UI layout decisions (frontend concern)
+- Per-user metadata field visibility rules (not in spec)
+
+## Decisions
+
+### D1: Type enum
+**Decision**: Six types — `text`, `number`, `date`, `select`, `multi-select`, `boolean`. Stored as VARCHAR(20).
+**Alternatives considered**:
+- `url`/`email` as first-class types — deferred; handle as text+regex validation for now
+- `richtext` — rejected; XSS surface not justified at MVP
+**Rationale**: Covers all widget-filtering use cases from spec triage.
+
+### D2: Value encoding strategy
+**Decision**: TEXT column in `oc_mydash_metadata_values.value`. Plain string for scalar types;
+JSON array string for `select`/`multi-select`. `boolean` stored as `"1"`/`"0"`.
+**Alternatives considered**:
+- Typed columns per type — rejected; painful migrations when adding types
+- JSON column for all — rejected; MariaDB JSONB support inconsistent across supported NC versions
+**Rationale**: TEXT is universally supported; `MetadataValueService` parses/validates on read/write.
+
+### D3: Validation failure response
+**Decision**: Type-mismatched value write returns HTTP 422 `{"error":"validation_failed","field":"value","type":"<expected>"}`.
+**Alternatives considered**: HTTP 400 — 422 is more semantically precise per RFC 9110.
+**Rationale**: Consistent with MyDash API error contract.
+
+### D4: Orphan-value tolerance
+**Decision**: Deleting a field does NOT auto-delete its values. `MetadataValueService` hides orphaned
+values via `JOIN` on existing field IDs. `GET /api/admin/metadata-fields/orphans` surfaces them.
+**Alternatives considered**:
+- Hard cascade — rejected; silent irreversible data loss
+- Soft-delete field — adds complexity without MVP benefit
+**Rationale**: Preserving orphan rows is safer; admin cleanup endpoint provides governance.
+
+### D5: Cascade-on-field-delete safety gate
+**Decision**: `DELETE /api/admin/metadata-fields/{id}` without query param returns HTTP 409 if
+values exist. `?cascade=true` deletes values and the field definition in a transaction.
+**Alternatives considered**:
+- Always cascade — rejected; matches the philosophy in `dashboard-tree` D5 for consistency
+**Rationale**: Explicit opt-in for destructive operations. Two-step pattern used consistently
+across MyDash delete flows.
+
+### D6: Filter-by-metadata query approach
+**Decision**: Dashboard list endpoint accepts `?meta[fieldSlug]=value` params; translated to
+`INNER JOIN oc_mydash_metadata_values` with `WHERE field_id = ? AND value = ?` per param.
+**Alternatives considered**:
+- Full-text search across value column — rejected; too broad, breaks type semantics
+- POST body filter — rejected; GET semantics for list queries, bookmarkable URLs
+**Rationale**: SQL join approach is simple, indexed on `(dashboard_uuid, field_id)`, and keeps
+query logic server-side rather than loading all metadata to filter in PHP.
+
+### D7: Field-slug uniqueness scope
+**Decision**: Field slugs are globally unique (admin-defined, reused across dashboards).
+**Alternatives considered**: Per-dashboard scope — rejected; widget configs reference fields by slug (`meta.topic`), so global uniqueness makes configs portable.
+**Rationale**: Simpler widget configuration; fields are admin-governed, not per-dashboard inventions.
+
+## Risks / Trade-offs
+
+- **Multi-select filter** → `?meta[tags]=news` matches exact JSON string, not containment; document this; array containment is v2
+- **Filter fan-out** → each `?meta[]` param adds a JOIN; cap at 5 simultaneous filters to avoid runaway queries
+
+## Open follow-ups
+
+- Add `contains` operator for multi-select filter (JSON_CONTAINS or PHP post-filter)
+- Consider `fieldRequired` flag for form-validation use cases
+- Evaluate `fieldOrder` integer for admin UI ordering

--- a/openspec/changes/dashboard-metadata-fields/proposal.md
+++ b/openspec/changes/dashboard-metadata-fields/proposal.md
@@ -1,0 +1,60 @@
+# Dashboard Metadata Fields
+
+## Why
+
+Today MyDash dashboards have no way for administrators to attach custom, queryable metadata to every dashboard. Users often need to tag dashboards with attributes like "department", "project stage", "audience segment", or custom organizational dimensions so that dashboards can be filtered, grouped, or faceted in search and discovery. Without this capability, administrators must either mandate a naming convention (fragile and unscalable) or build ad-hoc workarounds. This change introduces a global metadata field registry that administrators can configure once, with per-dashboard field values that end users populate and that the system can query for filtering.
+
+## What Changes
+
+- Add a new `oc_mydash_metadata_fields` table to persist global field definitions: each field has a machine-name `key` (unique, lowercase, slugified), a display `label`, a `type` (text, number, date, select, multi-select, boolean), optional `options` for select types, a `required` flag, sort order, and timestamps.
+- Add a new `oc_mydash_metadata_values` table to persist field values per dashboard: each row links a dashboard UUID to a field ID and stores the value (type-encoded: JSON for arrays, ISO-8601 for dates, decimal string for numbers, "0"/"1" for booleans).
+- Add admin CRUD endpoints for field definitions: `GET|POST /api/admin/metadata-fields`, `GET|PUT|DELETE /api/admin/metadata-fields/{id}` — admin-only via `IGroupManager::isAdmin`.
+- Add value read/write endpoints per dashboard: `GET /api/dashboards/{uuid}/metadata` (returns a flat key-value object); `PUT /api/dashboards/{uuid}/metadata` (upserts every key in the request body, ignoring omitted keys).
+- Add type validation at write time: reject non-numeric input for number fields, non-existent options for select fields, null/empty for required fields (HTTP 400).
+- Forbid renaming field `key` (unique stable identifier — admins must create a new field and migrate manually). Allow edits to `label`, `sortOrder`, `required`, and `options`.
+- Add cascading delete for field definitions with explicit `?cascade=true` confirmation.
+- Add `GET /api/dashboards?metadata.<key>=<value>` filtering with support for exact match (text/select/boolean) and range queries (number/date via `min` / `max` suffix).
+- Handle stale field references gracefully: if a value row references a deleted field, hide it from read responses and surface orphans in admin tooling without crashing.
+
+## Capabilities
+
+### New Capabilities
+
+- `dashboard-metadata-fields` — a new, self-contained capability for defining, populating, querying, and validating custom metadata on dashboards.
+
+### Modified Capabilities
+
+(none — this is a new, standalone capability with no changes to existing capabilities)
+
+## Impact
+
+**Affected code:**
+
+- `lib/Db/MetadataField.php` (new entity) — field definition model with id, key, label, type, options, required, sortOrder, createdAt, updatedAt
+- `lib/Db/MetadataFieldMapper.php` (new mapper) — CRUD for field definitions; find by key; find all; ensure key uniqueness
+- `lib/Db/MetadataValue.php` (new entity) — value record model with id, dashboardUuid, fieldId, value
+- `lib/Db/MetadataValueMapper.php` (new mapper) — CRUD for values; find by dashboard; upsert; delete by field with cascade
+- `lib/Service/MetadataService.php` (new service) — coordinate field + value operations; validate field type matching; handle orphan detection; route filtering queries
+- `lib/Controller/MetadataAdminController.php` (new controller) — admin field definition endpoints (`GET|POST /api/admin/metadata-fields`, `GET|PUT|DELETE /api/admin/metadata-fields/{id}`)
+- `lib/Controller/DashboardController.php` (modified) — add `GET|PUT /api/dashboards/{uuid}/metadata` endpoints; update list/get endpoints to support `metadata.<key>=...` query filters
+- `appinfo/routes.php` — register 6 new routes (admin field CRUD + dashboard metadata read/write)
+- `lib/Migration/VersionXXXXDate2026...php` (new migration) — create `oc_mydash_metadata_fields` and `oc_mydash_metadata_values` tables with proper indexes
+- `src/stores/dashboards.js` (modified) — track metadata per dashboard; expose getter for field definitions
+- `src/views/DashboardMetadataForm.vue` (new component) — admin form to create/edit field definitions
+- `src/views/DashboardMetadataPanel.vue` (new component) — per-dashboard form to populate metadata values (if UI is shipped in this change; can defer to follow-up)
+
+**Affected APIs:**
+
+- 6 new admin routes: 2 for field listing/creation, 4 for field detail/edit/delete
+- 2 new dashboard routes: 1 for metadata read, 1 for metadata write
+- 1 modified dashboard list/get routes to support `metadata.*` filter syntax
+
+**Dependencies:**
+
+- `OCP\IGroupManager` — already injected elsewhere, used to check admin status
+- No new composer or npm dependencies (all validation is built-in)
+
+**Migration:**
+
+- Zero-impact: new tables only, no existing data affected
+- The migration creates two new tables with proper composite indexes for fast lookups by dashboard and field

--- a/openspec/changes/dashboard-metadata-fields/specs/dashboard-metadata-fields/spec.md
+++ b/openspec/changes/dashboard-metadata-fields/specs/dashboard-metadata-fields/spec.md
@@ -1,0 +1,294 @@
+---
+status: draft
+---
+
+# Dashboard Metadata Fields Specification
+
+## Purpose
+
+Dashboard Metadata Fields allow administrators to define custom, queryable attributes that can be attached to every dashboard in a MyDash instance. Once an administrator defines a global registry of field definitions (e.g., "department", "project stage", "audience"), end users populate values for those fields on their dashboards. The field values are then queryable for filtering dashboards in search, widget configuration, and API calls. This capability standardizes what would otherwise be ad-hoc naming conventions and enables the discovery and organization of dashboards at scale.
+
+## Data Model
+
+### Metadata Field Definition (oc_mydash_metadata_fields)
+
+Stores the global registry of field definitions:
+
+- **id**: Auto-increment integer primary key
+- **key**: Unique VARCHAR(64) machine name (lowercase, alphanumeric + underscore only, URL-safe)
+- **label**: VARCHAR(255) human-readable field name (shown in UI)
+- **type**: ENUM('text', 'number', 'date', 'select', 'multi-select', 'boolean')
+  - `text`: arbitrary string (no length constraint in type definition; validation at write time if needed)
+  - `number`: decimal number (stored as string, validated as numeric at write)
+  - `date`: ISO-8601 date string (YYYY-MM-DD)
+  - `select`: single-choice from a defined set of options
+  - `multi-select`: multiple choices from a defined set of options (stored as JSON array)
+  - `boolean`: true/false (stored as "0" or "1" string)
+- **options**: JSON NULL-or-array field. Only populated for `select` and `multi-select` types. For other types, MUST be NULL. Format: `["option1", "option2", ...]` (array of strings)
+- **required**: SMALLINT(0 or 1) — whether the field MUST have a value on every dashboard (0 = optional, 1 = required)
+- **sortOrder**: INT — used to order fields in admin UI and API list responses
+- **createdAt**: DATETIME
+- **updatedAt**: DATETIME
+
+### Metadata Value (oc_mydash_metadata_values)
+
+Stores field values per dashboard. Each row is a (dashboardUuid, fieldId) pair with a type-encoded value:
+
+- **id**: Auto-increment integer primary key
+- **dashboardUuid**: VARCHAR(36) foreign key to `oc_mydash_dashboards.uuid`
+- **fieldId**: INT foreign key to `oc_mydash_metadata_fields.id` (if field is deleted, the value row becomes orphaned)
+- **value**: TEXT (type-encoded):
+  - text: plain string
+  - number: decimal string (e.g., "42.5")
+  - date: ISO-8601 string (e.g., "2026-05-01")
+  - select: single option string (e.g., "marketing")
+  - multi-select: JSON array of strings (e.g., `["feature1", "feature2"]`)
+  - boolean: "0" or "1" string
+- **Composite unique constraint**: (dashboardUuid, fieldId) — only one value per field per dashboard
+
+### Orphaned Values
+
+If a field definition is deleted without cascade, the corresponding value rows remain in the database with a stale `fieldId` that no longer has a matching field definition. The system MUST:
+- Never crash when reading orphaned values
+- Hide orphaned values from `GET /api/dashboards/{uuid}/metadata` responses
+- Offer admin tooling to detect and clean up orphans
+- Optionally support cascading delete to avoid orphans entirely
+
+## ADDED Requirements
+
+### Requirement: REQ-MDFL-001 Field Definition CRUD
+
+Administrators MUST be able to create, read, update, and delete field definitions via a dedicated admin API endpoint. Field definitions form the global schema against which all dashboard values are validated.
+
+#### Scenario: Create a text field definition
+
+- GIVEN a logged-in administrator
+- WHEN they send `POST /api/admin/metadata-fields` with body `{"key": "department", "label": "Department", "type": "text", "required": 1}`
+- THEN the system MUST create a MetadataField record with:
+  - `key` set to "department" (lowercase, unique)
+  - `label` set to "Department"
+  - `type` set to "text"
+  - `required` set to 1
+  - `options` set to NULL (text type does not use options)
+  - `sortOrder` defaulting to 0
+  - timestamps set to current time
+- AND return HTTP 201 with the created field object
+
+#### Scenario: Validate key format
+
+- GIVEN an administrator
+- WHEN they send `POST /api/admin/metadata-fields` with body `{"key": "Invalid Key", "label": "L", "type": "text"}`
+- THEN the system MUST return HTTP 400 with error `"Field key must be lowercase alphanumeric with underscores only"`
+- AND no record MUST be created
+
+#### Scenario: Create a select field with options
+
+- GIVEN an administrator
+- WHEN they send `POST /api/admin/metadata-fields` with body `{"key": "status", "label": "Status", "type": "select", "options": ["open", "closed", "pending"]}`
+- THEN the system MUST create a field with:
+  - `type` set to "select"
+  - `options` set to `["open", "closed", "pending"]`
+- AND return HTTP 201
+
+#### Scenario: Select field without options is rejected
+
+- GIVEN an administrator
+- WHEN they send `POST /api/admin/metadata-fields` with body `{"key": "status", "label": "Status", "type": "select"}`
+- THEN the system MUST return HTTP 400 with error `"Select type requires non-empty options array"`
+- AND no record MUST be created
+
+#### Scenario: Non-admin cannot create field definitions
+
+- GIVEN a logged-in non-admin user "alice"
+- WHEN she sends `POST /api/admin/metadata-fields` with any body
+- THEN the system MUST return HTTP 403
+
+#### Scenario: List all field definitions
+
+- GIVEN 3 field definitions exist with sortOrder values 10, 0, 5
+- WHEN an admin sends `GET /api/admin/metadata-fields`
+- THEN the system MUST return HTTP 200 with an array of all 3 fields
+- AND fields MUST be sorted by `sortOrder` ascending (0, 5, 10)
+
+### Requirement: REQ-MDFL-002 Field Definition Updates
+
+Administrators MUST be able to update a field definition's metadata (label, sort order, required flag, options), but renaming the field's `key` MUST be forbidden — the key is the stable identifier and renaming it breaks existing values.
+
+#### Scenario: Update field label and sortOrder
+
+- GIVEN a field with id=5, key="department", label="Dept", sortOrder=0
+- WHEN an admin sends `PUT /api/admin/metadata-fields/5` with body `{"label": "Department (Required)", "sortOrder": 100}`
+- THEN the system MUST update the label and sortOrder
+- AND set `updatedAt` to current time
+- AND return HTTP 200 with the updated field
+
+#### Scenario: Forbid key rename
+
+- GIVEN a field with id=5, key="department"
+- WHEN an admin sends `PUT /api/admin/metadata-fields/5` with body `{"key": "division"}`
+- THEN the system MUST return HTTP 400 with error `"Field key cannot be renamed"`
+- AND the key MUST remain "department"
+
+### Requirement: REQ-MDFL-003 Field Definition Deletion
+
+Administrators MUST be able to delete field definitions. Deletion has two modes: soft (reject if orphans would be created) or cascade (delete all values).
+
+#### Scenario: Delete field with no values
+
+- GIVEN a field id=5 with no corresponding value rows
+- WHEN an admin sends `DELETE /api/admin/metadata-fields/5`
+- THEN the system MUST delete the field
+- AND return HTTP 200
+
+#### Scenario: Delete field with cascade
+
+- GIVEN a field id=5 with 3 corresponding value rows
+- WHEN an admin sends `DELETE /api/admin/metadata-fields/5?cascade=true`
+- THEN the system MUST delete the field definition
+- AND cascade-delete all 3 value rows
+- AND return HTTP 200
+
+### Requirement: REQ-MDFL-004 Dashboard Metadata Read
+
+Users MUST be able to read all metadata values for a given dashboard as a flat key-value object.
+
+#### Scenario: Get metadata for a dashboard
+
+- GIVEN user "alice" has a dashboard with uuid="abc-123" and three populated field values: department="marketing", priority=8, status="approved"
+- WHEN she sends `GET /api/dashboards/abc-123/metadata`
+- THEN the system MUST return HTTP 200 with body:
+  ```json
+  {
+    "department": "marketing",
+    "priority": "8",
+    "status": "approved"
+  }
+  ```
+
+#### Scenario: Empty metadata for a new dashboard
+
+- GIVEN a dashboard with uuid="xyz-789" has no metadata values set
+- WHEN a user sends `GET /api/dashboards/xyz-789/metadata`
+- THEN the system MUST return HTTP 200 with an empty object `{}`
+
+#### Scenario: Orphaned field values are hidden
+
+- GIVEN a dashboard with a value row where fieldId=999 (field no longer exists)
+- WHEN a user sends `GET /api/dashboards/xyz-789/metadata`
+- THEN the system MUST NOT include that orphaned value in the response
+- AND MUST NOT crash
+
+### Requirement: REQ-MDFL-005 Dashboard Metadata Write
+
+Users MUST be able to set or update metadata values for a dashboard via a flat key-value object. Omitted keys are NOT deleted; only keys in the request body are upserted.
+
+#### Scenario: Set metadata on a dashboard
+
+- GIVEN a dashboard with uuid="abc-123" and no prior metadata
+- WHEN user sends `PUT /api/dashboards/abc-123/metadata` with body `{"department": "marketing", "priority": "5"}`
+- THEN the system MUST create value rows for both fields
+- AND return HTTP 200 with the updated metadata object
+
+#### Scenario: Partial update (upsert specific keys)
+
+- GIVEN a dashboard already has metadata: `{"department": "marketing", "priority": "5", "status": "open"}`
+- WHEN user sends `PUT /api/dashboards/abc-123/metadata` with body `{"department": "sales", "status": "approved"}`
+- THEN the system MUST update "department" and "status"
+- AND leave "priority" unchanged at "5"
+- AND return the complete updated metadata object
+
+#### Scenario: Setting a required field to null
+
+- GIVEN the "department" field is marked required
+- WHEN user sends `PUT /api/dashboards/abc-123/metadata` with body `{"department": null}`
+- THEN the system MUST return HTTP 400 with error `"Field 'Department' is required"`
+
+### Requirement: REQ-MDFL-006 Type Validation at Write
+
+The system MUST validate each value against its field's type definition before persisting. Invalid values are rejected with a 400 error.
+
+#### Scenario: Number field validation
+
+- GIVEN a number field "priority"
+- WHEN user sends `PUT /api/dashboards/{uuid}/metadata` with body `{"priority": "not-a-number"}`
+- THEN the system MUST return HTTP 400 with error `"Field 'Priority' must be a valid number"`
+
+#### Scenario: Number field accepts decimal
+
+- GIVEN a number field "score"
+- WHEN user sends `PUT /api/dashboards/{uuid}/metadata` with body `{"score": "42.75"}`
+- THEN the system MUST accept and store it
+
+#### Scenario: Date field validation
+
+- GIVEN a date field "go-live"
+- WHEN user sends `PUT /api/dashboards/{uuid}/metadata` with body `{"go-live": "invalid-date"}`
+- THEN the system MUST return HTTP 400 with error `"Field 'Go Live' must be a valid date (YYYY-MM-DD)"`
+
+#### Scenario: Select field validation
+
+- GIVEN a select field "status" with options `["open", "closed", "pending"]`
+- WHEN user sends `PUT /api/dashboards/{uuid}/metadata` with body `{"status": "rejected"}`
+- THEN the system MUST return HTTP 400 with error `"Field 'Status' value 'rejected' not in allowed options"`
+
+### Requirement: REQ-MDFL-007 Dashboard Filtering by Metadata
+
+The system MUST expose a query filter mechanism on the dashboard list endpoint to filter dashboards by metadata values using `?metadata.<key>=<value>` syntax.
+
+#### Scenario: Filter dashboards by text field (exact match)
+
+- GIVEN three dashboards with department values "marketing", "sales", "engineering"
+- WHEN a user sends `GET /api/dashboards?metadata.department=marketing`
+- THEN the system MUST return only the dashboard with department="marketing"
+
+#### Scenario: Filter dashboards by numeric range
+
+- GIVEN five dashboards with priority values 1, 3, 5, 7, 9
+- WHEN a user sends `GET /api/dashboards?metadata.priority.min=5&metadata.priority.max=7`
+- THEN the system MUST return dashboards with priority 5 and 7 (inclusive range)
+
+#### Scenario: Multiple metadata filters (AND logic)
+
+- GIVEN dashboards with varying department and priority values
+- WHEN a user sends `GET /api/dashboards?metadata.department=marketing&metadata.priority.min=5`
+- THEN the system MUST return only dashboards matching BOTH conditions
+
+#### Scenario: Filter by select field
+
+- GIVEN dashboards with status values "open", "closed", "pending"
+- WHEN a user sends `GET /api/dashboards?metadata.status=open`
+- THEN the system MUST return only dashboards with status="open"
+
+### Requirement: REQ-MDFL-008 Permission and Ownership
+
+Reading and writing metadata MUST be scoped to the dashboard's owner (for personal dashboards) or to users with access to the dashboard.
+
+#### Scenario: User can read their own dashboard's metadata
+
+- GIVEN user "alice" owns dashboard "abc-123"
+- WHEN she sends `GET /api/dashboards/abc-123/metadata`
+- THEN the system MUST return HTTP 200 with the metadata
+
+#### Scenario: User cannot read another user's dashboard metadata
+
+- GIVEN user "bob" owns dashboard "xyz-789", and user "alice" does not have access
+- WHEN alice sends `GET /api/dashboards/xyz-789/metadata`
+- THEN the system MUST return HTTP 403 or 404
+
+#### Scenario: User can write metadata for their own dashboard
+
+- GIVEN user "alice" owns dashboard "abc-123"
+- WHEN she sends `PUT /api/dashboards/abc-123/metadata` with body `{"department": "marketing"}`
+- THEN the system MUST update the metadata and return HTTP 200
+
+## Non-Functional Requirements
+
+- **Performance**: `GET /api/admin/metadata-fields` MUST return within 200ms for up to 1000 fields. `GET /api/dashboards?metadata.*=*` MUST return within 1000ms for 10,000 dashboards with filtering applied (indexed queries).
+- **Data integrity**: Field key uniqueness MUST be enforced at the database layer via unique constraint.
+- **Localization**: All error messages, field labels, and option values MUST support English and Dutch via the i18n system.
+- **Graceful degradation**: If metadata reading fails for orphaned values, the system MUST log and continue (never crash the dashboard load).
+- **Backward compatibility**: Dashboards without any metadata MUST continue to work (empty metadata object), and the metadata endpoints are opt-in (clients not using them are unaffected).
+
+## Implementation Status
+
+**Not yet implemented** — this is a new capability being introduced with this change.

--- a/openspec/changes/dashboard-metadata-fields/tasks.md
+++ b/openspec/changes/dashboard-metadata-fields/tasks.md
@@ -1,0 +1,142 @@
+# Tasks — dashboard-metadata-fields
+
+## 1. Schema migration
+
+- [ ] 1.1 Create `lib/Migration/VersionXXXXDate2026...AddMetadataFieldsTable.php` creating `oc_mydash_metadata_fields` table with columns: `id INT PRIMARY KEY`, `key VARCHAR(64) UNIQUE NOT NULL`, `label VARCHAR(255) NOT NULL`, `type ENUM('text','number','date','select','multi-select','boolean') NOT NULL`, `options JSON NULL`, `required SMALLINT(0/1) DEFAULT 0`, `sortOrder INT DEFAULT 0`, `createdAt DATETIME`, `updatedAt DATETIME`
+- [ ] 1.2 Same migration creates `oc_mydash_metadata_values` table with columns: `id INT PRIMARY KEY`, `dashboardUuid VARCHAR(36) NOT NULL`, `fieldId INT NOT NULL`, `value TEXT NOT NULL`, composite unique constraint on `(dashboardUuid, fieldId)`, foreign key `fieldId` → `oc_mydash_metadata_fields(id)`
+- [ ] 1.3 Add composite indexes: `idx_metadata_fields_key` on `key`, `idx_metadata_values_dashboard` on `dashboardUuid`, `idx_metadata_values_field` on `fieldId`
+- [ ] 1.4 Confirm migration is reversible; verify schema applied cleanly on sqlite, mysql, and postgres locally
+
+## 2. Domain model — Field definitions
+
+- [ ] 2.1 Create `lib/Db/MetadataField.php` entity with getters/setters for: id, key, label, type, options (JSON-decoded to array on read), required, sortOrder, createdAt, updatedAt
+- [ ] 2.2 Add constants for field types: `const TYPE_TEXT = 'text'`, `TYPE_NUMBER = 'number'`, `TYPE_DATE = 'date'`, `TYPE_SELECT = 'select'`, `TYPE_MULTI_SELECT = 'multi-select'`, `TYPE_BOOLEAN = 'boolean'`
+- [ ] 2.3 Add `jsonSerialize()` method to return all fields with options JSON-encoded if present
+- [ ] 2.4 Add validation helper method `isSelectType(): bool` (returns true if type is `select` or `multi-select`)
+
+## 3. Domain model — Field values
+
+- [ ] 3.1 Create `lib/Db/MetadataValue.php` entity with getters/setters for: id, dashboardUuid, fieldId, value
+- [ ] 3.2 Add `jsonSerialize()` method returning all fields
+
+## 4. Mapper layer — Fields
+
+- [ ] 4.1 Create `lib/Db/MetadataFieldMapper.php` with methods: `create(MetadataField): int`, `findAll(): array`, `find(int $id): ?MetadataField`, `findByKey(string $key): ?MetadataField`, `update(MetadataField): bool`, `delete(int $id): bool`
+- [ ] 4.2 Enforce `key` uniqueness: `findByKey()` checks for existing key before insert/update; throw `DuplicateKeyException` on collision
+- [ ] 4.3 Add `deleteWithCascade(int $id): bool` that deletes the field definition AND all corresponding value rows in `oc_mydash_metadata_values`
+- [ ] 4.4 Add fixture-based test: create field, read it back, update label + sortOrder, verify key cannot be changed, delete with cascade confirms all values gone
+
+## 5. Mapper layer — Values
+
+- [ ] 5.1 Create `lib/Db/MetadataValueMapper.php` with methods: `create(MetadataValue): int`, `findByDashboard(string $dashboardUuid): array`, `findByDashboardAndField(string $dashboardUuid, int $fieldId): ?MetadataValue`, `upsert(MetadataValue): int` (insert if new, update if exists), `deleteByDashboard(string $dashboardUuid): int`, `deleteByField(int $fieldId): int`
+- [ ] 5.2 Add test fixture: create dashboard with 3 field values, upsert a value (verify update path), delete by dashboard (verify cascade), verify orphan-safe read
+
+## 6. Service layer — Metadata service
+
+- [ ] 6.1 Create `lib/Service/MetadataService.php` with dependency injection: `MetadataFieldMapper`, `MetadataValueMapper`, `IGroupManager`
+- [ ] 6.2 Implement admin-only guard `ensureAdminAccess(string $userId)` that throws `\OCP\AppFramework\OCS\OCSForbiddenException` if not admin
+- [ ] 6.3 Implement `createFieldDefinition(string $key, string $label, string $type, ?array $options, bool $required, ?int $sortOrder): MetadataField` with validation:
+  - `key` must be lowercase, max 64 chars, alphanumeric + underscore only (slugified via a helper)
+  - `label` must be 1-255 chars
+  - `type` must be one of the enum values
+  - if type is `select` or `multi-select`, `options` must be a non-empty array of strings; if not select type, options MUST be null
+  - throw 400 errors (via `BadRequestException`) for validation failures
+- [ ] 6.4 Implement `updateFieldDefinition(int $id, array $patch): MetadataField` that allows updating `label`, `sortOrder`, `required`, and `options`, but FORBIDS changing `key` (throw 400 if attempted)
+- [ ] 6.5 Implement `deleteFieldDefinition(int $id, bool $cascade = false): bool` that:
+  - if `cascade` is false and orphan values exist, throw 409 Conflict with hint to use `?cascade=true`
+  - if `cascade` is true or no orphans, delete field and cascade-delete all values
+- [ ] 6.6 Implement `getMetadataForDashboard(string $dashboardUuid): array` that:
+  - issues 1 JOIN query: `SELECT v.value, f.key FROM oc_mydash_metadata_values v JOIN oc_mydash_metadata_fields f ON v.fieldId = f.id WHERE v.dashboardUuid = ?`
+  - returns flat key-value object `{key: value, ...}`
+  - gracefully handles stale fieldId references (orphans): skip those rows and log a warning
+  - never crash on orphaned values
+- [ ] 6.7 Implement `setMetadataForDashboard(string $dashboardUuid, array $keyValues): void` that:
+  - for each key in the input, resolve fieldId via mapper
+  - throw 400 if key does not exist
+  - validate value against field type and constraints
+  - upsert each value row
+  - throw 400 on validation failure (e.g., "field 'department' is required", "field 'status' value 'unknown' not in options")
+- [ ] 6.8 Implement `filterDashboards(array $dashboards, ?array $metadataFilters): array` that:
+  - accepts filters in shape: `{"metadata.department": "marketing", "metadata.priority": {"min": 5, "max": 10}, "metadata.date": {"after": "2026-01-01"}}`
+  - for each filter, load field definition to determine type
+  - evaluate every dashboard against the filter set (all must match for dashboard to be included)
+  - text/select/boolean: exact match
+  - number/date: range query if `min`/`max` or `after`/`before` keys present
+  - return filtered array
+
+## 7. Validation service helper
+
+- [ ] 7.1 Create `lib/Service/MetadataValidationService.php` with method `validateValue(string $value, MetadataField $field): void` that:
+  - for text: no validation beyond length (can be empty if not required)
+  - for number: ensure value is numeric (decimal allowed), throw 400 if not
+  - for date: ensure value is ISO-8601 string (YYYY-MM-DD), throw 400 if not
+  - for select: value must be in `field->options`, throw 400 if not
+  - for multi-select: value must be JSON array of strings from `field->options`, throw 400 if any element not in options
+  - for boolean: value must be exactly "0" or "1" string, throw 400 otherwise
+  - if field is required and value is null/empty string/empty array, throw 400
+- [ ] 7.2 Add test: validate number field rejects "abc", accepts "42.5", rejects empty if required
+
+## 8. Controller — Admin field endpoints
+
+- [ ] 8.1 Create `lib/Controller/MetadataAdminController.php` with `#[NoAdminRequired]` + runtime admin check in every method
+- [ ] 8.2 Implement `listFields()` mapped to `GET /api/admin/metadata-fields` — returns `["fields": [Field[], "count": int]` with fields sorted by sortOrder
+- [ ] 8.3 Implement `createField(string $key, string $label, string $type, ?array $options, int $required = 0, int $sortOrder = 0)` mapped to `POST /api/admin/metadata-fields` — returns 201 + Field
+- [ ] 8.4 Implement `getField(int $id)` mapped to `GET /api/admin/metadata-fields/{id}` — returns Field or 404
+- [ ] 8.5 Implement `updateField(int $id, ?string $label, ?int $sortOrder, ?int $required, ?array $options)` mapped to `PUT /api/admin/metadata-fields/{id}` — returns 200 + updated Field, or 400 if key change attempted
+- [ ] 8.6 Implement `deleteField(int $id, bool $cascade = false)` mapped to `DELETE /api/admin/metadata-fields/{id}?cascade=true|false` — returns 200 on success, 409 if orphans and no cascade, 403 if not admin
+
+## 9. Controller — Dashboard metadata endpoints
+
+- [ ] 9.1 Modify `lib/Controller/DashboardController.php` to add `getMetadata(string $uuid)` mapped to `GET /api/dashboards/{uuid}/metadata` (logged-in user, read-only) — returns flat key-value object
+- [ ] 9.2 Add `setMetadata(string $uuid)` mapped to `PUT /api/dashboards/{uuid}/metadata` (logged-in user) — accepts flat key-value object, upserts all keys, returns 200 + updated metadata
+- [ ] 9.3 Modify `listDashboards()` and `getDashboard(uuid)` methods to accept optional query filter `?metadata.<key>=<value>` and pass to `MetadataService::filterDashboards()`
+- [ ] 9.4 Add test: list dashboards filter by `?metadata.department=marketing`, verify only matching dashboards returned
+
+## 10. Routes registration
+
+- [ ] 10.1 Register 6 routes in `appinfo/routes.php`:
+  - `GET /api/admin/metadata-fields` → MetadataAdminController::listFields
+  - `POST /api/admin/metadata-fields` → MetadataAdminController::createField
+  - `GET /api/admin/metadata-fields/{id}` → MetadataAdminController::getField
+  - `PUT /api/admin/metadata-fields/{id}` → MetadataAdminController::updateField
+  - `DELETE /api/admin/metadata-fields/{id}` → MetadataAdminController::deleteField
+  - `GET /api/dashboards/{uuid}/metadata` → DashboardController::getMetadata
+  - `PUT /api/dashboards/{uuid}/metadata` → DashboardController::setMetadata
+- [ ] 10.2 Confirm all routes follow Nextcloud routing conventions and auth guards
+
+## 11. Frontend store
+
+- [ ] 11.1 Extend `src/stores/dashboards.js` to add getter `metadataFields` that returns all field definitions (loaded from admin endpoint)
+- [ ] 11.2 Add `metadataByDashboard` computed property that returns `{dashboardUuid: {key: value, ...}, ...}`
+- [ ] 11.3 Add action `fetchMetadataFields()` that calls `GET /api/admin/metadata-fields` and caches result
+- [ ] 11.4 Add action `updateDashboardMetadata(dashboardUuid, keyValues)` that calls `PUT /api/dashboards/{uuid}/metadata` and updates store
+
+## 12. PHPUnit tests
+
+- [ ] 12.1 `MetadataFieldMapperTest` — create/read/update/delete cycle, key uniqueness, cascade delete
+- [ ] 12.2 `MetadataValueMapperTest` — upsert cycle, find by dashboard, orphan rows safe
+- [ ] 12.3 `MetadataServiceTest::createFieldDefinition` — valid types, invalid key/label/options, select type requires options
+- [ ] 12.4 `MetadataServiceTest::updateFieldDefinition` — allow label/sortOrder/required/options, forbid key change
+- [ ] 12.5 `MetadataServiceTest::validateValue` — number/date/select/multi-select/boolean validation, required fields
+- [ ] 12.6 `MetadataServiceTest::setMetadataForDashboard` — rejects non-existent field key, validates types, upserts values
+- [ ] 12.7 `MetadataServiceTest::getMetadataForDashboard` — returns key-value object, handles orphan stale fieldIds gracefully
+- [ ] 12.8 `MetadataServiceTest::filterDashboards` — text exact match, number range, date range, multi-filter AND logic
+- [ ] 12.9 `MetadataAdminControllerTest` — 403 for non-admin on all endpoints, CRUD success cases
+- [ ] 12.10 `DashboardControllerTest` — get/put metadata, filter by metadata on list endpoint
+
+## 13. End-to-end Playwright tests
+
+- [ ] 13.1 Admin creates text field "department" (required), numeric field "priority" (1-10), select field "status" (options: open, in-review, approved)
+- [ ] 13.2 User populates dashboard with all three field values
+- [ ] 13.3 Admin updates "status" options (removes "in-review"); verify user's dashboard still shows old value (graceful stale-field tolerance)
+- [ ] 13.4 Filter dashboards by `?metadata.department=marketing` via API; verify correct subset returned
+- [ ] 13.5 User updates dashboard metadata via PUT; verify new values persisted and visible on next GET
+
+## 14. Quality gates
+
+- [ ] 14.1 `composer check:strict` (PHPCS, PHPMD, Psalm, PHPStan) passes — fix any pre-existing issues encountered
+- [ ] 14.2 ESLint + Stylelint clean on all touched Vue/JS files
+- [ ] 14.3 Update generated OpenAPI spec / Postman collection to document all new endpoints and field definition schema
+- [ ] 14.4 `i18n` keys for all validation error messages (`Field '<key>' is required`, `Value '<value>' not in options for field '<label>'`, etc.) in both `nl` and `en`
+- [ ] 14.5 SPDX headers on every new PHP file (inside docblock per convention) — gate-spdx must pass
+- [ ] 14.6 Run all 10 `hydra-gates` locally before opening PR

--- a/openspec/changes/dashboard-public-share/design.md
+++ b/openspec/changes/dashboard-public-share/design.md
@@ -1,0 +1,83 @@
+# Design — Public-share render
+
+## Context
+
+The `dashboard-public-share` spec introduces anonymous read-only rendering of dashboards via URL-safe tokens with optional password protection, expiry, and view tracking. No Nextcloud account is required; a share token in the URL is sufficient to render the dashboard.
+
+Before writing the spec, we analysed the corresponding feature in a commercially available reference application to understand battle-tested throttle patterns. That analysis surfaced a concrete behavioural discrepancy: the spec assumed **per-share-per-IP** throttling (i.e., failed unlock attempts are tracked per `(token, IP)` pair), whereas the reference implementation tracks failed attempts **per-IP globally across all share actions**, using a single fixed action name with no token component.
+
+The discrepancy matters because the two models have different properties under attack. IP-global throttling stops broad scanning (one attacker, many targets) earlier, but also risks blocking a whole office or school behind a shared NAT if any one person hits the limit. Per-share throttling is more granular — the limit for share A doesn't bleed into share B — but is easier to bypass by creating many shares and spreading attempts across them.
+
+This design document records the decisions made, their rationale, and the resulting changes required in the spec.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Decide the throttle scope (IP-global vs per-share-per-IP) and document it with rationale.
+- Nail down the two distinct action buckets and their concrete limits.
+- Fix the HTTP response code for throttle trips (spec said 503; NC convention says 429).
+- Specify the service-account read path for GroupFolder-backed dashboard content.
+- Confirm the view-count debounce key and mechanism.
+
+**Non-Goals:**
+- Designing the share-creation rate limit (admin-only endpoint; separate concern).
+- Defining the full data model or migration — those live in `proposal.md`.
+- Specifying the UI for share management — deferred to a follow-up.
+
+## Decisions
+
+### D1: Throttle scope — IP-global vs per-share-per-IP
+
+**Decision**: IP-global across all share actions, split into two action buckets:
+- `mydash_share_access` — page-render failures, limit 60 req/60 s per IP
+- `mydash_share_password` — wrong-password submissions, limit 10 req/60 s per IP
+
+Both buckets apply regardless of which share token is targeted. This matches the reference implementation.
+
+**Alternatives considered:**
+- **Per-share-per-IP** (the spec's original assumption): the throttle key would include the share token, e.g., `mydash_share_password:{token}`. Rejected for v1 because it requires a custom throttle key instead of NC's stock `IThrottler` action names, adds code complexity, and the "many-shares bypass" attack it prevents is already substantially mitigated by the share-creation endpoint being owner-or-admin only (an anonymous attacker cannot create new shares).
+
+**Rationale**: NC's `IThrottler` + `BruteForceProtection` are designed around fixed action strings and give administrators a well-understood knob. IP-global throttling reliably stops broad scanning attacks — an attacker trying many share tokens from the same IP hits the ceiling quickly. The NAT collision trade-off is real but acceptable: the threshold (60 general / 10 password per minute) is high enough that legitimate users behind shared NAT are unlikely to collide, and the attack surface for a targeted single-share brute force is limited by the BCrypt cost of password verification. Keeping v1 simple and auditable outweighs the marginal gain of per-share scoping.
+
+**Source evidence**:
+- `intravox-source/lib/Controller/PageController.php:107, 197, 271` — `#[BruteForceProtection(action: 'intravox_share_access')]` and `#[BruteForceProtection(action: 'intravox_share_password')]` — single fixed action names with no token interpolation
+- `intravox-source/lib/Controller/PageController.php:106, 196, 270` — `#[AnonRateThrottle(limit: 60, period: 60)]` (general access) and `#[AnonRateThrottle(limit: 10, period: 60)]` (password) — also IP-global
+- `intravox-source/lib/Controller/PageController.php:318-323` — `registerBruteForceAttempt()` registers the IP without any per-share scoping
+
+### D2: Throttle action names — `mydash_*` prefix
+
+**Decision**: Use `mydash_share_access` and `mydash_share_password` (not the source app's names).
+
+**Rationale**: Nextcloud's `IThrottler` stores attempt counters keyed by action string. Using an app-prefixed name prevents counter collisions if another app's throttle action happened to share the same string, and makes the counter's origin unambiguous in the NC admin throttle log.
+
+### D3: Brute-force lockout response code
+
+**Decision**: When the throttle trips, return HTTP 429 (Too Many Requests) with NC's standard `IThrottler` JSON body. Not HTTP 503.
+
+**Rationale**: HTTP 429 is the correct semantic for rate limiting (RFC 6585). NC's own `ThrottlingMiddleware` returns 429; using 503 would be inconsistent with NC conventions and would mislead monitoring systems that treat 5xx as server errors. The spec's existing scenario (REQ-PSHR-009) currently states 503 and must be corrected.
+
+### D4: Service-account read for GroupFolder-backed shares (REQ-PSHR-010)
+
+**Decision**: A successful public-share render of a dashboard whose content lives in the GroupFolder backend MUST NOT use the requesting client's session for file ACL evaluation. The controller MUST obtain the GroupFolder content via a system/service-account context so that the GroupFolder ACL bypass mechanism grants access through the share token, not through a session that does not exist for anonymous users.
+
+**Rationale**: Anonymous users have no Nextcloud session. Passing a null or non-existent user context to GroupFolder's ACL evaluator causes the read to fail silently or return empty widget data. A service-account read path is the only correct mechanism; it is already established in the sibling `groupfolder-storage-backend` spec.
+
+**Source evidence**: The reference implementation's page controller resolves GroupFolder resources through the share record itself rather than through `getUserFolder()` on the current session, keeping file access decoupled from the viewer's identity.
+
+### D5: Per-IP debouncing of view-count increments (REQ-PSHR-007)
+
+**Decision**: View-count is incremented at most once per `(token, IP)` pair per 60-second window. Implemented via NC `ICache` with TTL 60 s. Key pattern: `mydash_vc_{token}_{ip}`. Matches the spec's existing assumption — no change required to the requirement, only the implementation detail is pinned here.
+
+**Rationale**: Database-level debounce (checking `lastViewedAt`) is not thread-safe under concurrent requests; cache-level TTL keys give atomic set-if-absent semantics without a transaction.
+
+## Spec changes implied
+
+- **REQ-PSHR-009 (throttle scope)**: rewrite the "Throttle is per-IP per-share" scenario to specify IP-global semantics; remove the `SHOULD be tracked per-share (implementation may vary)` hedge.
+- **REQ-PSHR-009 (action names)**: change any source-app action name references to `mydash_share_access` and `mydash_share_password`; add the concrete limits (60/60 s and 10/60 s).
+- **REQ-PSHR-009 (response code)**: replace HTTP 503 with HTTP 429 in the throttle-trip scenario.
+- **REQ-PSHR-010 (service-account read)**: add a NOTE specifying that the service-account context must be obtained before any GroupFolder file-system call, and that the anonymous viewer's session MUST NOT be passed to the ACL evaluator.
+
+## Open follow-ups
+
+- Whether to add a separate share-creation rate limit (owner-only endpoint, less critical but cheap to add at the controller layer).
+- Whether `?password=<...>` query-param submission (vs `X-Share-Password` header) should be explicitly supported or removed — browser history leaks the password in the query-param form; the current spec permits both but does not flag the security trade-off.

--- a/openspec/changes/dashboard-public-share/proposal.md
+++ b/openspec/changes/dashboard-public-share/proposal.md
@@ -1,0 +1,78 @@
+# Dashboard Public Share
+
+## Why
+
+Dashboard owners today cannot share a read-only view of their dashboards with external stakeholders without giving them Nextcloud login access. The existing `dashboard-sharing` capability is user-to-user (Nextcloud users must be logged in). This change introduces anonymous public sharing via URL-safe tokens, with optional password protection, expiry, and view tracking, enabling organisations to expose dashboards to partners, clients, and the public without account provisioning.
+
+## What Changes
+
+- Add `oc_mydash_public_shares` table with `token` (UNIQUE), `passwordHash` (BCrypt), `expiresAt`, `revokedAt` (soft-delete), `viewCount`, and `lastViewedAt` columns
+- Add `POST /api/dashboards/{uuid}/public-share` (owner-or-admin) to create a share with optional password and expiry; returns `{token, url, passwordRequired, expiresAt}`
+- Add `GET /api/dashboards/{uuid}/public-shares` (owner-or-admin) to list active (non-revoked) shares for a dashboard
+- Add `DELETE /api/dashboards/{uuid}/public-shares/{id}` (owner-or-admin) to soft-revoke a share
+- Add `GET /s/{token}` (PUBLIC) to render the dashboard anonymously; requires password unlock if `passwordHash IS NOT NULL`; returns HTTP 401 with `passwordRequired: true` if locked
+- Add `POST /s/{token}/unlock` (PUBLIC) to verify password and return `{access: true/false}`; throttled via `IThrottler` (10 failed per hour per IP → HTTP 503)
+- All mutation endpoints (`POST /api/dashboards/*/placements`, `PUT /api/dashboard/{uuid}`, etc.) detect public-share bearer and return HTTP 403 with "Cannot modify dashboard via public share"
+- View-count increments debounced per (token, IP, minute) to prevent refresh-spam inflation
+- Token expiry (`expiresAt < now()`) or revocation (`revokedAt IS NOT NULL`) returns HTTP 404 (no leak of existence)
+- Public-share rendering of GroupFolder-backed dashboard content MUST use a service-account read path (not the viewer's session) per the sibling `groupfolder-storage-backend` spec
+
+## Capabilities
+
+### New Capabilities
+
+- `dashboard-public-share` — enables anonymous read-only rendering via password-protected and/or time-limited tokens
+
+### Modified Capabilities
+
+- `dashboards` — existing REQ-DASH-001..010 unchanged; no mutation endpoint impact from this spec
+
+The existing `dashboard-sharing` capability (user-to-user) is unchanged; this is a distinct surface for public sharing.
+
+## Impact
+
+**Affected code:**
+
+- `lib/Db/PublicShare.php` — new Entity for `oc_mydash_public_shares` with fields: `id`, `dashboardUuid`, `token`, `passwordHash`, `expiresAt`, `createdBy`, `createdAt`, `revokedAt`, `viewCount`, `lastViewedAt`
+- `lib/Db/PublicShareMapper.php` — new Mapper with methods: `findByToken(string $token)`, `findByDashboardUuid(string $uuid)`, `findActiveByDashboardUuid(string $uuid)`, `save()`, `delete()`, `softRevoke(int $id)`, `incrementViewCount(int $id, string $ip)` (with debounce logic)
+- `lib/Service/PublicShareService.php` — new Service with: `createPublicShare(string $uuid, ?string $password, ?string $expiresAt)` (owner-or-admin guard), `listActiveShares(string $uuid)`, `revokeShare(int $id)`, `renderShare(string $token, ?string $password)` (with expiry/revoke checks), `unlockShare(string $token, string $password)` (with throttle guard via `IThrottler`)
+- `lib/Controller/PublicShareController.php` — new Controller (partially public, no `#[NoAdminRequired]` on all methods since some require auth):
+  - `POST /api/dashboards/{uuid}/public-share` — owner-or-admin
+  - `GET /api/dashboards/{uuid}/public-shares` — owner-or-admin
+  - `DELETE /api/dashboards/{uuid}/public-shares/{id}` — owner-or-admin
+  - `GET /s/{token}` — PUBLIC (no login required)
+  - `POST /s/{token}/unlock` — PUBLIC
+- `lib/Service/DashboardService.php` — extend with guard logic for mutations: check if request is public-share bearer (via context/middleware), throw `PublicShareReadOnlyException` (403) if mutating
+- `appinfo/routes.php` — register 5 new routes (3 authenticated, 2 public)
+- `lib/Migration/VersionXXXXDate2026...AddPublicShares.php` — schema migration adding `oc_mydash_public_shares` table with unique index on `token` and composite index on `(dashboardUuid, revokedAt)` for fast active-share queries
+- `src/stores/publicShares.js` — new Vuex/Pinia store module tracking active shares and token state
+- `src/views/DashboardPublicView.vue` — new public share render page (read-only, password unlock modal if needed)
+- `src/views/ShareManagement.vue` — new UI in dashboard settings to create, list, and revoke shares (deferred to follow-up if preferred)
+
+**Affected APIs:**
+
+- 5 new routes (3 authenticated, 2 public)
+- Existing `GET /api/dashboards` and mutation endpoints unchanged (but mutations now guard against public-share bearer)
+
+**Dependencies:**
+
+- `OCP\Security\IHasher` — already available, used for BCrypt password hashing
+- `OCP\Util::generateSecureRandom(64)` — for token generation
+- `OCP\Util\IThrottler` — already available, used for unlock attempt throttling
+- No new composer or npm dependencies
+
+**Migration:**
+
+- Zero-impact: new table only. No existing data affected.
+- Optional: add a database cleanup job to periodically hard-delete (not just soft-revoke) shares with `revokedAt IS NOT NULL AND revokedAt < (now - 90 days)` to reclaim storage
+
+**GroupFolder Integration:**
+
+Per the sibling `groupfolder-storage-backend` spec, when a dashboard's widgets reference GroupFolder-backed content, the public-share render MUST use a service-account file-read path instead of the anonymous user's non-existent session. The implementation detail is in the GroupFolder spec's `## Impact` section; this spec assumes that service-account mechanism is available via a helper method or DI.
+
+## Standards & References
+
+- Nextcloud security best practices: BCrypt with cost factor ≥ 10 for all password hashing
+- UUID v4 for dashboard foreign keys (existing `DashboardFactory::generateUuid()` pattern)
+- WCAG 2.1 AA: public-share render page must be operable via keyboard
+- i18n: all error messages in both `nl` and `en` per the i18n requirement

--- a/openspec/changes/dashboard-public-share/specs/dashboard-public-share/spec.md
+++ b/openspec/changes/dashboard-public-share/specs/dashboard-public-share/spec.md
@@ -148,9 +148,9 @@ Password-protected shares MUST require a POST unlock before rendering via the pu
 
 #### Scenario: Unlock is throttled to prevent brute-force
 - GIVEN a public share with a password
-- WHEN an attacker sends 11 failed unlock attempts from IP `203.0.113.100` within 60 minutes
-- THEN the system MUST invoke Nextcloud's `IThrottler` service
-- AND return HTTP 503 (Service Unavailable) on the 11th attempt with `Retry-After` header
+- WHEN an attacker sends 11 failed unlock attempts from IP `203.0.113.100` within 60 seconds
+- THEN the system MUST invoke Nextcloud's `IThrottler` service with action `mydash_share_password` (limit: 10 per 60 s, IP-global)
+- AND return HTTP 429 (Too Many Requests) on the 11th attempt with `Retry-After` header
 
 #### Scenario: Query param password alternative to header
 - GIVEN a password-protected share
@@ -228,22 +228,25 @@ Shares with `expiresAt < now()` OR `revokedAt IS NOT NULL` MUST return HTTP 404 
 
 Failed unlock attempts MUST be throttled via Nextcloud's `IThrottler` to prevent password guessing.
 
-#### Scenario: 10 failed unlocks per hour allowed
+#### Scenario: 10 failed unlocks per 60 seconds allowed
 - GIVEN a public share with a password
 - WHEN an attacker sends unlock requests with wrong passwords from IP `203.0.113.50`
 - THEN the first 10 attempts MUST return HTTP 401
-- AND the 11th attempt within the 60-minute window MUST return HTTP 503
+- AND the 11th attempt within the 60-second window MUST return HTTP 429
+- NOTE: The throttle action is `mydash_share_password` with limit 10 per 60 s, tracked IP-globally (not per-share). The IThrottler action string contains no token component.
 
-#### Scenario: Throttle is per-IP per-share
-- GIVEN two different public shares
-- WHEN IP `203.0.113.50` sends 10 failed unlocks against share A and 10 failed unlocks against share B
-- THEN the throttle counter SHOULD be tracked per-share (implementation may vary)
+#### Scenario: Throttle is IP-global across all shares
+- GIVEN two different public shares A and B
+- WHEN IP `203.0.113.50` sends 10 failed unlocks against share A
+- THEN the throttle counter for `mydash_share_password` is IP-global: those 10 attempts count toward share B as well
+- AND a subsequent failed unlock attempt against share B from the same IP MUST return HTTP 429
+- NOTE: There is no per-share scoping of the throttle. An attacker trying many tokens from the same IP hits the ceiling across all shares simultaneously.
 
 #### Scenario: Throttle resets after time window
 - GIVEN IP `203.0.113.50` exhausted 10 failed attempts
-- AND 60+ minutes pass with no new attempts
+- AND 60+ seconds pass with no new attempts
 - WHEN they send another unlock attempt
-- THEN the system MUST accept it (not return 503)
+- THEN the system MUST accept it (not return 429)
 
 ### Requirement: REQ-PSHR-010 Service-Account File Read for GroupFolder Content
 
@@ -254,6 +257,7 @@ Public shares referencing dashboards with GroupFolder-backed content MUST use a 
 - WHEN an anonymous user renders the dashboard via a public share token
 - THEN the system MUST use a service-account file-read context (NOT the anonymous user's non-existent session)
 - AND the GroupFolder backend's ACL bypass mechanism MUST allow the render
+- NOTE: The service-account context MUST be obtained before any GroupFolder filesystem call. The anonymous viewer's session (which does not exist) MUST NOT be passed to the GroupFolder ACL evaluator. Passing a null or non-existent user context causes reads to fail silently or return empty widget data.
 
 #### Scenario: Widget data accessible via service account
 - GIVEN a GroupFolder resource is readable only by members of group "Engineering"

--- a/openspec/changes/dashboard-public-share/specs/dashboard-public-share/spec.md
+++ b/openspec/changes/dashboard-public-share/specs/dashboard-public-share/spec.md
@@ -1,0 +1,271 @@
+---
+capability: dashboard-public-share
+delta: true
+status: draft
+---
+
+# Dashboard Public Share — New Capability Specification
+
+## ADDED Requirements
+
+### Requirement: REQ-PSHR-001 Create Public Share
+
+Dashboard owners (or admins) MUST be able to create a public share with an optional password and expiry date.
+
+#### Scenario: Create a public share without password
+- GIVEN a logged-in Nextcloud user "alice" who owns dashboard "Sales Pipeline" (uuid `550e8400-e29b-41d4-a716-446655440001`)
+- WHEN she sends `POST /api/dashboards/550e8400-e29b-41d4-a716-446655440001/public-share` with body `{}`
+- THEN the system MUST create a new public share record with a generated 64-byte URL-safe random `token`, `passwordHash` set to NULL, `expiresAt` set to NULL, and `createdBy` set to "alice"
+- AND return HTTP 201 with response body `{token, url, passwordRequired: false, expiresAt: null}`
+
+#### Scenario: Create a public share with password
+- GIVEN user "alice" owns dashboard uuid `550e8400-e29b-41d4-a716-446655440001`
+- WHEN she sends `POST /api/dashboards/550e8400-e29b-41d4-a716-446655440001/public-share` with body `{"password": "SecurePass123!"}`
+- THEN the system MUST hash the password via BCrypt (cost factor ≥ 10) and store the hash (NOT plaintext) in `passwordHash`
+- AND return `passwordRequired: true` in the response
+
+#### Scenario: Create a public share with expiry
+- GIVEN user "alice" owns the dashboard
+- WHEN she sends `POST /api/dashboards/550e8400-e29b-41d4-a716-446655440001/public-share` with body `{"expiresAt": "2026-12-31T23:59:59Z"}`
+- THEN the system MUST parse the ISO 8601 timestamp and store it in the `expiresAt` column
+- AND return the expiry in the response
+
+#### Scenario: Create multiple shares for one dashboard
+- GIVEN user "alice" owns a dashboard and has already created one public share for it
+- WHEN she creates a second share with different password/expiry settings
+- THEN both shares MUST be active simultaneously with independent tokens and passwords
+- AND each share MUST NOT affect the other
+
+#### Scenario: Non-owner cannot create shares
+- GIVEN user "bob" does NOT own dashboard uuid `550e8400-e29b-41d4-a716-446655440001`
+- WHEN he sends `POST /api/dashboards/550e8400-e29b-41d4-a716-446655440001/public-share`
+- THEN the system MUST return HTTP 403
+- AND no share MUST be created
+
+### Requirement: REQ-PSHR-002 List Active Shares
+
+Dashboard owners MUST be able to list all active (non-revoked) public shares for their dashboard.
+
+#### Scenario: List shares for a dashboard with multiple active shares
+- GIVEN user "alice" owns a dashboard with 3 active shares and 1 revoked share
+- WHEN she sends `GET /api/dashboards/550e8400-e29b-41d4-a716-446655440001/public-shares`
+- THEN the system MUST return HTTP 200 with an array of 3 shares (revoked excluded)
+- AND each share object MUST include: `id`, `token` (fully visible, not redacted), `url`, `passwordRequired`, `expiresAt`, `viewCount`, `lastViewedAt`
+
+#### Scenario: List shares for a dashboard with no shares
+- GIVEN user "alice" owns a dashboard with zero shares
+- WHEN she sends `GET /api/dashboards/550e8400-e29b-41d4-a716-446655440001/public-shares`
+- THEN the system MUST return HTTP 200 with an empty array `[]`
+
+#### Scenario: Non-owner cannot list shares
+- GIVEN user "bob" does NOT own the dashboard
+- WHEN he sends `GET /api/dashboards/550e8400-e29b-41d4-a716-446655440001/public-shares`
+- THEN the system MUST return HTTP 403
+
+#### Scenario: Revoked shares are not included in list
+- GIVEN user "alice" has 5 shares, 2 of which have `revokedAt IS NOT NULL`
+- WHEN she fetches the list
+- THEN exactly 3 shares MUST be returned
+
+### Requirement: REQ-PSHR-003 Revoke Public Share
+
+Dashboard owners MUST be able to soft-revoke a share via setting `revokedAt` without hard-deleting the row.
+
+#### Scenario: Soft-revoke a public share
+- GIVEN user "alice" owns a dashboard and share id=7 is active
+- WHEN she sends `DELETE /api/dashboards/550e8400-e29b-41d4-a716-446655440001/public-shares/7`
+- THEN the system MUST set `revokedAt` to the current timestamp (soft-delete)
+- AND NOT hard-delete the row from the database
+- AND return HTTP 204 (No Content)
+
+#### Scenario: Revoked share is no longer valid
+- GIVEN share id=7 has been revoked (`revokedAt IS NOT NULL`)
+- WHEN an anonymous user tries to access `GET /s/{token-for-share-7}`
+- THEN the system MUST return HTTP 404 (not distinguishing whether token never existed or was revoked)
+
+#### Scenario: Non-owner cannot revoke shares
+- GIVEN user "bob" does NOT own the dashboard
+- WHEN he sends `DELETE /api/dashboards/550e8400-e29b-41d4-a716-446655440001/public-shares/7`
+- THEN the system MUST return HTTP 403
+
+#### Scenario: Revoking already-revoked share is idempotent
+- GIVEN share id=7 already has `revokedAt IS NOT NULL`
+- WHEN alice sends DELETE for the same share again
+- THEN the system MUST return HTTP 204 (no error)
+
+### Requirement: REQ-PSHR-004 Public Render Dashboard (Anonymous)
+
+Anonymous users MUST be able to render a dashboard via a public share token, subject to password protection and expiry checks.
+
+#### Scenario: Public render via valid token without password
+- GIVEN a public share with `token = "vK9mP2qL7xR4nJ5tU8wS3cF6gH1jZ0bY"` (no password, not revoked, not expired)
+- WHEN an unauthenticated user sends `GET /s/vK9mP2qL7xR4nJ5tU8wS3cF6gH1jZ0bY`
+- THEN the system MUST validate the token, confirm `revokedAt IS NULL` and expiry not elapsed, load the dashboard and placements
+- AND return HTTP 200 with the dashboard data (read-only JSON, no edit endpoints exposed)
+
+#### Scenario: Invalid token returns 404
+- GIVEN a request with `token = "invalid-token-does-not-exist"`
+- WHEN `GET /s/invalid-token-does-not-exist` is sent
+- THEN the system MUST return HTTP 404
+
+#### Scenario: Revoked token returns 404
+- GIVEN a share with a valid token but `revokedAt IS NOT NULL`
+- WHEN the token is used to render
+- THEN the system MUST return HTTP 404 (avoid leaking whether the token ever existed)
+
+#### Scenario: Expired token returns 404
+- GIVEN a share with `expiresAt = "2026-04-30T23:59:59Z"` and the current time is 2026-05-01T00:00:00Z
+- WHEN the token is used to render
+- THEN the system MUST return HTTP 404
+
+#### Scenario: Public render must not reuse user session for GroupFolder content
+- GIVEN dashboard content lives in the GroupFolder backend (sibling spec: `groupfolder-storage-backend`)
+- WHEN a public-share token renders the dashboard
+- THEN the system MUST use a service-account path (NOT the current Nextcloud user's permissions)
+- SO that the GroupFolder ACL bypass mechanism allows the render as intended
+
+### Requirement: REQ-PSHR-005 Password Gate (Unlock)
+
+Password-protected shares MUST require a POST unlock before rendering via the public share UI.
+
+#### Scenario: Password-protected share returns 401 without unlock
+- GIVEN a public share with `passwordHash IS NOT NULL` and `token = "abc123"`
+- WHEN an anonymous user sends `GET /s/abc123` without unlock
+- THEN the system MUST return HTTP 401 with body `{passwordRequired: true}`
+- AND the dashboard data MUST NOT be included
+
+#### Scenario: Unlock with correct password
+- GIVEN a share with BCrypt password hash for password "SecurePass123!"
+- WHEN an anonymous user sends `POST /s/abc123/unlock` with body `{"password": "SecurePass123!"}`
+- THEN the system MUST verify the plaintext password against the stored hash via `password_verify()`
+- AND return HTTP 200 with body `{access: true}`
+
+#### Scenario: Unlock with incorrect password
+- GIVEN the same share and password
+- WHEN the user sends `POST /s/abc123/unlock` with body `{"password": "WrongPassword"}`
+- THEN the system MUST return HTTP 401 with body `{access: false}`
+- AND NOT block subsequent attempts (throttle is separate)
+
+#### Scenario: Unlock is throttled to prevent brute-force
+- GIVEN a public share with a password
+- WHEN an attacker sends 11 failed unlock attempts from IP `203.0.113.100` within 60 minutes
+- THEN the system MUST invoke Nextcloud's `IThrottler` service
+- AND return HTTP 503 (Service Unavailable) on the 11th attempt with `Retry-After` header
+
+#### Scenario: Query param password alternative to header
+- GIVEN a password-protected share
+- WHEN an anonymous user sends `GET /s/abc123?password=SecurePass123!` OR includes header `X-Share-Password: SecurePass123!`
+- THEN the system MUST accept either method
+- AND return HTTP 200 with the rendered dashboard (server-side verification)
+
+### Requirement: REQ-PSHR-006 Read-Only Enforcement
+
+Any mutation endpoint accessed with a public-share token (not a logged-in Nextcloud user session) MUST return HTTP 403.
+
+#### Scenario: Cannot create widget on public share
+- GIVEN an anonymous user has rendered dashboard via public share
+- WHEN they attempt `POST /api/dashboards/{uuid}/placements`
+- THEN the system MUST detect the public-share bearer and return HTTP 403 with message "Cannot modify dashboard via public share"
+
+#### Scenario: Cannot edit dashboard via public share
+- GIVEN a public share allows viewing
+- WHEN an anonymous user attempts `PUT /api/dashboard/{uuid}` to rename
+- THEN the system MUST return HTTP 403
+
+#### Scenario: Cannot delete dashboard via public share
+- GIVEN a public share allows viewing
+- WHEN an anonymous user attempts `DELETE /api/dashboard/{uuid}`
+- THEN the system MUST return HTTP 403
+
+#### Scenario: Logged-in user on public share renders read-only
+- GIVEN an authenticated Nextcloud user accesses the public share link
+- THEN the system MUST render it as read-only (same as anonymous)
+- AND the user's normal dashboard edit permissions MUST NOT override the public-share read-only mode
+
+### Requirement: REQ-PSHR-007 View Count Debouncing
+
+View counts MUST be incremented at most once per minute per (token, client IP) pair to prevent refresh-spam inflation.
+
+#### Scenario: Repeated renders from same IP in one minute
+- GIVEN a public share with `viewCount = 10`
+- WHEN the same IP renders the dashboard at t=0s, t=15s, t=45s (all within 60 seconds)
+- THEN `viewCount` MUST be incremented to 11 (once only)
+- AND `lastViewedAt` MUST be set to the latest render time (t=45s)
+
+#### Scenario: Renders from different IPs are counted separately
+- GIVEN the same share
+- WHEN IP `203.0.113.42` renders at t=0s and IP `203.0.113.43` renders at t=10s
+- THEN `viewCount` MUST be incremented once per IP (each IP counts independently)
+
+#### Scenario: Renders beyond the 60-second window reset the debounce
+- GIVEN the same share
+- WHEN IP `203.0.113.42` renders at t=0s and again at t=65s (beyond the 60-second window)
+- THEN `viewCount` MUST be incremented twice (one per window)
+
+### Requirement: REQ-PSHR-008 Expiry and Revocation 404 Response
+
+Shares with `expiresAt < now()` OR `revokedAt IS NOT NULL` MUST return HTTP 404 and avoid leaking whether the token ever existed.
+
+#### Scenario: Expired share returns 404
+- GIVEN a share with `expiresAt = "2026-04-30T23:59:59Z"`
+- AND the current time is 2026-05-01T00:00:00Z
+- WHEN an anonymous user attempts `GET /s/{token}`
+- THEN the system MUST return HTTP 404
+
+#### Scenario: Share expiring in the future is still valid
+- GIVEN a share with `expiresAt = "2026-05-02T12:00:00Z"`
+- AND the current time is 2026-05-01T14:00:00Z
+- WHEN the token is used to render
+- THEN the system MUST return HTTP 200
+
+#### Scenario: Share with null expiresAt never expires
+- GIVEN a share with `expiresAt IS NULL`
+- WHEN the token is rendered at any future time
+- THEN the system MUST NOT apply expiry logic
+- AND the share MUST remain valid until revoked
+
+### Requirement: REQ-PSHR-009 Brute-Force Protection
+
+Failed unlock attempts MUST be throttled via Nextcloud's `IThrottler` to prevent password guessing.
+
+#### Scenario: 10 failed unlocks per hour allowed
+- GIVEN a public share with a password
+- WHEN an attacker sends unlock requests with wrong passwords from IP `203.0.113.50`
+- THEN the first 10 attempts MUST return HTTP 401
+- AND the 11th attempt within the 60-minute window MUST return HTTP 503
+
+#### Scenario: Throttle is per-IP per-share
+- GIVEN two different public shares
+- WHEN IP `203.0.113.50` sends 10 failed unlocks against share A and 10 failed unlocks against share B
+- THEN the throttle counter SHOULD be tracked per-share (implementation may vary)
+
+#### Scenario: Throttle resets after time window
+- GIVEN IP `203.0.113.50` exhausted 10 failed attempts
+- AND 60+ minutes pass with no new attempts
+- WHEN they send another unlock attempt
+- THEN the system MUST accept it (not return 503)
+
+### Requirement: REQ-PSHR-010 Service-Account File Read for GroupFolder Content
+
+Public shares referencing dashboards with GroupFolder-backed content MUST use a service-account read path, not the viewer's session.
+
+#### Scenario: Public share rendering GroupFolder content uses service account
+- GIVEN a dashboard containing a widget that references a GroupFolder resource
+- WHEN an anonymous user renders the dashboard via a public share token
+- THEN the system MUST use a service-account file-read context (NOT the anonymous user's non-existent session)
+- AND the GroupFolder backend's ACL bypass mechanism MUST allow the render
+
+#### Scenario: Widget data accessible via service account
+- GIVEN a GroupFolder resource is readable only by members of group "Engineering"
+- AND an anonymous public-share user is not a member of "Engineering"
+- WHEN the service-account render path is used
+- THEN the service account MUST have appropriate read permissions (granted by GroupFolder admin configuration)
+- AND the widget data MUST be included in the render
+
+---
+
+## Summary of `dashboard-public-share` Capability
+
+This new capability introduces anonymous read-only sharing of dashboards via URL-safe tokens with optional password protection, expiry, and view tracking. The 10 requirements cover creation, listing, revocation, anonymous rendering, password gating, read-only enforcement, view-count debouncing, expiry/revocation 404 responses, brute-force protection, and GroupFolder service-account integration.
+
+**Spec version**: draft (2026-05-01)

--- a/openspec/changes/dashboard-public-share/tasks.md
+++ b/openspec/changes/dashboard-public-share/tasks.md
@@ -1,0 +1,125 @@
+# Tasks — dashboard-public-share
+
+## 1. Schema migration
+
+- [ ] 1.1 Create `lib/Migration/VersionXXXXDate2026...AddPublicShares.php` with table `oc_mydash_public_shares` containing all required fields: `id` (auto-increment PK), `dashboardUuid` (VARCHAR 36), `token` (VARCHAR 64 UNIQUE NOT NULL), `passwordHash` (VARCHAR 255 NULL), `expiresAt` (TIMESTAMP NULL), `createdBy` (VARCHAR 64), `createdAt` (TIMESTAMP NOT NULL), `revokedAt` (TIMESTAMP NULL), `viewCount` (INT DEFAULT 0), `lastViewedAt` (TIMESTAMP NULL)
+- [ ] 1.2 Add composite index on `(dashboardUuid, revokedAt)` for fast active-share queries (filter where `revokedAt IS NULL`)
+- [ ] 1.3 Add foreign key constraint from `dashboardUuid` to `oc_mydash_dashboards.uuid` with ON DELETE CASCADE
+- [ ] 1.4 Confirm migration is reversible (drop table in postSchemaChange rollback path)
+- [ ] 1.5 Run migration locally against sqlite, mysql, and postgres; verify schema applied cleanly each time
+
+## 2. Domain model
+
+- [ ] 2.1 Create `lib/Db/PublicShare.php` Entity with all fields as properties + getters/setters (Entity `__call` pattern — no named args on setters)
+- [ ] 2.2 Ensure `PublicShare::jsonSerialize()` excludes `passwordHash` (security — never expose hashed password to API responses)
+- [ ] 2.3 Ensure `PublicShare` includes `url` computed property (`https://nextcloud.instance/s/{token}`)
+
+## 3. Mapper layer
+
+- [ ] 3.1 Create `lib/Db/PublicShareMapper.php` extending `QBMapper` with methods:
+  - `findByToken(string $token): PublicShare` — returns single row or throws `DoesNotExistException`
+  - `findByDashboardUuid(string $uuid): array` — all shares (active + revoked) for a dashboard
+  - `findActiveByDashboardUuid(string $uuid): array` — `WHERE revokedAt IS NULL AND (expiresAt IS NULL OR expiresAt > now())`
+  - `save(PublicShare $share): PublicShare` — insert or update
+  - `delete(PublicShare $share): void` — hard-delete (used by cleanup job only)
+  - `softRevoke(int $id): void` — `UPDATE ... SET revokedAt = now() WHERE id = ?`
+  - `incrementViewCount(int $id, string $ip): void` — check debounce (max once per minute per IP per token), then `UPDATE viewCount, lastViewedAt`
+- [ ] 3.2 Debounce logic: store last-seen (token, IP) pair in Redis/APCu (optional) or inline via transaction snapshot; if `lastViewedAt` is within 60 seconds ago, skip increment
+- [ ] 3.3 Add fixture-based PHPUnit test covering: active shares, revoked shares (soft-delete), expired shares, debounce logic
+
+## 4. Service layer
+
+- [ ] 4.1 Create `lib/Service/PublicShareService.php` with methods:
+  - `createPublicShare(string $dashboardUuid, ?string $password, ?string $expiresAt): PublicShare` — owner-or-admin guard, validate UUID exists, hash password via `IHasher::hash()`, generate token via `Util::generateSecureRandom(64)`, persist, return entity
+  - `listActiveShares(string $dashboardUuid): array` — ownership guard, call mapper `findActiveByDashboardUuid()`, return array
+  - `revokeShare(int $id): void` — owner-or-admin guard (verify share's dashboard is owned), call mapper `softRevoke()`, return success
+  - `renderShareContent(string $token): array` — PUBLIC method (no auth check), validate token exists and not revoked/expired (throw `ShareExpiredException` or `ShareNotFoundException`), load dashboard and placements, return read-only JSON
+  - `unlockShare(string $token, string $password): bool` — PUBLIC method, throttle check via `IThrottler` (key format: `public_share_unlock_{token}_{IP}`, allow 10/hour), verify password via `IHasher::verify()`, return bool
+- [ ] 4.2 Ownership guard implementation: inject `IUserSession` to get current user, query dashboard to verify `userId` matches OR user is admin
+- [ ] 4.3 Add exception classes: `ShareExpiredException`, `ShareNotFoundException`, `SharePasswordRequired`, `ShareReadOnlyException`
+
+## 5. Controller + routes
+
+- [ ] 5.1 Create `lib/Controller/PublicShareController.php` extending `Controller` with methods:
+  - `createPublicShare(string $uuid)` — POST /api/dashboards/{uuid}/public-share, parse `password` and `expiresAt` from request body, call service, return 201 with `{token, url, passwordRequired, expiresAt}`
+  - `listPublicShares(string $uuid)` — GET /api/dashboards/{uuid}/public-shares, return 200 with array of shares (active only, includes full token and view metrics)
+  - `revokePublicShare(string $uuid, int $id)` — DELETE /api/dashboards/{uuid}/public-shares/{id}, call service, return 204
+  - `renderPublicShare(string $token)` — GET /s/{token}, check query param `?password=` OR header `X-Share-Password`, call service with password, catch `SharePasswordRequired` and return 401 with `{passwordRequired: true}`, catch `ShareExpiredException|ShareNotFoundException` and return 404, return 200 with dashboard JSON
+  - `unlockPublicShare(string $token)` — POST /s/{token}/unlock, parse `password` from request body, call service, return 200 `{access: true}` on match, return 401 `{access: false}` on mismatch, catch throttle exception and return 503 with `Retry-After` header
+- [ ] 5.2 Public routes (no `#[NoAdminRequired]` semantic; manual `#[PublicPage]` or equivalent for GET /s/* endpoints)
+- [ ] 5.3 Authenticated routes use standard `#[NoAdminRequired]` (user-scoped, not admin-only by attribute; guard inside service)
+- [ ] 5.4 Register all 5 routes in `appinfo/routes.php`:
+  - `POST /api/dashboards/{uuid}/public-share` — authenticated
+  - `GET /api/dashboards/{uuid}/public-shares` — authenticated
+  - `DELETE /api/dashboards/{uuid}/public-shares/{id}` — authenticated
+  - `GET /s/{token}` — public
+  - `POST /s/{token}/unlock` — public
+- [ ] 5.5 Verify every route carries correct Nextcloud auth attributes
+
+## 6. Read-only enforcement
+
+- [ ] 6.1 Create middleware or request context detector to identify if the current request is bearer-only a public-share token (compare against `PublicShare` table if token appears in Authorization header)
+- [ ] 6.2 Extend `DashboardService` mutations (update, delete, create placements, etc.) with guard: if request is public-share bearer, throw `ShareReadOnlyException` (403)
+- [ ] 6.3 Extend `WidgetService`, `PlacementService` mutations similarly
+- [ ] 6.4 PHPUnit test: create public share, attempt `POST /api/dashboard/{uuid}/placements` via bearer token, verify 403
+
+## 7. GroupFolder service-account integration
+
+- [ ] 7.1 When `renderShareContent()` loads dashboard placements, check if any widget references GroupFolder-backed content (consult sibling spec for signal — e.g., widget `source` field)
+- [ ] 7.2 If GroupFolder content is detected, switch file-read context to service account: inject `FolderManagementHandler` (or equivalent) and set impersonation context
+- [ ] 7.3 PHPUnit test (mocked): public share renders GroupFolder-backed widget without leaking underlying user session
+
+## 8. Frontend store
+
+- [ ] 8.1 Create `src/stores/publicShares.js` (Vuex or Pinia) with state: `shares` (map), `unlockedTokens` (set), getters for active shares per dashboard
+- [ ] 8.2 Actions: `createShare(uuid, password?, expiresAt?)` → POST call, store token locally
+- [ ] 8.3 Actions: `fetchShares(uuid)` → GET call, update state
+- [ ] 8.4 Actions: `revokeShare(uuid, id)` → DELETE call, remove from state
+- [ ] 8.5 Create `src/views/DashboardPublicShareView.vue` or equivalent — PUBLIC component, no login UI, renders dashboard data (read-only), password unlock modal if needed
+- [ ] 8.6 Unlock modal calls `POST /s/{token}/unlock`, caches result in localStorage or session cookie, re-renders on success
+
+## 9. PHPUnit tests
+
+- [ ] 9.1 `PublicShareMapperTest::findByToken` — valid token, invalid token (DoesNotExistException), token case-sensitivity
+- [ ] 9.2 `PublicShareMapperTest::findActiveByDashboardUuid` — revoked shares filtered, expired shares filtered (by timestamp comparison), active shares included
+- [ ] 9.3 `PublicShareMapperTest::incrementViewCount` — debounce logic: same IP within 60s skips increment, different IP increments, beyond 60s resets debounce
+- [ ] 9.4 `PublicShareServiceTest::createPublicShare` — password hashing, token generation, response includes `{token, url, passwordRequired, expiresAt}`
+- [ ] 9.5 `PublicShareServiceTest::unlockShare` — correct password verifies, wrong password fails, throttle after 10 failures
+- [ ] 9.6 `PublicShareServiceTest::renderShareContent` — expired share throws exception, revoked share throws exception, valid share returns dashboard + placements
+- [ ] 9.7 `PublicShareControllerTest::revokeShare` — non-owner returns 403, revoke sets `revokedAt`, idempotent on already-revoked
+- [ ] 9.8 `DashboardServiceTest` — mutations guarded: public-share bearer on POST /placements returns 403, same on PUT /dashboard/{uuid}
+
+## 10. End-to-end Playwright tests
+
+- [ ] 10.1 Dashboard owner creates a public share (no password) via API, anonymous user visits `/s/{token}`, dashboard renders read-only
+- [ ] 10.2 Dashboard owner creates password-protected share, anonymous user visits `/s/{token}`, receives 401 with `passwordRequired: true`, POSTs unlock with correct password, gets 200 + dashboard
+- [ ] 10.3 Dashboard owner creates share with expiry 1 minute in future, token renders successfully, test waits > 1 minute, token returns 404
+- [ ] 10.4 Dashboard owner revokes a share, anonymous user visits token, gets 404
+- [ ] 10.5 Dashboard owner lists public shares, sees all active shares with correct token, passwordRequired, viewCount, lastViewedAt
+- [ ] 10.6 Multiple renders from same IP within 60s increment viewCount once; renders > 60s apart both increment
+- [ ] 10.7 View count debounce: user reloads page 5 times in 30s, viewCount increments by 1; waits 65s, reloads again, increments by 1 more
+
+## 11. Quality gates
+
+- [ ] 11.1 `composer check:strict` (PHPCS, PHPMD, Psalm, PHPStan) passes — fix any pre-existing issues encountered along the way
+- [ ] 11.2 ESLint + Stylelint clean on all touched Vue/JS files
+- [ ] 11.3 SPDX headers on every new PHP file (inside the docblock per the SPDX-in-docblock convention) — gate-spdx must pass
+- [ ] 11.4 i18n: add message keys for `share_created`, `share_password_required`, `share_expired`, `share_revoked`, `share_view_count`, `cannot_modify_public_share`, `unlock_throttled` in both `nl` and `en` per the i18n requirement
+- [ ] 11.5 Update OpenAPI spec / Postman collection with 5 new endpoints
+- [ ] 11.6 Test coverage: all 10 `hydra-gates` passing locally before opening PR
+- [ ] 11.7 Performance: public share token lookup (via indexed query on unique `token`) must complete in < 50ms locally
+- [ ] 11.8 No hardcoded domain in URLs; use `OCP\Server::get(IURLGenerator::class)->absolute('s/' . $token)` for URL generation
+
+## 12. Documentation
+
+- [ ] 12.1 Add public-share workflow to `openspec/specs/dashboards/spec.md` (if deemed necessary, or leave as separate capability spec)
+- [ ] 12.2 Add API documentation example (request/response JSON) in `docs/` directory or OpenAPI spec
+- [ ] 12.3 Add "Sharing dashboards publicly" how-to guide in user-facing docs
+
+## 13. Optional follow-up changes (deferred)
+
+- [ ] 13.1 Admin UI for managing shares from dashboard settings (create, revoke via form instead of API)
+- [ ] 13.2 Share analytics dashboard (chart of views over time per share)
+- [ ] 13.3 Token regeneration (revoke old, create new with same settings)
+- [ ] 13.4 Whitelist-by-email feature (share only with specific email-confirmed users)
+- [ ] 13.5 Database cleanup job to hard-delete revoked shares older than 90 days

--- a/openspec/changes/dashboard-reactions/design.md
+++ b/openspec/changes/dashboard-reactions/design.md
@@ -1,0 +1,90 @@
+# Design — Dashboard Reactions
+
+## Context
+
+This capability adds emoji reactions to dashboards. The spec (`dashboard-reactions`) pins the
+`oc_mydash_dashboard_reactions` table, per-dashboard + global toggles, admin allow-list, idempotent
+POST, and hide-on-disable behaviour. Deliberately NOT built on `ICommentsManager` — diverging from
+`dashboard-comments`. The source app has no equivalent; the closest NC precedent is Deck's card
+reactions, which also uses a dedicated table. This design covers storage schema, allow-list
+mechanics, toggle semantics, and aggregation query shape.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Justify own table over ICommentsManager
+- Document composite unique constraint and idempotent-POST semantics
+- Specify allow-list storage and default value
+- Define hide-on-disable behaviour (rows preserved, API returns empty)
+- Specify aggregation query shape for dashboard detail response
+
+**Non-Goals:**
+- Reactions on comments (separate concern if ever needed)
+- Real-time push on new reactions (NC notification/activity framework is out of scope for MVP)
+- Custom emoji upload (allow-list is admin-controlled text list only)
+
+## Decisions
+
+### D1: Own table over ICommentsManager
+**Decision**: Store reactions in `oc_mydash_dashboard_reactions(id, dashboard_uuid, user_id, emoji,
+created_at)` with a composite unique index on `(dashboard_uuid, user_id, emoji)`.
+**Alternatives considered**:
+- NC `ICommentsManager` — rejected; designed for text comments, not emoji counts; makes
+  "show dashboards alice reacted to" a full comment-table scan; audit semantics differ
+- NC `oc_reactions` table (used by Talk) — rejected; not a public OCP API, subject to change
+**Rationale**: Own table gives clean query patterns for user-centric queries (`WHERE user_id = ?`)
+and dashboard-centric aggregation (`GROUP BY emoji`). Schema is minimal and stable.
+
+### D2: Idempotent POST semantics
+**Decision**: `POST /dashboards/{id}/reactions` with an already-reacted emoji returns HTTP 200.
+`INSERT IGNORE` (or equivalent); always returns current counts.
+**Alternatives considered**:
+- HTTP 409 — rejected; forces pre-check round-trip
+- HTTP 201 first / 200 repeat — rejected; complicates optimistic UI
+**Rationale**: Idempotent toggle UX; client POSTs freely and trusts returned counts.
+
+### D3: Allow-list storage
+**Decision**: Admin setting `mydash.reactions_allowed_emojis` (NC `IAppConfig`) stores a JSON
+array. Default value: `["👍","❤️","🎉","😂","🤔","😢"]`.
+**Alternatives considered**:
+- Hardcoded enum in code — rejected; admin customisation is a spec requirement
+- Per-dashboard allow-list — rejected; admin wants global governance; per-dashboard adds
+  complexity without a clear use case
+**Rationale**: `IAppConfig` is the canonical NC mechanism for admin settings. JSON array in a
+text config key is simple, readable, and patchable via `occ config:app:set`.
+
+### D4: Allow-list enforcement point
+**Decision**: Enforced at write time in `ReactionService::addReaction()`. Emoji not in the allow-list
+returns HTTP 422 `emoji_not_allowed`.
+**Alternatives considered**:
+- Enforce at read time (filter stored reactions) — rejected; allows garbage data into the DB
+**Rationale**: Write-time enforcement keeps the table clean. If admin narrows the allow-list later,
+existing rows with now-disallowed emojis are preserved but hidden at read time (see D5).
+
+### D5: Hide-on-disable semantics
+**Decision**: When globally or per-dashboard disabled, `GET` returns `{"reactions": {}}` and `POST`
+returns HTTP 403. Existing rows are NOT deleted; re-enabling restores everything.
+**Alternatives considered**: Delete rows on disable — rejected; irreversible, violates least surprise.
+**Rationale**: Disable is a governance control, not a purge.
+
+### D6: Aggregation query shape
+**Decision**: Dashboard detail endpoint includes `reactions` as a pre-aggregated map:
+`{"👍": {"count": 5, "userReacted": true}}`. Computed via single `SELECT emoji, COUNT(*) as count,
+MAX(user_id = ?) as user_reacted FROM oc_mydash_dashboard_reactions WHERE dashboard_uuid = ?
+GROUP BY emoji`.
+**Alternatives considered**:
+- Separate `GET /reactions` endpoint — available for detail use, but summary map baked into
+  dashboard detail avoids extra round-trips in the common case
+**Rationale**: One query returns both aggregate and per-user state. The `:currentUserId` param is
+injected by `ReactionService` from the NC session.
+
+## Risks / Trade-offs
+
+- **Emoji encoding edge cases** → Multi-codepoint emoji (skin tones, ZWJ sequences) stored as UTF-8 strings; MySQL `utf8mb4` required — verify collation on `emoji` column
+- **Allow-list narrowing** → Rows with now-disallowed emojis are hidden but not purged; surface count of hidden rows in admin panel
+
+## Open follow-ups
+
+- Add admin endpoint `GET /api/admin/reactions/orphaned` to show rows with emojis no longer in allow-list
+- Evaluate NC Activity integration: log `reacted_to_dashboard` event on first reaction per user per dashboard
+- Consider rate-limiting reaction POSTs (e.g. 60/min per user) to prevent abuse

--- a/openspec/changes/dashboard-reactions/proposal.md
+++ b/openspec/changes/dashboard-reactions/proposal.md
@@ -1,0 +1,58 @@
+# Dashboard Reactions
+
+## Why
+
+Today MyDash dashboards are one-directional: users view content but cannot provide lightweight social feedback. Teams using shared dashboards want emoji reactions (👍, ❤️, 🎉, etc.) to mark useful or appreciated dashboards without full-featured comments. This is a low-friction engagement signal that aligns with modern collaborative tools.
+
+## What Changes
+
+- Add a new `oc_mydash_dashboard_reactions` table with schema: `id` (PK), `dashboardUuid VARCHAR(36)`, `userId VARCHAR(64)`, `emoji VARCHAR(32)`, `reactedAt TIMESTAMP`, unique constraint on `(dashboardUuid, userId, emoji)`. Users can react with multiple distinct emojis but cannot duplicate the same emoji on the same dashboard.
+- Add a per-dashboard `reactionsEnabled SMALLINT(0/1) NULL` column to `oc_mydash_dashboards`. NULL = follow global setting; 1 = force on; 0 = force off.
+- Add admin settings: `mydash.reactions_enabled_default` (boolean, default true) for global toggle, and `mydash.reactions_allowed_emojis` (JSON array, default `["👍","❤️","🎉","😂","🤔","😢"]`) for allowed emoji whitelist.
+- Expose `GET /api/dashboards/{uuid}/reactions` returning `{counts: {emoji: number, ...}, mine: [emoji, ...], enabled: boolean}`.
+- Expose `POST /api/dashboards/{uuid}/reactions` body `{emoji}` to add a reaction (idempotent, 200 not 409).
+- Expose `DELETE /api/dashboards/{uuid}/reactions/{emoji}` to remove calling user's reaction (idempotent 204).
+- Expose `GET /api/dashboards/{uuid}/reactions/{emoji}/users` returning `[{userId, displayName, reactedAt}]` capped at 100, with cursor-based pagination.
+- Permission: only users who can VIEW the dashboard can react.
+- Cascade delete: deleting a dashboard removes all its reactions.
+
+## Capabilities
+
+### New Capabilities
+
+- `dashboard-reactions`: lightweight emoji reactions on dashboards with admin-configurable emoji list and per-dashboard toggle.
+
+### Modified Capabilities
+
+- `dashboards`: adds cascade-delete requirement for reactions.
+
+## Impact
+
+**Affected code:**
+
+- `lib/Db/DashboardReaction.php` — new entity (id, dashboardUuid, userId, emoji, reactedAt)
+- `lib/Db/DashboardReactionMapper.php` — new mapper with methods: `findByDashboard`, `findByEmoji`, `addReaction`, `removeReaction`, `countByDashboard`, `deleteByDashboardUuid`
+- `lib/Db/Dashboard.php` — add nullable `reactionsEnabled` field with getter/setter
+- `lib/Service/ReactionService.php` — new service: validation, permission checks, emoji whitelist enforcement, idempotent add/remove logic
+- `lib/Controller/DashboardController.php` — four new endpoints: GET reactions, POST add, DELETE remove, GET users-by-emoji
+- `appinfo/routes.php` — register four new routes
+- `appinfo/info.xml` — add admin settings declarations
+- `lib/Migration/VersionXXXXDate2026...php` — schema migration
+- `src/stores/dashboards.js` — track reactions per dashboard, wire `GET /api/dashboards/{uuid}/reactions`
+- `lib/Service/DashboardService.php` — pass cascade-delete signal to `ReactionService` on dashboard deletion
+
+**Affected APIs:**
+
+- 4 new read/write routes (no existing routes changed)
+- Existing `GET /api/dashboards`, `GET /api/dashboard` unchanged
+
+**Dependencies:**
+
+- No new composer or npm dependencies
+- Uses existing `IAppConfig` for admin settings
+- Uses existing `IGroupManager` for permission checks (VIEW permission inherited from `dashboards` capability)
+
+**Migration:**
+
+- Zero-impact: new table and nullable column only. Existing dashboards default to `reactionsEnabled = NULL` (follows global setting), so all existing dashboards respect the global toggle.
+- No data backfill required.

--- a/openspec/changes/dashboard-reactions/specs/dashboard-reactions/spec.md
+++ b/openspec/changes/dashboard-reactions/specs/dashboard-reactions/spec.md
@@ -1,0 +1,303 @@
+---
+status: draft
+---
+
+# Dashboard Reactions Specification
+
+## Purpose
+
+Dashboard reactions enable lightweight social feedback via emoji on MyDash dashboards. Users can react with a configurable whitelist of emojis to mark dashboards as useful, appreciated, or funny, without requiring full-featured comments. Reactions are aggregated by emoji and visible to all viewers. An administrator can enable/disable reactions globally and per-dashboard, and can curate the allowed emoji list.
+
+## Data Model
+
+### oc_mydash_dashboard_reactions table
+
+Each reaction is stored with the following fields:
+- **id**: Auto-increment integer primary key
+- **dashboardUuid**: VARCHAR(36) NOT NULL, foreign key reference to `oc_mydash_dashboards.uuid`
+- **userId**: VARCHAR(64) NOT NULL, Nextcloud user ID of the reactor
+- **emoji**: VARCHAR(32) NOT NULL, Unicode emoji string (e.g., `👍`, `❤️`, `🎉`)
+- **reactedAt**: TIMESTAMP NOT NULL, timestamp when reaction was created
+
+### Composite Constraints
+
+- **Unique index** `(dashboardUuid, userId, emoji)` — one user can react with multiple distinct emojis to the same dashboard, but cannot duplicate the same emoji for the same dashboard
+- **Index** `dashboardUuid` — fast lookups by dashboard
+- **Index** `emoji` — fast lookups of reactors by emoji type
+
+### oc_mydash_dashboards Extension
+
+- **reactionsEnabled**: SMALLINT(0/1) NULL — per-dashboard toggle. NULL = follow global setting; 1 = reactions enabled; 0 = reactions disabled
+
+### Admin Settings
+
+- **mydash.reactions_enabled_default**: Boolean (default: true) — global toggle for reactions feature
+- **mydash.reactions_allowed_emojis**: JSON array of strings (default: `["👍","❤️","🎉","😂","🤔","😢"]`) — whitelist of allowed emoji
+
+## ADDED Requirements
+
+### Requirement: REQ-RXN-001 Add Reaction
+
+Users who can VIEW a dashboard MUST be able to add an emoji reaction to that dashboard.
+
+#### Scenario: User adds a reaction to a dashboard they can view
+- GIVEN a logged-in user "alice" who can view dashboard with UUID `dash-123`
+- WHEN she sends `POST /api/dashboards/dash-123/reactions` with body `{"emoji": "👍"}`
+- THEN the system MUST create a new DashboardReaction record with `dashboardUuid='dash-123'`, `userId='alice'`, `emoji='👍'`, and current timestamp
+- AND the response MUST return HTTP 200 with the updated reactions summary `{counts: {"👍": 1, ...}, mine: ["👍"], enabled: true}`
+
+#### Scenario: User cannot react to a dashboard they cannot view
+- GIVEN a logged-in user "bob" who cannot VIEW dashboard with UUID `dash-456`
+- WHEN he sends `POST /api/dashboards/dash-456/reactions` with body `{"emoji": "❤️"}`
+- THEN the system MUST return HTTP 403 (permission denied)
+- AND no reaction row MUST be created
+
+#### Scenario: User attempts to react with non-whitelisted emoji
+- GIVEN user "alice" can view dashboard `dash-123`
+- AND the allowed emoji list is `["👍","❤️","🎉","😂","🤔","😢"]`
+- WHEN she sends `POST /api/dashboards/dash-123/reactions` with body `{"emoji": "🚀"}`
+- THEN the system MUST return HTTP 400 with error message "Emoji not allowed"
+- AND no reaction row MUST be created
+
+#### Scenario: User re-posts the same emoji (idempotent)
+- GIVEN user "alice" has already reacted with `👍` to dashboard `dash-123`
+- WHEN she sends `POST /api/dashboards/dash-123/reactions` with body `{"emoji": "👍"}` again
+- THEN the system MUST return HTTP 200 with the same summary (no duplicate created, unique constraint prevents it)
+- AND the count for `👍` MUST remain 1
+
+#### Scenario: User can react with multiple distinct emojis to the same dashboard
+- GIVEN user "alice" has already reacted with `👍` to dashboard `dash-123`
+- WHEN she sends `POST /api/dashboards/dash-123/reactions` with body `{"emoji": "❤️"}`
+- THEN the system MUST create a second reaction row `(dash-123, alice, ❤️)`
+- AND the response MUST show `{counts: {"👍": 1, "❤️": 1, ...}, mine: ["👍", "❤️"], enabled: true}`
+
+### Requirement: REQ-RXN-002 Remove Reaction
+
+Users who have reacted to a dashboard MUST be able to remove their own reactions.
+
+#### Scenario: User removes a reaction they made
+- GIVEN user "alice" has reacted with `👍` to dashboard `dash-123`
+- WHEN she sends `DELETE /api/dashboards/dash-123/reactions/👍`
+- THEN the system MUST delete the reaction row `(dash-123, alice, 👍)`
+- AND the response MUST return HTTP 204 (No Content)
+
+#### Scenario: User attempts to remove a reaction they did not make
+- GIVEN user "bob" has not reacted to dashboard `dash-123`
+- WHEN he sends `DELETE /api/dashboards/dash-123/reactions/👍`
+- THEN the system MUST return HTTP 204 (idempotent — delete of non-existent is not an error)
+- AND no database error MUST be logged
+
+#### Scenario: User cannot remove another user's reaction
+- GIVEN user "alice" has reacted with `❤️` to dashboard `dash-123`
+- WHEN user "bob" sends `DELETE /api/dashboards/dash-123/reactions/❤️`
+- THEN if "bob" has NOT reacted with `❤️`, the delete is idempotent and returns 204 (per REQ-RXN-002 idempotency)
+- NOTE: The DELETE endpoint is not authenticated per-reactor; it removes the calling user's reaction with that emoji. Removing other users' reactions is prevented by the unique constraint: only the calling user's row can be deleted.
+
+### Requirement: REQ-RXN-003 Get Reactions Summary
+
+Users viewing a dashboard MUST be able to see the aggregate reaction counts and their own reactions.
+
+#### Scenario: User retrieves reactions on a dashboard they can view
+- GIVEN dashboard `dash-123` has reactions: 3 users with `👍`, 1 user with `❤️`, 2 users with `🎉`
+- AND user "alice" has reacted with `👍` and `🎉` to this dashboard
+- WHEN she sends `GET /api/dashboards/dash-123/reactions`
+- THEN the system MUST return HTTP 200 with body:
+  ```json
+  {
+    "counts": {"👍": 3, "❤️": 1, "🎉": 2},
+    "mine": ["👍", "🎉"],
+    "enabled": true
+  }
+  ```
+
+#### Scenario: User cannot view reactions if they cannot view the dashboard
+- GIVEN user "bob" cannot VIEW dashboard `dash-456`
+- WHEN he sends `GET /api/dashboards/dash-456/reactions`
+- THEN the system MUST return HTTP 403 (permission denied)
+
+#### Scenario: No reactions yet on a dashboard
+- GIVEN dashboard `dash-789` has zero reactions
+- WHEN user "alice" (who can view it) sends `GET /api/dashboards/dash-789/reactions`
+- THEN the system MUST return HTTP 200 with body:
+  ```json
+  {
+    "counts": {},
+    "mine": [],
+    "enabled": true
+  }
+  ```
+
+#### Scenario: Reactions disabled on dashboard
+- GIVEN dashboard `dash-999` has `reactionsEnabled = 0` (force off)
+- AND it has 5 existing reactions in the database
+- WHEN user "alice" sends `GET /api/dashboards/dash-999/reactions`
+- THEN the system MUST return HTTP 200 with:
+  ```json
+  {
+    "counts": {},
+    "mine": [],
+    "enabled": false
+  }
+  ```
+- NOTE: Existing reactions are hidden (not deleted), but new reactions cannot be added (REQ-RXN-005)
+
+### Requirement: REQ-RXN-004 List Reactors by Emoji
+
+Users MUST be able to see which users have reacted with a specific emoji to a dashboard, with pagination.
+
+#### Scenario: User retrieves reactors for a specific emoji
+- GIVEN dashboard `dash-123` has 3 users who reacted with `👍`: alice, bob, carol (in chronological order)
+- AND user "dave" can view dashboard `dash-123`
+- WHEN dave sends `GET /api/dashboards/dash-123/reactions/👍/users`
+- THEN the system MUST return HTTP 200 with body:
+  ```json
+  [
+    {"userId": "alice", "displayName": "Alice Smith", "reactedAt": "2026-03-20 10:00:00"},
+    {"userId": "bob", "displayName": "Bob Jones", "reactedAt": "2026-03-20 10:05:00"},
+    {"userId": "carol", "displayName": "Carol Brown", "reactedAt": "2026-03-20 10:10:00"}
+  ]
+  ```
+
+#### Scenario: Pagination with cursor
+- GIVEN dashboard `dash-123` has 150 users who reacted with `🎉`
+- WHEN user "alice" sends `GET /api/dashboards/dash-123/reactions/🎉/users` (first request, no cursor)
+- THEN the system MUST return HTTP 200 with the first 100 results plus a `nextCursor` field (if more exist):
+  ```json
+  [
+    {"userId": "user1", "displayName": "User 1", "reactedAt": "..."},
+    ...
+    {"userId": "user100", "displayName": "User 100", "reactedAt": "..."}
+  ]
+  ```
+- AND the response header MUST include `Link: <...?cursor=xyz>; rel="next"` if more results exist
+
+#### Scenario: Emoji with no reactors
+- GIVEN dashboard `dash-123` has no reactions with emoji `😢`
+- WHEN user "alice" (who can view `dash-123`) sends `GET /api/dashboards/dash-123/reactions/😢/users`
+- THEN the system MUST return HTTP 200 with an empty array `[]`
+
+#### Scenario: User cannot view reactors if they cannot view the dashboard
+- GIVEN user "bob" cannot VIEW dashboard `dash-456`
+- WHEN he sends `GET /api/dashboards/dash-456/reactions/👍/users`
+- THEN the system MUST return HTTP 403
+
+### Requirement: REQ-RXN-005 Global Reactions Toggle
+
+Administrators MUST be able to enable or disable reactions for all dashboards at once via an admin setting.
+
+#### Scenario: Admin disables reactions globally
+- GIVEN the admin setting `mydash.reactions_enabled_default` is false
+- WHEN user "alice" sends `GET /api/dashboards/dash-123/reactions`
+- THEN the response MUST include `"enabled": false`
+- AND any `POST /api/dashboards/dash-123/reactions` MUST return HTTP 403 with message "Reactions are disabled"
+
+#### Scenario: Admin re-enables reactions globally
+- GIVEN the admin setting `mydash.reactions_enabled_default` is true
+- WHEN user "alice" sends `POST /api/dashboards/dash-123/reactions` with body `{"emoji": "👍"}`
+- THEN the system MUST create the reaction and return HTTP 200
+- NOTE: Existing reactions remain in the database; they are just hidden/disabled when the toggle is off
+
+#### Scenario: Dashboards created before global toggle change inherit the toggle state
+- GIVEN dashboard `dash-old` was created when `mydash.reactions_enabled_default` was true
+- AND admin then sets `mydash.reactions_enabled_default` to false
+- WHEN user "alice" sends `GET /api/dashboards/dash-old/reactions`
+- THEN the response MUST include `"enabled": false` (the dashboard follows the new global setting, since its `reactionsEnabled` is NULL)
+
+### Requirement: REQ-RXN-006 Per-Dashboard Reactions Toggle
+
+Administrators MUST be able to enable or disable reactions on individual dashboards, overriding the global setting.
+
+#### Scenario: Admin enables reactions on a dashboard that has global reactions disabled
+- GIVEN global setting `mydash.reactions_enabled_default` is false
+- AND dashboard `dash-123` has `reactionsEnabled = 1` (force on)
+- WHEN user "alice" sends `GET /api/dashboards/dash-123/reactions`
+- THEN the response MUST include `"enabled": true`
+- AND user "alice" can POST reactions to this dashboard
+
+#### Scenario: Admin disables reactions on a dashboard that has global reactions enabled
+- GIVEN global setting `mydash.reactions_enabled_default` is true
+- AND dashboard `dash-456` has `reactionsEnabled = 0` (force off)
+- WHEN user "bob" sends `GET /api/dashboards/dash-456/reactions`
+- THEN the response MUST include `"enabled": false`
+- AND user "bob" cannot POST reactions (returns 403)
+
+#### Scenario: Null reactionsEnabled field follows global setting
+- GIVEN global setting `mydash.reactions_enabled_default` is true
+- AND dashboard `dash-789` has `reactionsEnabled = NULL`
+- WHEN user "carol" sends `GET /api/dashboards/dash-789/reactions`
+- THEN the response MUST include `"enabled": true` (inherits global)
+
+#### Scenario: Admin updates per-dashboard toggle
+- GIVEN dashboard `dash-123` with `reactionsEnabled = 1`
+- WHEN an admin updates it to `reactionsEnabled = 0`
+- THEN user "alice" immediately sees `"enabled": false` on next GET request
+- NOTE: Existing reactions remain in the database, hidden but not deleted
+
+### Requirement: REQ-RXN-007 Allowed Emoji Whitelist
+
+Administrators MUST be able to configure which emoji are allowed via an admin setting.
+
+#### Scenario: Admin updates the allowed emoji list
+- GIVEN the admin setting `mydash.reactions_allowed_emojis` is `["👍","❤️","🎉"]`
+- WHEN user "alice" sends `POST /api/dashboards/dash-123/reactions` with body `{"emoji": "😂"}`
+- THEN the system MUST return HTTP 400 with message "Emoji not allowed"
+
+#### Scenario: Empty emoji in whitelist
+- GIVEN the admin setting `mydash.reactions_allowed_emojis` is `[]`
+- WHEN user "alice" sends `POST /api/dashboards/dash-123/reactions` with body `{"emoji": "👍"}`
+- THEN the system MUST return HTTP 400 ("Emoji not allowed")
+- AND GET reactions still works, returning counts and `enabled: true` (disabling via empty list is allowed, but typically the global toggle would be used)
+
+#### Scenario: Default allowed emoji list
+- GIVEN a fresh MyDash installation with no custom admin setting
+- AND user "alice" sends `POST /api/dashboards/dash-123/reactions` with body `{"emoji": "👍"}`
+- THEN the system MUST accept it and create the reaction
+- AND the default list MUST be `["👍","❤️","🎉","😂","🤔","😢"]`
+
+### Requirement: REQ-RXN-008 Permission Enforcement
+
+Only users who can VIEW a dashboard MUST be able to react, retrieve reactions, or list reactors.
+
+#### Scenario: User cannot react to a dashboard they cannot view
+- GIVEN user "alice" does NOT have VIEW permission on dashboard `dash-secret`
+- WHEN she sends `POST /api/dashboards/dash-secret/reactions` with any body
+- THEN the system MUST return HTTP 403
+
+#### Scenario: User in a group cannot react if group permissions revoked
+- GIVEN a group-shared dashboard `dash-group` that user "bob" could view
+- AND an admin revokes bob's group membership
+- WHEN bob sends `POST /api/dashboards/dash-group/reactions`
+- THEN the system MUST return HTTP 403 (permission check re-evaluated at request time)
+
+#### Scenario: User with full permission can react
+- GIVEN user "alice" is the owner of a personal dashboard `dash-123` (permissionLevel: full)
+- WHEN she sends `POST /api/dashboards/dash-123/reactions`
+- THEN the reaction MUST be created and return HTTP 200
+
+### Requirement: REQ-RXN-009 Cascade Delete on Dashboard Deletion
+
+When a dashboard is deleted, ALL reactions on that dashboard MUST be removed.
+
+#### Scenario: Dashboard deletion cascades to reactions
+- GIVEN dashboard `dash-123` has 10 reactions from 5 users
+- WHEN an admin deletes the dashboard (via `DELETE /api/dashboard/dash-123`)
+- THEN the system MUST delete all 10 reaction rows in `oc_mydash_dashboard_reactions` where `dashboardUuid = 'dash-123'`
+- AND subsequent GET requests for that dashboard MUST return 404
+
+#### Scenario: Cascade delete does not affect other dashboards' reactions
+- GIVEN dashboard `dash-A` has 3 reactions and dashboard `dash-B` has 5 reactions
+- WHEN the user deletes dashboard `dash-A`
+- THEN the 3 reactions on `dash-A` MUST be deleted
+- AND the 5 reactions on `dash-B` MUST remain unchanged
+
+## Non-Functional Requirements
+
+- **Performance**: `GET /api/dashboards/{uuid}/reactions` MUST return within 200ms. `GET /api/dashboards/{uuid}/reactions/{emoji}/users` with 100-item result MUST return within 300ms (pagination used if > 100).
+- **Data integrity**: The unique constraint `(dashboardUuid, userId, emoji)` MUST be enforced at the database level to prevent duplicate reactions.
+- **Idempotency**: POST add and DELETE remove MUST be fully idempotent (same request sent twice produces the same result without error).
+- **Localization**: All error messages (`"Emoji not allowed"`, `"Reactions disabled"`, etc.) MUST support English and Dutch per i18n requirements.
+- **Cascade safety**: Deleting a dashboard MUST reliably cascade-delete all reactions in the same transaction.
+
+### Current Implementation Status
+
+**Not yet implemented** — this is a new capability.

--- a/openspec/changes/dashboard-reactions/tasks.md
+++ b/openspec/changes/dashboard-reactions/tasks.md
@@ -1,0 +1,102 @@
+# Tasks — dashboard-reactions
+
+## 1. Schema migration
+
+- [ ] 1.1 Create `lib/Migration/VersionXXXXDate2026...AddDashboardReactionsTable.php` with `oc_mydash_dashboard_reactions` table: `id (PK)`, `dashboardUuid VARCHAR(36) NOT NULL`, `userId VARCHAR(64) NOT NULL`, `emoji VARCHAR(32) NOT NULL`, `reactedAt TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP`
+- [ ] 1.2 Same migration adds unique constraint `idx_mydash_react_uuid_user_emoji` on `(dashboardUuid, userId, emoji)` to prevent duplicate reactions
+- [ ] 1.3 Same migration adds index `idx_mydash_react_uuid` on `dashboardUuid` for fast lookups by dashboard
+- [ ] 1.4 Same migration adds index `idx_mydash_react_emoji` on `emoji` for fast lookups of reactors by emoji
+- [ ] 1.5 Same migration adds `reactionsEnabled SMALLINT(0/1) NULL` column to `oc_mydash_dashboards`
+- [ ] 1.6 Migration is reversible (drop table, drop columns, drop indexes in postSchemaChange rollback)
+- [ ] 1.7 Run migration locally against sqlite, mysql, and postgres; verify clean application each time
+
+## 2. Domain model
+
+- [ ] 2.1 Create `lib/Db/DashboardReaction.php` entity with fields: id, dashboardUuid, userId, emoji, reactedAt; add getters/setters (Entity `__call` pattern — no named args)
+- [ ] 2.2 Add `Dashboard::reactionsEnabled` field to `Dashboard.php` with getter/setter
+- [ ] 2.3 Update `Dashboard::jsonSerialize()` to include `reactionsEnabled` (nullable in output)
+- [ ] 2.4 In `DashboardReaction::jsonSerialize()` include all fields; `emoji` as-is (unicode string), `reactedAt` in "Y-m-d H:i:s" format for consistency with dashboard timestamps
+
+## 3. Mapper layer
+
+- [ ] 3.1 Create `lib/Db/DashboardReactionMapper.php` extending `QBMapper`
+- [ ] 3.2 Add `findByDashboard(string $dashboardUuid): array` — `WHERE dashboardUuid = ?` ordered by `reactedAt DESC`
+- [ ] 3.3 Add `findByEmoji(string $dashboardUuid, string $emoji): array` — `WHERE dashboardUuid = ? AND emoji = ?` ordered by `reactedAt DESC`, used for `/users` endpoint
+- [ ] 3.4 Add `findByUser(string $userId, string $dashboardUuid): array` — `WHERE dashboardUuid = ? AND userId = ?`, returns calling user's reactions on a dashboard
+- [ ] 3.5 Add `countByEmoji(string $dashboardUuid): array` — returns `[emoji => count, ...]` associative array via SQL GROUP BY
+- [ ] 3.6 Add `addReaction(string $dashboardUuid, string $userId, string $emoji): DashboardReaction` — insert new row, throw `IntegrityConstraintViolationException` if duplicate already exists (caller handles idempotency)
+- [ ] 3.7 Add `removeReaction(string $dashboardUuid, string $userId, string $emoji): bool` — delete matching row, return true if found, false if not (idempotent)
+- [ ] 3.8 Add `deleteByDashboardUuid(string $dashboardUuid): int` — cascade delete all reactions for dashboard, return count deleted
+- [ ] 3.9 Add PHPUnit test fixtures: add reactions, count by emoji, find by user, delete by dashboard UUID
+
+## 4. Admin settings
+
+- [ ] 4.1 Update `appinfo/info.xml` to declare two admin settings: `mydash.reactions_enabled_default` (type bool, default true) and `mydash.reactions_allowed_emojis` (type string/JSON, default `["👍","❤️","🎉","😂","🤔","😢"]`)
+- [ ] 4.2 Add getter methods in a new config service or extend existing `ConfigService`: `isReactionsEnabledByDefault()` and `getAllowedEmojis(): array`
+
+## 5. Service layer
+
+- [ ] 5.1 Create `lib/Service/ReactionService.php` with methods:
+  - `isReactionsEnabled(Dashboard $dashboard): bool` — checks `reactionsEnabled` field (null = follow global, 1 = true, 0 = false)
+  - `validateEmoji(string $emoji): void` — throw `\InvalidArgumentException` if emoji not in whitelist
+  - `addReaction(string $dashboardUuid, string $userId, string $emoji): DashboardReaction` — permission check + validation + call mapper, swallow IntegrityConstraintViolation (idempotent)
+  - `removeReaction(string $dashboardUuid, string $userId, string $emoji): bool` — permission check + call mapper
+  - `getReactionsSummary(string $dashboardUuid): array` — returns `{counts: {emoji: number, ...}, mine: [emoji, ...], enabled: boolean}`
+  - `getReactorsByEmoji(string $dashboardUuid, string $emoji, ?string $cursor): array` — returns `[{userId, displayName, reactedAt}]` capped at 100 with pagination
+  - `deleteReactionsByDashboard(string $dashboardUuid): void` — called from DashboardService on cascade delete
+- [ ] 5.2 Permission checks: throw `\OCP\AppFramework\OCS\OCSException` (403) if user cannot VIEW the dashboard (inherit permission model from `dashboards` capability)
+- [ ] 5.3 All validation errors throw `\OCP\AppFramework\OCS\OCSException` with appropriate HTTP status (400 for bad emoji, 403 for permission, 500 for DB)
+
+## 6. Controller + routes
+
+- [ ] 6.1 Add `DashboardController::getReactions(string $uuid)` mapped to `GET /api/dashboards/{uuid}/reactions` (logged-in) — calls `ReactionService::getReactionsSummary()`, returns JSON with `{counts, mine, enabled}`
+- [ ] 6.2 Add `DashboardController::addReaction(string $uuid)` mapped to `POST /api/dashboards/{uuid}/reactions` (logged-in) — body `{emoji}`, calls `ReactionService::addReaction()`, returns 200 with updated summary (idempotent)
+- [ ] 6.3 Add `DashboardController::removeReaction(string $uuid, string $emoji)` mapped to `DELETE /api/dashboards/{uuid}/reactions/{emoji}` (logged-in) — calls `ReactionService::removeReaction()`, returns 204 always (idempotent)
+- [ ] 6.4 Add `DashboardController::getReactorsByEmoji(string $uuid, string $emoji, ?string $cursor)` mapped to `GET /api/dashboards/{uuid}/reactions/{emoji}/users` (logged-in) — query param `cursor`, calls `ReactionService::getReactorsByEmoji()`, returns `[{userId, displayName, reactedAt}]`
+- [ ] 6.5 Register all four routes in `appinfo/routes.php` with proper format requirements (uuid = UUID regex, emoji = any non-empty string)
+- [ ] 6.6 All four methods carry `#[NoAdminRequired]` (permission check is runtime, not declarative)
+
+## 7. Dashboard cascade delete
+
+- [ ] 7.1 Update `DashboardService::deleteDashboard(string $uuid)` to call `ReactionService::deleteReactionsByDashboard()` before deleting the dashboard record
+- [ ] 7.2 Verify cascade order: reactions deleted first, then dashboard
+
+## 8. Frontend store
+
+- [ ] 8.1 Extend `src/stores/dashboards.js` with `reactionsSummary` object keyed by dashboard UUID: `{counts: {emoji: number, ...}, mine: [emoji, ...], enabled: boolean}`
+- [ ] 8.2 Add action `fetchReactionsSummary(dashboardUuid)` that calls `GET /api/dashboards/{uuid}/reactions` and caches the result
+- [ ] 8.3 Add action `addReaction(dashboardUuid, emoji)` that calls `POST /api/dashboards/{uuid}/reactions`, updates local store (idempotent)
+- [ ] 8.4 Add action `removeReaction(dashboardUuid, emoji)` that calls `DELETE /api/dashboards/{uuid}/reactions/{emoji}`, updates local store (idempotent)
+- [ ] 8.5 Defer UI component (emoji picker, reaction bar) to follow-up `dashboard-reactions-ui` change
+
+## 9. PHPUnit tests
+
+- [ ] 9.1 `DashboardReactionMapperTest::testAddReaction` — insert and retrieve, verify unique constraint on duplicate
+- [ ] 9.2 `DashboardReactionMapperTest::testRemoveReaction` — delete by UUID+user+emoji, verify idempotent (not-found returns false)
+- [ ] 9.3 `DashboardReactionMapperTest::testCountByEmoji` — multiple reactions per emoji, verify counts
+- [ ] 9.4 `DashboardReactionMapperTest::testDeleteByDashboardUuid` — cascade delete all reactions for a dashboard
+- [ ] 9.5 `ReactionServiceTest::testAddReactionIdempotent` — re-post same emoji returns 200, summary unchanged
+- [ ] 9.6 `ReactionServiceTest::testValidateEmojiRejectsNonWhitelisted` — emoji not in list throws InvalidArgumentException
+- [ ] 9.7 `ReactionServiceTest::testPermissionCheckViewOnly` — non-view-capable user cannot react (403)
+- [ ] 9.8 `ReactionServiceTest::testIsReactionsEnabled` — null follows global, 1 = true, 0 = false
+- [ ] 9.9 `DashboardServiceTest::testDeleteDashboardCascadesReactions` — deleting dashboard removes all its reactions
+- [ ] 9.10 `ReactionServiceTest::testGetReactorsByEmojiPagination` — cursor-based pagination, 100-item cap
+
+## 10. End-to-end Playwright tests
+
+- [ ] 10.1 Logged-in user can POST reaction to a dashboard they can view (API call from fixture), verify 200
+- [ ] 10.2 User re-posts same emoji, verify 200 and reaction count unchanged (idempotent)
+- [ ] 10.3 User can DELETE their reaction, verify 204
+- [ ] 10.4 User cannot react to dashboard they cannot view (403)
+- [ ] 10.5 Admin disables reactions globally, user GETs summary, verify `enabled: false` and POST returns 403
+- [ ] 10.6 Admin sets per-dashboard toggle `reactionsEnabled = 0`, user GETs summary, verify `enabled: false` regardless of global setting
+- [ ] 10.7 Admin deletes a dashboard, verify all reactions cascade-deleted
+
+## 11. Quality gates
+
+- [ ] 11.1 `composer check:strict` (PHPCS, PHPMD, Psalm, PHPStan) passes — fix any pre-existing issues encountered
+- [ ] 11.2 ESLint + Stylelint clean on all touched Vue/JS files
+- [ ] 11.3 Update OpenAPI spec / Postman collection for the four new endpoints
+- [ ] 11.4 i18n keys for all error messages (`"Emoji not allowed"`, `"Reactions disabled"`, etc.) in both `nl` and `en` per the i18n requirement
+- [ ] 11.5 SPDX headers on every new PHP file (inside the docblock per the SPDX-in-docblock convention) — gate-spdx must pass
+- [ ] 11.6 Run all 10 `hydra-gates` locally before opening PR

--- a/openspec/changes/dashboard-rss-feeds/design.md
+++ b/openspec/changes/dashboard-rss-feeds/design.md
@@ -1,0 +1,89 @@
+# Design — Dashboard RSS Feeds
+
+## Context
+
+This capability provides a per-user RSS/Atom feed of accessible dashboards, gated by a revocable
+token. The spec (`dashboard-rss-feeds`) pins one-token-per-user, ACL enforcement at render time,
+and dual RSS 2.0 / Atom output. Deleted dashboards disappear naturally via ACL checks at render
+time — `dashboard-cascade-events` is not involved.
+
+Source confirms the pattern: `intravox-source/lib/Db/FeedToken.php` and
+`intravox-source/lib/Controller/FeedController.php`. `generateToken()` deletes any existing token
+before insert — we match this replace-not-accumulate behaviour. This design covers token format,
+storage schema, revoke-regenerate flow, format negotiation, and ACL timing.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Specify token format and storage schema
+- Document revoke-then-regenerate flow (POST always replaces)
+- Define feed format selection via Accept header
+- Specify ACL enforcement at render time (not token-issue time)
+- Document feed item content and ordering
+
+**Non-Goals:**
+- Push/webhook delivery (feed is pull-only)
+- Per-dashboard granularity tokens (one token covers all user-accessible dashboards)
+- Feed caching layer (HTTP cache headers are sufficient)
+
+## Decisions
+
+### D1: Token format
+**Decision**: `random_bytes(32)` encoded as URL-safe base64 (no padding) → ~43 chars. Stored as CHAR(43).
+**Source evidence**: `intravox-source/lib/Db/FeedToken.php:~40` — `bin2hex(random_bytes(32))` (64-char hex).
+We switch to base64url: shorter, same entropy (256-bit), URL-safe without encoding.
+**Alternatives considered**:
+- UUIDv4 — rejected; only 122 bits entropy
+- Hex (source) — 64 chars; functional but unnecessarily long
+**Rationale**: base64url is the compact, high-entropy, URL-safe standard choice.
+
+### D2: Storage schema
+**Decision**: Table `oc_mydash_feed_tokens(id, user_id, token, created_at)` with `UNIQUE(user_id)`
+and `UNIQUE(token)`. `user_id` unique enforces one-token-per-user at DB level.
+**Source evidence**: `intravox-source/lib/Db/FeedToken.php:~25-35` — `user_id` unique index
+confirmed; the delete-before-insert in `generateToken()` is the application-level guarantee.
+**Alternatives considered**:
+- Allow multiple tokens per user with revocation list — rejected; spec is explicit on one-token model
+**Rationale**: DB-level uniqueness is the safety net. Application-level delete-before-insert
+(wrapped in a transaction) is the primary mechanism, matching source behaviour.
+
+### D3: Revoke-then-regenerate flow
+**Decision**: `POST /api/me/feed-token` handles both generation and rotation — always deletes
+existing token (if any) and inserts a new one in one transaction. Returns HTTP 200
+`{"token":"<new>","feedUrl":"<url>"}`. No separate DELETE endpoint.
+**Source evidence**: `intravox-source/lib/Controller/FeedController.php:~55` — single action, delete-then-insert.
+**Alternatives considered**: POST+DELETE+PUT — rejected; three endpoints for one atomic concept.
+**Rationale**: Atomic replace; old token invalid immediately after commit.
+
+### D4: Feed format negotiation
+**Decision**: `GET /api/feed/{token}` returns RSS 2.0 by default; `Accept: application/atom+xml`
+switches to Atom 1.0. `?format=atom` accepted as fallback for clients that can't set headers.
+**Alternatives considered**: JSON Feed — deferred; low demand; addable later without breaking RSS/Atom.
+**Rationale**: RSS 2.0 default covers widest reader range; Accept-header negotiation is standard.
+
+### D5: ACL enforcement at feed-render time
+**Decision**: `FeedController` resolves user from token, then calls
+`DashboardService::getAccessibleDashboards($userId)` — the same method as the regular API.
+No ACL snapshot at token-issue time.
+**Source evidence**: `intravox-source/lib/Controller/FeedController.php:~80-110` — render-time access checks.
+**Alternatives considered**: ACL snapshot at token issue — rejected; stale snapshot exposes revoked shares.
+**Rationale**: Real-time ACL; un-shared dashboards vanish from feed on next fetch without token rotation.
+
+### D6: Feed item content and ordering
+**Decision**: Each item: `<title>` = dashboard title, `<link>` = public URL, `<description>` =
+plain-text summary (stripped), `<pubDate>` = `updated_at`. Ordered by `updated_at` DESC, capped at 50.
+**Alternatives considered**:
+- No item cap — rejected; thousands of items break most readers and slow generation
+- Order by `created_at` — rejected; recent edits are more relevant to subscribers
+**Rationale**: 50-item cap matches feed reader conventions; `updated_at` surfaces active dashboards.
+
+## Risks / Trade-offs
+
+- **Token in URL** → appears in server logs and browser history; document as password-equivalent; HTTPS required (standard NC assumption)
+- **Feed generation cost** → `getAccessibleDashboards` may be expensive at scale; add `Cache-Control: max-age=300` as first-line throttle
+
+## Open follow-ups
+
+- Add `?limit=` param (default 50, max 200) once usage data is available
+- Evaluate per-dashboard `includedInFeed` opt-out flag if privacy concerns arise
+- Add Atom `<updated>` feed-level element for conditional GET / `If-Modified-Since` support

--- a/openspec/changes/dashboard-rss-feeds/proposal.md
+++ b/openspec/changes/dashboard-rss-feeds/proposal.md
@@ -1,0 +1,65 @@
+# Dashboard RSS Feeds
+
+## Why
+
+MyDash users increasingly need to share dashboard updates with external systems (monitoring tools, RSS readers, email digests, n8n workflows) without granting full Nextcloud access. Today, this requires either embedding dashboards in iframes (fragile, requires browser login) or manually exporting data. A per-user RSS feed token enables seamless integration with standard feed consumers while respecting each user's existing dashboard ACLs (permissions) — no new authorization model needed.
+
+## What Changes
+
+- Add `oc_mydash_feed_tokens` table with `userId`, `token`, `createdAt`, `lastUsedAt`, `revokedAt` fields and UNIQUE constraint on `(userId)` for one-token-per-user rotation.
+- Add `GET /api/feed/token` (authed) — issue or return existing user token, providing both the token string and an absolute feed URL.
+- Add `POST /api/feed/token/regenerate` (authed) — atomically revoke the current token and issue a new one.
+- Add `DELETE /api/feed/token` (authed) — soft-revoke the current token; subsequent `GET` will re-create if desired.
+- Add `GET /feed/{token}.xml` (public, no Nextcloud auth) — resolve token to user, filter dashboards by token-user's ACLs, return RSS 2.0 or Atom feed; update `lastUsedAt`; return 404 for invalid or revoked tokens.
+- Token format: 32 random bytes, base64-url encoded, non-enumerable, cryptographically strong.
+- Opt-in model: feeds are off by default; users must call `GET /api/feed/token` to enable.
+- Feed items: one per accessible dashboard, reverse-chronological by `updatedAt`, capped at 50 (admin-tunable via `mydash.feed_item_cap`). Each item carries dashboard name, deep-link, description (escaped), pubDate, UUID guid, and owner display name.
+- Filtering: feeds respect the token-owner's permissions (from the existing permissions capability); private dashboards visible only to the token-owner do not leak to public feed consumers.
+
+## Capabilities
+
+### New Capabilities
+
+- `dashboard-rss-feeds`: provides REQ-FEED-001 through REQ-FEED-009 (token issue, regenerate, revoke, public feed rendering, item content, ACL filtering, item cap, opt-in, token format).
+
+### Modified Capabilities
+
+- None. The `dashboards` capability is unchanged; the new feed is an alternative *output* of the same dashboard data, not a change to dashboard structure or CRUD.
+
+## Impact
+
+**Affected code:**
+
+- `lib/Db/FeedToken.php` — new entity for token records
+- `lib/Db/FeedTokenMapper.php` — new mapper for CRUD operations on feed tokens
+- `lib/Service/FeedTokenService.php` — token generation, revocation, and resolution logic
+- `lib/Service/FeedService.php` — render RSS/Atom feed from dashboards, apply ACL filter, enforce caps
+- `lib/Controller/FeedController.php` — endpoint implementations (GET /api/feed/token, POST /api/feed/token/regenerate, DELETE /api/feed/token, GET /feed/{token}.xml)
+- `appinfo/routes.php` — register four new routes (two authed, two public)
+- `lib/Migration/VersionXXXXDate2026...php` — schema migration adding `oc_mydash_feed_tokens` table
+- `config/sensitive-parameters.php` — mark `token` column as sensitive in logs (if such file exists in the app)
+
+**Affected APIs:**
+
+- 4 new routes (no existing routes modified)
+- Existing `GET /api/dashboards` and related CRUD routes unchanged
+- New public route `/feed/{token}.xml` requires no Nextcloud auth
+
+**Dependencies:**
+
+- `OCP\IConfig` — for reading `mydash.feed_item_cap` config
+- `OCP\IUserManager` — for resolving display names from user IDs
+- No new composer or npm dependencies; use PHP's built-in `random_bytes()` and base64 encoding
+
+**Migration:**
+
+- Creates a new table; zero impact on existing data.
+- All users start with no token (opt-in); feeds remain private until a token is explicitly requested.
+
+**Security:**
+
+- Tokens are cryptographically random and URL-safe, resistant to brute-force enumeration.
+- Invalid or revoked tokens return HTTP 404 (not 403) to avoid leaking token existence.
+- Feed content is filtered by the token-owner's ACLs; no new authorization bypass is created.
+- Tokens should be treated as secrets and not logged in plaintext (mark sensitive in logging config).
+

--- a/openspec/changes/dashboard-rss-feeds/specs/dashboard-rss-feeds/spec.md
+++ b/openspec/changes/dashboard-rss-feeds/specs/dashboard-rss-feeds/spec.md
@@ -1,0 +1,252 @@
+---
+status: draft
+---
+
+# Dashboard RSS Feeds Specification
+
+## Purpose
+
+Expose a user's accessible dashboards as an RSS 2.0 / Atom feed accessible without Nextcloud browser authentication via a per-user secret token. Each user may opt-in by requesting their feed token; the feed is filtered by the token-owner's dashboard ACLs (permissions) so private content remains private. The feed enables integration with RSS readers, monitoring tools, and third-party systems without requiring full Nextcloud login.
+
+## Data Model
+
+Feed tokens are stored in a new `oc_mydash_feed_tokens` table with the following fields:
+- **id**: Auto-increment integer primary key
+- **userId**: Nextcloud user ID (VARCHAR(64)), for whom this token was issued
+- **token**: URL-safe cryptographically random token string (VARCHAR(64))
+- **createdAt**: Timestamp (DATETIME) when the token was first generated
+- **lastUsedAt**: Nullable timestamp (DATETIME NULL) of the last successful feed request
+- **revokedAt**: Nullable timestamp (DATETIME NULL) indicating soft revocation
+
+Constraints:
+- UNIQUE index on `(userId)` — only one token per user at any time (rotation via revoke + regenerate)
+- Token format: 32 random bytes encoded as base64-url string, yielding approximately 43 characters (not enumerable, not time-based, cryptographically strong)
+
+## ADDED Requirements
+
+### Requirement: REQ-FEED-001 Token Issue
+
+Users MUST be able to request and receive their personal feed token on first call, creating it atomically if not yet issued.
+
+#### Scenario: Request token for first time
+- GIVEN a logged-in Nextcloud user "alice" who has never requested a feed token
+- WHEN she sends `GET /api/feed/token`
+- THEN the system MUST:
+  - Generate a 32-byte random token and base64-url-encode it
+  - Insert a record in `oc_mydash_feed_tokens` with `userId='alice'`, the generated token, `createdAt` set to now, `lastUsedAt=NULL`, `revokedAt=NULL`
+  - Return HTTP 200 with JSON body `{"token": "...", "url": "https://example.com/feed/<token>.xml"}`
+- AND the `url` MUST be an absolute URL (e.g., `https://myinstance.example/index.php/apps/mydash/api/feed/<token>.xml`)
+
+#### Scenario: Request token when one already exists
+- GIVEN user "alice" has previously issued a token with value "abc...xyz"
+- WHEN she sends `GET /api/feed/token`
+- THEN the system MUST return HTTP 200 with the existing token (no duplicate created)
+- AND the response MUST include `{"token": "abc...xyz", "url": "...abc...xyz.xml"}`
+
+#### Scenario: Unauthenticated request is rejected
+- GIVEN an unauthenticated client (no Nextcloud session)
+- WHEN it sends `GET /api/feed/token`
+- THEN the system MUST return HTTP 401 Unauthorized
+
+### Requirement: REQ-FEED-002 Token Regenerate
+
+Users MUST be able to revoke and reissue a new token in a single atomic operation, invalidating the old token.
+
+#### Scenario: Regenerate an existing token
+- GIVEN user "bob" has an existing token "old_token_xyz"
+- WHEN he sends `POST /api/feed/token/regenerate`
+- THEN the system MUST:
+  - Set `revokedAt` on the old token record to now
+  - Generate a new 32-byte random token and base64-url-encode it
+  - Insert or update to create a fresh record with `userId='bob'`, the new token, `createdAt` set to now, `lastUsedAt=NULL`, `revokedAt=NULL`
+  - Return HTTP 200 with `{"token": "new_token_...", "url": "...new_token_....xml"}`
+- AND the old token MUST no longer resolve any feeds (returns 404)
+
+#### Scenario: Regenerate when no token exists
+- GIVEN user "charlie" has never requested a token
+- WHEN he sends `POST /api/feed/token/regenerate`
+- THEN the system MUST generate and return a new token (same as first-time issuance)
+- AND HTTP 200 with the token and URL
+
+#### Scenario: Unauthenticated regenerate is rejected
+- GIVEN an unauthenticated client
+- WHEN it sends `POST /api/feed/token/regenerate`
+- THEN the system MUST return HTTP 401
+
+### Requirement: REQ-FEED-003 Token Soft-Revoke
+
+Users MUST be able to soft-revoke (disable) their token without deleting the database record, enabling re-enablement or re-issuance later.
+
+#### Scenario: Soft-revoke an active token
+- GIVEN user "diana" has an active token
+- WHEN she sends `DELETE /api/feed/token`
+- THEN the system MUST:
+  - Set `revokedAt` on her token record to now
+  - Return HTTP 204 No Content
+- AND the token MUST no longer resolve any feeds (returns 404 on public `/feed/<token>.xml` request)
+
+#### Scenario: Revoke when no token exists
+- GIVEN user "eve" has never requested a token
+- WHEN she sends `DELETE /api/feed/token`
+- THEN the system MUST return HTTP 204 (idempotent, treat as success even if no token was active)
+
+#### Scenario: Re-issue after revocation
+- GIVEN user "frank" has previously revoked his token via `DELETE /api/feed/token`
+- WHEN he sends `GET /api/feed/token`
+- THEN the system MUST issue a NEW token (the revoked record remains, a new one is inserted)
+- AND the old revoked token MUST NOT be re-activated
+
+#### Scenario: Unauthenticated revoke is rejected
+- GIVEN an unauthenticated client
+- WHEN it sends `DELETE /api/feed/token`
+- THEN the system MUST return HTTP 401
+
+### Requirement: REQ-FEED-004 Public Feed Rendering
+
+Public clients MUST be able to request and render a feed without Nextcloud session auth by providing a valid token, receiving a standards-compliant RSS or Atom feed.
+
+#### Scenario: Fetch feed with valid token
+- GIVEN a public client (no Nextcloud auth) and a valid token "secure_token_xyz" belonging to user "grace"
+- WHEN it sends `GET /feed/secure_token_xyz.xml`
+- THEN the system MUST:
+  - Resolve the user "grace" from the token record
+  - Return HTTP 200 with Content-Type `application/rss+xml` or `application/atom+xml`
+  - Return a valid RSS 2.0 or Atom feed with one `<item>` (RSS) or `<entry>` (Atom) per dashboard grace can access
+  - Set `lastUsedAt` on the token record to now
+- AND the response MUST include a `<title>` tag (e.g., "Grace's MyDash Dashboards") and `<link>` to the MyDash home
+
+#### Scenario: Fetch feed with invalid token
+- GIVEN a public client and a token that does not exist in the database
+- WHEN it sends `GET /feed/invalid_token.xml`
+- THEN the system MUST return HTTP 404 (do NOT leak whether the token ever existed)
+- AND `lastUsedAt` MUST NOT be updated
+
+#### Scenario: Fetch feed with revoked token
+- GIVEN a public client and a token that was previously revoked (has `revokedAt` set)
+- WHEN it sends `GET /feed/revoked_token.xml`
+- THEN the system MUST return HTTP 404 (treat revoked same as non-existent, do not leak revocation status)
+
+#### Scenario: Fetch feed with revoked-then-reissued user
+- GIVEN user "henry" revokes his token and later re-issues (generating a new one), and a client tries the old revoked token
+- WHEN it sends `GET /feed/old_revoked_token.xml`
+- THEN the system MUST return HTTP 404
+
+### Requirement: REQ-FEED-005 Feed Item Content
+
+Each dashboard the token-owner can access MUST appear as a separate `<item>` (RSS) or `<entry>` (Atom) in the feed, carrying essential metadata and respecting the user's ACLs.
+
+#### Scenario: Feed with multiple accessible dashboards
+- GIVEN user "iris" has three dashboards: "Work" (updated 2026-04-20), "Personal" (updated 2026-04-15), "Archived" (updated 2026-03-01), all accessible to iris per the permissions capability
+- WHEN a public client requests `GET /feed/iris_token.xml`
+- THEN the response MUST include three items in reverse-chronological order (most recent first):
+  1. "Work" (pubDate 2026-04-20T..., title "Work")
+  2. "Personal" (pubDate 2026-04-15T...)
+  3. "Archived" (pubDate 2026-03-01T...)
+- AND each item MUST carry:
+  - `<title>`: dashboard name (e.g., "Work")
+  - `<link>`: absolute deep-link to the dashboard in Nextcloud (e.g., `https://example.com/index.php/apps/mydash#/dashboard/uuid`)
+  - `<description>`: dashboard description (escaped for XML), or empty string if null
+  - `<pubDate>`: dashboard's `updatedAt` timestamp in RFC 2822 format (e.g., "Wed, 20 Apr 2026 14:30:00 +0000")
+  - `<guid isPermaLink="false">`: dashboard UUID (ensures feed readers detect updates correctly)
+  - `<author>`: display name of the dashboard owner (e.g., "Iris Smith")
+
+#### Scenario: Dashboard with null description
+- GIVEN dashboard "NoDesc" with `description=NULL`
+- WHEN it appears in a feed
+- THEN the `<description>` tag MUST be present but empty, or the tag MUST be omitted entirely
+- AND the item MUST remain valid RSS
+
+#### Scenario: Dashboard description with special XML characters
+- GIVEN dashboard "Special" with description "Profits & losses <Q2>" (contains `&`, `<`, `>`)
+- WHEN it appears in the feed
+- THEN all special characters MUST be XML-escaped in the `<description>` tag (e.g., `&amp;`, `&lt;`, `&gt;`)
+
+### Requirement: REQ-FEED-006 ACL Filtering
+
+Feeds MUST respect the token-owner's dashboard access permissions (permissions capability) such that private dashboards visible only to the token-owner do not leak their content to unauthorized observers.
+
+#### Scenario: Token-owner sees only accessible dashboards
+- GIVEN user "jack" has two dashboards: "Public" (visible to all, via permissions), "Private" (only visible to jack)
+- WHEN a public client requests jack's feed token
+- THEN the response MUST include only "Public"
+- AND "Private" MUST NOT appear in the feed
+
+#### Scenario: Shared dashboard via permissions
+- GIVEN dashboard "Shared" is configured to be visible to user "kate" (via permissions capability), and "kate"'s token is used
+- WHEN a public client requests /feed/kate_token.xml
+- THEN "Shared" MUST be included in the feed
+
+#### Scenario: Filtering is based on token-owner's identity, not requester IP
+- GIVEN user "leo" has token "leo_secret" and dashboard "Leo's Private" visible only to leo
+- WHEN ANY public client (any IP, any location) requests /feed/leo_secret.xml
+- THEN the feed MUST contain only dashboards accessible to leo (regardless of who or where the requester is)
+- AND "Leo's Private" MUST appear even if accessed from a different country
+
+### Requirement: REQ-FEED-007 Feed Item Count Cap
+
+Feeds MUST include at most N dashboards per feed (admin-configurable), ordered by most recent first, to prevent unbounded response sizes.
+
+#### Scenario: Feed respects default cap of 50 items
+- GIVEN user "maya" has 75 accessible dashboards, ordered by descending `updatedAt`
+- WHEN a public client requests /feed/maya_token.xml
+- THEN the response MUST include exactly 50 items (the newest 50 by `updatedAt`)
+- AND the oldest 25 dashboards MUST NOT appear
+
+#### Scenario: Administrator configures feed cap
+- GIVEN the `mydash.feed_item_cap` config is set to 10 (default: 50)
+- WHEN user "noah" requests /feed/noah_token.xml with 15 accessible dashboards
+- THEN the response MUST include exactly 10 items
+- AND the config value MUST be read from `OCP\IConfig::getAppValue('mydash', 'mydash.feed_item_cap', '50')`
+
+#### Scenario: Feed with fewer than cap dashboards
+- GIVEN user "olivia" has 8 accessible dashboards and the cap is 50
+- WHEN a public client requests /feed/olivia_token.xml
+- THEN the response MUST include all 8 items (no padding or errors)
+
+### Requirement: REQ-FEED-008 Per-User Opt-In
+
+Feeds MUST be off by default; users MUST explicitly opt-in by calling `GET /api/feed/token` to enable feed generation.
+
+#### Scenario: No feed token pre-created for any user
+- GIVEN a fresh MyDash installation with no users having requested feed tokens
+- WHEN an admin or system process tries to request /feed/any_token.xml
+- THEN the system MUST return HTTP 404 for any token
+
+#### Scenario: User explicitly requests token to enable feed
+- GIVEN user "paul" has never requested a feed token
+- WHEN paul sends `GET /api/feed/token`
+- THEN:
+  - A token is generated and stored
+  - The endpoint returns the token
+  - Only NOW can public clients access /feed/paul_token.xml (before, /feed/paul_token.xml would return 404 because no token record existed)
+
+#### Scenario: Revocation disables feed without deleting user
+- GIVEN user "quinn" has an active token and a feed accessible at /feed/quinn_token.xml
+- WHEN quinn sends `DELETE /api/feed/token`
+- THEN:
+  - /feed/quinn_token.xml returns HTTP 404
+  - quinn's user account remains intact
+  - If quinn later calls `GET /api/feed/token` again, a NEW token is issued (the old one is not reactivated)
+
+### Requirement: REQ-FEED-009 Token Format and Randomness
+
+Token format MUST be cryptographically random, URL-safe, and non-enumerable to prevent brute-force attacks.
+
+#### Scenario: Token is cryptographically random
+- GIVEN a MyDash instance with access to `random_bytes()` (PHP 7+)
+- WHEN user "rose" requests a token via `GET /api/feed/token`
+- THEN the generated token MUST be produced by `bin2hex(random_bytes(32))` or equivalent base64-url encoding
+- AND each token MUST be unique across all users (enforced by database UNIQUE constraint on (userId))
+
+#### Scenario: Token is URL-safe
+- GIVEN a generated token
+- WHEN it is used in a URL like /feed/{token}.xml
+- THEN it MUST NOT require URL-encoding (no `+`, `/`, `=` or other URL-unsafe characters after base64-url encoding)
+- NOTE: bin2hex() output is inherently URL-safe; base64-url encoding must use `-` and `_` instead of `+` and `/`
+
+#### Scenario: Token is not enumerable
+- GIVEN two consecutive token generations (e.g., from two different users)
+- WHEN their tokens are observed
+- THEN there MUST be no discernible pattern, incremental sequence, or time-based correlation
+- AND an attacker MUST NOT be able to guess a valid token even if they observe one or more valid tokens
+

--- a/openspec/changes/dashboard-rss-feeds/tasks.md
+++ b/openspec/changes/dashboard-rss-feeds/tasks.md
@@ -1,0 +1,101 @@
+# Tasks — dashboard-rss-feeds
+
+## 1. Schema migration
+
+- [ ] 1.1 Create `lib/Migration/VersionXXXXDate2026...AddFeedTokensTable.php` adding new `oc_mydash_feed_tokens` table with columns: `id` (INT, auto-increment, PK), `userId` (VARCHAR(64)), `token` (VARCHAR(64)), `createdAt` (DATETIME), `lastUsedAt` (DATETIME NULL), `revokedAt` (DATETIME NULL)
+- [ ] 1.2 Add UNIQUE index on `(userId)` to enforce one token per user; add index on `token` for fast public feed lookup
+- [ ] 1.3 Confirm migration is reversible (drop table in `postSchemaChange` rollback path)
+- [ ] 1.4 Run migration locally against sqlite, mysql, and postgres; verify schema applied cleanly each time
+
+## 2. Domain model
+
+- [ ] 2.1 Create `lib/Db/FeedToken.php` entity with fields: `id`, `userId`, `token`, `createdAt`, `lastUsedAt`, `revokedAt` (use Entity `__call` pattern, no named args in setters)
+- [ ] 2.2 Add getters/setters for each field with proper type hints and Entity conventions
+- [ ] 2.3 Add helper method `isRevoked()` returning `revokedAt !== null`
+- [ ] 2.4 Add helper method `isValid()` returning `revokedAt === null` (token is active)
+
+## 3. Mapper layer
+
+- [ ] 3.1 Create `lib/Db/FeedTokenMapper.php` extending `QBMapper`
+- [ ] 3.2 Add `FeedTokenMapper::findByToken(string $token): FeedToken` — returns token record; throws `DoesNotExistException` if not found or if revoked
+- [ ] 3.3 Add `FeedTokenMapper::findByUserId(string $userId): ?FeedToken` — returns active token for user or null if none exists
+- [ ] 3.4 Add `FeedTokenMapper::updateLastUsed(FeedToken $token): void` — sets `lastUsedAt` to now and persists
+- [ ] 3.5 Add fixture-based PHPUnit tests covering: token lookup, revoked token (not found), user with no token, update last-used
+
+## 4. Service layer — Token Management
+
+- [ ] 4.1 Create `lib/Service/FeedTokenService.php` with dependency injection: `FeedTokenMapper`, `ITimeFactory` (or \DateTime), `ILogger`
+- [ ] 4.2 Add `FeedTokenService::getOrCreateToken(string $userId): FeedToken` — atomically fetch existing token or create a new one; returns the token record
+- [ ] 4.3 Add `FeedTokenService::regenerateToken(string $userId): FeedToken` — set `revokedAt` on existing token, generate new token (32 random bytes, base64-url encoded), insert new record, return new token
+- [ ] 4.4 Add `FeedTokenService::revokeToken(string $userId): void` — set `revokedAt` on the user's active token; idempotent (succeeds even if no token exists)
+- [ ] 4.5 Add `FeedTokenService::resolveToken(string $token): ?FeedToken` — lookup token, return null if not found or revoked, else return token record; call `mapper.updateLastUsed()` before returning
+- [ ] 4.6 Token format: `bin2hex(random_bytes(32))` or equivalent base64-url encoding; ensure URL-safe output (no `+`, `/`, `=` if using base64-url)
+
+## 5. Service layer — Feed Rendering
+
+- [ ] 5.1 Create `lib/Service/FeedService.php` with dependencies: `DashboardMapper`, `PermissionService`, `IUserManager`, `IConfig`, `ILogger`
+- [ ] 5.2 Add `FeedService::renderFeed(FeedToken $token): string` — main entry point
+  - [ ] 5.2a Query all dashboards accessible to the token's user via `DashboardMapper::findByUserId(token.userId)`
+  - [ ] 5.2b Filter by the user's actual ACLs (call `PermissionService` or equivalent to check each dashboard)
+  - [ ] 5.2c Sort by `updatedAt` descending (most recent first)
+  - [ ] 5.2d Cap at `IConfig::getAppValue('mydash', 'mydash.feed_item_cap', '50')` items
+  - [ ] 5.2e Build RSS 2.0 or Atom feed XML; return as string
+- [ ] 5.3 Add `FeedService::buildRssFeed(array $dashboards, string $userId, string $feedUrl): string` — construct RSS 2.0 XML
+  - [ ] 5.3a `<rss version="2.0">` root, `<channel>` with `<title>`, `<link>` (Nextcloud root), `<description>`
+  - [ ] 5.3b One `<item>` per dashboard with: `<title>` (name), `<link>` (deep-link to dashboard), `<description>` (escaped), `<pubDate>` (RFC 2822, updatedAt), `<guid isPermaLink="false">` (UUID), `<author>` (owner display name)
+- [ ] 5.4 Add `FeedService::getOwnerDisplayName(string $userId): string` — resolve user's display name via `IUserManager::get(userId).getDisplayName()`; fallback to userId if user not found
+- [ ] 5.5 Add helper `escapeDashboardDescription(string $desc): string` — XML-escape `&`, `<`, `>`, `"` in descriptions to prevent injection
+
+## 6. Controller + routes
+
+- [ ] 6.1 Create `lib/Controller/FeedController.php` extending `ApiController`
+- [ ] 6.2 Add `FeedController::getToken()` mapped to `GET /api/feed/token` (`#[NoAdminRequired]`, logged-in user required)
+  - [ ] 6.2a Call `FeedTokenService::getOrCreateToken($this->userId)`
+  - [ ] 6.2b Return HTTP 200 with `{"token": "...", "url": "https://.../feed/<token>.xml"}`
+  - [ ] 6.2c Construct absolute feed URL using `IUrlGenerator` or similar (app root + route name + token)
+- [ ] 6.3 Add `FeedController::regenerateToken()` mapped to `POST /api/feed/token/regenerate` (`#[NoAdminRequired]`, logged-in)
+  - [ ] 6.3a Call `FeedTokenService::regenerateToken($this->userId)`
+  - [ ] 6.3b Return HTTP 200 with new token and URL
+- [ ] 6.4 Add `FeedController::revokeToken()` mapped to `DELETE /api/feed/token` (`#[NoAdminRequired]`, logged-in)
+  - [ ] 6.4a Call `FeedTokenService::revokeToken($this->userId)`
+  - [ ] 6.4b Return HTTP 204 No Content (idempotent)
+- [ ] 6.5 Add `FeedController::publicFeed(string $token)` mapped to `GET /feed/{token}.xml` (public, no auth required)
+  - [ ] 6.5a Call `FeedTokenService::resolveToken($token)` to fetch and validate token (returns null if revoked or not found)
+  - [ ] 6.5b If null, return HTTP 404 (do NOT differentiate between revoked and non-existent to avoid leaking status)
+  - [ ] 6.5c Call `FeedService::renderFeed($token)` to generate feed XML
+  - [ ] 6.5d Return HTTP 200 with Content-Type `application/rss+xml; charset=utf-8` and the feed body
+- [ ] 6.6 Register all four routes in `appinfo/routes.php` with correct requirements and methods
+- [ ] 6.7 Confirm methods carry correct auth attributes (`#[NoAdminRequired]` for authed endpoints, no attribute for public)
+
+## 7. Database sensitive-parameter marking
+
+- [ ] 7.1 If `config/sensitive-parameters.php` exists, add `oc_mydash_feed_tokens.token` to the sensitive list (prevents plaintext logging)
+- [ ] 7.2 If file does not exist, document the requirement in a code comment or TODO
+
+## 8. PHPUnit tests
+
+- [ ] 8.1 `FeedTokenMapperTest::findByToken` — valid token, revoked token, non-existent token
+- [ ] 8.2 `FeedTokenMapperTest::findByUserId` — user with active token, user with no token, user with only revoked tokens
+- [ ] 8.3 `FeedTokenMapperTest::updateLastUsed` — verify lastUsedAt is updated on persist
+- [ ] 8.4 `FeedTokenServiceTest::getOrCreateToken` — first call creates, second call returns same, isolation between users
+- [ ] 8.5 `FeedTokenServiceTest::regenerateToken` — old token revoked, new token unique, old no longer resolves
+- [ ] 8.6 `FeedTokenServiceTest::revokeToken` — idempotent on non-existent token
+- [ ] 8.7 `FeedTokenServiceTest::resolveToken` — valid token updates lastUsedAt, revoked token returns null, non-existent returns null
+- [ ] 8.8 `FeedServiceTest::renderFeed` — multi-dashboard fixture, correct sort order (newest first), ACL filtering (user sees only accessible), item cap enforced
+- [ ] 8.9 `FeedServiceTest::buildRssFeed` — valid RSS 2.0 XML structure, all fields present, special characters escaped
+- [ ] 8.10 `FeedControllerTest::publicFeed` — valid token (200, correct feed), revoked token (404), non-existent token (404)
+
+## 9. Integration tests (E2E)
+
+- [ ] 9.1 Create a dashboard fixture for integration testing; grant permission to specific user
+- [ ] 9.2 Test full flow: user A requests token, gets feed URL, public client fetches feed, verifies dashboard appears
+- [ ] 9.3 Test ACL: user B (different user) cannot access user A's private dashboard via user A's feed
+- [ ] 9.4 Test regenerate: token A → revoke+regenerate → token B, old feed returns 404, new feed works
+- [ ] 9.5 Test soft-revoke: token active → DELETE → 404, later GET /api/feed/token issues new token
+
+## 10. Documentation
+
+- [ ] 10.1 Add to `CHANGELOG.md`: "New capability `dashboard-rss-feeds`: per-user RSS feed token exposing accessible dashboards; opt-in via GET /api/feed/token"
+- [ ] 10.2 Document token format and security considerations in code comments and/or app README
+- [ ] 10.3 Document the four endpoints in app API docs (if such docs exist) or in a separate FEED_API.md file
+

--- a/openspec/changes/dashboard-templates/design.md
+++ b/openspec/changes/dashboard-templates/design.md
@@ -1,0 +1,174 @@
+# Design — Dashboard Templates
+
+## Context
+
+The existing `admin-templates` capability (REQ-TMPL-001..011, status: implemented) stores dashboard
+templates as rows in `oc_mydash_dashboards` with `type='admin_template'`. Admins create templates,
+target them at groups, and users receive personal copies on first access. The full storage model,
+distribution logic, and permission resolution are already live.
+
+This change (`dashboard-templates`) adds three capabilities on top of that foundation: a self-service
+gallery where any logged-in user can browse available templates; a save-as-template action that lets
+dashboard owners convert their work into a reusable blueprint; and three metadata fields
+(`templateCategory`, `templatePreviewImage`, `templateDescription`) that make templates discoverable.
+The new requirements are REQ-TMPL-012..015; existing REQ-TMPL-001..011 are untouched.
+
+A deep-dive into the reference implementation was conducted to understand how it handles templates.
+The reference implementation stores templates as filesystem folders under `/{lang}/_templates/`
+within a GroupFolder, with template membership inferred from path convention rather than a type
+discriminator. This design document records that divergence explicitly and explains why MyDash keeps
+its current DB enum approach.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Expose `GET /api/templates/gallery` — indexed, fast, list-only (no widget tree in response).
+- Expose `POST /api/dashboards/{uuid}/save-as-template` — owner-only, creates a deep-copied
+  `admin_template` row with a fresh UUID.
+- Add three nullable metadata columns to `oc_mydash_dashboards`: `templateCategory VARCHAR(64)`,
+  `templatePreviewImage TEXT`, `templateDescription TEXT`.
+- Reuse the `custom-icon-upload-pattern` for preview image upload; no parallel mechanism.
+- Keep the gallery query single-pass: `WHERE type='admin_template'` with optional
+  `AND templateCategory=?`, ordered by `(templateCategory, name)` or `lastUpdatedAt DESC`.
+
+**Non-Goals:**
+- Do NOT switch template storage to filesystem folders under `_templates/` — this is a deliberate
+  and permanent divergence from the reference implementation.
+- Do NOT change existing REQ-TMPL-001..011 endpoints, data model fields, or distribution logic.
+- Do NOT introduce a fixed enum for `templateCategory`; values are free-form admin-curated strings.
+- Do NOT add pagination to the gallery endpoint in this change (100+ templates within 500ms is the
+  performance target; pagination can be a follow-up if needed).
+- Do NOT modify the reference implementation's approach to templates — it is recorded as evidence
+  only, not as a target to converge on.
+
+## Decisions
+
+### D1: Storage model — keep DB type enum, deliberately diverge from reference implementation
+
+**Decision**: Templates remain `type='admin_template'` rows in `oc_mydash_dashboards`. The three new
+metadata fields are nullable columns on the same table. No filesystem folder convention is
+introduced.
+
+**Alternatives considered:**
+
+- **Filesystem folders under `_templates/` per language (the reference implementation's approach)**:
+  Rejected for five reasons:
+  1. The existing `admin-templates` capability (REQ-TMPL-001..011) is already shipped and live.
+     Switching storage models now is a breaking change — all existing templates, the distribution
+     chain, and permission resolution would need to be re-implemented.
+  2. DB enum lookup is a single indexed query (`WHERE type='admin_template'`). The filesystem
+     approach requires walking the full page tree and string-matching each path for the `/_templates/`
+     segment — worse performance at scale.
+  3. The DB enum cleanly separates concerns: one row per dashboard, one `type` column. The filesystem
+     path convention conflates location with kind, which makes the invariant harder to enforce and
+     test.
+  4. MyDash has two content-storage backends: database rows and groupfolder-backed dashboards (see
+     the `groupfolder-storage-backend` change). The filesystem `_templates/` approach only makes
+     sense in a GroupFolder world. DB-backed dashboards have no GroupFolder and therefore no
+     `_templates/` folder; a cross-backend representation requires the DB type column.
+  5. The reference implementation's filesystem approach grants templates GroupFolder ACL inheritance
+     "for free". MyDash achieves equivalent access control via the existing `dashboard-sharing`
+     capability; no ACL advantage is lost.
+
+**Rationale**: The DB enum approach was the correct design when `admin-templates` was built and
+remains correct here. The reference implementation's path convention is a reasonable fit for a
+purely GroupFolder-backed system with no `type` column; MyDash's architecture differs on both counts.
+Recording this as a deliberate divergence rather than a discrepancy ensures future contributors do
+not attempt convergence.
+
+**Source evidence (what the reference implementation does, not what we are adopting):**
+
+- `intravox-source/lib/Service/SetupService.php:337-341` — `_templates` subfolder is created under
+  each language folder (`nl/_templates/`, `en/_templates/`) during initial setup. Code:
+  ```php
+  $langFolder->newFolder('_templates');
+  $this->logger->info("Created _templates folder in {$lang}");
+  ```
+- `intravox-source/lib/Service/SetupService.php:664-699` — `migrateTemplatesFolders()` is an
+  idempotent migration that adds `_templates/` to existing installs that lack it. Runs per language.
+- `intravox-source/lib/Service/SetupService.php:711-784` — `installDefaultTemplates()` reads
+  `demo-data/templates/*.json`, creates a subfolder per template name under each language's
+  `_templates/`, writes the JSON, and copies a `_media/` folder alongside it. Template identity is
+  the subfolder name, not a DB row.
+- `intravox-source/lib/Service/PageService.php:564` — `navigation.json` and `footer.json` at the
+  language root are excluded from page listings; these are config files, not pages.
+- `intravox-source/lib/Service/PageService.php:1973` — The same exclusion is applied when scanning
+  for media: files named `navigation.json` or `footer.json` are skipped. Template membership is
+  inferred from path segment (`/_templates/`), not from any field inside the JSON.
+
+### D2: Gallery query
+
+**Decision**: `GET /api/templates/gallery` executes:
+```sql
+SELECT ... FROM oc_mydash_dashboards
+WHERE type = 'admin_template'
+[AND templateCategory = :cat]
+ORDER BY templateCategory IS NULL, templateCategory, name
+```
+Nulls sort last. Optional `?sort=updatedAt` switches to `ORDER BY updatedAt DESC`. Single query, no
+per-row joins. Widget placements are NOT fetched (gallery is list-only; instantiation fetches them).
+
+**Rationale**: Leverages the existing index on `type`; adding a composite index on
+`(type, templateCategory)` is noted in the spec delta (see REQ-TMPL-012). No N+1 risk because
+placements are excluded from the list response.
+
+### D3: Save-as-template
+
+**Decision**: `POST /api/dashboards/{uuid}/save-as-template` deep-copies the source dashboard's
+widget placements into a NEW row with `type='admin_template'`, a fresh UUID v4, and `userId=null`.
+The source dashboard is not modified. `basedOnTemplate` on the new template is set to null —
+templates do not chain.
+
+**Rationale**: A copy rather than a link means the new template is immediately independent. Edits
+to the source dashboard after save-as-template do not propagate to the template, matching the
+existing REQ-TMPL-006 independence guarantee that the distribution chain already provides for user
+copies.
+
+### D4: Preview image storage
+
+**Decision**: Reuse the `custom-icon-upload-pattern` from `openspec/changes/custom-icon-upload-pattern/`
+for `POST /api/admin/templates/{uuid}/preview-image`. Same upload endpoint shape, same storage path
+convention, same URL-return contract. The stored URL is written to `templatePreviewImage`.
+
+**Rationale**: Pattern reuse avoids inventing a parallel image-persistence mechanism. The
+custom-icon-upload pattern already handles file-type validation, Nextcloud Files storage, and
+public-share URL generation — all requirements for preview images are covered.
+
+### D5: Template categories — free-form string, not fixed enum
+
+**Decision**: `templateCategory` is `VARCHAR(64)` with no server-side enum constraint. Admins type
+whatever category label fits their organisation. The gallery groups by exact-match string; unknown
+categories appear as their own group.
+
+**Alternatives considered:**
+
+- **Fixed enum** (`marketing`, `engineering`, `hr`, …): Rejected — adding new categories would
+  require a schema migration, and customer category needs vary too widely to enumerate in the spec.
+  Free-form is consistent with how MyDash handles other admin-curated labels (e.g., `description`).
+
+**Rationale**: Free-form strings give admins immediate flexibility at the cost of no server-enforced
+taxonomy. The gallery UI can suggest existing category values (from a `DISTINCT templateCategory`
+query) to reduce accidental duplicates without requiring a fixed schema.
+
+## Spec changes implied
+
+- Add a NOTE to REQ-TMPL-012 that the gallery query should be backed by a composite index on
+  `(type, templateCategory)` to keep the optional category-filter path indexed.
+- Confirm REQ-TMPL-013 specifies deep-copy semantics (not a link or symlink) and that
+  `basedOnTemplate` on the new template is null.
+- Confirm REQ-TMPL-015 references the `custom-icon-upload-pattern` endpoint shape explicitly.
+- The existing `specs/admin-templates/spec.md` contains no filesystem-folder language; no removals
+  needed there. The thin `design.md` this document replaces did contain filesystem-folder guidance —
+  that is now superseded and should not be re-introduced.
+
+## Open follow-ups
+
+- `basedOnTemplate` on user copies: cascade-nullify vs leave stale when the referenced template is
+  deleted. Current behaviour (catch `DoesNotExistException`, fall back to own `permissionLevel`) is
+  functional but implicit; explicit nullify-on-delete may be cleaner.
+- `templateDescription` max length: REQ-TMPL-014 accepts 500 chars; no upper bound is set. Decide
+  whether TEXT is uncapped or capped (e.g. 2000 chars) before migration is written.
+- `demo-data-showcases` seeding: should showcase templates populate `templateCategory` automatically
+  or leave it null for manual admin curation?
+- Gallery filter UX: return a `categories` array in the gallery response (from `DISTINCT
+  templateCategory`) or expose a separate `GET /api/templates/gallery/categories` endpoint?

--- a/openspec/changes/dashboard-templates/proposal.md
+++ b/openspec/changes/dashboard-templates/proposal.md
@@ -1,0 +1,48 @@
+# Gallery and categorization for template discovery
+
+## Why
+
+Today, MyDash admins can create templates and distribute them to groups, but users have no way to **discover and instantiate** templates themselves. Templates exist as administrative snapshots visible only via the first-access distribution chain. Organizations need a self-service gallery where any dashboard owner can browse available templates, understand their purpose (with preview images and descriptions), filter by category, and create their own copy via "save as template" — converting a custom dashboard back into a reusable blueprint. This unblocks workflow-led adoption where teams build their own gold-standard layouts and share them within peer groups.
+
+## What Changes
+
+- Extend `oc_mydash_dashboards` rows of type `admin_template` with three new columns: `templateCategory` (VARCHAR 64, nullable), `templatePreviewImage` (TEXT, nullable), and `templateDescription` (TEXT, nullable, longer than the existing `description` field).
+- Expose `GET /api/templates/gallery` returning all `admin_template` dashboards with metadata (`uuid`, `name`, `description`, `category`, `previewImage`, `gridColumns`, `widgetCount`, `lastUpdatedAt`) — no widget tree content (list view only). Supports `?category=<cat>` filtering and `?sort=updatedAt` for recency.
+- Expose `POST /api/dashboards/{uuid}/save-as-template` — owner-only endpoint creating a new `admin_template` with a fresh UUID, deep-copied widget tree, and user-supplied `{name, description, category, previewImage}` metadata.
+- Expose `POST /api/admin/templates/{uuid}/preview-image` (multipart) for admins to upload preview images, persisted via the existing dashboard-icons custom-icon-upload pattern (read prior art in `openspec/changes/custom-icon-upload-pattern/`).
+- Existing template-from-template instantiation flow (REQ-TMPL-005) remains unchanged — this adds gallery + categorization UI on top.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `admin-templates`: adds REQ-TMPL-012 (gallery endpoint), REQ-TMPL-013 (save-as-template), REQ-TMPL-014 (template metadata), REQ-TMPL-015 (preview-image upload). Existing REQ-TMPL-001..011 untouched.
+
+## Impact
+
+**Affected code:**
+
+- `lib/Db/Dashboard.php` — add three new nullable fields with getters/setters
+- `lib/Db/DashboardMapper.php` — add `findAllTemplatesForGallery()` with optional category filter, sorting by category/name or updatedAt
+- `lib/Service/AdminTemplateService.php` — add gallery listing + filtering logic
+- `lib/Controller/TemplateController.php` (new) — expose `gallery()`, `saveAsTemplate()` endpoints
+- `lib/Controller/AdminController.php` — add `uploadPreviewImage()` endpoint
+- `appinfo/routes.php` — register three new routes
+- `lib/Migration/VersionXXXXDate2026...php` — schema migration adding three nullable columns
+- `src/stores/templates.js` — track gallery state + preview images
+- `src/views/TemplateGallery.vue` (new) — gallery UI with category filter, cards with preview images
+
+**Affected APIs:**
+
+- 3 new routes (no existing routes changed, gallery is read-only)
+- All endpoints support existing template distribution — no breaking changes
+
+**Dependencies:**
+
+- Custom-icon-upload pattern from `openspec/changes/custom-icon-upload-pattern/` (reused for preview-image storage)
+- No new composer or npm dependencies
+
+**Migration:**
+
+- Zero-impact: three new nullable columns. Existing rows get `NULL` defaults. Existing REQ-TMPL-001..011 endpoints continue unchanged.
+- No data backfill required.

--- a/openspec/changes/dashboard-templates/specs/admin-templates/spec.md
+++ b/openspec/changes/dashboard-templates/specs/admin-templates/spec.md
@@ -1,0 +1,199 @@
+---
+capability: admin-templates
+delta: true
+status: draft
+---
+
+# Admin Templates — Delta from change `dashboard-templates`
+
+## ADDED Requirements
+
+### Requirement: REQ-TMPL-012 Template Gallery Endpoint
+
+The system MUST expose a read-only gallery endpoint that lists all `admin_template` dashboards with metadata suitable for discovery and instantiation.
+
+#### Scenario: List all templates in gallery
+
+- GIVEN 3 admin templates exist with `templateCategory: 'marketing'`, `'engineering'`, and `null`
+- WHEN a logged-in user sends `GET /api/templates/gallery`
+- THEN the system MUST return HTTP 200 with an array of 3 template objects
+- AND each object MUST include: `uuid`, `name`, `description`, `category` (nullable string), `previewImage` (nullable URL), `gridColumns`, `widgetCount` (count of widget placements), `lastUpdatedAt`
+- AND the response MUST NOT include the widget tree or `isCompulsory` flag details (gallery is a list view, not a render)
+
+#### Scenario: Filter gallery by category
+
+- GIVEN 5 templates exist: 2 with `templateCategory: 'marketing'`, 2 with `templateCategory: 'engineering'`, 1 with `templateCategory: null`
+- WHEN a logged-in user sends `GET /api/templates/gallery?category=marketing`
+- THEN the system MUST return HTTP 200 with an array of 2 templates
+- AND the response MUST contain only templates where `templateCategory = 'marketing'`
+
+#### Scenario: Default sort order
+
+- GIVEN multiple templates exist with various categories and names
+- WHEN a user sends `GET /api/templates/gallery` (no sort parameter)
+- THEN results MUST be sorted first by `templateCategory` (null last), then by `name` alphabetically
+- AND this enables consistent ordering for pagination
+
+#### Scenario: Sort by recency
+
+- GIVEN 3 templates with `lastUpdatedAt` values: "2026-05-01 10:00:00", "2026-04-30 14:30:00", "2026-05-01 09:15:00"
+- WHEN a user sends `GET /api/templates/gallery?sort=updatedAt`
+- THEN the system MUST return results sorted by `lastUpdatedAt` descending (most recent first)
+- AND HTTP 200 MUST be returned
+
+#### Scenario: Gallery includes category null templates
+
+- GIVEN a template has `templateCategory: null`
+- WHEN a user calls `GET /api/templates/gallery` without category filter
+- THEN the template MUST be included
+- AND when calling `GET /api/templates/gallery?category=marketing`, the template with `null` category MUST NOT be included
+
+### Requirement: REQ-TMPL-013 Save-as-template Action
+
+Any dashboard owner MUST be able to convert their current dashboard into a reusable admin template, creating a snapshot with a fresh UUID and a deep-copied widget tree.
+
+#### Scenario: Save a personal dashboard as a template
+
+- GIVEN user "alice" owns a personal dashboard with 4 widget placements
+- WHEN she sends `POST /api/dashboards/{uuid}/save-as-template` with body:
+  ```json
+  {
+    "name": "Product Roadmap Template",
+    "description": "Standard layout for product planning dashboards",
+    "category": "product",
+    "previewImage": "https://example.com/roadmap-preview.png"
+  }
+  ```
+- THEN the system MUST create a new dashboard with `type: 'admin_template'` and a fresh UUID
+- AND the new template MUST have all 4 widget placements deep-copied from the source
+- AND each copied placement MUST be independent (editing the source dashboard MUST NOT affect the template)
+- AND `userId` on the template MUST be null (templates are admin-collective, not user-owned)
+- AND the response MUST return HTTP 201 with the newly created template object
+
+#### Scenario: Save-as-template resets isActive flag
+
+- GIVEN a personal dashboard with `isActive: 1` (currently selected by the user)
+- WHEN the dashboard is saved as a template
+- THEN the resulting template MUST have `isActive: 0` (templates are not user dashboards; no dashboard is active for them)
+
+#### Scenario: Non-owner cannot save another's dashboard as template
+
+- GIVEN user "alice" owns dashboard "Work"
+- WHEN user "bob" sends `POST /api/dashboards/{uuid}/save-as-template` (alice's dashboard UUID)
+- THEN the system MUST return HTTP 403
+- AND the template MUST NOT be created
+
+#### Scenario: Save-as-template with admin_template source
+
+- GIVEN a user "alice" has a personal copy of an admin template (with `basedOnTemplate: 3`)
+- WHEN she sends `POST /api/dashboards/{uuid}/save-as-template` with her copy's UUID
+- THEN the system MUST create a new admin template
+- AND the new template's `basedOnTemplate` MUST be null (templates do not chain; they are independent)
+- AND the copy's source lineage is NOT preserved
+
+#### Scenario: Save-as-template with missing optional fields
+
+- GIVEN a user sends `POST /api/dashboards/{uuid}/save-as-template` with body `{"name": "My Template"}` (omitting description, category, previewImage)
+- THEN the system MUST create the template with:
+  - `templateDescription: null`
+  - `templateCategory: null`
+  - `templatePreviewImage: null`
+- AND HTTP 201 MUST be returned with the new template
+
+### Requirement: REQ-TMPL-014 Template Metadata Fields
+
+Admin templates MUST support three new metadata fields for categorization and discovery.
+
+#### Scenario: Template metadata in gallery response
+
+- GIVEN a template with `templateCategory: 'marketing'`, `templateDescription: 'Use for campaign planning'`, `templatePreviewImage: 'https://example.com/img.png'`
+- WHEN a user retrieves the template via `GET /api/templates/gallery`
+- THEN the response MUST include all three metadata fields exactly as stored
+
+#### Scenario: Metadata persists across updates
+
+- GIVEN a template with `templateCategory: 'engineering'`
+- WHEN an admin sends `PUT /api/admin/templates/{id}` to update the template name (via existing REQ-TMPL-003 endpoint)
+- THEN `templateCategory` MUST remain `'engineering'` (unchanged)
+
+#### Scenario: Update template metadata via save-as-template
+
+- GIVEN user "alice" saves her dashboard as a template with `category: 'product'`
+- THEN the new template's `templateCategory` MUST be set to `'product'`
+
+#### Scenario: Template description field length
+
+- GIVEN a user provides a `description` string of 500 characters when calling save-as-template
+- THEN the system MUST accept and store the full 500 characters (unlike the regular `description` field, which may be shorter)
+- NOTE: The `templateDescription` column stores longer text; validation MUST NOT truncate
+
+#### Scenario: Metadata fields are nullable
+
+- GIVEN a template with all metadata fields set to null
+- WHEN the template is returned via any API endpoint
+- THEN the response MUST include the fields with null values
+- AND no error MUST be thrown
+
+### Requirement: REQ-TMPL-015 Preview Image Upload Endpoint
+
+Administrators MUST be able to upload a preview image for a template via multipart form, persisted using the existing dashboard-icons upload pattern.
+
+#### Scenario: Upload preview image for a template
+
+- GIVEN an admin user and an admin template with UUID "abc123"
+- WHEN the admin sends `POST /api/admin/templates/abc123/preview-image` with a multipart body containing `file=<binary PNG>` and optional `filename='roadmap-preview.png'`
+- THEN the system MUST save the image via the custom-icon-upload pattern (reusing the mechanism from `openspec/changes/custom-icon-upload-pattern/`)
+- AND the image MUST be persisted as a publicly accessible URL or a Nextcloud share
+- AND the template's `templatePreviewImage` field MUST be updated with the URL
+- AND the response MUST return HTTP 200 with `{"previewImage": "https://example.com/...png"}`
+
+#### Scenario: Non-admin cannot upload preview image
+
+- GIVEN a regular user "alice"
+- WHEN she sends `POST /api/admin/templates/abc123/preview-image` with a file
+- THEN the system MUST return HTTP 403
+- AND the template's `templatePreviewImage` MUST NOT be modified
+
+#### Scenario: Upload replaces previous preview image
+
+- GIVEN a template with `templatePreviewImage: 'https://example.com/old.png'`
+- WHEN an admin uploads a new image via `POST /api/admin/templates/{uuid}/preview-image`
+- THEN the system MUST overwrite the old URL
+- AND `templatePreviewImage` MUST point to the new image
+- AND the old image file MAY be cleaned up (implementation-dependent)
+
+#### Scenario: Invalid file format is rejected
+
+- GIVEN an admin sends `POST /api/admin/templates/abc123/preview-image` with a `.txt` file
+- THEN the system MUST return HTTP 400 with an error message
+- AND only image formats (PNG, JPG, GIF, WebP, SVG) MUST be accepted
+
+#### Scenario: Preview image URL in gallery response
+
+- GIVEN a template with a recently uploaded preview image
+- WHEN a user calls `GET /api/templates/gallery`
+- THEN the template object MUST include the `previewImage` URL
+- AND the image MUST be immediately accessible (no delay)
+
+## Non-Functional Requirements
+
+- **Performance**: `GET /api/templates/gallery` MUST return within 500ms even with 100+ templates. Gallery list SHOULD NOT fetch widget placements (no `findPlacements()` call per template).
+- **Data integrity**: Save-as-template deep-copy MUST be atomic — if placement copy fails, the entire operation MUST be rolled back.
+- **Security**: Only dashboard owners can call `POST /api/dashboards/{uuid}/save-as-template`. Only admins can call `POST /api/admin/templates/{uuid}/preview-image`.
+- **Storage**: Preview images MUST be stored using the existing custom-icon-upload pattern (read `openspec/changes/custom-icon-upload-pattern/spec.md` for specifics).
+- **Localization**: Error messages MUST support English and Dutch.
+
+### Current Implementation Status
+
+**Not yet implemented:**
+
+- REQ-TMPL-012 (Gallery endpoint): No `/api/templates/gallery` endpoint exists.
+- REQ-TMPL-013 (Save-as-template): No `/api/dashboards/{uuid}/save-as-template` endpoint exists.
+- REQ-TMPL-014 (Metadata fields): `templateCategory`, `templateDescription`, `templatePreviewImage` columns do not exist on `oc_mydash_dashboards`.
+- REQ-TMPL-015 (Preview image upload): No `/api/admin/templates/{uuid}/preview-image` endpoint exists.
+
+### Standards & References
+
+- Custom-icon-upload pattern: `openspec/changes/custom-icon-upload-pattern/` — reuse for image persistence
+- Nextcloud file upload: `OCP\Files\IRootFolder`, public-share URL generation
+- WCAG 2.1 AA: Gallery UI images should have alt text, category filters should be keyboard-operable

--- a/openspec/changes/dashboard-templates/specs/admin-templates/spec.md
+++ b/openspec/changes/dashboard-templates/specs/admin-templates/spec.md
@@ -6,11 +6,28 @@ status: draft
 
 # Admin Templates — Delta from change `dashboard-templates`
 
+> NOTE (D1 — Storage divergence): MyDash stores templates as `type='admin_template'` rows in
+> `oc_mydash_dashboards`. This is a **deliberate and permanent divergence** from the reference
+> implementation's `/{lang}/_templates/` filesystem-folder convention. Reasons: (1) the existing
+> REQ-TMPL-001..011 capability is already shipped — switching storage models is a breaking change;
+> (2) `WHERE type='admin_template'` is a single indexed query; the filesystem approach requires a
+> full page-tree walk with path-segment string-matching; (3) DB enum cleanly separates kind from
+> location; (4) MyDash supports DB-backed dashboards that have no GroupFolder and therefore no
+> `_templates/` folder — a cross-backend representation requires the DB type column; (5) ACL
+> equivalence is already provided by the `dashboard-sharing` capability. Do not attempt to converge
+> on the filesystem-folder approach.
+
 ## ADDED Requirements
 
 ### Requirement: REQ-TMPL-012 Template Gallery Endpoint
 
 The system MUST expose a read-only gallery endpoint that lists all `admin_template` dashboards with metadata suitable for discovery and instantiation.
+
+> NOTE (D2 — Index): The `WHERE type='admin_template' AND templateCategory=?` filter path MUST be
+> backed by a composite index on `(type, templateCategory)`. The migration adding the three new
+> metadata columns MUST also add this composite index to keep the optional category-filter query
+> indexed at scale. The base `WHERE type='admin_template'` path already benefits from the existing
+> index on `type`.
 
 #### Scenario: List all templates in gallery
 
@@ -51,6 +68,13 @@ The system MUST expose a read-only gallery endpoint that lists all `admin_templa
 ### Requirement: REQ-TMPL-013 Save-as-template Action
 
 Any dashboard owner MUST be able to convert their current dashboard into a reusable admin template, creating a snapshot with a fresh UUID and a deep-copied widget tree.
+
+> NOTE (D3 — Deep-copy semantics): `save-as-template` creates a **deep copy**, not a link or
+> reference. All widget placements are duplicated into a new row. The source dashboard is not
+> modified. The new template row MUST have `basedOnTemplate = null` — templates do not chain and
+> do not inherit lineage from the source dashboard. Edits to the source after save-as-template MUST
+> NOT propagate to the template; this is consistent with the independence guarantee already provided
+> by REQ-TMPL-006 for user copies.
 
 #### Scenario: Save a personal dashboard as a template
 
@@ -137,6 +161,14 @@ Admin templates MUST support three new metadata fields for categorization and di
 ### Requirement: REQ-TMPL-015 Preview Image Upload Endpoint
 
 Administrators MUST be able to upload a preview image for a template via multipart form, persisted using the existing dashboard-icons upload pattern.
+
+> NOTE (D4 — custom-icon-upload-pattern reuse): The `POST /api/admin/templates/{uuid}/preview-image`
+> endpoint MUST follow the **exact same endpoint shape** as defined in
+> `openspec/changes/custom-icon-upload-pattern/` — same multipart field name (`file`), same
+> file-type validation (PNG, JPG, GIF, WebP, SVG), same Nextcloud Files storage path convention,
+> and same public-share URL return contract (`{"previewImage": "<url>"}`). Do not introduce a
+> parallel image-persistence mechanism; the custom-icon-upload pattern already covers file-type
+> validation, Nextcloud Files storage, and public-share URL generation.
 
 #### Scenario: Upload preview image for a template
 

--- a/openspec/changes/dashboard-templates/tasks.md
+++ b/openspec/changes/dashboard-templates/tasks.md
@@ -1,0 +1,153 @@
+# Tasks — dashboard-templates
+
+## 1. Schema migration
+
+- [ ] 1.1 Create `lib/Migration/VersionXXXXDate2026...AddTemplateMetadataColumns.php` adding three columns to `oc_mydash_dashboards`:
+  - `templateCategory VARCHAR(64) NULL`
+  - `templateDescription TEXT NULL`
+  - `templatePreviewImage TEXT NULL`
+- [ ] 1.2 Migration adds index `idx_mydash_template_category` on `(templateCategory)` for fast category filtering
+- [ ] 1.3 Confirm migration is reversible (drop columns + index in `postSchemaChange` rollback path)
+- [ ] 1.4 Run migration locally against sqlite, mysql, and postgres; verify schema applied cleanly each time
+
+## 2. Domain model
+
+- [ ] 2.1 Add `templateCategory`, `templateDescription`, `templatePreviewImage` fields to `Dashboard` entity with getters/setters (Entity `__call` pattern — no named args)
+- [ ] 2.2 Update `Dashboard::jsonSerialize()` to include all three new fields (nullable in output)
+- [ ] 2.3 Add `Dashboard::getWidgetCount(): int` method that returns count of associated placements (used in gallery serialisation)
+
+## 3. Mapper layer
+
+- [ ] 3.1 Add `DashboardMapper::findAllTemplatesForGallery(?string $category = null, ?string $sortBy = 'name'): array`
+  - Filters to `type = 'admin_template'`
+  - If `$category` is provided, filters to `templateCategory = $category`
+  - If `$sortBy = 'name'` (default), sorts by `templateCategory, name`
+  - If `$sortBy = 'updatedAt'`, sorts by `updatedAt DESC` (recency)
+  - Returns full Dashboard entities (widget placements fetched separately if needed for count)
+- [ ] 3.2 Add `DashboardMapper::findByOwnerUuid(string $userId, string $uuid): ?Dashboard` — used by save-as-template ownership check
+- [ ] 3.3 Add fixture-based PHPUnit test covering: gallery with mixed categories, filter by category, sort by recency, empty category result
+
+## 4. Service layer
+
+- [ ] 4.1 In `AdminTemplateService` add `getGallery(?string $category = null, ?string $sort = 'name'): array` that:
+  - Calls `DashboardMapper::findAllTemplatesForGallery()`
+  - Serializes each template with gallery metadata (uuid, name, description, category, previewImage, gridColumns, widgetCount, lastUpdatedAt)
+  - Returns raw array (controller handles HTTP response wrapping)
+- [ ] 4.2 Add `DashboardService::saveAsTemplate(string $userId, string $dashboardUuid, array $metadata): Dashboard` that:
+  - Ownership check: dashboard must belong to `$userId` and have `type = 'user'`
+  - Create new Dashboard with `type = 'admin_template'`, fresh UUID, `userId = null`, inherited `gridColumns`
+  - Set `templateCategory`, `templateDescription`, `templatePreviewImage` from `$metadata`
+  - Deep-copy all placements from source via `WidgetPlacementMapper::copyPlacements(sourceId, newId)`
+  - Throw `\OCA\MyDash\Exception\PermissionException` on ownership mismatch
+  - Return the new template
+- [ ] 4.3 Add `AdminTemplateService::uploadPreviewImage(string $templateUuid, \Psr\Http\Message\UploadedFileInterface $file): string` that:
+  - Ownership check: admin-only via `IGroupManager::isAdmin()`
+  - Validate file MIME type (PNG, JPG, GIF, WebP, SVG only)
+  - Store via custom-icon-upload pattern (reuse from `openspec/changes/custom-icon-upload-pattern/`)
+  - Update template's `templatePreviewImage` to the new URL
+  - Return the new URL
+  - Throw `\OCA\MyDash\Exception\InvalidImageException` on invalid format or upload failure
+
+## 5. Controller + routes
+
+- [ ] 5.1 Create `lib/Controller/TemplateController.php` (new) extending `OCP\AppFramework\Controller`
+- [ ] 5.2 Add `TemplateController::gallery()` method:
+  - Route: `GET /api/templates/gallery`
+  - Attribute: `#[NoAdminRequired]` (logged-in user only)
+  - Query params: `category` (optional), `sort` (optional, default 'name')
+  - Call `AdminTemplateService::getGallery($category, $sort)`
+  - Return HTTP 200 with array of gallery objects
+- [ ] 5.3 Add `TemplateController::saveAsTemplate()` method:
+  - Route: `POST /api/dashboards/{uuid}/save-as-template`
+  - Attribute: `#[NoAdminRequired]` (logged-in user only)
+  - Extract user ID from `$this->userId`
+  - Request body: `{name, description, category, previewImage}` all optional except name
+  - Call `DashboardService::saveAsTemplate($userId, $uuid, $metadata)`
+  - Catch `PermissionException` → HTTP 403
+  - Return HTTP 201 with the new template object
+- [ ] 5.4 Add `AdminController::uploadPreviewImage()` method (add to existing `AdminController`):
+  - Route: `POST /api/admin/templates/{uuid}/preview-image`
+  - Attribute: `#[NoAdminRequired]` with in-body admin check
+  - Multipart body: `file` (required)
+  - Call `AdminTemplateService::uploadPreviewImage($uuid, $_FILES['file'])`
+  - Catch `InvalidImageException` → HTTP 400 with error message
+  - Return HTTP 200 with `{"previewImage": "..."}`
+- [ ] 5.5 Register three routes in `appinfo/routes.php`:
+  - `GET /api/templates/gallery`
+  - `POST /api/dashboards/{uuid}/save-as-template`
+  - `POST /api/admin/templates/{uuid}/preview-image`
+
+## 6. Widget placement copying
+
+- [ ] 6.1 Add `WidgetPlacementMapper::copyPlacements(int $sourceId, int $targetId): void` that:
+  - Query all placements for `sourceId`
+  - For each placement, create a new row for `targetId` with identical data (except id is auto-incremented)
+  - Do NOT copy `isCompulsory` flag (it's only meaningful for template→user distribution)
+- [ ] 6.2 Test via PHPUnit fixture: copy 4 placements, verify all appear on target, verify edit independence
+
+## 7. Frontend store
+
+- [ ] 7.1 Extend or create `src/stores/templates.js` with state for gallery:
+  - `galleryTemplates`: array of gallery objects with `{uuid, name, description, category, previewImage, gridColumns, widgetCount, lastUpdatedAt}`
+  - `selectedCategory`: currently active filter (optional, for UI state)
+  - `sortBy`: current sort order ('name' or 'updatedAt')
+- [ ] 7.2 Add actions:
+  - `fetchGallery(category?, sortBy?)` — calls `GET /api/templates/gallery` with query params
+  - `saveAsTemplate(dashboardUuid, metadata)` — calls `POST /api/dashboards/{uuid}/save-as-template`
+  - `uploadPreviewImage(templateUuid, file)` — calls `POST /api/admin/templates/{uuid}/preview-image`
+- [ ] 7.3 Update existing store methods that modify templates to invalidate gallery cache
+
+## 8. Frontend UI
+
+- [ ] 8.1 Create `src/views/TemplateGallery.vue` (new) displaying:
+  - List of gallery cards with preview image, title, description, category badge, grid-column count, last-updated date
+  - Category filter dropdown populated from unique categories in galleryTemplates
+  - Sort toggle (name / recency)
+  - "Save as template" action (route to save-as-template dialog after user selects source dashboard)
+- [ ] 8.2 Create `src/components/TemplateCard.vue` (new) for individual gallery card rendering with:
+  - Preview image (placeholder if null)
+  - Title, description, category badge
+  - "Use this template" button (instantiate via existing REQ-TMPL-005 flow)
+  - (Admin only) "Edit metadata" / "Upload preview" actions
+- [ ] 8.3 Create `src/components/SaveAsTemplateModal.vue` (new) for user to provide:
+  - Template name (required)
+  - Template description (optional, longer text)
+  - Category dropdown (optional, admin-curated list or freeform input)
+  - Preview image uploader (optional, file drag-drop)
+  - Confirm button calls store action
+- [ ] 8.4 Update `src/views/DashboardList.vue` to add "Save as template" action in dashboard context menu (calls SaveAsTemplateModal)
+- [ ] 8.5 Wire gallery view into main navigation (defer specific UI location to design phase)
+
+## 9. PHPUnit tests
+
+- [ ] 9.1 `DashboardMapperTest::findAllTemplatesForGallery` — basic lookup, category filter, sort by name vs updatedAt, empty result
+- [ ] 9.2 `DashboardMapperTest::findByOwnerUuid` — owned vs non-owned dashboard lookup
+- [ ] 9.3 `AdminTemplateServiceTest::gallery` — serialisation of gallery objects, widget count included
+- [ ] 9.4 `DashboardServiceTest::saveAsTemplate` — ownership check, fresh UUID, placement copy, metadata assignment, non-owner rejection (HTTP 403)
+- [ ] 9.5 `AdminTemplateServiceTest::uploadPreviewImage` — admin-only enforcement, MIME type validation, URL update, invalid format rejection
+- [ ] 9.6 `WidgetPlacementMapperTest::copyPlacements` — verify all fields copied, new IDs assigned, no side effects on source
+- [ ] 9.7 Test save-as-template with source dashboard having `isActive: 1` — verify resulting template has `isActive: 0`
+
+## 10. End-to-end Playwright tests
+
+- [ ] 10.1 User calls `GET /api/templates/gallery` and retrieves list with category and preview image metadata
+- [ ] 10.2 User filters gallery by category via `?category=marketing` and sees only matching templates
+- [ ] 10.3 User saves their personal dashboard as a template via `POST /api/dashboards/{uuid}/save-as-template` with metadata, receives HTTP 201 with new template UUID
+- [ ] 10.4 Saved template appears in gallery response with correct metadata
+- [ ] 10.5 Admin uploads preview image via `POST /api/admin/templates/{uuid}/preview-image`, template's `previewImage` field is updated
+- [ ] 10.6 Non-owner attempting save-as-template on another user's dashboard receives HTTP 403
+- [ ] 10.7 Non-admin attempting preview image upload receives HTTP 403
+
+## 11. Quality gates
+
+- [ ] 11.1 `composer check:strict` (PHPCS, PHPMD, Psalm, PHPStan) passes — fix any pre-existing issues encountered along the way
+- [ ] 11.2 ESLint + Stylelint clean on all touched Vue/JS files
+- [ ] 11.3 Update generated OpenAPI spec / Postman collection with three new endpoints
+- [ ] 11.4 `i18n` keys for all new strings in both `nl` and `en` per i18n requirement:
+  - "Save as template"
+  - "Template gallery"
+  - "Preview image"
+  - "Invalid image format"
+  - "Cannot delete the only dashboard" (if applicable)
+- [ ] 11.5 SPDX headers on every new PHP file (inside docblock per SPDX-in-docblock convention) — gate-spdx must pass
+- [ ] 11.6 Run all 10 `hydra-gates` locally before opening PR

--- a/openspec/changes/dashboard-tree/design.md
+++ b/openspec/changes/dashboard-tree/design.md
@@ -1,0 +1,90 @@
+# Design — Dashboard Tree
+
+## Context
+
+This capability adds parent/child hierarchy to dashboards via a `parentUuid` foreign key on
+`oc_mydash_dashboards`. The spec (`dashboard-tree`) pins the data model, API contract, max depth 5,
+per-parent slug uniqueness, and cascade-delete guard. Sibling spec `dashboard-cascade-events` owns
+delete propagation; this design covers write-path constraints and read-time breadcrumb derivation.
+
+Implementation lives in the existing `DashboardMapper` and a new `DashboardTreeService`. Adjacency-
+list is sufficient at depth 5 — no separate tree table needed. This design adds what the spec implies
+but doesn't spell out: cycle detection, enforcement points, breadcrumb caching, and slug uniqueness.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Document the cycle-detection algorithm used at write time
+- Specify slug uniqueness scope and query approach
+- Define breadcrumb computation strategy (on read vs. stored)
+- Specify max-depth enforcement point
+- Describe cascade-delete guard behaviour
+
+**Non-Goals:**
+- Moving subtrees (out of scope per spec)
+- Full-text search across tree hierarchy
+- UI tree-rendering decisions (frontend concern)
+
+## Decisions
+
+### D1: Cycle detection algorithm
+**Decision**: Visited-set DFS walking ancestor chain at write time before persisting `parentUuid`.
+**Source evidence**: No direct source — pattern is well-established for adjacency-list trees.
+**Alternatives considered**:
+- Nested set model — rejected; read-optimised but expensive writes and complex rebalancing at depth 5
+- Deferred async check — rejected; would allow transient invalid state
+**Rationale**: DFS over a max-5-deep chain costs at most 5 DB reads. Acceptable at write frequency.
+Setting a new `parentUuid` triggers DFS starting from the proposed parent walking upward; if the
+current dashboardUuid appears in the chain, reject with HTTP 422 `cycle_detected`.
+
+### D2: Slug uniqueness scope
+**Decision**: Unique per `(parentUuid, slug)` pair — siblings must have distinct slugs, not global.
+**Source evidence**: `intravox-source/lib/Service/PageService.php:~140` — slug uniqueness enforced
+within parent context only.
+**Alternatives considered**:
+- Global unique slug — rejected; makes deeply nested dashboards impossible to name naturally
+**Rationale**: Per-parent matches the spec contract and mirrors how filesystem directories work.
+Enforced via DB unique index on `(parent_uuid, slug)` (NULL-safe: root dashboards use `IS NULL` scope).
+
+### D3: Max-depth enforcement point
+**Decision**: Enforce at write time (create/move), not at read time.
+**Alternatives considered**:
+- Read-time pruning — rejected; silently hides data, confusing UX
+**Rationale**: Prevents invalid tree states reaching persistence. Service method
+`DashboardTreeService::getDepth(string $uuid): int` walks ancestors (max 5 hops) and throws if
+depth would exceed 5 after the proposed attach.
+
+### D4: Breadcrumb computation strategy
+**Decision**: Compute breadcrumbs on read by walking ancestor chain; no stored `breadcrumb` column.
+**Alternatives considered**:
+- Materialized path column — rejected; adds write complexity for a small read gain at depth 5
+- Separate index table (like `PageIndexService` in source) — rejected; over-engineering for ≤5 levels
+**Rationale**: At max depth 5 the ancestor walk is at most 4 additional queries (or 1 recursive CTE).
+`DashboardTreeService::getBreadcrumbs(string $uuid): array` returns ordered ancestor stubs. Results
+MAY be cached in APCu with a 60 s TTL keyed on `mydash_bc_{uuid}`.
+
+### D5: Cascade-delete guard
+**Decision**: Deleting a dashboard with children returns HTTP 409 unless `?force=true` is passed;
+`?force=true` delegates cascade to the `DashboardDeletedEvent` listener in `dashboard-cascade-events`.
+**Alternatives considered**:
+- Silent cascade always — rejected; destructive without user awareness
+**Rationale**: Two-step explicit confirmation pattern is safer; `dashboard-cascade-events` already
+owns the event-driven cascade logic so this spec does not duplicate it.
+
+### D6: Root-level parent representation
+**Decision**: Root dashboards store `parent_uuid = NULL`; API serialises as `"parentUuid": null`.
+**Alternatives considered**:
+- Sentinel UUID (`00000000-...`) — rejected; complicates queries unnecessarily
+**Rationale**: NULL is idiomatic for adjacency-list roots and maps cleanly to JSON null.
+
+## Risks / Trade-offs
+
+- **N+1 breadcrumb queries** → mitigate with APCu cache (60 s TTL) or single recursive CTE if DB supports it
+- **Slug index on NULL** → MySQL/MariaDB allows multiple NULLs in unique index; verify composite index covers `(parent_uuid, slug)` correctly in migration
+- **Concurrent reparent + cycle check race** → mitigate with `SELECT ... FOR UPDATE` on ancestor rows during DFS
+
+## Open follow-ups
+
+- Evaluate recursive CTE for breadcrumb fetch once MySQL 8+ is confirmed as minimum baseline
+- Consider subtree-move endpoint post-MVP (requires depth re-validation for entire subtree)
+- APCu breadcrumb TTL may need reducing if dashboards are renamed frequently — gather usage data first

--- a/openspec/changes/dashboard-tree/proposal.md
+++ b/openspec/changes/dashboard-tree/proposal.md
@@ -1,0 +1,54 @@
+# Dashboard hierarchy and tree navigation
+
+## Why
+
+Today MyDash treats all dashboards as a flat list. Users with many dashboards experience cognitive overload — there is no way to organize them into logical groups or categories. Organizations with hierarchical departments or workflows need to mirror that structure in the dashboard interface (e.g., marketing/campaigns/q1, operations/finance/budget, etc.). This change introduces a parent-child hierarchy allowing unlimited nesting, computed path-based URLs, breadcrumb navigation, and a tree view API so the frontend can render collapsible folder structures.
+
+## What Changes
+
+- Add a nullable `parentUuid VARCHAR(36)` column to `oc_mydash_dashboards`. Root dashboards have `parentUuid = null`. Child dashboards reference their parent by UUID.
+- Add a `slug VARCHAR(128)` column — URL-safe, unique per parent (siblings cannot share the same slug). Auto-generated from `name` on create when not supplied; admin/user can override.
+- Add a `sortOrder INT` column controlling left-to-right sibling ordering. Default 0; ties broken alphabetically by `name`.
+- Compute a `path` on render: slash-joined slug chain from root to this dashboard (e.g. `/marketing/campaigns/q1`). Path is computed, NOT stored.
+- Compute breadcrumbs on render: ordered list of `{uuid, name, slug}` from root to this dashboard. Breadcrumbs are computed, NOT stored.
+- Expose `GET /api/dashboards/tree` returning the full visible tree as nested objects `{uuid, name, slug, children: [...]}`.
+- Expose `GET /api/dashboards/by-path/{*path}` to resolve slug chains (e.g., `/marketing/campaigns/q1`) to the dashboard at that path.
+- Cycle prevention: setting `parentUuid` to any descendant MUST return HTTP 400.
+- Depth cap: max 5 levels deep (root + 4 descendants). Setting a parent that would exceed this returns HTTP 400.
+- Cascade on parent delete: deleting a dashboard with children MUST require an explicit `?cascade=true` query param; otherwise HTTP 409 with the count of children.
+- Move semantics: changing `parentUuid` re-parents the subtree; the slug chain (and URL) of every descendant changes accordingly.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `dashboards`: adds REQ-DASH-011 (hierarchy and tree structure), REQ-DASH-012 (slug uniqueness and path resolution), REQ-DASH-013 (breadcrumb and path computation), REQ-DASH-014 (tree API endpoints), REQ-DASH-015 (cycle and depth prevention), REQ-DASH-016 (cascade delete guards). Existing REQ-DASH-001..010 are untouched.
+
+## Impact
+
+**Affected code:**
+
+- `lib/Db/Dashboard.php` — extend entity with `parentUuid`, `slug`, `sortOrder` fields, path/breadcrumb computed getters
+- `lib/Db/DashboardMapper.php` — add `findByParent(string $parentUuid)`, `findByPath(string $path)`, `findDescendants(string $uuid)` queries
+- `lib/Service/DashboardService.php` — cycle/depth validation on update, slug auto-generation, cascade delete with guard
+- `lib/Service/TreeService.php` — new service for building nested tree structures and path resolution
+- `lib/Controller/DashboardController.php` — add `/api/dashboards/tree`, `/api/dashboards/by-path/{*path}` endpoints
+- `appinfo/routes.php` — register two new routes
+- `lib/Migration/VersionXXXXDate2026...php` — schema migration adding `parentUuid`, `slug`, `sortOrder` columns + composite index on `(parentUuid, slug)` and `sortOrder`
+- `src/stores/dashboards.js` — tree and path resolution helpers in store
+- `src/views/DashboardList.vue` or equivalent — update to render hierarchy (defer advanced UI to follow-up change; this change ships the backend)
+
+**Affected APIs:**
+
+- 2 new routes (`/tree`, `/by-path/{*path}`)
+- Existing `GET /api/dashboards` and `GET /api/dashboard/{id}` unchanged — hierarchy is an opt-in feature via the new endpoints
+- Existing `PUT /api/dashboard/{id}` and `DELETE /api/dashboard/{id}` handle `parentUuid` updates with cycle/depth guards
+
+**Dependencies:**
+
+- No new composer or npm dependencies
+
+**Migration:**
+
+- Zero-impact: migration adds nullable columns and new indexes. Existing rows get `parentUuid = NULL`, `slug = null`, `sortOrder = 0`. On first read, slug is auto-generated from name if null.
+- No data backfill required.

--- a/openspec/changes/dashboard-tree/specs/dashboards/spec.md
+++ b/openspec/changes/dashboard-tree/specs/dashboards/spec.md
@@ -1,0 +1,329 @@
+---
+capability: dashboards
+delta: true
+status: draft
+---
+
+# Dashboards — Delta from change `dashboard-tree`
+
+## ADDED Requirements
+
+### Requirement: REQ-DASH-011 Dashboard hierarchy and parent relationship
+
+The system MUST support an optional parent-child hierarchy among dashboards. Each dashboard MAY have a parent dashboard specified by UUID in a nullable `parentUuid` column. Dashboards with no parent are root-level dashboards. A dashboard MAY have unlimited children, but the total depth (root + descendants) MUST NOT exceed 5 levels.
+
+#### Scenario: Create a child dashboard
+
+- GIVEN user "alice" has a root dashboard "Marketing" with UUID `uuid-marketing`
+- WHEN she sends POST /api/dashboard with body `{"name": "Q1 Campaigns", "parentUuid": "uuid-marketing"}`
+- THEN the system MUST create a dashboard with `parentUuid = "uuid-marketing"`
+- AND the dashboard's depth-from-root MUST be 2 (root + 1 child)
+- AND the response MUST return HTTP 201 with the new dashboard object
+
+#### Scenario: Root dashboard has null parent
+
+- GIVEN user "alice" creates a dashboard without specifying `parentUuid`
+- WHEN she sends POST /api/dashboard with body `{"name": "Marketing"}`
+- THEN the system MUST set `parentUuid = null`
+- AND the dashboard MUST be a root-level dashboard
+
+#### Scenario: Non-existent parent returns 400
+
+- GIVEN a user "alice"
+- WHEN she sends POST /api/dashboard with body `{"name": "Child", "parentUuid": "uuid-nonexistent"}`
+- THEN the system MUST return HTTP 400 with `{error: "Parent dashboard not found"}`
+- AND no dashboard MUST be created
+
+#### Scenario: Changing parent moves the subtree
+
+- GIVEN user "alice" has dashboard tree: "Marketing" > "Q1 Campaigns" (child)
+- WHEN she sends PUT /api/dashboard/q1-campaigns-id with body `{"parentUuid": "uuid-finance"}`
+- THEN the system MUST move "Q1 Campaigns" under "Finance"
+- AND the dashboard's `parentUuid` MUST be updated to `uuid-finance`
+- AND the computed path MUST change from `/marketing/q1-campaigns` to `/finance/q1-campaigns`
+
+#### Scenario: Reading a dashboard includes parent reference
+
+- GIVEN dashboard "Q1 Campaigns" with `parentUuid = "uuid-marketing"`
+- WHEN the dashboard is fetched via GET /api/dashboard/{id}
+- THEN the response MUST include `parentUuid: "uuid-marketing"`
+
+#### Scenario: Null parent is preserved in serialization
+
+- GIVEN a root dashboard with `parentUuid = null`
+- WHEN the dashboard is serialized
+- THEN the JSON MUST include `parentUuid: null`
+
+### Requirement: REQ-DASH-012 Slug uniqueness and path resolution
+
+Each dashboard MUST have a `slug` field — a URL-safe string unique among its siblings (dashboards sharing the same parent). Slugs are auto-generated from the dashboard name if not supplied, and MAY be manually overridden. Slugs are used to form human-readable paths like `/marketing/campaigns/q1`.
+
+#### Scenario: Slug auto-generation from name
+
+- GIVEN a user "alice" creates a dashboard with name "Q1 Campaigns" and no explicit slug
+- WHEN she sends POST /api/dashboard with body `{"name": "Q1 Campaigns"}`
+- THEN the system MUST auto-generate `slug = "q1-campaigns"` (lowercased, spaces to dashes, max 128 chars)
+- AND the slug MUST be stored in the database
+
+#### Scenario: Slug uniqueness among siblings
+
+- GIVEN user "alice" has a parent dashboard "Marketing" with child "Q1 Campaigns" (slug `q1-campaigns`)
+- WHEN she sends POST /api/dashboard with body `{"name": "Q1 Campaigns", "parentUuid": "uuid-marketing"}` (attempting to create a second sibling with the same slug)
+- THEN the system MUST return HTTP 400 with `{error: "Slug must be unique among siblings"}`
+- AND no dashboard MUST be created
+
+#### Scenario: Custom slug override
+
+- GIVEN a user "alice"
+- WHEN she sends POST /api/dashboard with body `{"name": "Q1 Campaigns", "slug": "q1-custom"}`
+- THEN the system MUST use the supplied slug `q1-custom`
+- AND NOT auto-generate one from the name
+
+#### Scenario: Slug validation characters
+
+- GIVEN a user "alice"
+- WHEN she sends POST /api/dashboard with body `{"slug": "q1 campaigns!"}`
+- THEN the system MUST reject the slug and return HTTP 400
+- AND slugs MUST only allow alphanumeric, dash, and underscore characters
+
+#### Scenario: Reading a dashboard includes slug
+
+- GIVEN a dashboard with `slug = "q1-campaigns"`
+- WHEN the dashboard is fetched via GET /api/dashboard/{id}
+- THEN the response MUST include `slug: "q1-campaigns"`
+
+#### Scenario: Slug update does not auto-regenerate on name change
+
+- GIVEN a dashboard with `name = "Q1 Campaigns"` and `slug = "q1"`
+- WHEN user sends PUT /api/dashboard/{id} with body `{"name": "Q2 Campaigns"}` (name change, no slug supplied)
+- THEN the system MUST preserve `slug = "q1"`
+- AND MUST NOT auto-regenerate the slug to `q2-campaigns`
+
+### Requirement: REQ-DASH-013 Computed path and breadcrumb navigation
+
+The system MUST compute a `path` field on demand (not stored) by joining the slug chain from root to the target dashboard. The system MUST also compute `breadcrumbs` — an ordered list of `{uuid, name, slug}` objects from root to the target dashboard, used for navigation UI.
+
+#### Scenario: Compute path for root dashboard
+
+- GIVEN a root dashboard with `slug = "marketing"`
+- WHEN the path is computed
+- THEN the path MUST equal `/marketing`
+
+#### Scenario: Compute path for nested dashboard
+
+- GIVEN a dashboard tree: "Marketing" (slug `marketing`) > "Campaigns" (slug `campaigns`) > "Q1" (slug `q1`)
+- WHEN the path is computed for "Q1"
+- THEN the path MUST equal `/marketing/campaigns/q1`
+
+#### Scenario: Path updates when parent changes
+
+- GIVEN dashboard "Q1" with computed path `/marketing/campaigns/q1`
+- WHEN the parent of "Q1" is changed to "Finance" (slug `finance`)
+- THEN on next read, the path MUST equal `/finance/q1`
+
+#### Scenario: Breadcrumbs from root to target
+
+- GIVEN dashboard "Q1" in tree "Marketing" > "Campaigns" > "Q1"
+- WHEN breadcrumbs are computed
+- THEN the breadcrumbs MUST be:
+  - `{uuid: "uuid-marketing", name: "Marketing", slug: "marketing"}`
+  - `{uuid: "uuid-campaigns", name: "Campaigns", slug: "campaigns"}`
+  - `{uuid: "uuid-q1", name: "Q1", slug: "q1"}`
+- AND the list MUST be ordered from root to leaf
+
+#### Scenario: Root dashboard has single-item breadcrumbs
+
+- GIVEN a root dashboard with `uuid = "uuid-root"`, `name = "Marketing"`, `slug = "marketing"`
+- WHEN breadcrumbs are computed
+- THEN the breadcrumbs MUST be a single-item array: `{uuid: "uuid-root", name: "Marketing", slug: "marketing"}`
+
+#### Scenario: Breadcrumbs accessible via API
+
+- GIVEN a dashboard is returned via any GET endpoint
+- WHEN the response is inspected
+- THEN it SHOULD include a computed `breadcrumbs` field (optional per endpoint; at minimum available via `/api/dashboards/by-path/...`)
+
+### Requirement: REQ-DASH-014 Tree API endpoint
+
+The system MUST expose `GET /api/dashboards/tree` returning the full visible tree of dashboards as a nested structure `{uuid, name, slug, children: [...]}`, allowing the frontend to render collapsible hierarchies.
+
+#### Scenario: Tree endpoint returns nested structure
+
+- GIVEN user "alice" has dashboards: "Marketing" (root) with child "Campaigns", and "Finance" (root) with child "Budget"
+- WHEN she sends GET /api/dashboards/tree
+- THEN the response MUST contain two root objects in the `children` array:
+  - `{uuid: "uuid-marketing", name: "Marketing", slug: "marketing", children: [{uuid: "uuid-campaigns", ...}]}`
+  - `{uuid: "uuid-finance", name: "Finance", slug: "finance", children: [{uuid: "uuid-budget", ...}]}`
+- AND each node MUST include `uuid`, `name`, `slug`, and `children` (empty array if no children)
+
+#### Scenario: Tree endpoint respects user ownership
+
+- GIVEN user "alice" has 3 root dashboards and user "bob" has 2 root dashboards
+- WHEN alice sends GET /api/dashboards/tree
+- THEN the response MUST include only alice's 3 root dashboards (and their subtrees)
+- AND bob's dashboards MUST NOT be included
+
+#### Scenario: Tree endpoint includes sort order
+
+- GIVEN user "alice" has root dashboards with `sortOrder = 10, 5, 20` and same parent
+- WHEN she sends GET /api/dashboards/tree
+- THEN the `children` array MUST be sorted by `sortOrder` (5, 10, 20)
+- AND ties MUST be broken alphabetically by `name`
+
+#### Scenario: Empty tree returns empty children array
+
+- GIVEN user "bob" has no dashboards
+- WHEN he sends GET /api/dashboards/tree
+- THEN the response MUST be an empty array (or `{children: []}` depending on schema)
+
+### Requirement: REQ-DASH-015 Path-based dashboard resolution
+
+The system MUST expose `GET /api/dashboards/by-path/{*path}` to resolve a slug chain (e.g., `/marketing/campaigns/q1`) to the dashboard at that location, returning the dashboard object with computed breadcrumbs and path.
+
+#### Scenario: Resolve path to dashboard
+
+- GIVEN user "alice" has dashboard tree "Marketing" > "Campaigns" > "Q1"
+- WHEN she sends GET /api/dashboards/by-path/marketing/campaigns/q1
+- THEN the response MUST return the "Q1" dashboard object with computed path `/marketing/campaigns/q1` and breadcrumbs array
+
+#### Scenario: Path not found returns 404
+
+- GIVEN user "alice" has dashboard tree "Marketing" > "Campaigns" but no "Q2"
+- WHEN she sends GET /api/dashboards/by-path/marketing/campaigns/q2
+- THEN the system MUST return HTTP 404 with `{error: "Dashboard not found at path"}`
+
+#### Scenario: User cannot access other user's dashboard via path
+
+- GIVEN user "alice" has dashboard "Marketing" (slug `marketing`) and user "bob" has a different dashboard with the same slug
+- WHEN alice sends GET /api/dashboards/by-path/marketing
+- THEN the response MUST return only alice's "Marketing" dashboard
+- AND bob's dashboard MUST NOT be accessible to alice
+
+#### Scenario: Path is case-insensitive
+
+- GIVEN user "alice" has dashboard with `slug = "marketing"`
+- WHEN she sends GET /api/dashboards/by-path/MARKETING
+- THEN the system MUST resolve to the dashboard (slugs are stored lowercase, comparison must be case-insensitive or stored-case-matching)
+
+#### Scenario: Trailing slash is optional
+
+- GIVEN user "alice" has dashboard at path `/marketing/campaigns/q1`
+- WHEN she sends GET /api/dashboards/by-path/marketing/campaigns/q1/ (with trailing slash)
+- THEN the system MUST resolve to the dashboard (trailing slash must be ignored or normalized)
+
+### Requirement: REQ-DASH-016 Cycle prevention and depth validation
+
+The system MUST prevent setting a dashboard's parent to any of its own descendants (cycle prevention) and MUST enforce a maximum tree depth of 5 levels (root + 4 descendants).
+
+#### Scenario: Cycle detection on parent update
+
+- GIVEN user "alice" has dashboard tree "A" > "B" > "C"
+- WHEN she sends PUT /api/dashboard/a-id with body `{"parentUuid": "uuid-c"}`
+- THEN the system MUST return HTTP 400 with `{error: "Setting this parent would create a cycle"}`
+- AND the dashboard MUST NOT be updated
+
+#### Scenario: Self-parenting is rejected
+
+- GIVEN dashboard "Marketing" with UUID `uuid-marketing`
+- WHEN user "alice" sends PUT /api/dashboard/marketing-id with body `{"parentUuid": "uuid-marketing"}`
+- THEN the system MUST return HTTP 400
+- AND the dashboard MUST NOT be updated (cannot be its own parent)
+
+#### Scenario: Max depth exceeded on create
+
+- GIVEN user "alice" has a 5-level tree: A > B > C > D > E (depth = 5)
+- WHEN she sends POST /api/dashboard with body `{"name": "F", "parentUuid": "uuid-e"}` (attempting to add a 6th level)
+- THEN the system MUST return HTTP 400 with `{error: "Cannot exceed maximum tree depth of 5 levels"}`
+- AND no dashboard MUST be created
+
+#### Scenario: Max depth exceeded on parent update
+
+- GIVEN user "alice" has two trees: A > B > C > D (4 levels) and X > Y > Z (3 levels)
+- WHEN she sends PUT /api/dashboard/x-id with body `{"parentUuid": "uuid-d"}` (attempting to nest X > Y > Z under the 4-level tree, creating 7 levels total)
+- THEN the system MUST return HTTP 400 with `{error: "Cannot exceed maximum tree depth of 5 levels"}`
+- AND the parent MUST NOT be updated
+
+#### Scenario: Exactly 5 levels is allowed
+
+- GIVEN user "alice" creates a 5-level tree: A > B > C > D > E (depth = 5)
+- WHEN she sends POST /api/dashboard with body `{"name": "NewRoot"}`
+- THEN the system MUST allow creating the new root dashboard
+- AND multiple independent 5-level trees MAY coexist
+
+### Requirement: REQ-DASH-017 Sibling ordering
+
+Dashboards sharing the same parent MUST be ordered by a `sortOrder INT` column. Ties in `sortOrder` MUST be broken alphabetically by `name`. Ordering MUST be reflected in all tree and list responses.
+
+#### Scenario: Default sort order on create
+
+- GIVEN user "alice" creates dashboard "Marketing" without specifying `sortOrder`
+- WHEN the dashboard is created
+- THEN `sortOrder` MUST default to 0
+
+#### Scenario: Custom sort order on create
+
+- GIVEN user "alice"
+- WHEN she sends POST /api/dashboard with body `{"name": "Marketing", "sortOrder": 100}`
+- THEN the dashboard MUST be created with `sortOrder = 100`
+
+#### Scenario: Sort order respected in tree
+
+- GIVEN user "alice" has three root dashboards with `sortOrder = 20, 5, 15` respectively
+- WHEN she sends GET /api/dashboards/tree
+- THEN the `children` array MUST be ordered as: sortOrder 5, 15, 20
+
+#### Scenario: Tie-breaking by name
+
+- GIVEN user "alice" has two sibling dashboards both with `sortOrder = 0`, named "Zebra" and "Alice"
+- WHEN she sends GET /api/dashboards/tree
+- THEN the `children` array MUST be ordered as: "Alice" then "Zebra" (alphabetically)
+
+#### Scenario: Update sort order via PUT
+
+- GIVEN user "alice" has dashboard with `sortOrder = 10`
+- WHEN she sends PUT /api/dashboard/{id} with body `{"sortOrder": 50}`
+- THEN the dashboard MUST be updated to `sortOrder = 50`
+- AND tree responses MUST reflect the new order
+
+### Requirement: REQ-DASH-018 Cascade deletion with guard
+
+Deleting a dashboard with children MUST require an explicit `?cascade=true` query parameter. Without it, the system MUST return HTTP 409 with the count of children, preventing accidental loss of subtrees.
+
+#### Scenario: Delete parent without cascade returns 409
+
+- GIVEN user "alice" has dashboard "Marketing" with 3 child dashboards
+- WHEN she sends DELETE /api/dashboard/marketing-id (without `?cascade=true`)
+- THEN the system MUST return HTTP 409 with `{error: "Dashboard has 3 children. Use ?cascade=true to delete the subtree."}`
+- AND the dashboard MUST NOT be deleted
+
+#### Scenario: Delete parent with cascade deletes subtree
+
+- GIVEN user "alice" has dashboard "Marketing" > "Campaigns" > "Q1" (3 total)
+- WHEN she sends DELETE /api/dashboard/marketing-id?cascade=true
+- THEN the system MUST delete all 3 dashboards
+- AND all associated placements MUST be cascade-deleted per REQ-DASH-005
+- AND the response MUST return HTTP 200
+
+#### Scenario: Delete childless dashboard has no guard
+
+- GIVEN user "alice" has a root dashboard with no children
+- WHEN she sends DELETE /api/dashboard/{id} (with or without `?cascade=true`)
+- THEN the system MUST delete the dashboard (no cascade guard needed)
+- AND the response MUST return HTTP 200
+
+#### Scenario: Cascade parameter is case-insensitive
+
+- GIVEN user "alice" has a dashboard with children
+- WHEN she sends DELETE /api/dashboard/{id}?cascade=TRUE or ?cascade=Cascade
+- THEN the system MUST interpret it as true and delete the subtree
+
+#### Scenario: User cannot delete another user's dashboard subtree
+
+- GIVEN user "alice" has a dashboard tree
+- WHEN user "bob" sends DELETE /api/dashboard/alice-dashboard-id?cascade=true
+- THEN the system MUST return HTTP 403 (ownership check fails)
+- AND alice's dashboards MUST NOT be deleted
+
+## UNCHANGED Requirements
+
+All REQ-DASH-001 through REQ-DASH-010 from the base `dashboards` capability remain fully supported. Existing flat dashboard operations (create, list, update, delete without children) continue to work unchanged. This delta is additive and does not break backward compatibility for clients using the legacy `/api/dashboards` and `/api/dashboard/{id}` endpoints.

--- a/openspec/changes/dashboard-tree/tasks.md
+++ b/openspec/changes/dashboard-tree/tasks.md
@@ -1,0 +1,104 @@
+# Tasks — dashboard-tree
+
+## 1. Schema migration
+
+- [ ] 1.1 Create `lib/Migration/VersionXXXXDate2026...AddHierarchyColumns.php` adding `parentUuid VARCHAR(36) NULL`, `slug VARCHAR(128) NULL`, `sortOrder INT DEFAULT 0` to `oc_mydash_dashboards`
+- [ ] 1.2 Add composite unique index `idx_mydash_dash_parent_slug` on `(parentUuid, slug)` — siblings must have unique slugs per parent
+- [ ] 1.3 Add index `idx_mydash_dash_parent` on `(parentUuid)` for fast child lookups
+- [ ] 1.4 Add index `idx_mydash_dash_sort` on `(parentUuid, sortOrder)` for ordered sibling retrieval
+- [ ] 1.5 Confirm migration is reversible (drop columns + indexes in `postSchemaChange` rollback path)
+- [ ] 1.6 Run migration locally against sqlite, mysql, and postgres; verify schema applied cleanly each time
+
+## 2. Domain model
+
+- [ ] 2.1 Add `Dashboard::MAX_DEPTH = 5` constant (root + 4 descendants)
+- [ ] 2.2 Add `parentUuid`, `slug`, `sortOrder` fields to `Dashboard` entity with getters/setters (Entity `__call` pattern — no named args)
+- [ ] 2.3 Add computed getter `getDashboardPath(): string` returning slash-joined slug chain from root to this dashboard (e.g., `/marketing/campaigns/q1`)
+- [ ] 2.4 Add computed getter `getBreadcrumbs(): array` returning ordered list of `{uuid, name, slug}` from root to this dashboard (requires mapper queries up the tree)
+- [ ] 2.5 Update `Dashboard::jsonSerialize()` to include `parentUuid`, `slug`, `sortOrder` (all nullable/integer as-is; `path` and `breadcrumbs` are computed on-demand, not serialized by default)
+
+## 3. Mapper layer
+
+- [ ] 3.1 Add `DashboardMapper::findByParent(?string $parentUuid): array` — `WHERE parentUuid = ? ORDER BY sortOrder, name` (pass null for root-only dashboards)
+- [ ] 3.2 Add `DashboardMapper::findByPath(string $path): ?Dashboard` — split path by `/`, walk down the tree via successive parent lookups
+- [ ] 3.3 Add `DashboardMapper::findDescendants(string $ancestorUuid): array` — recursive traversal (or iterative with stack) to fetch all descendants of a given dashboard
+- [ ] 3.4 Add `DashboardMapper::findAncestors(string $uuid): array` — reverse traversal to fetch all parents up to root
+- [ ] 3.5 Add `DashboardMapper::countChildrenByParent(string $parentUuid): int` — used in cascade delete guard
+- [ ] 3.6 Add fixture-based PHPUnit test covering: tree with 5 levels (max depth), path resolution, cycle detection, dedup edge cases
+
+## 4. Service layer — validation
+
+- [ ] 4.1 Add `TreeService::validateNoCycle(string $uuid, ?string $newParentUuid): void` — checks if setting parent to `newParentUuid` would create a loop (i.e., `newParentUuid` is a descendant of `uuid`); throws `\InvalidArgumentException` if true
+- [ ] 4.2 Add `TreeService::validateDepth(?string $parentUuid): void` — counts ancestors of `parentUuid` and throws `\InvalidArgumentException` if adding a child would exceed MAX_DEPTH
+- [ ] 4.3 Update `DashboardFactory::create()` to auto-generate `slug` from `name` if not supplied; slug must be alphanumeric + dash/underscore, lowercased, max 128 chars
+- [ ] 4.4 Add validation in `DashboardFactory::create()` to reject `parentUuid` if it points to a non-existent dashboard; throw `\InvalidArgumentException`
+- [ ] 4.5 When `parentUuid` is updated via PUT, call `validateNoCycle()` and `validateDepth()` guards before persisting
+
+## 5. Service layer — tree and path
+
+- [ ] 5.1 Add `TreeService::buildTree(?string $parentUuid): array` — recursively fetch and nest children, returning `{uuid, name, slug, children: [...]}` structure
+- [ ] 5.2 Add `TreeService::getFullTree(): array` — build complete tree from all root dashboards (WHERE parentUuid IS NULL)
+- [ ] 5.3 Add `TreeService::resolvePath(string $path): ?Dashboard` — delegates to `DashboardMapper::findByPath()`
+- [ ] 5.4 Add `TreeService::computePath(string $uuid): string` — fetch ancestors and join slugs, e.g., `/marketing/campaigns/q1`
+- [ ] 5.5 Add `TreeService::computeBreadcrumbs(string $uuid): array` — fetch ancestors and return `{uuid, name, slug}` list from root to this dashboard
+- [ ] 5.6 Ensure all path operations are user-scoped (only dashboards owned/visible by the current user are included)
+
+## 6. Service layer — cascade delete
+
+- [ ] 6.1 Update `DashboardService::deleteDashboard()` to check if dashboard has children
+- [ ] 6.2 If children exist and `?cascade=true` query param is NOT present, return HTTP 409 with `{error: "Dashboard has N children", childCount: N}`
+- [ ] 6.3 If `?cascade=true` is present, recursively delete all descendants (placements cascade-deleted per existing REQ-DASH-005)
+- [ ] 6.4 Add `TreeService::deleteSubtree(string $uuid, bool $cascade): void` — recursive deletion logic
+- [ ] 6.5 Add PHPUnit test: delete dashboard with 3 descendants, no cascade → HTTP 409; delete with cascade=true → all 4 deleted
+
+## 7. Controller + routes
+
+- [ ] 7.1 Add `DashboardController::tree()` mapped to `GET /api/dashboards/tree` (logged-in user, `#[NoAdminRequired]`) — returns nested tree of all visible dashboards
+- [ ] 7.2 Add `DashboardController::byPath(string $path)` mapped to `GET /api/dashboards/by-path/{*path}` (logged-in user, `#[NoAdminRequired]`) — resolves path to dashboard, returns dashboard object with computed breadcrumbs
+- [ ] 7.3 Register both routes in `appinfo/routes.php` with proper requirements (`path` regex allows `/` separators)
+- [ ] 7.4 Both endpoints return 404 if path/tree is empty for the user (no visible dashboards)
+
+## 8. Frontend store
+
+- [ ] 8.1 Extend `src/stores/dashboards.js` with `dashboardTree` getter returning nested tree structure from `/api/dashboards/tree`
+- [ ] 8.2 Add `breadcrumbs` getter returning computed breadcrumbs for the active dashboard from `/api/dashboard` response (if endpoint includes them; otherwise fetch on demand)
+- [ ] 8.3 Add `dashboardByPath(path)` getter that resolves via `/api/dashboards/by-path/{path}` or caches the result
+- [ ] 8.4 Defer advanced tree UI (collapsible folders, drag-to-reorder) to follow-up change — this change only ships the backend + store scaffolding
+
+## 9. Slug auto-generation
+
+- [ ] 9.1 Create helper `SlugGenerator::slugify(string $name): string` — lowercases, replaces spaces with `-`, removes non-alphanumeric (except `-/_`), max 128 chars
+- [ ] 9.2 In `DashboardFactory::create()`, if `slug` is not supplied, call `SlugGenerator::slugify($name)` to auto-generate
+- [ ] 9.3 On `PUT /api/dashboard/{id}`, if `slug` is supplied, accept it; if omitted, preserve existing slug (do not re-slug on name change)
+- [ ] 9.4 Add `DashboardService::validateSlugUnique(?string $parentUuid, string $slug, ?string $excludeUuid): void` — ensures no sibling has the same slug; pass `$excludeUuid` when updating to allow keeping current slug
+
+## 10. PHPUnit tests
+
+- [ ] 10.1 `TreeServiceTest::buildTree` — 5-level tree, verify nesting and sort order
+- [ ] 10.2 `TreeServiceTest::resolvePath` — resolve `/marketing/campaigns/q1`, return correct dashboard
+- [ ] 10.3 `TreeServiceTest::computePath` — compute path from a deep descendant, verify ancestors resolved
+- [ ] 10.4 `TreeServiceTest::validateNoCycle` — attempt to set a descendant as parent, verify exception
+- [ ] 10.5 `TreeServiceTest::validateDepth` — attempt to add child at max depth, verify exception
+- [ ] 10.6 `DashboardControllerTest::testTreeEndpoint` — `/api/dashboards/tree` returns nested structure with 3+ dashboards
+- [ ] 10.7 `DashboardControllerTest::testByPathEndpoint` — `/api/dashboards/by-path/marketing/campaigns/q1` returns correct dashboard, includes breadcrumbs
+- [ ] 10.8 `DashboardControllerTest::testDeleteCascadeGuard` — delete with children, no cascade param → HTTP 409; cascade=true → deleted
+- [ ] 10.9 `DashboardMapperTest::findByParent` — root dashboards (parentUuid = NULL), child dashboards, sort order
+- [ ] 10.10 Test all 10 existing REQ-DASH-001..010 requirements still pass (regression — hierarchy must not break flat dashboard operations)
+
+## 11. End-to-end Playwright tests
+
+- [ ] 11.1 User creates dashboard "Marketing", then creates child "Q1 Campaigns" with parent set to "Marketing" UUID
+- [ ] 11.2 GET `/api/dashboards/by-path/marketing/q1-campaigns` returns the child dashboard with correct breadcrumbs
+- [ ] 11.3 GET `/api/dashboards/tree` returns nested structure with "Marketing" as parent of "Q1 Campaigns"
+- [ ] 11.4 User attempts to set a descendant as parent, receives HTTP 400
+- [ ] 11.5 User attempts to delete "Marketing" (which has 2 children) without cascade, receives HTTP 409; with cascade=true, all 3 deleted
+- [ ] 11.6 Path computation correctly reflects re-parenting (change parent, verify path updates on next page load)
+
+## 12. Quality gates
+
+- [ ] 12.1 `composer check:strict` (PHPCS, PHPMD, Psalm, PHPStan) passes — fix any pre-existing issues encountered along the way
+- [ ] 12.2 ESLint + Stylelint clean on all touched Vue/JS files
+- [ ] 12.3 Update generated OpenAPI spec / Postman collection so external API consumers see the new endpoints
+- [ ] 12.4 `i18n` keys for all new error messages (`Dashboard has children`, `Cycle detected`, `Maximum depth exceeded`, `Slug must be unique`) in both `nl` and `en` per the i18n requirement
+- [ ] 12.5 SPDX headers on every new PHP file (inside the docblock per the SPDX-in-docblock convention) — gate-spdx must pass
+- [ ] 12.6 Run all 10 `hydra-gates` locally before opening PR

--- a/openspec/changes/dashboard-versioning/design.md
+++ b/openspec/changes/dashboard-versioning/design.md
@@ -1,0 +1,89 @@
+# Design — Dashboard Versioning
+
+## Context
+
+This capability provides version history and restore for dashboard content. The spec
+(`dashboard-versioning`) pins the dual-backend model: `groupfolder` mode delegates to
+`\OCP\Files\Versions\IVersionManager`; `db` mode persists snapshots in `oc_mydash_dashboard_versions`.
+The `contentBackend` column routes to the correct strategy at runtime.
+
+Source confirms the NC interface: `intravox-source/lib/Service/PageService.php` lazy-loads
+`OCA\Files_Versions\Versions\IVersionManager`. Sibling spec `dashboard-draft-published` intersects
+on PUT triggers — draft-to-published transitions do NOT trigger versioning; only content edits do.
+This design documents strategy dispatch, debounce, restore semantics, and soft-failure handling.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Document strategy pattern dispatch at runtime
+- Specify debounce implementation (APCu, 60 s)
+- Define restore-as-reverse-snapshot semantics
+- Specify retention limit enforcement point (DB mode)
+- Document soft-failure contract when GroupFolder versioning is unavailable
+
+**Non-Goals:**
+- Content diffing / delta storage (snapshots are full blobs)
+- Version comparison UI (frontend concern)
+- Version export (separate spec if needed)
+
+## Decisions
+
+### D1: Strategy pattern dispatch
+**Decision**: `VersioningService` reads `dashboard->getContentBackend()` and instantiates either
+`DbVersionBackend` or `GroupFolderVersionBackend` at call time. Both implement
+`IVersionBackend` interface defined in MyDash.
+**Alternatives considered**:
+- Single code path with conditionals — rejected; grows unwieldy as backends diverge
+- DI container tagging — rejected; backend is per-dashboard, not per-service-lifetime
+**Rationale**: Strategy pattern keeps backend logic isolated and testable. The interface exposes
+`list()`, `create()`, `restore()`, and `isSupported()` methods.
+
+### D2: Debounce implementation
+**Decision**: APCu key `mydash_ver_debounce_{dashboardUuid}` set to `1` with TTL 60 s on every
+PUT. Version creation is skipped if the key exists at the start of the request.
+**Source evidence**: `intravox-source/lib/Service/PageService.php:~220` — debounce via APCu for
+page-content saves, TTL 60 s.
+**Alternatives considered**:
+- DB-side `last_versioned_at` timestamp check — rejected; adds DB write on every PUT even when
+skipping, and has clock-skew issues in multi-node setups
+**Rationale**: APCu is node-local and TTL-managed. Acceptable because version loss during a 60 s
+window is low-impact; explicit POST `/versions` always bypasses debounce.
+
+### D3: Restore-as-reverse-snapshot
+**Decision**: Before restore, `VersioningService` snapshots current content (labelled `pre-restore`),
+then applies the chosen version. Net effect: restore is itself reversible.
+**Alternatives considered**: No pre-restore snapshot — rejected; destructive with no undo.
+**Rationale**: Mirrors NC core file-restore behaviour. Adds one row per restore, well within 50-limit.
+
+### D4: Retention limit enforcement (DB mode)
+**Decision**: After every version write in DB mode, `DbVersionBackend::prune()` deletes the oldest
+rows beyond 50 (ordered by `created_at` ASC) for that `dashboard_uuid`.
+**Alternatives considered**:
+- Background job pruning — rejected; delays cleanup, allows table to grow unbounded between runs
+**Rationale**: Inline pruning keeps the table bounded without a background job dependency. Pruning
+≤50-row deletes per PUT is negligible overhead.
+
+### D5: Soft-failure for unavailable GroupFolder versioning
+**Decision**: If `IVersionManager` is unavailable (Files_Versions disabled or no GroupFolder backing),
+`isSupported()` returns `false` and the API returns HTTP 200 `{"versions": [], "modeSupported": false}`.
+**Alternatives considered**:
+- HTTP 501 — rejected; breaks clients that don't guard on status code
+- Silent fallback to DB backend — rejected; creates version rows in wrong backend
+**Rationale**: Transparency over silent fallback; re-enabling restores versioning without migration.
+
+### D6: Version trigger events
+**Decision**: Triggers: (1) PUT to content endpoint (debounced 60 s), (2) explicit POST to
+`/dashboards/{id}/versions`, (3) admin-manual. Draft saves do NOT trigger versioning.
+**Alternatives considered**: Trigger on all saves including drafts — rejected; pollutes history.
+**Rationale**: Aligns with `dashboard-draft-published` boundary; versioning tracks published lineage.
+
+## Risks / Trade-offs
+
+- **APCu node-locality** → debounce is per-node; user hitting different node within 60 s creates a second version. Acceptable — deduplication is best-effort
+- **IVersionManager stability** → metadata format may change across NC major versions; pin to OCP namespace, not OCA
+
+## Open follow-ups
+
+- Evaluate `\OCP\IMemcache` (Redis) for cluster-aware debounce
+- Add `?label=` param to explicit version POST for user annotations
+- Check whether `IVersionManager::rollback()` can replace custom restore logic in GroupFolder mode

--- a/openspec/changes/dashboard-versioning/proposal.md
+++ b/openspec/changes/dashboard-versioning/proposal.md
@@ -1,0 +1,72 @@
+# Dashboard Versioning
+
+## Why
+
+MyDash dashboards are living documents — users arrange widgets, adjust grid layouts, and update configurations over time. Without version history, accidental changes or overzealous reorganization become irreversible, forcing users to reconstruct layouts manually. Groupfolder-backed dashboards (via the sibling `groupfolder-storage-backend` change) enable storing dashboards as JSON files in Nextcloud Files, opening the door to leveraging Nextcloud's native versioning system. Database-backed dashboards (the current default) need a parallel versioning table. This change delivers a unified, backend-agnostic version history API: list versions, restore snapshots, and audit restores — all without requiring the UI or caller to know which storage backend is in use.
+
+## What Changes
+
+- Add `oc_mydash_dashboard_versions` table for database-backed snapshots, with per-dashboard retention (50 most recent).
+- Capture automatic snapshots on every successful dashboard content PUT (debounced to at most one per 60 seconds per dashboard).
+- Expose `GET /api/dashboards/{uuid}/versions` → ordered list of version metadata (newest first).
+- Expose `GET /api/dashboards/{uuid}/versions/{versionNumber}` → full snapshot body for restore preview.
+- Expose `POST /api/dashboards/{uuid}/versions` → explicit snapshot creation with optional note (bypasses debounce).
+- Expose `POST /api/dashboards/{uuid}/versions/{versionNumber}/restore` → revert to a historical snapshot (itself creating a new version capturing pre-restore state).
+- For groupfolder-backed dashboards: delegate to `\OCP\IVersionManager` (Nextcloud's file versioning), follow NC retention, graceful degradation if versioning is unavailable.
+- For database-backed dashboards: persist snapshots in the table, auto-prune to 50 versions per dashboard.
+- Emit Nextcloud activity events (`dashboard_restored`) on every restore for audit trail.
+- Permission guard: only owners and admins can list, view, or restore versions.
+
+## Capabilities
+
+### New Capabilities
+
+- `dashboard-versioning` — NEW capability for version history, snapshot management, and restore operations.
+
+### Modified Capabilities
+
+- (None — this is an entirely new capability, orthogonal to existing dashboard features.)
+
+## Impact
+
+**Affected code:**
+
+- `lib/Db/DashboardVersion.php` — NEW entity for version snapshots (database backend only).
+- `lib/Db/DashboardVersionMapper.php` — NEW mapper for version CRUD + retention pruning.
+- `lib/Service/DashboardVersionService.php` — NEW service for snapshot creation (automatic debounced + explicit), restore, and retention.
+- `lib/Service/VersioningStrategy/*.php` — NEW strategy pattern for backend-agnostic versioning (DatabaseVersioningStrategy, FilesVersioningStrategy).
+- `lib/Controller/DashboardVersionController.php` — NEW controller for all version endpoints.
+- `appinfo/routes.php` — register 4 new routes: `GET|POST /api/dashboards/{uuid}/versions`, `GET|POST /api/dashboards/{uuid}/versions/{versionNumber}/restore`.
+- `lib/Migration/VersionXXXXDate2026...AddDashboardVersionsTable.php` — schema migration creating `oc_mydash_dashboard_versions` with retention index.
+- `lib/Service/DashboardService.php` — integrate snapshot creation into PUT handler (debounce + call `DashboardVersionService::captureSnapshot()`).
+- `lib/Db/Dashboard.php` — add `contentBackend` field or equivalent to track which versioning mode a dashboard uses (database vs. groupfolder).
+- `src/views/DashboardDetail.vue` — (deferred to follow-up) UI for version list, restore button, version preview modal.
+
+**Affected APIs:**
+
+- 4 new routes, no existing routes changed
+- Existing dashboards remain unaffected until a change is saved (triggering the first automatic snapshot).
+
+**Dependencies:**
+
+- `OCP\IVersionManager` — for groupfolder backend integration (already available in Nextcloud 28+).
+- No new composer or npm dependencies.
+
+**Migration:**
+
+- Zero-impact: the migration only adds a new table (no existing tables modified). Existing dashboards do not automatically populate version history — versions are created going forward from the first PUT after the migration.
+- Optionally, admins can trigger a backfill of current states as "version 1" for all existing dashboards via a repair step (deferred to follow-up feature).
+
+## Dependencies
+
+This change **DEPENDS ON** the sibling `groupfolder-storage-backend` change for the content-backend abstraction. The versioning feature is neutral to storage backend and adapts dynamically, but the groupfolder backend must be in place to enable file-based versioning for dashboards stored in Nextcloud Files.
+
+Explicit dependency link: `groupfolder-storage-backend` change MUST be implemented and merged before or alongside `dashboard-versioning`.
+
+## Open Questions / Design Notes
+
+1. **Debounce window**: 60 seconds is proposed; tuning may be needed based on typical user interaction patterns (e.g., drag-and-drop saves rapidly vs. deliberate edits). Consider making this configurable in `config.php`.
+2. **Retention limit**: 50 versions per dashboard is proposed; storage impact depends on average widget-tree JSON size. Consider monitoring and adjusting after early adoption.
+3. **Explicit snapshot note length**: proposed VARCHAR(500) for notes. Longer notes should be supported but are not critical for MVP.
+4. **File-version synthesis**: for groupfolder backend, versionNumber will be synthesized from file-version timestamp if NC doesn't provide a sequence number. Order MUST be stable (newest-first) to ensure restore operations are deterministic.
+5. **Audit trail scope**: currently only restores emit activity events. Future enhancement: emit lower-severity activity for automatic snapshots if audit completeness is desired.

--- a/openspec/changes/dashboard-versioning/specs/dashboard-versioning/spec.md
+++ b/openspec/changes/dashboard-versioning/specs/dashboard-versioning/spec.md
@@ -1,0 +1,357 @@
+---
+capability: dashboard-versioning
+status: draft
+---
+
+# Dashboard Versioning Specification
+
+## Purpose
+
+Enable version history and one-click restoration for MyDash dashboards. The feature delegates storage strategy to the underlying content backend: dashboards stored in Nextcloud Files (via the `groupfolder` backend) use NC's native file versioning; dashboards in the database backend use a dedicated `oc_mydash_dashboard_versions` table. All APIs are backend-agnostic.
+
+## Data Model
+
+### Database Backend (Default)
+
+Each dashboard version snapshot is stored in `oc_mydash_dashboard_versions` with:
+- **id**: Auto-increment integer primary key
+- **dashboardUuid**: UUID of the parent dashboard
+- **versionNumber**: INT (auto-incremented per-dashboard, monotonic, starting at 1)
+- **snapshotJson**: MEDIUMTEXT containing the full widget tree and metadata at that point
+- **createdBy**: VARCHAR(64) Nextcloud user ID of the version creator
+- **createdAt**: TIMESTAMP of snapshot creation
+- **note**: TEXT NULL for optional version label/annotation
+- Composite unique index on `(dashboardUuid, versionNumber)` for fast per-dashboard lookups
+- Retention: automatically prune oldest versions beyond the 50-most-recent per dashboard
+
+### GroupFolder Backend
+
+Versions are stored via `\OCP\IVersionManager` on the dashboard's JSON file in Nextcloud Files. MyDash does NOT manage retention — Nextcloud's own versioning policies apply. If versioning is unavailable, the API gracefully returns `{versions: [], modeSupported: false}` with HTTP 200.
+
+## ADDED Requirements
+
+### Requirement: REQ-VERS-001 Snapshot Creation on Content Update
+
+The system MUST automatically capture a snapshot whenever a dashboard's content is successfully saved via PUT. Snapshots MUST be debounced — at most one snapshot per 60-second window per dashboard.
+
+#### Scenario: Automatic snapshot on PUT
+
+- GIVEN a dashboard "My Dashboard" with current content
+- WHEN a user sends PUT /api/dashboard/{uuid}/content with new widget positions
+- THEN the system MUST create a version snapshot in the appropriate backend (file-version for groupfolder, DB row for db mode) after the content is persisted
+- AND the snapshot MUST include the full widget tree and metadata as it was before the update
+
+#### Scenario: Debouncing rapid edits
+
+- GIVEN a dashboard and a user rapidly sends 5 PUT requests within 30 seconds
+- WHEN the user saves each change
+- THEN the system MUST create at most 1 snapshot for the entire burst (the first one at t=0, others ignored or batched until 60s passes)
+- AND subsequent updates after the 60-second window MUST create a new snapshot
+
+#### Scenario: Failed PUT does not create snapshot
+
+- GIVEN a PUT request that fails validation or encounters a database error
+- WHEN the request returns HTTP 400 or HTTP 500
+- THEN no version snapshot MUST be recorded
+- AND the dashboard content MUST remain unchanged
+
+#### Scenario: Snapshot captures full state
+
+- GIVEN a dashboard with 4 widgets at specific grid positions
+- WHEN a PUT updates widget positions and adds metadata
+- THEN the snapshot MUST include all 4 widgets and the new metadata exactly as persisted
+- AND the snapshot MUST be complete and restorable to the exact prior state
+
+### Requirement: REQ-VERS-002 Explicit Snapshot Creation
+
+The system MUST expose POST /api/dashboards/{uuid}/versions to allow users to explicitly create labelled snapshots with an optional note, independent of automatic debouncing.
+
+#### Scenario: Create a named snapshot
+
+- GIVEN a dashboard "My Dashboard" and a logged-in user "alice"
+- WHEN alice sends POST /api/dashboards/{uuid}/versions with body `{"note": "Before major redesign"}`
+- THEN the system MUST create a new version snapshot with the provided note
+- AND the snapshot MUST be immediately queryable via GET /api/dashboards/{uuid}/versions
+- AND the response MUST return HTTP 201 with the new version object including versionNumber
+
+#### Scenario: Explicit snapshot bypasses debounce
+
+- GIVEN a dashboard with an automatic snapshot captured at t=10s
+- WHEN the user sends POST /api/dashboards/{uuid}/versions with a note at t=30s (within the 60s debounce window)
+- THEN the system MUST create the explicit snapshot immediately (debounce does NOT apply)
+- AND the response MUST return HTTP 201
+
+#### Scenario: Empty note is valid
+
+- GIVEN a user creates an explicit snapshot
+- WHEN the request body contains `{"note": ""}` or omits note entirely
+- THEN the snapshot MUST be created with `note = NULL`
+- AND the API MUST return HTTP 201
+
+#### Scenario: Only owners and admins can create
+
+- GIVEN dashboard "My Dashboard" owned by "alice"
+- WHEN user "bob" (non-owner, non-admin) sends POST /api/dashboards/{uuid}/versions
+- THEN the system MUST return HTTP 403
+- AND no snapshot MUST be created
+
+### Requirement: REQ-VERS-003 List Versions
+
+The system MUST expose GET /api/dashboards/{uuid}/versions returning an ordered list of available versions, newest first, with metadata but NOT full snapshot content.
+
+#### Scenario: List versions for a dashboard with history
+
+- GIVEN a dashboard with 5 version snapshots
+- WHEN a user sends GET /api/dashboards/{uuid}/versions
+- THEN the response MUST return HTTP 200 with an array of 5 version objects
+- AND each object MUST include: versionNumber, createdBy, createdAt, note (may be null), sizeBytes
+- AND the array MUST be ordered newest-first (highest versionNumber first)
+
+#### Scenario: List versions backend-agnostic
+
+- GIVEN a dashboard stored in groupfolder backend
+- WHEN a user calls GET /api/dashboards/{uuid}/versions
+- THEN the system MUST resolve to `IVersionManager` file-versions and map each file-version to a compatible response object
+- AND the response format MUST be identical to database backend (versionNumber synthesized from file-version timestamp, createdBy from NC user ID if available, etc.)
+
+#### Scenario: List versions for a dashboard with no snapshots
+
+- GIVEN a dashboard that exists but has no version snapshots
+- WHEN a user sends GET /api/dashboards/{uuid}/versions
+- THEN the response MUST return HTTP 200 with an empty array `[]`
+- AND NOT HTTP 404 (the dashboard exists, it just has no history yet)
+
+#### Scenario: Soft-failure for unavailable versioning
+
+- GIVEN a dashboard on groupfolder backend and NC versioning is disabled or unavailable
+- WHEN a user sends GET /api/dashboards/{uuid}/versions
+- THEN the response MUST return HTTP 200 with body `{versions: [], modeSupported: false}`
+- AND MUST NOT return HTTP 500 or raise an error
+- AND the UI SHOULD show "version history disabled" to the user
+
+#### Scenario: Only owners and admins can list
+
+- GIVEN dashboard "My Dashboard" owned by "alice"
+- WHEN user "bob" (non-owner, non-admin) sends GET /api/dashboards/{uuid}/versions
+- THEN the system MUST return HTTP 403
+- AND no version list MUST be disclosed
+
+### Requirement: REQ-VERS-004 Fetch Version Snapshot
+
+The system MUST expose GET /api/dashboards/{uuid}/versions/{versionNumber} returning the full snapshot content at that version.
+
+#### Scenario: Fetch a specific version snapshot
+
+- GIVEN a dashboard with version 3 containing a snapshot
+- WHEN a user sends GET /api/dashboards/{uuid}/versions/3
+- THEN the response MUST return HTTP 200 with the full snapshotJson body (widget tree, metadata, etc.) exactly as stored
+- AND the response MUST be identical to the current dashboard content if version 3 is the latest
+
+#### Scenario: Fetch non-existent version
+
+- GIVEN a dashboard with 5 versions (versionNumber 1..5)
+- WHEN a user sends GET /api/dashboards/{uuid}/versions/99
+- THEN the system MUST return HTTP 404
+- AND the response MUST indicate "version not found"
+
+#### Scenario: Only owners and admins can fetch
+
+- GIVEN dashboard owned by "alice"
+- WHEN user "bob" sends GET /api/dashboards/{uuid}/versions/3
+- THEN the system MUST return HTTP 403
+
+### Requirement: REQ-VERS-005 Restore Version
+
+The system MUST expose POST /api/dashboards/{uuid}/versions/{versionNumber}/restore to replace the current dashboard content with a historical snapshot. The restore operation is itself reversible — a pre-restore snapshot is automatically created.
+
+#### Scenario: Restore a previous version
+
+- GIVEN a dashboard with 5 versions, current content at version 5
+- WHEN a user sends POST /api/dashboards/{uuid}/versions/3/restore
+- THEN the system MUST:
+  1. Capture the current state (version 5 content) as a NEW version snapshot BEFORE overwriting
+  2. Replace the dashboard content with version 3's snapshotJson
+  3. Return HTTP 200 with the newly restored state
+- AND subsequent GET /api/dashboards/{uuid}/versions MUST list the pre-restore snapshot as the newest version (versionNumber 6)
+
+#### Scenario: Restore is reversible
+
+- GIVEN a user restored from version 3 to version 5's content, creating version 6
+- WHEN they later send POST /api/dashboards/{uuid}/versions/6/restore
+- THEN the content returns to the original version 5 state
+- AND a new snapshot (version 7) is created capturing version 6 before the reversal
+
+#### Scenario: Restore to the current version is a no-op
+
+- GIVEN a dashboard at version 5 (current)
+- WHEN a user sends POST /api/dashboards/{uuid}/versions/5/restore
+- THEN the system MUST return HTTP 200 (idempotent)
+- AND NO new snapshot MUST be created (content unchanged)
+
+#### Scenario: Restore non-existent version
+
+- GIVEN a dashboard with 5 versions
+- WHEN a user sends POST /api/dashboards/{uuid}/versions/99/restore
+- THEN the system MUST return HTTP 404
+- AND no content MUST be modified
+
+#### Scenario: Only owners and admins can restore
+
+- GIVEN dashboard owned by "alice"
+- WHEN user "bob" sends POST /api/dashboards/{uuid}/versions/3/restore
+- THEN the system MUST return HTTP 403
+- AND content MUST NOT be modified
+
+#### Scenario: Restore updates the modified timestamp
+
+- GIVEN a dashboard last modified at 2026-03-01 10:00:00
+- WHEN a user restores a version
+- THEN the dashboard's updatedAt MUST be set to the current timestamp (2026-03-01 10:15:00 or whenever the restore occurs)
+- AND subsequent GET /api/dashboard/{uuid} MUST reflect the new updatedAt
+
+### Requirement: REQ-VERS-006 Version Retention
+
+The system MUST automatically prune old snapshots, keeping only the 50 most recent versions per dashboard in database backend. GroupFolder backend follows Nextcloud's own retention policies.
+
+#### Scenario: Automatic pruning in database backend
+
+- GIVEN a database-backed dashboard with 60 versions (versionNumber 1..60)
+- WHEN the system prunes (triggered after a new snapshot creation if total > 50)
+- THEN versions 1..10 MUST be deleted
+- AND versions 11..60 MUST remain
+- AND versionNumber MUST remain monotonic across the range (no renumbering)
+
+#### Scenario: GroupFolder backend defers to Nextcloud
+
+- GIVEN a groupfolder-backed dashboard with file-versions
+- WHEN versions are created and NC's own retention policy kicks in
+- THEN MyDash MUST NOT independently prune NC file-versions
+- AND the system MUST respect NC's retention settings
+
+#### Scenario: Pruning does not affect versionNumber sequence
+
+- GIVEN a database-backed dashboard where versions 1..10 were pruned, versions 11..60 remain
+- WHEN a user creates a new snapshot (next version)
+- THEN the new snapshot MUST have versionNumber 61 (monotonic), NOT 51
+- AND the versionNumber sequence MUST be unbroken from 11 onwards
+
+#### Scenario: Edge case — exactly 50 versions
+
+- GIVEN a dashboard with exactly 50 versions
+- WHEN a new snapshot is created
+- THEN the system MUST create version 51
+- AND prune the oldest (version 1)
+- AND the final state MUST have exactly 50 versions (11..60)
+
+### Requirement: REQ-VERS-007 Restore Audit Trail
+
+The system MUST emit a Nextcloud activity event for every restore, enabling audit and history reconstruction.
+
+#### Scenario: Activity event on restore
+
+- GIVEN a user "alice" restores dashboard {uuid} from version 3
+- WHEN the restore completes
+- THEN the system MUST emit a Nextcloud activity event with type `dashboard_restored`
+- AND the event data MUST include: dashboardUuid, restoredFrom (versionNumber), restoredBy (alice), restoredAt (current timestamp)
+- AND admins viewing the activity log MUST see this event
+
+#### Scenario: Activity events include full context
+
+- GIVEN a restore event is emitted
+- WHEN an admin queries the activity log
+- THEN the event MUST be human-readable (e.g., "Alice restored dashboard 'My Dashboard' from version 3")
+- AND the event MUST link to the dashboard (via uuid) if the activity UI supports it
+
+#### Scenario: Automatic snapshots do NOT emit activity
+
+- GIVEN a PUT operation creates an automatic snapshot (debounced)
+- WHEN the snapshot is created
+- THEN NO activity event MUST be emitted (only explicit restores audit)
+- NOTE: Automatic snapshots may emit less critical audit logs if desired, but activity events are reserved for restore actions
+
+### Requirement: REQ-VERS-008 Mode-Aware Backend
+
+The system MUST transparently adapt all version endpoints to the dashboard's content backend (database vs. groupfolder file). The caller MUST NOT need to know which backend is in use.
+
+#### Scenario: Database backend returns versions from table
+
+- GIVEN a database-backed dashboard
+- WHEN a user calls GET /api/dashboards/{uuid}/versions
+- THEN the system MUST query oc_mydash_dashboard_versions table
+- AND return version objects constructed from DB rows
+- AND each version MUST have a canonical versionNumber (INT)
+
+#### Scenario: GroupFolder backend returns file-versions
+
+- GIVEN a groupfolder-backed dashboard with a file at /user_files/Group%20Folder/dashboard.json and 3 NC file-versions
+- WHEN a user calls GET /api/dashboards/{uuid}/versions
+- THEN the system MUST call `IVersionManager::getVersions()` on the file
+- AND map each file-version object to a compatible response format
+- AND synthesize versionNumber from file-version timestamp if NC doesn't provide one, ensuring monotonic ordering
+
+#### Scenario: GroupFolder backend fetch snapshot
+
+- GIVEN a groupfolder-backed dashboard and a user requests GET /api/dashboards/{uuid}/versions/2
+- WHEN the request is made
+- THEN the system MUST retrieve the specific file-version from NC (not from the current live file)
+- AND return the full file content
+- AND return HTTP 200 with the version body
+
+#### Scenario: GroupFolder backend restore
+
+- GIVEN a groupfolder-backed dashboard at version 5
+- WHEN a user sends POST /api/dashboards/{uuid}/versions/3/restore
+- THEN the system MUST:
+  1. Capture current content as a new file-version (NC creates this automatically when the file is written)
+  2. Call the NC file-version revert API to restore version 3
+  3. Return HTTP 200
+- AND the content MUST revert to version 3's state
+
+#### Scenario: Mode detection is automatic
+
+- GIVEN a dashboard object
+- WHEN version endpoints are called
+- THEN the system MUST check the dashboard's `contentBackend` field or equivalent to determine mode
+- AND route the call accordingly WITHOUT requiring a mode parameter in the API request
+
+### Requirement: REQ-VERS-009 Soft-Failure Tolerance
+
+The system MUST degrade gracefully when version storage is unavailable, returning HTTP 200 with an indication that versioning is not available, rather than raising HTTP 5xx errors.
+
+#### Scenario: GroupFolder versioning disabled
+
+- GIVEN a groupfolder-backed dashboard and NC File versioning is disabled
+- WHEN a user calls GET /api/dashboards/{uuid}/versions
+- THEN the response MUST be HTTP 200 with body `{versions: [], modeSupported: false}`
+- AND no error MUST be logged (this is expected behavior)
+
+#### Scenario: IVersionManager unavailable
+
+- GIVEN a groupfolder-backed dashboard
+- WHEN `IVersionManager` is not accessible or throws an exception
+- THEN the system MUST catch the exception and return HTTP 200 `{versions: [], modeSupported: false}`
+- AND a warning MAY be logged for ops visibility
+
+#### Scenario: Database connection error is NOT soft-fail
+
+- GIVEN a database-backed dashboard and the database is unreachable
+- WHEN a user calls GET /api/dashboards/{uuid}/versions
+- THEN the system MUST return HTTP 500 (database errors are NOT soft-fail conditions)
+- AND an error MUST be logged
+- NOTE: Soft-fail applies only to Nextcloud versioning unavailability (groupfolder mode), not database unavailability
+
+#### Scenario: Graceful degradation UI hint
+
+- GIVEN the API returns `{versions: [], modeSupported: false}` for a groupfolder dashboard
+- WHEN the frontend receives this response
+- THEN the UI SHOULD display "Version history is not available for this dashboard"
+- AND the restore button SHOULD be disabled or hidden
+
+## Non-Functional Requirements
+
+- **Performance**: GET /api/dashboards/{uuid}/versions MUST return within 500ms for dashboards with up to 50 versions. Restore operations MUST complete within 2 seconds.
+- **Consistency**: The 60-second debounce window MUST be enforced consistently even under concurrent requests from different users on the same dashboard.
+- **Storage**: Database backend MUST prune to 50 versions per dashboard; each MEDIUMTEXT snapshot can store up to 16MB of JSON.
+- **Auditability**: Every restore action MUST be logged via Nextcloud activity with full context (uuid, version, user, timestamp).
+- **Accessibility**: Version list UI MUST be keyboard-operable and screen-reader friendly.
+- **Localization**: All error messages and activity event descriptions MUST support English and Dutch.

--- a/openspec/changes/dashboard-versioning/tasks.md
+++ b/openspec/changes/dashboard-versioning/tasks.md
@@ -1,0 +1,115 @@
+# Tasks — dashboard-versioning
+
+## 1. Schema migration
+
+- [ ] 1.1 Create `lib/Migration/VersionXXXXDate2026...AddDashboardVersionsTable.php` adding `oc_mydash_dashboard_versions` table with columns: id (PK), dashboardUuid, versionNumber, snapshotJson (MEDIUMTEXT), createdBy, createdAt, note
+- [ ] 1.2 Same migration adds composite unique index `idx_mydash_dvers_uuid_num` on `(dashboardUuid, versionNumber)` for efficient per-dashboard lookups
+- [ ] 1.3 Add composite index `idx_mydash_dvers_created` on `(dashboardUuid, createdAt DESC)` for fast "newest-first" ordering
+- [ ] 1.4 Confirm migration is reversible (drop table in `preSchemaChange` / `postSchemaChange` rollback path)
+- [ ] 1.5 Run migration locally against sqlite, mysql, and postgres; verify schema applied cleanly each time
+
+## 2. Domain model
+
+- [ ] 2.1 Create `lib/Db/DashboardVersion.php` entity with properties: id, dashboardUuid, versionNumber, snapshotJson, createdBy, createdAt, note
+- [ ] 2.2 Add getter/setter for each property (Entity `__call` pattern — no named args on setters)
+- [ ] 2.3 Add `Dashboard::BACKEND_DATABASE = 'database'` and `Dashboard::BACKEND_GROUPFOLDER = 'groupfolder'` constants (or equivalent for content-backend tracking)
+- [ ] 2.4 Add `contentBackend` field to `Dashboard` entity if not already present (part of `groupfolder-storage-backend` change; coordinate with that spec)
+
+## 3. Mapper layer
+
+- [ ] 3.1 Create `lib/Db/DashboardVersionMapper.php` with standard insert/update/delete + findByDashboardUuid(string $dashboardUuid): array
+- [ ] 3.2 Add `findLatestByDashboard(string $dashboardUuid, int $limit): array` — returns newest N versions ordered DESC by versionNumber
+- [ ] 3.3 Add `findByDashboardAndVersion(string $dashboardUuid, int $versionNumber): DashboardVersion` — single-version fetch, throws NotFound if missing
+- [ ] 3.4 Add `pruneOldVersions(string $dashboardUuid, int $keepCount = 50): void` — DELETE oldest versions beyond keepCount for this dashboard
+- [ ] 3.5 Add `countByDashboard(string $dashboardUuid): int` — used to determine when pruning threshold is crossed
+- [ ] 3.6 Add fixture-based PHPUnit test covering: insert/fetch, ordering by versionNumber, pruning logic, edge case (exactly 50 versions)
+
+## 4. Service layer — versioning strategy pattern
+
+- [ ] 4.1 Create `lib/Service/VersioningStrategy/VersioningStrategyInterface.php` with methods: listVersions(), fetchSnapshot(), restoreVersion(), createSnapshot()
+- [ ] 4.2 Create `lib/Service/VersioningStrategy/DatabaseVersioningStrategy.php` — implements interface using DashboardVersionMapper, handles pruning, returns DB-row-backed version objects
+- [ ] 4.3 Create `lib/Service/VersioningStrategy/FilesVersioningStrategy.php` — implements interface using `IVersionManager`, maps NC file-versions to compatible response objects, handles soft-failure (returns empty list if versioning unavailable), synthesizes versionNumber from timestamp
+- [ ] 4.4 Create strategy factory: `DashboardVersioningStrategyFactory::create(Dashboard $dashboard): VersioningStrategyInterface` — routes to Database or Files strategy based on `$dashboard->getContentBackend()`
+
+## 5. Service layer — version management
+
+- [ ] 5.1 Create `lib/Service/DashboardVersionService.php` with `__construct(DashboardVersioningStrategyFactory, IAppConfig)` injections
+- [ ] 5.2 Add `captureSnapshot(Dashboard $dashboard, string $snapshotJson, string $createdBy, ?string $note = null): void` — routes to strategy, enforces debounce (at most one snapshot per 60s per dashboard via APCu cache key `mydash:snapshot_ts:{dashboardUuid}`)
+- [ ] 5.3 Add `listVersions(Dashboard $dashboard, string $requestingUser): array` — permission check (owner or admin), calls strategy->listVersions()
+- [ ] 5.4 Add `fetchSnapshot(Dashboard $dashboard, int $versionNumber, string $requestingUser): string` — permission check, calls strategy->fetchSnapshot() to get full JSON body
+- [ ] 5.5 Add `restoreVersion(Dashboard $dashboard, int $versionNumber, string $restoringUser): string` — permission check, captures pre-restore state as new snapshot, calls strategy->restoreVersion(), emits activity event, returns new content
+- [ ] 5.6 Update `DashboardService::updateDashboard()` or equivalent to call `DashboardVersionService::captureSnapshot()` after successful content save (pass the new snapshotJson, the userId, and null for note to capture automatic snapshot)
+- [ ] 5.7 Add i18n key for activity event: `activity_dashboard_restored` with params `{dashboard, version, user}` in both nl and en
+
+## 6. Controller + routes
+
+- [ ] 6.1 Create `lib/Controller/DashboardVersionController.php` with `__construct(Request, IAppConfig, DashboardVersionService, DashboardService)` injections
+- [ ] 6.2 Add `listVersions(string $uuid)` mapped to `GET /api/dashboards/{uuid}/versions` (`#[NoAdminRequired]`)
+  - Permission check: dashboard owner or admin
+  - Returns: `{versions: [{versionNumber, createdBy, createdAt, note, sizeBytes}, ...], modeSupported: true|false}` ordered newest-first
+- [ ] 6.3 Add `fetchVersion(string $uuid, int $versionNumber)` mapped to `GET /api/dashboards/{uuid}/versions/{versionNumber}` (`#[NoAdminRequired]`)
+  - Permission check: dashboard owner or admin
+  - Returns: full snapshot body (JSON content of dashboard at that version)
+- [ ] 6.4 Add `createVersion(string $uuid)` mapped to `POST /api/dashboards/{uuid}/versions` (`#[NoAdminRequired]`)
+  - Permission check: dashboard owner or admin
+  - Parses request body for optional `note` field
+  - Calls `DashboardVersionService::captureSnapshot()` with current dashboard content + note
+  - Returns: HTTP 201 with new version object
+- [ ] 6.5 Add `restoreVersion(string $uuid, int $versionNumber)` mapped to `POST /api/dashboards/{uuid}/versions/{versionNumber}/restore` (`#[NoAdminRequired]`)
+  - Permission check: dashboard owner or admin
+  - Calls `DashboardVersionService::restoreVersion()`
+  - Returns: HTTP 200 with restored dashboard content
+- [ ] 6.6 Register all 4 routes in `appinfo/routes.php` with proper URL requirements (`{uuid}` = UUID regex, `{versionNumber}` = integer)
+- [ ] 6.7 Confirm every method carries `#[NoAdminRequired]` attribute and performs in-body permission checks via `PermissionService` or equivalent
+
+## 7. Integration into existing PUT handler
+
+- [ ] 7.1 Locate `DashboardService::updateDashboard()` or the controller method that handles PUT /api/dashboard/{uuid}/content
+- [ ] 7.2 After successful content persistence, insert a call to `DashboardVersionService::captureSnapshot()` with the new content JSON, userId, and null note
+- [ ] 7.3 Ensure the debounce check inside `captureSnapshot()` prevents duplicate snapshots during rapid saves
+- [ ] 7.4 Test locally: rapid PUT requests should trigger at most one snapshot in a 60s window
+
+## 8. Activity event integration
+
+- [ ] 8.1 Inject `IActivityManager` into `DashboardVersionService`
+- [ ] 8.2 In `restoreVersion()` after successful restore, call `IActivityManager->publish()` with event type `dashboard_restored`, subject `{dashboardUuid}`, and attributes `{versionNumber, restoringUser, restoredAt}`
+- [ ] 8.3 Register activity event type in `appinfo/app.php` or via `ActivityProvider` if the app uses one
+- [ ] 8.4 Add i18n translation for activity message (both nl and en) in `translationfiles/` or equivalent
+
+## 9. PHPUnit tests
+
+- [ ] 9.1 `DashboardVersionMapperTest::testInsertAndFind` — insert version, fetch by dashboardUuid + versionNumber, verify all fields
+- [ ] 9.2 `DashboardVersionMapperTest::testLatestVersions` — insert 5 versions, fetch latest 3, verify descending order
+- [ ] 9.3 `DashboardVersionMapperTest::testPruneOldVersions` — insert 60 versions, prune to 50, verify oldest 10 deleted, newest 50 remain, versionNumbers unbroken from 11
+- [ ] 9.4 `FilesVersioningStrategyTest::testListVersionsGracefulDegradation` — mock IVersionManager to throw exception, verify strategy returns empty list and `modeSupported: false`
+- [ ] 9.5 `DashboardVersionServiceTest::testDebounce` — call captureSnapshot twice within 60s, verify only 1 DB insert; call after 60s, verify 2nd insert succeeds
+- [ ] 9.6 `DashboardVersionServiceTest::testRestoreCreatesNewSnapshot` — call restoreVersion(), verify pre-restore state captured as new version before content is overwritten
+- [ ] 9.7 `DashboardVersionServiceTest::testPermissionGuard` — non-owner calls listVersions/fetchSnapshot/restoreVersion, verify HTTP 403 returned
+- [ ] 9.8 `DashboardVersionServiceTest::testRestoreEmitsActivity` — mock IActivityManager, call restoreVersion(), verify activity event published with correct payload
+- [ ] 9.9 `DashboardVersionControllerTest::testListVersionsNewestFirst` — call GET /api/dashboards/{uuid}/versions, verify array ordered newest-first
+- [ ] 9.10 `DashboardVersionControllerTest::testFetchNonExistentVersion` — call GET /api/dashboards/{uuid}/versions/99 for non-existent version, verify HTTP 404
+
+## 10. End-to-end Playwright tests
+
+- [ ] 10.1 Authenticated user saves a dashboard, waits 61 seconds, saves again; call GET /api/dashboards/{uuid}/versions, verify 2 snapshots exist
+- [ ] 10.2 Call POST /api/dashboards/{uuid}/versions with `{"note": "v1.0"}` within 60s of last PUT; verify explicit snapshot created despite debounce window
+- [ ] 10.3 Call POST /api/dashboards/{uuid}/versions/{versionNumber}/restore, verify content reverted and new snapshot created
+- [ ] 10.4 Restore the pre-restore version (reversibility); verify content restored to original and a new version created
+- [ ] 10.5 Test groupfolder backend: dashboard stored in Files; call GET /api/dashboards/{uuid}/versions; verify file-versions are mapped to response objects
+- [ ] 10.6 Test soft-failure: disable NC versioning for a groupfolder dashboard; call GET /api/dashboards/{uuid}/versions; verify HTTP 200 with `{versions: [], modeSupported: false}`
+- [ ] 10.7 Non-owner user attempts to call GET /api/dashboards/{uuid}/versions, POST restore; verify HTTP 403 each time
+
+## 11. Quality gates
+
+- [ ] 11.1 `composer check:strict` (PHPCS, PHPMD, Psalm, PHPStan) passes — fix any pre-existing issues encountered along the way
+- [ ] 11.2 ESLint + Stylelint clean on all touched Vue/JS files (none for this backend-focused change, but verify if controller generates API responses that affect frontend)
+- [ ] 11.3 Update generated OpenAPI spec / Postman collection to include the 4 new endpoints
+- [ ] 11.4 i18n keys for all new error messages and activity events in both `nl` and `en`
+- [ ] 11.5 SPDX headers on every new PHP file (inside the docblock per the SPDX-in-docblock convention) — gate-spdx must pass
+- [ ] 11.6 Run all hydra-gates locally before opening PR
+
+## 12. Documentation
+
+- [ ] 12.1 Add endpoint documentation to `README.md` or API docs: GET|POST /api/dashboards/{uuid}/versions, GET /api/dashboards/{uuid}/versions/{versionNumber}, POST restore
+- [ ] 12.2 Note the 60-second debounce window and 50-version retention limit in configuration docs
+- [ ] 12.3 Mention soft-failure behavior for groupfolder backend versioning unavailability

--- a/openspec/changes/dashboard-view-analytics/design.md
+++ b/openspec/changes/dashboard-view-analytics/design.md
@@ -1,0 +1,105 @@
+# Design — Dashboard View Analytics
+
+## Context
+
+MyDash currently has no way to track which dashboards are being used. This change adds aggregate, privacy-preserving view counts per dashboard (daily buckets) with admin query endpoints and a Vue frontend instrumentation layer. The capability is defined in `dashboard-view-analytics/spec.md` as REQ-ANLT-001 through REQ-ANLT-011.
+
+The source this feature is ported from uses a static hash strategy: `hash('sha256', $userId . $config->getSystemValue('secret', ''))` (see `intravox-source/lib/Service/AnalyticsService.php:288-291`). The Nextcloud instance secret is never rotated, meaning the same user always produces the same hash for all time. The "daily boundary" in the source comes from a `view_date = today()` composite key in an `intravox_uv` table — not from any salt rotation.
+
+This creates a meaningful privacy risk: if the `intravox_uv` table (or its equivalent) were ever leaked, a party who learns the static salt could re-identify which user hash corresponds to which user across years of stored rows. For an analytics feature that explicitly advertises privacy preservation, that is an unacceptable residual risk.
+
+MyDash diverges from the source on this point deliberately. The daily boundary the source achieves through `view_date` is preserved — but the hash is made non-static by rotating the salt each UTC day and keeping no salt history. This means cross-day re-identification from the database alone becomes computationally infeasible.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Track aggregate view counts (total views + unique viewer count) per dashboard per UTC day.
+- Use a daily-rotating salt so the viewer hash is only valid within a 24-hour window.
+- Deduplicate unique viewers via an in-process cache (no per-user-per-event rows persisted to the database).
+- Provide admin query endpoints for top dashboards, per-dashboard breakdown, instance summary, and CSV export.
+- Support per-user opt-out and global admin disable.
+- Auto-purge rows older than a configurable retention period (default 365 days).
+
+**Non-Goals:**
+
+- Cross-day re-identification of users from analytics tables — this MUST NOT be possible from the stored data alone.
+- Per-event logging of individual user views (no raw user IDs or hashes stored in the database at any point).
+- Real-time analytics or WebSocket push — aggregates are batch-computed daily.
+- Unauthenticated view tracking — only authenticated users' view events are counted.
+- Analytics for non-dashboard entities (widgets, tiles, admin pages).
+
+## Decisions
+
+### D1: Unique-viewer dedup salt — daily-rotating, NOT static
+
+**Decision**: Compute viewer hash as `sha256(userId || dailySalt)` where `dailySalt` is a 32-byte random value generated at 00:00 UTC and stored in `IConfig` under `mydash.analytics_dailysalt`. When the salt rotates, the previous value is overwritten — no salt history is kept. This means cross-day hashes for the same user are computationally uncorrelated.
+
+**Alternatives considered:**
+
+- **Static instance-secret salt (the source's approach)**: `hash('sha256', $userId . $config->getSystemValue('secret'))`. Rejected for v1 because the static salt means the same user always produces the same hash across all days. A leak of the analytics table combined with knowledge of the salt (e.g., from a separate config leak) would allow re-identification of any user's full view history indefinitely. Analytics tables are low-sensitivity and often included in broader DB exports — the risk of a joint leak is non-trivial.
+
+**Source evidence (what the source does, not what we adopt)**:
+
+- `intravox-source/lib/Service/AnalyticsService.php:288-291` — `hashUserId()` uses static `config.secret` as the salt.
+- `intravox-source/lib/Service/AnalyticsService.php:296-306` — `trackUserView()` inserts into `intravox_uv` with `(page_id, user_hash, view_date)`; uniqueness boundary is the `view_date` column, not salt rotation.
+
+**Rationale**: The daily boundary for unique-viewer counting is retained (one count per user per dashboard per UTC day) but the mechanism shifts to salt rotation instead of a stored uv row. Admins viewing "last 7 days" or "last 30 days" aggregates do not need cross-day user correlation — they need accurate daily counts. The cost (no ability to identify if the same physical user appeared on both 2026-05-01 and 2026-05-02) is accepted as a privacy feature, not a limitation.
+
+### D2: Salt rotation mechanism — daily cron, no historical retention
+
+**Decision**: A daily background job (`SaltRotationJob`) generates a fresh 32-byte random salt at 00:00 UTC using `random_bytes(32)` and stores the hex-encoded value in `IConfig` under `mydash.analytics_dailysalt`. The previous salt is overwritten with no backup. The dedup cache TTL (see D3) is set to expire at the next UTC midnight, ensuring the cache and salt lifetimes are aligned.
+
+**Rationale**: Overwriting (not appending) the salt means no historical salt table exists to leak. This is a deliberate design constraint — once a day has passed, its viewer hashes are permanently uncorrelated with user IDs. A single `IConfig` key needs no migration and is readable by any process without coordination.
+
+### D3: Tables — `oc_mydash_dashboard_views` (daily aggregates only, no per-event log)
+
+**Decision**: ONE table with columns `(id PK, dashboardUuid VARCHAR(36), viewBucket DATE, viewCount INT, uniqueViewerCount INT)` and a composite unique index on `(dashboardUuid, viewBucket)`. There is no per-user-per-day event log table. Unique-viewer deduplication is handled exclusively through a Nextcloud `ICache` entry keyed on `(dashboardUuid, viewerHash)` with a TTL expiring at the next UTC midnight.
+
+**Alternatives considered:**
+
+- **Match source: separate `oc_mydash_dashboard_view_log` (or `intravox_uv`-equivalent) table**: Rejected. Keeping per-event rows (even hashed) creates a long-lived table whose rows are individually attributable within a day's salt window. The cache-based approach gives identical dedup semantics with no residual per-user rows in the database.
+
+**Source evidence**:
+
+- `intravox-source/lib/Service/AnalyticsService.php:44-46` — source has both `intravox_uv` (per-event uv log) and `intravox_page_stats` (aggregate). We collapse this to one aggregate table + cache.
+
+**Rationale**: Aggregate rows are the only data needed for every admin query endpoint. Cache-based dedup is cheaper than a DB insert-or-ignore per view event and leaves no hashes at rest. The cache is ephemeral by design — it does not survive process restarts longer than its TTL, which is acceptable because a restart mid-day may cause a small uniqueViewerCount undercount for that day.
+
+### D4: Retention — 365 days for aggregates (admin-tunable, min 30, max 3650)
+
+**Decision**: Aggregate rows with `viewBucket < CURRENT_DATE - retentionDays` are purged by a daily background job (`PurgeViewsJob`). The default is 365 days. Admins override via `mydash.analytics_retention_days`. Values below 30 are clamped to 30; values above 3650 are clamped to 3650.
+
+**Rationale**: 365 days supports year-over-year comparisons ("this month vs. same month last year"), which is the most common admin reporting horizon. The minimum of 30 keeps the admin dashboard charts meaningful. The maximum of 3650 (10 years) covers compliance use cases without permitting unbounded growth by default.
+
+### D5: Opt-out — per-user setting, default off (opted in)
+
+**Decision**: User setting `mydash.user_setting.analytics_optout` (boolean, default `false` — opted in). When `true`, the `POST /api/dashboards/{uuid}/view-event` handler short-circuits immediately with HTTP 204, writing no cache entry and touching no database row.
+
+**Rationale**: Privacy regulation (AVG/GDPR) requires a meaningful opt-out path. Short-circuiting before any hash is computed ensures zero data is generated for opted-out users, not just zero data stored — no transient identifiers are created mid-request.
+
+### D6: Global admin disable — `mydash.analytics_enabled` (default `true`)
+
+**Decision**: When an admin sets `mydash.analytics_enabled = false`, every `POST /view-event` returns HTTP 204 with a complete no-op. The frontend checks a config endpoint on mount and suppresses the request entirely when analytics is disabled, avoiding unnecessary HTTP round-trips.
+
+**Rationale**: Organisations with stricter internal policies may need to disable all view tracking. A single `IConfig` key is simpler than per-scope or per-group toggles and is effective immediately on the next request without cache invalidation.
+
+### D7: Front-end debouncing — once per dashboard mount, 1-second window
+
+**Decision**: `DashboardView.vue` calls `POST /api/dashboards/{uuid}/view-event` once on `mounted()`, debounced with a 1-second window keyed on `dashboardUuid`. A reload triggers a new event (debounce is per-mount, not per-session). Multi-tab opens of different dashboard UUIDs are NOT debounced against each other.
+
+**Rationale**: The 1-second debounce eliminates double-counts from near-simultaneous tab opens of the same dashboard while remaining invisible to normal single-tab navigation. Keying on UUID ensures concurrent tabs of different dashboards each generate their own event, which is the correct behaviour.
+
+## Spec Changes Implied
+
+- **REQ-ANLT-003 (unique-viewer dedup)**: Pin the daily-rotating-salt approach with no historical retention. Add a NOTE documenting deliberate divergence from the source's static-secret approach and the privacy rationale.
+- **REQ-ANLT-002 (view-event endpoint)**: Pin the per-`(dashboardUuid, viewerHash)` cache key for dedup; specify cache TTL = seconds until next UTC midnight.
+- **REQ-ANLT-009 (retention)**: Confirm 365-day default; document the 30/3650 clamp bounds explicitly.
+- **New scenario under REQ-ANLT-003**: Salt rotation — verify that hashes computed with yesterday's salt cannot be reproduced after rotation (no history kept).
+
+## Open Follow-ups
+
+- Whether to expose an admin endpoint returning the current daily salt expiry time for monitoring purposes. Current position: no — publishing salt metadata is marginally useful but creates a target for timing-based attacks. Trivial to add if explicitly requested.
+- Whether bot and crawler view events should be filtered by User-Agent. User-Agent sniffing is unreliable and easily spoofed; defer until customers report inflated counts from known crawlers.
+- Whether the per-user opt-out setting should surface in the standard Nextcloud Personal Settings UI. Yes — this is sibling-capability work (`user-privacy-settings`) and not in scope for this change.
+- Cache invalidation on process restart mid-day: accepted as a known minor undercount. Document in the capability README so operators understand the trade-off before tuning OPcache aggressiveness.

--- a/openspec/changes/dashboard-view-analytics/proposal.md
+++ b/openspec/changes/dashboard-view-analytics/proposal.md
@@ -1,0 +1,63 @@
+# Dashboard View Analytics
+
+## Why
+
+MyDash admins today have no way to understand which dashboards are actually being used. Without visibility into dashboard engagement, organizations cannot optimize their intranet content, identify stale dashboards, or validate that their information architecture is effective. Admins need aggregate, privacy-preserving view counts per dashboard (daily buckets) to understand usage patterns, surface top dashboards, and identify low-engagement content for improvement or retirement.
+
+## What Changes
+
+- Extend `oc_mydash_dashboards` with a reference to daily view-count rows (one-to-many via composite key).
+- Create a new table `oc_mydash_dashboard_views` with columns: `id` (PK), `dashboardUuid VARCHAR(36)`, `viewBucket DATE`, `viewCount INT DEFAULT 0`, `uniqueViewerCount INT DEFAULT 0`, with composite unique index `(dashboardUuid, viewBucket)` — ONE row per (dashboard, day).
+- Expose `POST /api/dashboards/{uuid}/view-event` — called on dashboard load; increments daily counters (authed users only). Body: `{}`. Returns 204.
+- Unique-viewer counting is privacy-preserving: hash userId with a daily-rotating salt, store in cache, do NOT store raw user IDs. Deduplication via cache lookup.
+- Per-user opt-out: setting `mydash.user_setting.analytics_optout` (default `false`). When set, that user's view events are no-ops.
+- Global admin disable: setting `mydash.analytics_enabled` (default `true`). When `false`, all view events are no-ops.
+- Admin query endpoints:
+  - `GET /api/admin/analytics/dashboards/top?period=7d|30d|90d&limit=10` — top dashboards by view count
+  - `GET /api/admin/analytics/dashboards/{uuid}?period=7d|30d|90d` — daily breakdown for one dashboard
+  - `GET /api/admin/analytics/summary?period=7d|30d|90d` — instance-wide totals + top-5 list
+  - `GET /api/admin/analytics/export?period=30d` — CSV download (admin-only)
+- Daily background job purges rows older than 365 days (configurable via `mydash.analytics_retention_days`, min 30, max 3650).
+- Frontend instrumentation: Vue dashboard render calls `POST /api/dashboards/{uuid}/view-event` once on mount, debounced to prevent multi-tab inflation.
+- Admin UI: new "Analytics" tab in MyDash admin section showing top dashboards, 30-day trends chart.
+
+## Capabilities
+
+### New Capability
+
+- `dashboard-view-analytics`: adds REQ-ANLT-001..REQ-ANLT-011 for schema, view-event tracking, privacy, per-user opt-out, global disable, admin query endpoints, retention purge, CSV export, frontend instrumentation, and admin UI.
+
+## Impact
+
+**Affected code:**
+
+- `lib/Db/DashboardView.php` (new) — entity for `oc_mydash_dashboard_views` rows
+- `lib/Db/DashboardViewMapper.php` (new) — mapper for view-count rows, find-by-bucket, upsert, purge
+- `lib/Migration/VersionXXXXDate2026...AddDashboardViewsTable.php` (new) — schema migration creating table + composite index
+- `lib/Service/AnalyticsService.php` (new) — aggregation queries (top, detail, summary), CSV generation
+- `lib/Controller/AnalyticsController.php` (new) — admin query endpoints
+- `lib/Controller/DashboardController.php` — add `viewEvent()` POST endpoint
+- `lib/Service/DashboardService.php` — add call to AnalyticsService from view-event handler
+- `appinfo/routes.php` — register 5 new routes (1 public authed, 4 admin)
+- `lib/BackgroundJob/PurgeViewsJob.php` (new) — daily retention purge
+- `appinfo/app.php` — register background job
+- `src/stores/dashboards.js` — add view-event fetch call on mount
+- `src/views/DashboardView.vue` — call store action on component mount (debounced)
+- `src/views/AdminAnalytics.vue` (new) — admin analytics UI with charts + tables
+- `src/components/AnalyticsChart.vue` (new) — 30-day sparkline chart
+
+**Affected APIs:**
+
+- 5 new routes (1 authed public, 4 admin-only)
+- No existing routes changed
+
+**Dependencies:**
+
+- No new composer or npm dependencies
+
+**Migration:**
+
+- Zero-impact: new table. No changes to existing dashboard rows.
+- Background job runs daily (after app upgrade, Nextcloud scheduler picks it up).
+- Default settings enable analytics globally; admins can disable per-user or instance-wide.
+

--- a/openspec/changes/dashboard-view-analytics/specs/dashboard-view-analytics/spec.md
+++ b/openspec/changes/dashboard-view-analytics/specs/dashboard-view-analytics/spec.md
@@ -51,6 +51,8 @@ The system MUST track dashboard view events in a dedicated relational table with
 
 The system MUST expose an authenticated endpoint that records a view event when a user loads a dashboard.
 
+> **NOTE (MyDash-deliberate):** Unique-viewer deduplication uses a per-`(dashboardUuid, viewerHash)` cache key stored in Nextcloud `ICache`. The cache TTL is set to the number of seconds remaining until the next UTC midnight at the time the entry is written (i.e. `TTL = seconds_until_next_UTC_midnight()`), not a fixed 86400 seconds. This ensures the cache entry expires exactly when the daily salt rotates, keeping cache and salt lifetimes aligned. See REQ-ANLT-003 for the salt approach.
+
 #### Scenario: Authenticated user records a view event
 
 - GIVEN a logged-in user "alice" loads a dashboard with UUID "uuid-101"
@@ -58,6 +60,14 @@ The system MUST expose an authenticated endpoint that records a view event when 
 - THEN the system MUST return HTTP 204 (No Content)
 - AND the system MUST increment the view counter in the `oc_mydash_dashboard_views` row for today
 - AND no response body is returned
+
+#### Scenario: Dedup cache key is per dashboard and viewer hash
+
+- GIVEN user "alice" (userId: 1) posts a view event for dashboard "uuid-101" on 2026-05-01
+- WHEN the system checks for a duplicate within the same UTC day
+- THEN the system MUST use a cache key of the form `mydash_anlt_{dashboardUuid}_{viewerHash}`
+- AND the cache entry TTL MUST be set to the number of seconds remaining until the next UTC midnight
+- AND the system MUST NOT use a fixed 86400-second TTL
 
 #### Scenario: Unauthenticated user is rejected
 
@@ -84,6 +94,8 @@ The system MUST expose an authenticated endpoint that records a view event when 
 
 The system MUST count unique viewers per day using privacy-preserving hashing with a salt that rotates daily, preventing cross-day user correlation.
 
+> **NOTE (MyDash-deliberate — diverges from static-secret approach):** This requirement intentionally departs from the pattern of computing `sha256(userId || instanceSecret)` using the static Nextcloud instance secret as a salt. A static salt means the same user produces an identical hash for every day, forever; a leak of the analytics table combined with a separate config leak would allow full cross-day re-identification. MyDash instead uses a 32-byte random salt generated at 00:00 UTC by `SaltRotationJob`, stored in `IConfig` under `mydash.analytics_dailysalt`, and **overwritten** (not appended) at each rotation. No salt history is retained. The result: viewer hashes from different days are computationally uncorrelated, and cross-day re-identification from the analytics table alone is infeasible. Same-day unique-viewer counting is unaffected. This is a deliberate privacy improvement, not a limitation.
+
 #### Scenario: Same user on same day increments viewCount but not uniqueViewerCount twice
 
 - GIVEN user "alice" (userId: 1) loads a dashboard "uuid-103" at 10:00 AM on 2026-05-01
@@ -98,12 +110,13 @@ The system MUST count unique viewers per day using privacy-preserving hashing wi
 - GIVEN user "bob" (userId: 2) loads a dashboard on 2026-05-01 at 11:00 PM
 - AND loads the same dashboard again on 2026-05-02 at 12:00 AM (next day)
 - WHEN the system computes unique-viewer hashes:
-  - On 2026-05-01, hash = SHA256("userId=2" + "salt-2026-05-01")
-  - On 2026-05-02, hash = SHA256("userId=2" + "salt-2026-05-02")
-- THEN the two hashes MUST be different
-- AND the system MUST NOT be able to correlate bob's viewing across days
+  - On 2026-05-01, hash = SHA256(userId || dailySalt_2026-05-01)
+  - On 2026-05-02, hash = SHA256(userId || dailySalt_2026-05-02)
+  - where `dailySalt_2026-05-01` and `dailySalt_2026-05-02` are independent 32-byte random values
+- THEN the two hashes MUST be different (with overwhelming probability)
+- AND the system MUST NOT be able to correlate bob's viewing across days from the analytics table alone
 - AND `uniqueViewerCount` for 2026-05-01 is 1, and for 2026-05-02 is 1 (independent counts)
-- NOTE: Salt rotates at UTC midnight; implementations MUST use UTC date for bucket, not local time
+- NOTE: Salt rotates at UTC midnight; implementations MUST use UTC date for view bucket, not local time
 
 #### Scenario: Different users on same day increment uniqueViewerCount separately
 
@@ -117,10 +130,21 @@ The system MUST count unique viewers per day using privacy-preserving hashing wi
 - GIVEN user "diana" (userId: 4) posts a view event for dashboard "uuid-105" on 2026-05-01
 - WHEN the system increments uniqueViewerCount
 - THEN the system MUST:
-  - Compute hash = SHA256("userId=4" + "salt-2026-05-01")
-  - Store hash in Nextcloud ICache with TTL = 86400 seconds (24 hours, until next UTC midnight)
+  - Read `mydash.analytics_dailysalt` from `IConfig` (populated by `SaltRotationJob`)
+  - Compute hash = SHA256(userId || dailySalt)
+  - Store hash in Nextcloud `ICache` with TTL = seconds until next UTC midnight
   - NOT store the raw userId or hash in `oc_mydash_dashboard_views`
-  - Increment uniqueViewerCount only if hash is NOT already in cache
+  - Increment `uniqueViewerCount` only if hash is NOT already in cache
+
+#### Scenario: Salt rotation discards previous salt with no history retained
+
+- GIVEN `SaltRotationJob` ran on 2026-05-01 and stored `dailySalt_A` in `mydash.analytics_dailysalt`
+- AND viewer hashes for 2026-05-01 were computed using `dailySalt_A`
+- WHEN `SaltRotationJob` runs at 00:00 UTC on 2026-05-02
+- THEN `mydash.analytics_dailysalt` MUST be overwritten with a new 32-byte random value `dailySalt_B`
+- AND `dailySalt_A` MUST NOT be stored anywhere (no history table, no backup key, no log entry)
+- AND the system MUST NOT be able to reproduce the 2026-05-01 viewer hashes after rotation
+- NOTE: The loss of salt history is deliberate — it makes cross-day re-identification from the analytics table computationally infeasible even if an attacker later obtains the current salt
 
 ### Requirement: REQ-ANLT-004 Per-User Analytics Opt-Out
 
@@ -298,6 +322,8 @@ The system MUST expose an admin-only endpoint that returns aggregate statistics 
 ### Requirement: REQ-ANLT-009 Analytics Data Retention and Purge
 
 The system MUST automatically purge view-count rows older than a configurable retention period to prevent unbounded database growth.
+
+> **NOTE:** Default retention is **365 days** (supporting year-over-year comparisons). The valid range is **30–3650 days** inclusive (minimum preserves meaningful chart windows; maximum covers decade-scale compliance without permitting unbounded growth by default). Values outside this range MUST be clamped by the system — implementation may reject or silently clamp, but the effective retention used by `PurgeViewsJob` MUST always fall within [30, 3650]. Table: `oc_mydash_dashboard_views`.
 
 #### Scenario: Default retention is 365 days
 

--- a/openspec/changes/dashboard-view-analytics/specs/dashboard-view-analytics/spec.md
+++ b/openspec/changes/dashboard-view-analytics/specs/dashboard-view-analytics/spec.md
@@ -1,0 +1,418 @@
+---
+status: draft
+---
+
+# Dashboard View Analytics
+
+## ADDED Requirements
+
+### Requirement: REQ-ANLT-001 Dashboard Views Table Schema
+
+The system MUST track dashboard view events in a dedicated relational table with daily aggregation buckets, privacy-preserving counters, and composite unique indexes.
+
+#### Scenario: Create views table with correct schema
+
+- GIVEN the system has no `oc_mydash_dashboard_views` table
+- WHEN the schema migration runs
+- THEN the system MUST create `oc_mydash_dashboard_views` with columns:
+  - `id` (INT AUTO_INCREMENT, PRIMARY KEY)
+  - `dashboardUuid` (VARCHAR 36, NOT NULL, foreign key reference to `oc_mydash_dashboards.uuid`)
+  - `viewBucket` (DATE, NOT NULL — calendar date in UTC)
+  - `viewCount` (INT DEFAULT 0, NOT NULL)
+  - `uniqueViewerCount` (INT DEFAULT 0, NOT NULL)
+- AND the system MUST create a composite unique index on `(dashboardUuid, viewBucket)`
+- AND the system MUST create an index on `(viewBucket)` for efficient date-range queries
+
+#### Scenario: One row per dashboard per day
+
+- GIVEN a dashboard exists with UUID "uuid-123"
+- WHEN a view event is recorded for "uuid-123" on 2026-05-01
+- AND another view event is recorded for "uuid-123" on 2026-05-01
+- THEN the system MUST maintain only ONE row with `(dashboardUuid = 'uuid-123', viewBucket = '2026-05-01')`
+- AND subsequent view events on the same date MUST increment the counters in that single row (no new rows created)
+
+#### Scenario: Two different days create separate rows
+
+- GIVEN a dashboard "uuid-456" exists
+- WHEN a view event is recorded on 2026-05-01
+- AND another view event is recorded on 2026-05-02
+- THEN the system MUST maintain TWO separate rows:
+  - Row 1: `(dashboardUuid = 'uuid-456', viewBucket = '2026-05-01', viewCount = 1, uniqueViewerCount = X)`
+  - Row 2: `(dashboardUuid = 'uuid-456', viewBucket = '2026-05-02', viewCount = 1, uniqueViewerCount = Y)`
+
+#### Scenario: Schema supports multiple databases
+
+- GIVEN the Nextcloud instance may use SQLite, MySQL, or PostgreSQL
+- WHEN the migration runs on any of these databases
+- THEN the table MUST be created with identical semantics
+- AND the composite unique index MUST enforce uniqueness on all three backends
+
+### Requirement: REQ-ANLT-002 View Event Endpoint
+
+The system MUST expose an authenticated endpoint that records a view event when a user loads a dashboard.
+
+#### Scenario: Authenticated user records a view event
+
+- GIVEN a logged-in user "alice" loads a dashboard with UUID "uuid-101"
+- WHEN she sends `POST /api/dashboards/uuid-101/view-event` with body `{}`
+- THEN the system MUST return HTTP 204 (No Content)
+- AND the system MUST increment the view counter in the `oc_mydash_dashboard_views` row for today
+- AND no response body is returned
+
+#### Scenario: Unauthenticated user is rejected
+
+- GIVEN an unauthenticated request (no session or bearer token)
+- WHEN the request sends `POST /api/dashboards/uuid-101/view-event`
+- THEN the system MUST return HTTP 401 (Unauthorized)
+- AND no view count is recorded
+
+#### Scenario: Invalid dashboard UUID returns 404
+
+- GIVEN no dashboard exists with UUID "uuid-nonexistent"
+- WHEN an authed user sends `POST /api/dashboards/uuid-nonexistent/view-event`
+- THEN the system MUST return HTTP 404 (Not Found)
+- AND no row is created in `oc_mydash_dashboard_views`
+
+#### Scenario: Empty request body is valid
+
+- GIVEN a valid dashboard UUID "uuid-102"
+- WHEN a user sends `POST /api/dashboards/uuid-102/view-event` with `Content-Type: application/json` and body `{}`
+- THEN HTTP 204 MUST be returned
+- AND the view counter MUST be incremented
+
+### Requirement: REQ-ANLT-003 Unique Viewer Deduplication with Daily-Rotating Salt
+
+The system MUST count unique viewers per day using privacy-preserving hashing with a salt that rotates daily, preventing cross-day user correlation.
+
+#### Scenario: Same user on same day increments viewCount but not uniqueViewerCount twice
+
+- GIVEN user "alice" (userId: 1) loads a dashboard "uuid-103" at 10:00 AM on 2026-05-01
+- AND at 10:15 AM the same user loads the same dashboard again
+- WHEN both view events are recorded
+- THEN the system MUST have:
+  - `viewCount = 2` (both events counted)
+  - `uniqueViewerCount = 1` (alice counted once per day)
+
+#### Scenario: Daily salt rotation prevents user re-identification across days
+
+- GIVEN user "bob" (userId: 2) loads a dashboard on 2026-05-01 at 11:00 PM
+- AND loads the same dashboard again on 2026-05-02 at 12:00 AM (next day)
+- WHEN the system computes unique-viewer hashes:
+  - On 2026-05-01, hash = SHA256("userId=2" + "salt-2026-05-01")
+  - On 2026-05-02, hash = SHA256("userId=2" + "salt-2026-05-02")
+- THEN the two hashes MUST be different
+- AND the system MUST NOT be able to correlate bob's viewing across days
+- AND `uniqueViewerCount` for 2026-05-01 is 1, and for 2026-05-02 is 1 (independent counts)
+- NOTE: Salt rotates at UTC midnight; implementations MUST use UTC date for bucket, not local time
+
+#### Scenario: Different users on same day increment uniqueViewerCount separately
+
+- GIVEN user "alice" (userId: 1) loads dashboard "uuid-104" on 2026-05-01
+- AND user "charlie" (userId: 3) loads the same dashboard on 2026-05-01
+- WHEN view events are recorded
+- THEN `uniqueViewerCount = 2` for (dashboardUuid='uuid-104', viewBucket='2026-05-01')
+
+#### Scenario: Hash stored in cache, not in database
+
+- GIVEN user "diana" (userId: 4) posts a view event for dashboard "uuid-105" on 2026-05-01
+- WHEN the system increments uniqueViewerCount
+- THEN the system MUST:
+  - Compute hash = SHA256("userId=4" + "salt-2026-05-01")
+  - Store hash in Nextcloud ICache with TTL = 86400 seconds (24 hours, until next UTC midnight)
+  - NOT store the raw userId or hash in `oc_mydash_dashboard_views`
+  - Increment uniqueViewerCount only if hash is NOT already in cache
+
+### Requirement: REQ-ANLT-004 Per-User Analytics Opt-Out
+
+The system MUST allow individual users to disable their participation in view-count tracking.
+
+#### Scenario: User opts out; their events are ignored
+
+- GIVEN user "eve" (userId: 5) sets their preference `mydash.user_setting.analytics_optout = true`
+- WHEN she loads a dashboard "uuid-106" and posts `POST /api/dashboards/uuid-106/view-event`
+- THEN the system MUST return HTTP 204
+- AND the system MUST NOT increment any counters in `oc_mydash_dashboard_views`
+- AND the system MUST NOT add her hash to the cache
+
+#### Scenario: User opts back in; events resume
+
+- GIVEN user "eve" previously had `analytics_optout = true`
+- AND she changes it to `analytics_optout = false` (or deletes the setting)
+- WHEN she loads dashboard "uuid-107" and posts a view event
+- THEN the system MUST increment counters as normal
+
+#### Scenario: Opt-out is per-user, not global
+
+- GIVEN user "eve" has opted out
+- AND user "frank" (userId: 6) has NOT opted out
+- WHEN both load the same dashboard "uuid-108" on 2026-05-01
+- THEN the system MUST:
+  - Ignore eve's event entirely (no counter change)
+  - Record frank's event normally (viewCount += 1, uniqueViewerCount += 1 if first time today)
+  - Result: `viewCount = 1, uniqueViewerCount = 1`
+
+### Requirement: REQ-ANLT-005 Global Admin Disable
+
+The system MUST provide an admin-configurable setting to disable all view-event recording instance-wide.
+
+#### Scenario: Global disable turns off all tracking
+
+- GIVEN the admin sets `mydash.analytics_enabled = false`
+- WHEN any user sends `POST /api/dashboards/{uuid}/view-event`
+- THEN the system MUST return HTTP 204
+- AND the system MUST NOT increment any counters
+- AND the system MUST NOT add hashes to the cache
+
+#### Scenario: Global re-enable resumes tracking
+
+- GIVEN analytics were previously disabled
+- AND the admin sets `mydash.analytics_enabled = true`
+- WHEN a user posts a view event
+- THEN tracking MUST resume as normal
+
+#### Scenario: Default is enabled
+
+- GIVEN a fresh MyDash installation with no explicit setting
+- WHEN a user posts a view event
+- THEN the system MUST treat `mydash.analytics_enabled` as `true` (default)
+- AND tracking MUST proceed normally
+
+### Requirement: REQ-ANLT-006 Top Dashboards Query Endpoint
+
+The system MUST expose an admin-only endpoint that returns the most-viewed dashboards in a configurable date range.
+
+#### Scenario: List top 10 dashboards by view count (7-day period)
+
+- GIVEN 5 dashboards exist with cumulative 7-day view counts: 100, 50, 30, 20, 10
+- WHEN an admin sends `GET /api/admin/analytics/dashboards/top?period=7d&limit=10`
+- THEN the system MUST return HTTP 200 with an array of dashboard objects
+- AND the array MUST be sorted by `viewCount` descending: [100, 50, 30, 20, 10]
+- AND each object MUST include: `dashboardUuid`, `name` (from `oc_mydash_dashboards`), `viewCount` (sum of 7 days), `uniqueViewerCount` (sum of 7 days)
+- AND the array MUST contain exactly 5 objects (fewer than the requested limit)
+
+#### Scenario: Limit parameter is respected
+
+- GIVEN 20 dashboards exist
+- WHEN an admin sends `GET /api/admin/analytics/dashboards/top?period=30d&limit=5`
+- THEN the system MUST return exactly 5 dashboards (the top 5)
+
+#### Scenario: Period parameter filters date range
+
+- GIVEN dashboards have view rows for dates: 2026-04-01, 2026-04-15, 2026-05-01
+- WHEN an admin sends `GET /api/admin/analytics/dashboards/top?period=7d&limit=10`
+  - (period=7d means last 7 days, which is 2026-04-24 to 2026-05-01, inclusive)
+- THEN the system MUST sum only rows where `viewBucket >= '2026-04-24'`
+- AND rows from 2026-04-01 and 2026-04-15 MUST NOT be included
+
+#### Scenario: Non-admin receives 403
+
+- GIVEN a logged-in user "grace" (userId: 7) who is NOT an admin
+- WHEN she sends `GET /api/admin/analytics/dashboards/top?period=7d`
+- THEN the system MUST return HTTP 403 (Forbidden)
+
+#### Scenario: Valid periods are 7d, 30d, 90d
+
+- GIVEN an admin requests with `?period=7d`, `?period=30d`, or `?period=90d`
+- THEN the system MUST accept and calculate the correct date range
+- NOTE: Period calculation is inclusive of the end date (today, UTC) and exclusive of dates before start
+
+### Requirement: REQ-ANLT-007 Per-Dashboard Analytics Query
+
+The system MUST expose an admin-only endpoint that returns a daily breakdown of view counts for a specific dashboard.
+
+#### Scenario: Daily breakdown for a dashboard (30-day period)
+
+- GIVEN dashboard "uuid-109" has view rows for 2026-04-01 through 2026-05-01
+- WHEN an admin sends `GET /api/admin/analytics/dashboards/uuid-109?period=30d`
+- THEN the system MUST return HTTP 200 with an array of daily records:
+  ```json
+  [
+    { "viewBucket": "2026-04-25", "viewCount": 5, "uniqueViewerCount": 3 },
+    { "viewBucket": "2026-04-26", "viewCount": 8, "uniqueViewerCount": 4 },
+    ...
+    { "viewBucket": "2026-05-01", "viewCount": 12, "uniqueViewerCount": 6 }
+  ]
+  ```
+- AND only rows where `viewBucket >= CURRENT_DATE - 30 days` MUST be included
+- AND the array MUST be sorted by `viewBucket` ascending (oldest first)
+
+#### Scenario: Missing days are omitted
+
+- GIVEN a dashboard has view rows for 2026-04-20, 2026-04-22, 2026-04-25 (days 21 and 23-24 missing)
+- WHEN an admin queries with `period=7d`
+- THEN the response MUST include only the 3 dates that have rows
+- AND the system MUST NOT fabricate rows with `viewCount = 0` for missing dates
+
+#### Scenario: Non-existent dashboard returns 404
+
+- GIVEN no dashboard with UUID "uuid-nonexistent"
+- WHEN an admin sends `GET /api/admin/analytics/dashboards/uuid-nonexistent?period=7d`
+- THEN the system MUST return HTTP 404
+
+#### Scenario: Non-admin receives 403
+
+- GIVEN a logged-in non-admin user
+- WHEN they send `GET /api/admin/analytics/dashboards/uuid-109?period=7d`
+- THEN the system MUST return HTTP 403 (Forbidden)
+
+### Requirement: REQ-ANLT-008 Instance Summary Endpoint
+
+The system MUST expose an admin-only endpoint that returns aggregate statistics across the entire instance, including totals and top-5 dashboards.
+
+#### Scenario: Summary returns instance-wide totals and top-5
+
+- GIVEN the instance has 50 dashboards with a cumulative 30-day view count of 5000 and unique viewers 1200
+- WHEN an admin sends `GET /api/admin/analytics/summary?period=30d`
+- THEN the system MUST return HTTP 200 with a JSON object:
+  ```json
+  {
+    "totalViewCount": 5000,
+    "totalUniqueViewers": 1200,
+    "dashboardCount": 50,
+    "period": "30d",
+    "top5": [
+      { "dashboardUuid": "uuid-A", "name": "...", "viewCount": 500, "uniqueViewerCount": 200 },
+      { "dashboardUuid": "uuid-B", "name": "...", "viewCount": 450, "uniqueViewerCount": 190 },
+      ...
+    ]
+  }
+  ```
+- AND `top5` MUST be sorted by `viewCount` descending
+
+#### Scenario: Period parameter changes calculation
+
+- GIVEN the instance totals are:
+  - 7d: 500 views, 200 unique
+  - 30d: 2000 views, 600 unique
+- WHEN an admin sends `GET /api/admin/analytics/summary?period=7d`
+- THEN the response MUST include `totalViewCount: 500, totalUniqueViewers: 200`
+- AND when they send `GET /api/admin/analytics/summary?period=30d`
+- THEN the response MUST include `totalViewCount: 2000, totalUniqueViewers: 600`
+
+#### Scenario: Non-admin receives 403
+
+- GIVEN a logged-in non-admin user
+- WHEN they send `GET /api/admin/analytics/summary?period=7d`
+- THEN the system MUST return HTTP 403 (Forbidden)
+
+### Requirement: REQ-ANLT-009 Analytics Data Retention and Purge
+
+The system MUST automatically purge view-count rows older than a configurable retention period to prevent unbounded database growth.
+
+#### Scenario: Default retention is 365 days
+
+- GIVEN a fresh installation with no explicit retention setting
+- WHEN the daily purge job runs
+- THEN rows with `viewBucket < CURRENT_DATE - 365 days` MUST be deleted
+- AND rows within the last 365 days MUST be preserved
+
+#### Scenario: Admin can configure retention period
+
+- GIVEN an admin sets `mydash.analytics_retention_days = 90`
+- WHEN the purge job runs
+- THEN only rows with `viewBucket < CURRENT_DATE - 90 days` MUST be deleted
+- AND the new retention becomes effective on the next job run
+
+#### Scenario: Retention minimum and maximum bounds
+
+- GIVEN the admin attempts to set `mydash.analytics_retention_days = 10` (below minimum 30)
+- THEN the system MUST either:
+  - Reject the setting change with an error message, OR
+  - Silently clamp to minimum 30 days
+- AND when the admin attempts `mydash.analytics_retention_days = 5000` (above maximum 3650)
+- THEN the system MUST clamp to maximum 3650 days
+- NOTE: Admins can configure retention between 30 and 3650 days inclusive
+
+#### Scenario: Purge job is automatic and idempotent
+
+- GIVEN the daily purge job has run once and deleted old rows
+- WHEN it runs again (on the next day or re-triggered)
+- THEN no errors MUST occur
+- AND rows deleted in the previous run MUST remain deleted (no resurrection)
+- NOTE: Job MUST be registered with Nextcloud scheduler and run daily at a fixed time (e.g., 02:00 UTC)
+
+#### Scenario: Purge logs execution
+
+- GIVEN the daily purge job runs
+- WHEN rows are deleted
+- THEN the system MUST log:
+  - The number of rows deleted
+  - The date cutoff used (e.g., "Purged 1250 rows older than 2025-05-01")
+- AND no personally-identifying information MUST appear in logs
+
+### Requirement: REQ-ANLT-010 CSV Export Endpoint
+
+The system MUST expose an admin-only endpoint that exports analytics data in CSV format for external analysis.
+
+#### Scenario: CSV export contains dashboard statistics
+
+- GIVEN analytics data exists for multiple dashboards
+- WHEN an admin sends `GET /api/admin/analytics/export?period=30d`
+- THEN the system MUST return HTTP 200 with `Content-Type: text/csv`
+- AND the response MUST have a `Content-Disposition: attachment; filename=dashboard-analytics-2026-05-01.csv` header
+- AND the CSV MUST contain columns: `dashboardUuid`, `dashboardName`, `viewBucket`, `viewCount`, `uniqueViewerCount`
+- AND rows MUST be sorted by `dashboardUuid`, then `viewBucket` ascending
+- AND the CSV MUST include a header row
+
+#### Scenario: CSV respects period parameter
+
+- GIVEN analytics data exists for a 90-day window
+- WHEN an admin sends `GET /api/admin/analytics/export?period=7d`
+- THEN the CSV MUST include only rows where `viewBucket >= CURRENT_DATE - 7 days`
+- AND rows outside the period MUST be excluded
+
+#### Scenario: Non-admin receives 403
+
+- GIVEN a logged-in non-admin user
+- WHEN they send `GET /api/admin/analytics/export?period=30d`
+- THEN the system MUST return HTTP 403 (Forbidden)
+- AND no CSV is generated
+
+#### Scenario: CSV filename includes export date
+
+- GIVEN an admin exports on 2026-05-01
+- WHEN the CSV is downloaded
+- THEN the filename MUST be `dashboard-analytics-2026-05-01.csv` (today's UTC date in YYYY-MM-DD format)
+
+### Requirement: REQ-ANLT-011 Frontend View-Event Instrumentation
+
+The system MUST call the view-event endpoint from the Vue frontend when a dashboard is loaded, with debouncing to prevent multi-tab inflation.
+
+#### Scenario: Dashboard component calls view-event on mount
+
+- GIVEN a user navigates to a dashboard view in MyDash
+- WHEN the DashboardView.vue component mounts
+- THEN the component MUST call `POST /api/dashboards/{uuid}/view-event` exactly once
+- AND the request MUST be sent asynchronously (not blocking render)
+- AND the HTTP 204 response MUST be handled silently (no UI change)
+
+#### Scenario: Debouncing prevents multi-tab double-counting
+
+- GIVEN a user opens the same dashboard in two browser tabs simultaneously
+- WHEN both tabs load and try to post view events within 1 second
+- THEN only ONE `POST /api/dashboards/{uuid}/view-event` MUST be sent
+- AND the second tab's event MUST be debounced/cancelled
+- NOTE: Debounce window is 1 second per dashboard instance; debounce is per-tab-session, not cross-tab
+
+#### Scenario: Different dashboards are not debounced against each other
+
+- GIVEN a user opens dashboard "uuid-110" in one tab
+- AND dashboard "uuid-111" in another tab (same window/session)
+- WHEN both tabs mount simultaneously
+- THEN both `POST /api/dashboards/{uuid-110}/view-event` and `POST /api/dashboards/{uuid-111}/view-event` MUST be sent
+- AND debouncing applies per-uuid, not globally
+
+#### Scenario: Reload on same dashboard triggers new event
+
+- GIVEN a user is viewing dashboard "uuid-112" in a tab
+- AND they reload the page (F5)
+- WHEN the page reloads and DashboardView.vue mounts again
+- THEN a new `POST /api/dashboards/{uuid-112}/view-event` MUST be sent
+- AND this new event is NOT suppressed by the previous one (debounce is per-mount, not per-session)
+
+#### Scenario: View-event is not sent if analytics is disabled
+
+- GIVEN the admin has set `mydash.analytics_enabled = false`
+- WHEN a user loads a dashboard (and the frontend sees the setting, e.g., via config endpoint)
+- THEN the component MUST NOT call `POST /api/dashboards/{uuid}/view-event`
+- AND no request MUST be sent to the backend

--- a/openspec/changes/dashboard-view-analytics/tasks.md
+++ b/openspec/changes/dashboard-view-analytics/tasks.md
@@ -1,0 +1,271 @@
+# Tasks — dashboard-view-analytics
+
+## 1. Schema migration
+
+- [ ] 1.1 Create `lib/Migration/VersionXXXXDate2026...AddDashboardViewsTable.php` creating `oc_mydash_dashboard_views`:
+  - `id INT AUTO_INCREMENT PRIMARY KEY`
+  - `dashboardUuid VARCHAR(36) NOT NULL, FOREIGN KEY REFERENCES oc_mydash_dashboards(uuid) ON DELETE CASCADE`
+  - `viewBucket DATE NOT NULL`
+  - `viewCount INT DEFAULT 0 NOT NULL`
+  - `uniqueViewerCount INT DEFAULT 0 NOT NULL`
+  - Composite unique index on `(dashboardUuid, viewBucket)`
+  - Index on `(viewBucket)` for date-range queries
+- [ ] 1.2 Migration is reversible (DROP TABLE + cascading foreign keys cleaned up)
+- [ ] 1.3 Test migration locally on SQLite, MySQL, PostgreSQL; verify schema applied cleanly
+
+## 2. Domain model
+
+- [ ] 2.1 Create `lib/Db/DashboardView.php` entity with fields:
+  - `$id` (int)
+  - `$dashboardUuid` (string, 36 chars)
+  - `$viewBucket` (string, DATE format YYYY-MM-DD)
+  - `$viewCount` (int)
+  - `$uniqueViewerCount` (int)
+  - Getters/setters using Entity `__call` pattern (no named args)
+- [ ] 2.2 Add `DashboardView::jsonSerialize()` for API responses
+
+## 3. Mapper layer
+
+- [ ] 3.1 Create `lib/Db/DashboardViewMapper.php` extending `QBMapper` with methods:
+  - `findByDashboardAndBucket(string $dashboardUuid, string $viewBucket): ?DashboardView`
+  - `findByDashboardInRange(string $dashboardUuid, string $startDate, string $endDate): array` (ordered by viewBucket ASC)
+  - `findTopDashboardsInRange(string $startDate, string $endDate, int $limit): array` (sum viewCount per dashboard, ordered DESC)
+  - `findInstanceSummaryInRange(string $startDate, string $endDate): array` (totals across all dashboards)
+  - `upsertView(string $dashboardUuid, string $viewBucket, int $viewCountDelta, int $uniqueCountDelta): DashboardView` (INSERT or UPDATE)
+  - `deleteOlderThan(string $beforeDate): int` (purge; returns count deleted)
+- [ ] 3.2 Add PHPUnit test for mapper covering: upsert with increment, find by dashboard, find in range, delete older than, empty results
+
+## 4. Cache layer for unique-viewer dedup
+
+- [ ] 4.1 Create `lib/Service/UniqueViewerDedup.php` service with:
+  - `getSaltForDate(string $viewBucketDate): string` — retrieves or generates daily salt (stored in ICache with TTL = 25h, timezone UTC)
+  - `hashUserForDate(int $userId, string $viewBucketDate): string` — SHA256(userId + salt), returns hex string
+  - `isNewUniqueViewer(int $userId, string $viewBucketDate): bool` — checks cache for hash; if not found, adds to cache (TTL 86400s until next UTC midnight) and returns true; otherwise returns false
+  - Cache key format: `mydash_viewer_hash_{viewBucketDate}_{hash}` (prevents collision across dates)
+- [ ] 4.2 Test via PHPUnit: dedup identifies first view vs repeat, salt rotates at midnight boundary, cache TTL is correct
+
+## 5. Analytics service
+
+- [ ] 5.1 Create `lib/Service/AnalyticsService.php` with methods:
+  - `recordViewEvent(string $dashboardUuid, int $userId, bool $isOptedOut, bool $isGloballyDisabled): bool` — increments counters; returns true if recorded, false if skipped
+    - Skips if opted out or disabled
+    - Calls upsertView to increment viewCount
+    - Calls UniqueViewerDedup::isNewUniqueViewer() and increments uniqueViewerCount if true
+  - `getTopDashboards(string $period, int $limit): array` — queries top dashboards, joins with `oc_mydash_dashboards` to include name
+  - `getDashboardDetail(string $dashboardUuid, string $period): array` — queries daily breakdown for one dashboard
+  - `getInstanceSummary(string $period): array` — returns totals + top 5
+  - `generateCsvExport(string $period): string` — returns CSV text (headers + rows)
+  - Helper: `periodToDateRange(string $period): array` — parses "7d|30d|90d" to [startDate, endDate] in UTC
+- [ ] 5.2 Test via PHPUnit: all query methods with fixtures, CSV generation correctness, period parsing, empty result handling
+
+## 6. Controller + endpoints
+
+- [ ] 6.1 Add `viewEvent()` method to existing `lib/Controller/DashboardController.php`:
+  - Route: `POST /api/dashboards/{uuid}/view-event`
+  - Attribute: `#[NoAdminRequired]` (logged-in users only)
+  - Extract user ID from `$this->userId`
+  - Fetch dashboard to verify existence
+  - Check user setting `mydash.user_setting.analytics_optout`
+  - Check global setting `mydash.analytics_enabled` (default true)
+  - Call `AnalyticsService::recordViewEvent($uuid, $userId, $isOptedOut, $isGloballyDisabled)`
+  - Return HTTP 204 (empty response)
+- [ ] 6.2 Create `lib/Controller/AnalyticsController.php` (new) extending `OCP\AppFramework\Controller` with methods:
+  - `topDashboards()` endpoint:
+    - Route: `GET /api/admin/analytics/dashboards/top`
+    - Attribute: `#[NoAdminRequired]` with in-body admin check via `IGroupManager::isAdmin($this->userId)`
+    - Query params: `period` (7d|30d|90d, default 30d), `limit` (int, default 10)
+    - Call `AnalyticsService::getTopDashboards($period, $limit)`
+    - Return HTTP 200 with array of objects: `{dashboardUuid, name, viewCount, uniqueViewerCount}`
+  - `dashboardDetail()` endpoint:
+    - Route: `GET /api/admin/analytics/dashboards/{uuid}`
+    - Attribute: `#[NoAdminRequired]` with in-body admin check
+    - Path param: `uuid`
+    - Query param: `period` (default 30d)
+    - Call `AnalyticsService::getDashboardDetail($uuid, $period)`
+    - Catch `DashboardNotFound` → HTTP 404
+    - Return HTTP 200 with array of daily records: `{viewBucket, viewCount, uniqueViewerCount}`
+  - `instanceSummary()` endpoint:
+    - Route: `GET /api/admin/analytics/summary`
+    - Attribute: `#[NoAdminRequired]` with in-body admin check
+    - Query param: `period` (default 30d)
+    - Call `AnalyticsService::getInstanceSummary($period)`
+    - Return HTTP 200 with object: `{totalViewCount, totalUniqueViewers, dashboardCount, period, top5: [...]}`
+  - `exportCsv()` endpoint:
+    - Route: `GET /api/admin/analytics/export`
+    - Attribute: `#[NoAdminRequired]` with in-body admin check
+    - Query param: `period` (default 30d)
+    - Call `AnalyticsService::generateCsvExport($period)`
+    - Set response headers: `Content-Type: text/csv`, `Content-Disposition: attachment; filename=dashboard-analytics-{CURRENT_DATE}.csv`
+    - Return HTTP 200 with CSV text body
+- [ ] 6.3 Register routes in `appinfo/routes.php`:
+  - `POST /api/dashboards/{uuid}/view-event` → DashboardController::viewEvent
+  - `GET /api/admin/analytics/dashboards/top` → AnalyticsController::topDashboards
+  - `GET /api/admin/analytics/dashboards/{uuid}` → AnalyticsController::dashboardDetail
+  - `GET /api/admin/analytics/summary` → AnalyticsController::instanceSummary
+  - `GET /api/admin/analytics/export` → AnalyticsController::exportCsv
+
+## 7. Background job
+
+- [ ] 7.1 Create `lib/BackgroundJob/PurgeViewsJob.php` extending `OCP\BackgroundJob\TimedJob`:
+  - Constructor sets `$this->setInterval(86400)` (daily)
+  - `protected function run($argument)`:
+    - Fetch setting `mydash.analytics_retention_days` (default 365, clamped 30–3650)
+    - Compute cutoff date: `CURRENT_DATE - retention_days`
+    - Call `DashboardViewMapper::deleteOlderThan($cutoffDate)`
+    - Log result: "Purged X rows older than YYYY-MM-DD"
+    - Do NOT log user identifiable information
+- [ ] 7.2 Register job in `appinfo/app.php` via `\OCP\BackgroundJob\IJobList::add(PurgeViewsJob::class)`
+
+## 8. Configuration defaults
+
+- [ ] 8.1 Define default settings in app config (e.g., via migration or in-code):
+  - `mydash.analytics_enabled` → `true`
+  - `mydash.analytics_retention_days` → `365`
+- [ ] 8.2 Per-user setting `mydash.user_setting.analytics_optout` → default `false` (user opts in by default)
+  - Stored in `oc_preferences` with key `mydash.analytics_optout` per user
+
+## 9. Frontend store
+
+- [ ] 9.1 Add action to `src/stores/dashboards.js`:
+  - `recordViewEvent(dashboardUuid)` — calls `POST /api/dashboards/{dashboardUuid}/view-event`, handles 204 response silently, logs errors to console (not user-visible)
+- [ ] 9.2 Add action to `src/stores/admin.js` (or create if missing):
+  - `fetchTopDashboards(period, limit)` — calls `GET /api/admin/analytics/dashboards/top?period=...&limit=...`
+  - `fetchDashboardDetail(uuid, period)` — calls `GET /api/admin/analytics/dashboards/{uuid}?period=...`
+  - `fetchInstanceSummary(period)` — calls `GET /api/admin/analytics/summary?period=...`
+  - `exportAnalytics(period)` — calls `GET /api/admin/analytics/export?period=...`, triggers browser download
+- [ ] 9.3 Store state for analytics UI: `topDashboards`, `dashboardDetail`, `instanceSummary`, `loading`, `error`
+
+## 10. Frontend instrumentation
+
+- [ ] 10.1 Update `src/views/DashboardView.vue`:
+  - On component mount, call store action `recordViewEvent(dashboardUuid)`
+  - Wrap call in debounce with 1-second window per dashboard UUID
+  - Debounce instance stored in component data (per component, not global)
+  - Check app config for `analytics_enabled` — if false, skip the call entirely
+  - Handle network errors silently (log to console, no user-facing error)
+- [ ] 10.2 Example code pattern:
+  ```javascript
+  import { debounce } from 'lodash-es'
+  
+  mounted() {
+    if (!this.analyticsEnabled) return
+    this.debouncedRecordView = debounce(() => {
+      this.dashboardsStore.recordViewEvent(this.dashboardUuid)
+    }, 1000)
+    this.debouncedRecordView()
+  }
+  ```
+
+## 11. Frontend admin UI
+
+- [ ] 11.1 Create `src/views/AdminAnalytics.vue` (new) displaying:
+  - "Analytics" header
+  - Period selector (7d, 30d, 90d) with default 30d
+  - Instance summary card showing: total views, total unique viewers, dashboard count
+  - "Top Dashboards" table showing top 10 with columns: name, view count, unique viewers, trend sparkline
+  - "Export" button calls `exportAnalytics(period)` to download CSV
+  - Loading spinner while data is fetched
+  - Error message if query fails
+- [ ] 11.2 Create `src/components/AnalyticsChart.vue` (new) displaying 30-day sparkline:
+  - Accepts props: `dashboardUuid`, `period`
+  - Fetches dashboard detail via store
+  - Renders small 30-day trend line chart (using existing charting library, e.g., Chart.js if available)
+  - Shows min/max/avg view count in tooltip
+- [ ] 11.3 Integrate AdminAnalytics into main admin navigation:
+  - Add "Analytics" link to admin sidebar/menu (location TBD by design)
+  - Route: `/admin/analytics` or similar
+
+## 12. Configuration UI (optional)
+
+- [ ] 12.1 In existing MyDash admin settings view, add "Analytics Settings" section:
+  - Toggle: "Enable view tracking" (sets `mydash.analytics_enabled`)
+  - Input: "Retention period (days)" with spinbox, min 30, max 3650 (sets `mydash.analytics_retention_days`)
+  - Display current retention value and delete cutoff date
+  - "Save" button persists changes
+- [ ] 12.2 Per-user setting in user preferences view:
+  - Checkbox: "Opt out of dashboard analytics" (toggles `mydash.user_setting.analytics_optout`)
+  - Help text: "Your dashboard views will not be counted"
+
+## 13. PHPUnit tests
+
+- [ ] 13.1 `DashboardViewMapperTest`:
+  - `upsertView` with increment (INSERT, then UPDATE)
+  - `findByDashboardAndBucket` with and without data
+  - `findByDashboardInRange` multiple days, empty range
+  - `findTopDashboardsInRange` ordering, limit, joins name
+  - `findInstanceSummaryInRange` totals
+  - `deleteOlderThan` with cutoff date, verify count returned
+- [ ] 13.2 `UniqueViewerDedupTest`:
+  - `isNewUniqueViewer` detects first view, rejects duplicate same day
+  - Salt rotates at date boundary (mock current date)
+  - Cache TTL is correct (verify cache has 86400s TTL)
+  - Different users not confused
+- [ ] 13.3 `AnalyticsServiceTest`:
+  - `recordViewEvent` increments view count
+  - Skips if opted out (no DB change)
+  - Skips if globally disabled
+  - Calls UniqueViewerDedup for unique count
+  - `getTopDashboards` returns sorted by viewCount desc
+  - `getDashboardDetail` returns daily breakdown
+  - `getInstanceSummary` returns totals + top 5
+  - `generateCsvExport` produces valid CSV with correct headers and data
+  - Period parsing ("7d", "30d", "90d")
+- [ ] 13.4 `DashboardControllerTest::viewEvent`:
+  - Authed user records event → 204
+  - Unauthenticated user → 401
+  - Nonexistent dashboard → 404
+  - Opted-out user → 204 but no DB change
+  - Global disable → 204 but no DB change
+- [ ] 13.5 `AnalyticsControllerTest`:
+  - Non-admin receives 403 on all endpoints
+  - `topDashboards` returns sorted array, respects limit and period
+  - `dashboardDetail` nonexistent uuid → 404
+  - `instanceSummary` returns object with totals and top 5
+  - `exportCsv` returns CSV with correct headers and filename
+- [ ] 13.6 `PurgeViewsJobTest`:
+  - Job runs and deletes rows older than retention cutoff
+  - Rows within retention are preserved
+  - Retention bounds are enforced (min 30, max 3650)
+  - Job is idempotent
+
+## 14. Playwright E2E tests
+
+- [ ] 14.1 User calls `POST /api/dashboards/{uuid}/view-event`, receives 204
+- [ ] 14.2 Admin calls `GET /api/admin/analytics/dashboards/top?period=7d`, receives array
+- [ ] 14.3 Admin calls `GET /api/admin/analytics/dashboards/{uuid}?period=30d`, receives daily breakdown
+- [ ] 14.4 Admin calls `GET /api/admin/analytics/summary?period=30d`, receives totals + top 5
+- [ ] 14.5 Admin calls `GET /api/admin/analytics/export?period=30d`, downloads CSV
+- [ ] 14.6 Non-admin receives 403 on admin endpoints
+- [ ] 14.7 Opted-out user's POST view-event returns 204 with no counter change
+- [ ] 14.8 Vue component calls `POST /api/dashboards/{uuid}/view-event` on mount (verify via network log)
+- [ ] 14.9 Multi-tab debouncing: open same dashboard in two tabs, verify only ONE request sent
+
+## 15. Quality gates
+
+- [ ] 15.1 `composer check:strict` (PHPCS, PHPMD, Psalm, PHPStan) passes
+- [ ] 15.2 ESLint + Stylelint clean on all Vue/JS files
+- [ ] 15.3 SPDX headers on all new PHP files (inside docblock per SPDX-in-docblock convention)
+- [ ] 15.4 `i18n` translation keys for all new UI strings (nl + en):
+  - "View Analytics"
+  - "Top Dashboards"
+  - "Total Views"
+  - "Unique Viewers"
+  - "Analytics Settings"
+  - "Enable view tracking"
+  - "Retention period (days)"
+  - "Opt out of analytics"
+  - "Your dashboard views will not be counted"
+  - "Export Analytics"
+  - Period labels: "Last 7 days", "Last 30 days", "Last 90 days"
+- [ ] 15.5 Update generated OpenAPI spec / Postman collection with 5 new endpoints
+- [ ] 15.6 Run all `hydra-gates` locally before opening PR
+
+## 16. Documentation
+
+- [ ] 16.1 Update `README.md` or `docs/ANALYTICS.md` with:
+  - Overview of view-tracking feature
+  - Privacy model (no user IDs stored, daily salt rotation)
+  - Admin configuration (retention, global disable)
+  - User opt-out instructions
+  - API endpoints reference
+

--- a/openspec/changes/demo-data-showcases/design.md
+++ b/openspec/changes/demo-data-showcases/design.md
@@ -1,0 +1,200 @@
+# Design — Demo data showcases
+
+## Context
+
+The spec (`REQ-DEMO-001` through `REQ-DEMO-009`) was written before the source app's showcase structure was examined in detail. This document resolves the open design question about how bundled showcase templates are stored and what their content looks like, so the spec can be grounded in the real file format rather than a hypothetical one.
+
+Source examined: `intravox-source/showcases/`, `intravox-source/demo-data/`, `intravox-source/lib/Service/DemoDataService.php`, `intravox-source/lib/Controller/DemoDataController.php`, `intravox-source/lib/Command/ImportDemoDataCommand.php`, `intravox-source/lib/Command/AddDemoFieldsCommand.php`.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Resolve the open question about file format and storage location for bundled showcases.
+- Identify which widget types the reference showcases use (confirming what MyDash must support at install time).
+- Clarify the idempotency, localization, and asset bundling mechanisms as actually implemented.
+
+**Non-Goals:**
+- Spec edits (follow-up task).
+- Changing which showcases ship (that is a product decision).
+- Mirroring the source app's group-folder-based storage model — MyDash uses a different storage pattern.
+
+---
+
+## Decisions
+
+### D1: Showcase storage location + format
+
+**Decision**: Showcases are stored as a **ZIP archive** containing a machine-readable `export.json` and a `{locale}/` directory tree with per-page JSON files, per-page `_media/` image assets, a root `navigation.json`, and a root `footer.json`. The `appdata/demo/` path assumed in the spec does not match the source — the actual path is `showcases/{id}/` with the canonical delivery artifact being `{id}.zip`.
+
+**Source evidence**:
+- `intravox-source/showcases/de-bron/` contains `export.json`, `de-bron.zip`, loose JPEG assets, and a `nl/` directory.
+- `unzip -l de-bron.zip` reveals: `export.json` (machine-readable manifest + full page dump), `nl/` (locale tree), `nl/home.json`, `nl/navigation.json`, `nl/footer.json`, `nl/_media/*.jpg`.
+- `intravox-source/lib/Service/ImportService.php:57-63` — `importFromZip()` opens `export.json` inside the ZIP as the canonical entry point.
+- `intravox-source/lib/Service/DemoDataService.php:786-817` — `getBundledDemoDataPath()` resolves the path at `{appPath}/demo-data/{language}/`, which is a different (flat locale tree) path used only for the generic product demo data, NOT for showcases.
+
+The two systems are distinct:
+- **`demo-data/`** — product tour content (generic IntraVox pages, multi-locale `nl/`, `en/`, `de/`, `fr/`). Installed via `importBundledDemoData()`.
+- **`showcases/`** — persona-specific intranet examples (healthcare org, university, municipality, tech company, law firm). Installed by importing the showcase ZIP through the same `importFromZip()` pathway.
+
+**MyDash implication**: MyDash should adopt the ZIP + `export.json` format as the canonical showcase bundle format, not a flat JSON file at `appdata/demo/{id}.json`. The spec's assumed schema is mostly compatible but the delivery artifact is a ZIP, not a bare JSON.
+
+---
+
+### D2: Schema shape
+
+**Decision**: The per-showcase schema is a **two-level structure**. The `export.json` wraps one or more pages; individual page files (`home.json` etc.) carry the actual layout. The spec's widget schema shape (`type`, `position`, `config`) is wrong — the real schema uses `type`, `column`, `order`, plus type-specific flat fields.
+
+**Top-level `export.json` shape** (`intravox-source/showcases/de-bron/export.json:1-20`):
+```json
+{
+  "exportVersion": "1.3",
+  "schemaVersion": "1.3",
+  "exportDate": "2026-03-07T12:00:00.000Z",
+  "exportedBy": "IntraVox Showcase - ...",
+  "requiresMinVersion": "0.8.11",
+  "language": "nl",
+  "pages": [
+    {
+      "_exportPath": "home",
+      "uniqueId": "page-<stable-uuid>",
+      "title": "...",
+      "content": { /* full page object */ }
+    }
+  ],
+  "navigation": { "type": "megamenu", "items": [ ... ] },
+  "footer": { "content": "..." },
+  "comments": []
+}
+```
+
+**Per-page content object** (`nl/home.json` in each showcase):
+```json
+{
+  "uniqueId": "page-<stable-uuid>",
+  "title": "...",
+  "language": "nl",
+  "layout": {
+    "columns": 1,
+    "headerRow": {            /* optional — only van-der-berg uses it */
+      "enabled": true,
+      "backgroundColor": "...",
+      "widgets": [ ... ]
+    },
+    "rows": [
+      {
+        "columns": 1,           /* 1-4 */
+        "backgroundColor": "var(--color-...) | \"\"",
+        "collapsible": true,    /* optional */
+        "sectionTitle": "...",  /* required if collapsible */
+        "defaultCollapsed": true,
+        "widgets": [
+          {
+            "type": "heading|text|image|links|divider|video|news|people|file",
+            "column": 1,
+            "order": 1,
+            /* type-specific fields inline (see D3) */
+          }
+        ]
+      }
+    ],
+    "sideColumns": {
+      "left":  { "enabled": false, "backgroundColor": "", "widgets": [] },
+      "right": { "enabled": true,  "backgroundColor": "...", "widgets": [ ... ] }
+    }
+  }
+}
+```
+
+The spec schema (`gridColumns`, `metadataFields`, `widgets[].position.{x,y,w,h}`, `widgets[].config`) does not match. The actual layout is row-based (not grid-coordinate-based), uses `column` + `order` integers, and embeds widget configuration inline rather than in a `config` sub-object.
+
+---
+
+### D3: Widget types referenced
+
+**Decision**: 8 distinct widget types appear across all 5 showcases and the `demo-data/` locale trees. All 8 must be supported at install time or handled by the skip-on-missing mechanism.
+
+| Widget type | Count (showcases) | Count (demo-data) | Notes |
+|---|---|---|---|
+| `heading`   | 60 | 376 | `content`, `level` (1-5) |
+| `text`      | 42 | 313 | `content` (markdown) |
+| `divider`   | 39 | 149 | `style`, `color`, `height` |
+| `links`     | 16 | 114 | `layout` (tiles\|list), `columns`, `items[]` |
+| `image`     | 14 | 165 | `src` (relative filename), `alt`, `objectFit`, optional `caption` |
+| `file`      | 7  | 0   | `path` (groupfolder-relative), `name` |
+| `news`      | 4  | 7   | `sourcePath`, `layout` (carousel\|grid), `columns`, `limit`, `sortBy`, `sortOrder`, `showImage`, `showDate`, `showExcerpt`, `autoplayInterval`, `filters` |
+| `video`     | 2  | 1   | `provider` (embed), `src` (URL), `title`, `autoplay`, `loop`, `muted` |
+| `people`    | 2  | 0   | `selectionMode`, `filters`, `layout` (card), `columns`, `limit`, `sortBy`, `showFields{}` |
+
+Source: grep of all `"type":` lines in `intravox-source/showcases/*/export.json` and `intravox-source/demo-data/**/*.json`.
+
+Widget types `calendar`, `welcome`, `recent-activity` referenced in the spec scenarios do NOT appear in any showcase. They are spec fiction; remove them from examples.
+
+**Spec-critical finding**: `people` and `news` are the two highest-complexity widgets. `people` queries live Nextcloud user data (role, department, custom LDAP fields). `news` cross-references other pages by `sourcePath`. Both require runtime resolution at display time — they do NOT embed their data in the showcase JSON.
+
+---
+
+### D4: Idempotency mechanism
+
+**Decision**: The source app tracks idempotency via `IConfig::getAppValue(APP_ID, 'demo_data_imported', 'false')` — a single boolean per app, not per showcase. There is NO per-showcase tracking. The `--force` CLI flag bypasses the guard; without it, the command exits early if the flag is set.
+
+Source: `intravox-source/lib/Service/DemoDataService.php:69-78` (`isDemoDataImported` / `markDemoDataImported`), `intravox-source/lib/Command/ImportDemoDataCommand.php:69-73`.
+
+**MyDash implication**: The spec's approach (query existing `group_shared` dashboards with `metadata.showcaseId`) is more granular and correct for a multi-showcase system. Adopt it. The source app's single-flag approach is a simplification that only works when there is one "demo dataset" being installed.
+
+---
+
+### D5: Localization handling
+
+**Decision**: Showcases are **NL-only**. All 5 showcase directories have exactly one locale subdirectory (`nl/`). There are no `en/`, `de/`, or `fr/` variants for any showcase. The `export.json` carries `"language": "nl"` in all 5 cases.
+
+The separate `demo-data/` product tour content IS multi-locale: `nl/`, `en/`, `de/`, `fr/` directories exist, but `de/` and `fr/` are marked as non-full (`"full": false`) in `LANGUAGE_META`. English and Dutch are full; German and French are partial stubs.
+
+**MyDash implication**: The spec assumes each showcase ships `{id}-en.json` and `{id}-nl.json`. Reality: showcases are NL-only. The spec's REQ-DEMO-001 scenario "Localized showcase files are provided" and REQ-DEMO-007 localization requirements should be rewritten to reflect that v1 showcases are NL-only, with a language fallback path documented for future expansion. The `?lang=` parameter on the install endpoint can remain for forward compatibility but will always resolve to NL in v1.
+
+---
+
+### D6: Asset bundling
+
+**Decision**: Images are **bundled as real JPEG files** inside the showcase ZIP under `{locale}/_media/`. They are NOT external URLs and NOT base64-embedded. The JPEG filenames are referenced in widget `src` fields as bare filenames (e.g., `"src": "zorgteam.jpg"`), not paths. Resolution to actual file happens at display time by resolving relative to the page's `_media/` folder.
+
+Source: `unzip -l de-bron.zip` shows `nl/_media/locatie.jpg`, `nl/_media/verpleging.jpg`, `nl/_media/zorgteam.jpg`. The `export.json` widget entry reads `"src": "zorgteam.jpg"`.
+
+The ZIP also contains loose JPEG copies at the root of the showcase directory (e.g., `intravox-source/showcases/de-bron/zorgteam.jpg`) — these appear to be build-time artifacts or convenience copies, not the canonical location.
+
+**MyDash implication**: On install, the service must extract `{locale}/_media/` from the ZIP and store the images alongside the installed page data (or in Nextcloud Files). The spec does not currently specify where installed media lands — this needs to be decided.
+
+---
+
+## Spec changes implied
+
+The following REQ-DEMO-NNN items need rewriting based on this investigation:
+
+- **REQ-DEMO-001 (Bundled showcase files)**: Change storage format from `appdata/demo/{id}-{lang}.json` to `showcases/{id}/{id}.zip` (ZIP archive with `export.json` manifest). Change schema example from grid-coordinate `position.{x,y,w,h}` + `config` to row-based `column`/`order` inline flat fields. Update showcase ID set: replace `marketing`, `engineering`, `all-staff`, `project`, `community` with the actual 5: `de-bron` (healthcare), `de-linden` (university), `gemeente-duin` (municipality), `horizon-labs` (tech/startup), `van-der-berg` (legal). Alternatively keep fictional IDs but be explicit the bundled themes differ. Remove `metadataFields` from the schema — no showcase uses it.
+
+- **REQ-DEMO-001 scenarios "Localized showcase files are provided"** and **REQ-DEMO-007**: Rewrite to reflect NL-only for v1; the `?lang=` fallback path exists but always resolves to NL in v1. Mark multi-locale as a v2 goal.
+
+- **REQ-DEMO-003 / REQ-DEMO-005 (install scenarios with widget types `welcome`, `calendar`, `recent-activity`)**: Replace example widget types with actual ones: `heading`, `text`, `image`, `links`, `divider`, `video`, `news`, `people`, `file`.
+
+- **REQ-DEMO-003**: Add a sub-scenario for media asset extraction — when a showcase is installed, images in `_media/` must be stored somewhere accessible. The spec currently says nothing about this.
+
+- **REQ-DEMO-004 (idempotency)**: The mechanism described (query by `metadata.showcaseId`) is sound and more correct than the source app's boolean flag. Keep it, but document that the source app used a cruder approach.
+
+- **REQ-DEMO-009 (CLI)**: Command name shape is fine. Add a `--force` flag to allow reinstall without UUID-return shortcut (matches source app pattern).
+
+---
+
+## Open follow-ups
+
+1. **Media storage on install**: Where do extracted `_media/` images live in MyDash? Options: (a) Nextcloud Files under a shared folder, (b) app-level storage path, (c) DB as blob. Must be decided before implementation.
+
+2. **`file` widget install behavior**: The `file` widget takes a groupfolder-relative path (`"path": "Protocollen/Medicatieprotocol_2026.pdf"`). These files do not exist in a fresh install. Does MyDash skip these silently (like unknown widget types), create placeholder entries, or omit the widget? The skip-on-missing mechanism in REQ-DEMO-005 applies to unknown widget *types*, not to missing *files referenced by known widget types* — a gap in the spec.
+
+3. **`news` widget cross-page resolution**: The `news` widget references `sourcePath` (e.g., `"sourcePath": "nieuws"`). This is a sibling page path within the same locale tree. When installing a single-page showcase (only `home.json` in the ZIP), the `news` widget's source will resolve to nothing. Either multi-page showcases should be added, or the `news` widget should gracefully show empty state, or the spec should note this caveat.
+
+4. **`people` widget live data**: The `people` widget renders live Nextcloud user directory data. It will work in any installation (it just shows real users filtered by configured criteria), but the showcase's demo filters (e.g., `"selectionMode": "filter", "filters": []`) may show unexpected results in non-demo environments. No spec change needed, but worth noting in the admin UI install confirmation.
+
+5. **`headerRow` layout key**: One showcase (`van-der-berg`) uses `layout.headerRow` (a special full-width row rendered above the main grid). The spec and the schema example omit this. If MyDash adopts the same layout model, `headerRow` needs to be in the layout schema.
+
+6. **Showcase naming for MyDash**: The source showcases use Dutch fictional organization names. MyDash may want locale-neutral IDs (e.g., `healthcare`, `education`, `government`, `technology`, `legal`) with themed content that can be translated. Decide before writing the actual showcase JSON files.
+
+7. **`requiresMinVersion` field in `export.json`**: All 5 export manifests carry `"requiresMinVersion": "0.8.11"`. MyDash should define a minimum app version check at import time and return a clear error if the running version is older.

--- a/openspec/changes/demo-data-showcases/proposal.md
+++ b/openspec/changes/demo-data-showcases/proposal.md
@@ -1,6 +1,6 @@
 # Demo Data Showcases
 
-Bundled "showcase" dashboards — fully populated example dashboards illustrating different use cases (marketing, engineering, all-staff, project, community). Admins can install them with one click to give end users a reference design and reduce blank-canvas friction.
+Bundled "showcase" dashboards — fully populated example dashboards illustrating different organizational use cases (healthcare, university, municipality, tech startup, law firm). Admins can install them with one click to give end users a reference design and reduce blank-canvas friction.
 
 ## Why
 
@@ -8,28 +8,28 @@ MyDash dashboards start blank by default — users must build from scratch, crea
 
 ## What Changes
 
-- **NEW** Bundled showcase JSON files under `appdata/demo/` containing 5 ready-made dashboards (marketing, engineering, all-staff, project, community), each with pre-configured widgets, metadata fields, and localization.
+- **NEW** Bundled showcase ZIP archives under `showcases/{id}/` containing 5 ready-made dashboards (`de-bron`, `de-linden`, `gemeente-duin`, `horizon-labs`, `van-der-berg`), each with pre-configured widgets and NL-locale content. Each ZIP contains `export.json` plus `nl/` page files and `_media/` image assets.
 - **NEW** Admin UI: "Demo data" tab in MyDash admin section listing showcases with preview thumbnail, description, and per-showcase "Install" / "Uninstall" button.
 - **NEW** `GET /api/admin/demo-showcases` endpoint returning list of available showcases with metadata and installation status.
 - **NEW** `POST /api/admin/demo-showcases/{id}/install?lang=en|nl` endpoint creating showcase as a `group_shared` dashboard (via REQ-DASH-012 default-group sentinel) visible to all users. Returns installed dashboard UUID and list of skipped widgets (if any).
 - **NEW** `DELETE /api/admin/demo-showcases/{id}` endpoint soft-removing installed showcase (cascade delete widgets). Idempotent: 204 if not installed.
 - **NEW** Widget skip mechanism: if a showcase references a widget type that doesn't exist at install time, the widget is silently skipped and recorded in response warnings (graceful degradation).
-- **NEW** Localization: each showcase ships with default language; install endpoint accepts `?lang=en|nl` to fetch localized variant if available.
+- **NEW** Localization: all v1 showcases are NL-only; install endpoint accepts `?lang=` for forward compatibility but always resolves to `nl` in v1. Multi-locale support is a v2 goal.
 - **NEW** Idempotency: reinstalling an already-installed showcase returns the existing dashboard UUID without duplication.
-- **NEW** CLI commands: `php occ mydash:demo-showcases:install <id>` and `php occ mydash:demo-showcases:list`.
-- **NEW** Read-only enforcement: bundled showcase files in `appdata/demo/` cannot be edited via admin UI (they are app data, not user data). The installed dashboard is fully editable like any other.
+- **NEW** CLI commands: `php occ mydash:demo-showcases:install <id> [--force]` and `php occ mydash:demo-showcases:list`. The `--force` flag bypasses the idempotency guard for reinstallation.
+- **NEW** Read-only enforcement: bundled showcase ZIPs under `showcases/` cannot be edited via admin UI (they are app data, not user data). The installed dashboard is fully editable like any other.
 
 ## Capabilities
 
 ### New Capabilities
-- `demo-data-showcases`: Admin-installable bundle of pre-built example dashboards with widget skip-on-missing, multi-language support, and idempotent installation.
+- `demo-data-showcases`: Admin-installable bundle of pre-built example dashboards (ZIP archives with `export.json` + media) with widget skip-on-missing, NL-only localization in v1, and per-showcase idempotent installation.
 
 ### Modified Capabilities
 - (none — showcases integrate with core `dashboards` capability via REQ-DASH-012 default-group and standard widget storage.)
 
 ## Impact
 
-- New files: `appdata/demo/` with 5 JSON showcase definitions, `lib/Controller/AdminDemoShowcasesController.php`, `lib/Service/DemoShowcasesService.php`, `src/components/AdminDemoData.vue`, CLI command class.
+- New files: `showcases/` with 5 ZIP showcase archives, `lib/Controller/AdminDemoShowcasesController.php`, `lib/Service/DemoShowcasesService.php`, `src/components/AdminDemoData.vue`, CLI command class.
 - Routes: `GET /api/admin/demo-showcases`, `POST /api/admin/demo-showcases/{id}/install`, `DELETE /api/admin/demo-showcases/{id}`.
 - Database: NO new tables — showcases are read-only files, installations stored in existing `oc_mydash_dashboards` table (with type `group_shared`, groupId `default`).
 - Frontend: Admin tab with showcase list, thumbnails, install/uninstall buttons.
@@ -37,7 +37,7 @@ MyDash dashboards start blank by default — users must build from scratch, crea
 
 ## Affected code units
 
-- `appdata/demo/` — JSON showcase files (marketing, engineering, all-staff, project, community)
+- `showcases/` — ZIP showcase archives (`de-bron`, `de-linden`, `gemeente-duin`, `horizon-labs`, `van-der-berg`)
 - `lib/Controller/AdminDemoShowcasesController.php` — endpoints for list, install, delete
 - `lib/Service/DemoShowcasesService.php` — load showcases from disk, validate widget types, install/uninstall logic
 - `src/components/AdminDemoData.vue` — admin UI with showcase list, thumbnails, buttons
@@ -50,13 +50,13 @@ The demo showcases are a self-contained feature: bundled templates, installation
 
 ## Approach
 
-- Showcases stored as JSON files in `appdata/demo/` (read-only from app).
-- Install endpoint creates a `group_shared` dashboard with `groupId = 'default'` (visible to all users via REQ-DASH-012).
+- Showcases stored as ZIP archives in `showcases/{id}/{id}.zip` (read-only from app). Each ZIP contains `export.json` manifest, `nl/` page JSON files, and `nl/_media/` JPEG assets.
+- Install endpoint opens the ZIP, reads `export.json`, extracts `_media/` assets to an accessible location, and creates a `group_shared` dashboard with `groupId = 'default'` (visible to all users via REQ-DASH-012).
 - Widget skip mechanism: unknown widget types recorded in response `skippedWidgets` array; installation proceeds with remaining widgets.
-- Localization: each showcase file names like `marketing-en.json` or `marketing-nl.json`; install endpoint prefers user locale, falls back to default.
-- Idempotency: track installed showcase ID in dashboard metadata (or query existing group_shared dashboard with showcase tag); reinstall returns existing UUID.
-- CLI commands mirror endpoints for ops convenience.
-- Read-only enforcement: admin UI displays showcase files as non-editable templates; only installed dashboard is mutable.
+- Localization: v1 showcases are NL-only; install endpoint accepts `?lang=` for forward compatibility, always resolves to `nl`.
+- Idempotency: track installed showcase ID in dashboard `metadata.showcaseId`; reinstall returns existing UUID. `--force` flag on CLI bypasses the guard.
+- CLI commands mirror endpoints for ops convenience, with `--force` flag on install.
+- Read-only enforcement: admin UI displays showcase ZIPs as non-editable templates; only installed dashboard is mutable.
 
 ## Notes
 

--- a/openspec/changes/demo-data-showcases/proposal.md
+++ b/openspec/changes/demo-data-showcases/proposal.md
@@ -1,0 +1,68 @@
+# Demo Data Showcases
+
+Bundled "showcase" dashboards — fully populated example dashboards illustrating different use cases (marketing, engineering, all-staff, project, community). Admins can install them with one click to give end users a reference design and reduce blank-canvas friction.
+
+## Why
+
+MyDash dashboards start blank by default — users must build from scratch, creating friction and uncertainty about what's possible. Organizations need pre-built, validated dashboard templates that showcase best practices, accelerate onboarding, and reduce time-to-value. Unlike static documentation, interactive templates let users discover widget capability in context and customize from a working example. Admin control ensures quality and consistency while lowering user anxiety about the "right" way to set up a dashboard.
+
+## What Changes
+
+- **NEW** Bundled showcase JSON files under `appdata/demo/` containing 5 ready-made dashboards (marketing, engineering, all-staff, project, community), each with pre-configured widgets, metadata fields, and localization.
+- **NEW** Admin UI: "Demo data" tab in MyDash admin section listing showcases with preview thumbnail, description, and per-showcase "Install" / "Uninstall" button.
+- **NEW** `GET /api/admin/demo-showcases` endpoint returning list of available showcases with metadata and installation status.
+- **NEW** `POST /api/admin/demo-showcases/{id}/install?lang=en|nl` endpoint creating showcase as a `group_shared` dashboard (via REQ-DASH-012 default-group sentinel) visible to all users. Returns installed dashboard UUID and list of skipped widgets (if any).
+- **NEW** `DELETE /api/admin/demo-showcases/{id}` endpoint soft-removing installed showcase (cascade delete widgets). Idempotent: 204 if not installed.
+- **NEW** Widget skip mechanism: if a showcase references a widget type that doesn't exist at install time, the widget is silently skipped and recorded in response warnings (graceful degradation).
+- **NEW** Localization: each showcase ships with default language; install endpoint accepts `?lang=en|nl` to fetch localized variant if available.
+- **NEW** Idempotency: reinstalling an already-installed showcase returns the existing dashboard UUID without duplication.
+- **NEW** CLI commands: `php occ mydash:demo-showcases:install <id>` and `php occ mydash:demo-showcases:list`.
+- **NEW** Read-only enforcement: bundled showcase files in `appdata/demo/` cannot be edited via admin UI (they are app data, not user data). The installed dashboard is fully editable like any other.
+
+## Capabilities
+
+### New Capabilities
+- `demo-data-showcases`: Admin-installable bundle of pre-built example dashboards with widget skip-on-missing, multi-language support, and idempotent installation.
+
+### Modified Capabilities
+- (none — showcases integrate with core `dashboards` capability via REQ-DASH-012 default-group and standard widget storage.)
+
+## Impact
+
+- New files: `appdata/demo/` with 5 JSON showcase definitions, `lib/Controller/AdminDemoShowcasesController.php`, `lib/Service/DemoShowcasesService.php`, `src/components/AdminDemoData.vue`, CLI command class.
+- Routes: `GET /api/admin/demo-showcases`, `POST /api/admin/demo-showcases/{id}/install`, `DELETE /api/admin/demo-showcases/{id}`.
+- Database: NO new tables — showcases are read-only files, installations stored in existing `oc_mydash_dashboards` table (with type `group_shared`, groupId `default`).
+- Frontend: Admin tab with showcase list, thumbnails, install/uninstall buttons.
+- Dependencies: uses existing `DashboardService`, `WidgetService`, no new external libraries.
+
+## Affected code units
+
+- `appdata/demo/` — JSON showcase files (marketing, engineering, all-staff, project, community)
+- `lib/Controller/AdminDemoShowcasesController.php` — endpoints for list, install, delete
+- `lib/Service/DemoShowcasesService.php` — load showcases from disk, validate widget types, install/uninstall logic
+- `src/components/AdminDemoData.vue` — admin UI with showcase list, thumbnails, buttons
+- `appinfo/routes.php` — add three new API routes (GET list, POST install, DELETE uninstall)
+- `lib/Command/DemoShowcasesCommand.php` — CLI commands for install and list
+
+## Why a new capability
+
+The demo showcases are a self-contained feature: bundled templates, installation logic, skip-on-missing, localization, and CLI exposure. They depend on core dashboard and widget infrastructure but add no breaking changes to dashboards. Keeping them standalone lets us evolve showcase templates, add new locales, and refine install behavior independently.
+
+## Approach
+
+- Showcases stored as JSON files in `appdata/demo/` (read-only from app).
+- Install endpoint creates a `group_shared` dashboard with `groupId = 'default'` (visible to all users via REQ-DASH-012).
+- Widget skip mechanism: unknown widget types recorded in response `skippedWidgets` array; installation proceeds with remaining widgets.
+- Localization: each showcase file names like `marketing-en.json` or `marketing-nl.json`; install endpoint prefers user locale, falls back to default.
+- Idempotency: track installed showcase ID in dashboard metadata (or query existing group_shared dashboard with showcase tag); reinstall returns existing UUID.
+- CLI commands mirror endpoints for ops convenience.
+- Read-only enforcement: admin UI displays showcase files as non-editable templates; only installed dashboard is mutable.
+
+## Notes
+
+- Dashboard templates cannot be user-owned (they're templates, not personal customizations) — must use `group_shared` type with default-group sentinel.
+- Per-user customization (e.g., hiding widgets, reordering) is OUT of scope for v1 — users install showcase and edit from there like any dashboard.
+- Showcase preview images are static PNG files bundled in `appdata/demo/` — live preview is OUT of scope for v1.
+- Showcase versioning (e.g., "Marketing v2") is OUT of scope for v1; one version per showcase name.
+- Export showcase from installed dashboard back to template file is OUT of scope for v1.
+- Showcase naming, "demo-data-showcases" terminology avoids any reference to intravox, intra, or voxcloud.

--- a/openspec/changes/demo-data-showcases/specs/demo-data-showcases/spec.md
+++ b/openspec/changes/demo-data-showcases/specs/demo-data-showcases/spec.md
@@ -1,0 +1,351 @@
+---
+status: draft
+---
+
+# Demo Data Showcases Specification
+
+## Purpose
+
+The `demo-data-showcases` capability provides administrators with one-click installation of pre-built, fully populated example dashboards that illustrate different organizational use cases (marketing, engineering, all-staff, project, community). Showcases are bundled as JSON templates, loaded from disk on demand, and installed as `group_shared` dashboards visible to all users (via REQ-DASH-012 default-group sentinel). The capability includes widget type validation, graceful skip-on-missing for unknown widgets, multi-language support, and idempotent installation via API and CLI commands.
+
+## Data Model
+
+Showcases are read-only JSON files stored in `appdata/demo/` with the structure:
+
+```json
+{
+  "id": "marketing",
+  "name": "Marketing Overview",
+  "description": "Dashboard for marketing campaigns, leads, and ROI tracking",
+  "language": "en",
+  "showcaseTag": "marketing",
+  "gridColumns": 12,
+  "metadataFields": [
+    {"name": "campaignId", "label": "Campaign ID", "type": "text"},
+    {"name": "roi", "label": "ROI %", "type": "number"}
+  ],
+  "widgets": [
+    {
+      "type": "welcome",
+      "position": {"x": 0, "y": 0, "w": 12, "h": 2},
+      "config": {"title": "Welcome to Marketing Dashboard"}
+    },
+    {
+      "type": "calendar",
+      "position": {"x": 0, "y": 2, "w": 6, "h": 4},
+      "config": {"showWeekends": true}
+    }
+  ]
+}
+```
+
+Showcase installations create `group_shared` dashboard records with:
+- `type = 'group_shared'`
+- `groupId = 'default'` (visible to all users via REQ-DASH-012)
+- `metadata.showcaseId = '{showcase-id}'` (for idempotency tracking)
+- `metadata.sourceLanguage = '{language-code}'`
+
+The system maintains a registry of installed showcases by querying existing dashboards with matching showcase ID in metadata.
+
+## ADDED Requirements
+
+### Requirement: REQ-DEMO-001 Bundled showcase JSON files
+
+The system MUST ship with at least 5 showcase JSON files in `appdata/demo/` directory, each defining a complete dashboard template. File naming convention: `{showcase-id}-{lang-code}.json` (e.g., `marketing-en.json`, `marketing-nl.json`). Each file MUST contain:
+- `id`: Unique showcase identifier (immutable)
+- `name`: Human-readable showcase title (localized by filename)
+- `description`: One-sentence description of use case
+- `language`: Language code (`'en'` or `'nl'`)
+- `showcaseTag`: Category tag (`'marketing'`, `'engineering'`, `'all-staff'`, `'project'`, `'community'`)
+- `gridColumns`: Dashboard grid width (integer, typically 12)
+- `metadataFields`: Array of optional custom metadata field definitions
+- `widgets`: Array of pre-configured widget objects with type, position, and config
+
+The 5 bundled showcases MUST be: `marketing`, `engineering`, `all-staff`, `project`, `community`.
+
+#### Scenario: Showcase files exist and load without error
+- **GIVEN** MyDash is installed and enabled
+- **WHEN** the system initializes
+- **THEN** all 5 showcase JSON files MUST be readable from `appdata/demo/`
+- **AND** each file MUST parse as valid JSON with required fields
+
+#### Scenario: Localized showcase files are provided
+- **GIVEN** showcase `marketing`
+- **WHEN** admin installs with `lang=en` and separately with `lang=nl`
+- **THEN** the system MUST load `marketing-en.json` for the first request
+- **AND** `marketing-nl.json` for the second request
+
+#### Scenario: Missing localized file falls back to default language
+- **GIVEN** showcase `marketing` has `marketing-en.json` but no `marketing-fr.json`
+- **WHEN** admin installs with `lang=fr`
+- **THEN** the system MUST fall back to `marketing-en.json`
+- **AND** the installed dashboard MUST carry `metadata.sourceLanguage = 'en'` to preserve the fact
+
+#### Scenario: Invalid showcase JSON is rejected
+- **GIVEN** a malformed JSON file in `appdata/demo/`
+- **WHEN** the system attempts to load it
+- **THEN** the system MUST log an error
+- **AND** the showcase MUST NOT appear in the available list
+- **AND** installation attempts MUST return HTTP 500
+
+### Requirement: REQ-DEMO-002 List available showcases endpoint
+
+The system MUST expose `GET /api/admin/demo-showcases` returning a JSON array of available showcases. Response format:
+
+```json
+[
+  {
+    "id": "marketing",
+    "name": "Marketing Overview",
+    "description": "Dashboard for marketing campaigns, leads, and ROI tracking",
+    "thumbnailUrl": "/apps/mydash/appdata/demo/marketing-thumbnail.png",
+    "language": "en",
+    "isInstalled": true,
+    "installedDashboardUuid": "9b2df4a1-2e8c-4a3b-8f1c-5d7e9a1b2c3d"
+  }
+]
+```
+
+The endpoint MUST be admin-only (HTTP 403 for non-admin users). Response MUST include installation status (`isInstalled` boolean) and UUID if installed. Showcase list MUST be deduplicated by `id` (prefer the user's locale if available, else the first found).
+
+#### Scenario: List endpoint requires admin role
+- **GIVEN** a non-admin user
+- **WHEN** they send `GET /api/admin/demo-showcases`
+- **THEN** the system MUST return HTTP 403
+
+#### Scenario: All showcases appear in the list
+- **GIVEN** 5 showcase JSON files in `appdata/demo/`
+- **WHEN** admin calls `GET /api/admin/demo-showcases`
+- **THEN** the response MUST include 5 items
+- **AND** each item MUST have `id`, `name`, `description`, `thumbnailUrl`, `language`, `isInstalled`
+
+#### Scenario: Installation status is accurate
+- **GIVEN** admin has installed showcase `marketing`
+- **WHEN** they call `GET /api/admin/demo-showcases`
+- **THEN** the `marketing` item MUST have `isInstalled: true`
+- **AND** MUST include `installedDashboardUuid`
+
+#### Scenario: Installation status is false if not yet installed
+- **GIVEN** showcase `engineering` has never been installed
+- **WHEN** admin calls `GET /api/admin/demo-showcases`
+- **THEN** the `engineering` item MUST have `isInstalled: false`
+- **AND** MUST NOT include `installedDashboardUuid` (or it MUST be null)
+
+### Requirement: REQ-DEMO-003 Install showcase endpoint
+
+The system MUST expose `POST /api/admin/demo-showcases/{id}/install?lang=en|nl` creating an installed showcase as a `group_shared` dashboard with `groupId = 'default'`. The created dashboard MUST be visible to all users (via REQ-DASH-012). Response format:
+
+```json
+{
+  "installedDashboardUuid": "9b2df4a1-2e8c-4a3b-8f1c-5d7e9a1b2c3d",
+  "skippedWidgets": []
+}
+```
+
+If any widget types are unknown at install time, they MUST be silently skipped and listed in `skippedWidgets` array (graceful degradation). The endpoint MUST be admin-only (HTTP 403 for non-admin). Return HTTP 201 on success, HTTP 404 if showcase not found, HTTP 400 if validation fails.
+
+#### Scenario: Install showcase creates visible group-shared dashboard
+- **GIVEN** admin sends `POST /api/admin/demo-showcases/marketing/install`
+- **WHEN** the installation completes successfully
+- **THEN** the system MUST create a dashboard with `type = 'group_shared'`, `groupId = 'default'`
+- **AND** all users MUST see it in their `GET /api/dashboards/visible` response
+- **AND** the response MUST return HTTP 201 with `installedDashboardUuid`
+
+#### Scenario: Install with language parameter
+- **GIVEN** admin sends `POST /api/admin/demo-showcases/marketing/install?lang=nl`
+- **WHEN** showcase `marketing-nl.json` exists
+- **THEN** the system MUST load the Dutch variant
+- **AND** the installed dashboard MUST carry `metadata.sourceLanguage = 'nl'`
+
+#### Scenario: Locale fallback if not available
+- **GIVEN** admin sends `POST /api/admin/demo-showcases/marketing/install?lang=fr`
+- **WHEN** `marketing-fr.json` does not exist
+- **THEN** the system MUST fall back to the first available language (typically `marketing-en.json`)
+- **AND** the response MUST include the effective language used
+
+#### Scenario: Unknown showcase returns 404
+- **GIVEN** admin sends `POST /api/admin/demo-showcases/unknown-id/install`
+- **WHEN** no showcase with that ID exists
+- **THEN** the system MUST return HTTP 404 with message "Showcase not found"
+
+#### Scenario: Non-admin user cannot install
+- **GIVEN** a non-admin user
+- **WHEN** they send `POST /api/admin/demo-showcases/marketing/install`
+- **THEN** the system MUST return HTTP 403
+
+#### Scenario: Widgets with unknown types are skipped
+- **GIVEN** showcase JSON references widget type `future-widget-v2` which is not registered
+- **WHEN** admin installs the showcase
+- **THEN** the widget MUST NOT be created
+- **AND** the response MUST include `skippedWidgets: ["future-widget-v2"]`
+- **AND** the installation MUST succeed (HTTP 201) with remaining valid widgets installed
+
+#### Scenario: Response warns of skipped widgets
+- **GIVEN** a showcase installation where 2 widgets are skipped
+- **WHEN** the installation completes
+- **THEN** the response MUST include `skippedWidgets: ["unknown-type-1", "unknown-type-2"]`
+- **AND** the frontend or CLI MUST display a warning to the user
+
+#### Scenario: Showcase metadata preserved for idempotency
+- **GIVEN** an installed showcase dashboard
+- **WHEN** the system queries it by dashboard ID
+- **THEN** the dashboard metadata MUST contain `showcaseId: 'marketing'` (or equivalent tag)
+- **AND** MUST also contain the source language
+
+### Requirement: REQ-DEMO-004 Idempotent installation
+
+Reinstalling an already-installed showcase MUST return the existing dashboard's UUID without creating a duplicate. The system MUST track installation state by querying existing `group_shared` dashboards with matching `showcaseId` in metadata.
+
+#### Scenario: Reinstall returns same UUID
+- **GIVEN** admin has installed showcase `marketing`, receiving UUID `U1`
+- **WHEN** they install `marketing` again
+- **THEN** the system MUST return the same UUID `U1`
+- **AND** no new dashboard MUST be created
+- **AND** the existing dashboard MUST NOT be modified
+
+#### Scenario: Each showcase maintains separate installation state
+- **GIVEN** admin has installed both `marketing` and `engineering`
+- **WHEN** they query installation status for both
+- **THEN** both MUST show `isInstalled: true` with different UUIDs
+- **AND** each has its own showcase metadata
+
+### Requirement: REQ-DEMO-005 Widget type validation and skip-on-missing
+
+At install time, the system MUST validate each widget type in the showcase against the registered widget registry. If a widget type is not registered (unknown), it MUST be silently skipped, recorded in the response, and logged; the installation MUST succeed with valid widgets only.
+
+#### Scenario: All known widget types are installed
+- **GIVEN** a showcase with widgets of types `welcome`, `calendar`, `recent-activity` (all registered)
+- **WHEN** the showcase is installed
+- **THEN** all 3 widgets MUST be created
+- **AND** `skippedWidgets` MUST be empty
+
+#### Scenario: Unknown widget type is skipped
+- **GIVEN** a showcase with widget type `future-timeline` (not registered)
+- **WHEN** the showcase is installed
+- **THEN** that widget MUST NOT be created
+- **AND** `skippedWidgets` MUST include `"future-timeline"`
+- **AND** other widgets in the showcase MUST still be created
+
+#### Scenario: Mixed valid and invalid widgets
+- **GIVEN** a showcase with 5 widgets: 3 known, 2 unknown
+- **WHEN** the showcase is installed
+- **THEN** 3 valid widgets MUST be created
+- **AND** 2 invalid widgets MUST be skipped
+- **AND** `skippedWidgets` MUST be `["unknown-1", "unknown-2"]`
+- **AND** the response MUST warn the admin
+
+#### Scenario: Skip is logged for audit
+- **GIVEN** a showcase installation with skipped widgets
+- **WHEN** the installation completes
+- **THEN** the system MUST log the event with showcase ID, widget types skipped, and admin user ID
+- **AND** logs MUST be queryable for audit purposes
+
+### Requirement: REQ-DEMO-006 Uninstall showcase endpoint
+
+The system MUST expose `DELETE /api/admin/demo-showcases/{id}` soft-removing an installed showcase (delete the dashboard and cascade to widget placements). The endpoint MUST be idempotent: calling it twice MUST both return HTTP 204, whether the showcase was installed or not.
+
+#### Scenario: Uninstall deletes the dashboard
+- **GIVEN** admin has installed showcase `marketing`, creating dashboard `D1`
+- **WHEN** they send `DELETE /api/admin/demo-showcases/marketing`
+- **THEN** the system MUST soft-delete dashboard `D1` and all its widget placements
+- **AND** the response MUST return HTTP 204
+- **AND** `GET /api/dashboards/visible` for any user MUST no longer include `D1`
+
+#### Scenario: Uninstall is idempotent
+- **GIVEN** admin sends `DELETE /api/admin/demo-showcases/marketing`
+- **WHEN** the showcase is not installed (or was already uninstalled)
+- **THEN** the system MUST return HTTP 204 (not 404)
+
+#### Scenario: Uninstall cascades to widgets
+- **GIVEN** an installed showcase with 5 widgets
+- **WHEN** admin uninstalls the showcase
+- **THEN** the dashboard MUST be deleted
+- **AND** all 5 widget placements MUST be deleted
+- **AND** no orphaned widgets MUST remain
+
+#### Scenario: Non-admin cannot uninstall
+- **GIVEN** a non-admin user
+- **WHEN** they send `DELETE /api/admin/demo-showcases/marketing`
+- **THEN** the system MUST return HTTP 403
+
+### Requirement: REQ-DEMO-007 Localization support
+
+Each showcase MUST support localization via separate JSON files per language. The install endpoint accepts an optional `?lang=en|nl` query parameter to select the desired language variant. If the exact language is not available, the system MUST fall back to the first available variant (typically English). The installed dashboard MUST record its source language in metadata for audit and potential future re-install.
+
+#### Scenario: Install with explicit language preference
+- **GIVEN** showcase `marketing` has both `marketing-en.json` and `marketing-nl.json`
+- **WHEN** admin sends `POST /api/admin/demo-showcases/marketing/install?lang=nl`
+- **THEN** the system MUST load and install `marketing-nl.json`
+- **AND** the dashboard metadata MUST record `sourceLanguage: 'nl'`
+
+#### Scenario: Language fallback if not available
+- **GIVEN** showcase `engineering` has only `engineering-en.json`
+- **WHEN** admin requests `?lang=de`
+- **THEN** the system MUST fall back to `engineering-en.json` (first available)
+- **AND** the installed dashboard MUST note the fallback in metadata or logs
+
+#### Scenario: Default language if no parameter given
+- **GIVEN** showcase `marketing` with both EN and NL variants
+- **WHEN** admin sends `POST /api/admin/demo-showcases/marketing/install` (no `?lang` param)
+- **THEN** the system MUST select based on admin's user locale (if available)
+- **OR** fall back to English
+
+#### Scenario: List endpoint includes language code
+- **GIVEN** showcase list response
+- **WHEN** items are returned
+- **THEN** each item MUST include a `language` field (`'en'`, `'nl'`, etc.)
+- **AND** the frontend MUST display the language to the admin
+
+### Requirement: REQ-DEMO-008 Read-only showcase source files
+
+Bundled showcase JSON files in `appdata/demo/` are read-only template definitions and MUST NOT be edited or deleted by admins via the admin UI. Only the installed dashboard (a copy in `oc_mydash_dashboards` table) is mutable. The admin UI MUST display showcase templates as non-editable and non-deletable, with "Install" and "Uninstall" buttons for managing installations only.
+
+#### Scenario: Showcase source files are not listed in editable templates
+- **GIVEN** admin views the template management or dashboard list
+- **WHEN** they look for editable templates
+- **THEN** showcase source files MUST NOT appear
+- **AND** showcase installations (installed dashboards) MUST appear as regular group-shared dashboards
+
+#### Scenario: Installed dashboard is fully editable
+- **GIVEN** admin has installed showcase `marketing`
+- **WHEN** they view the installed dashboard
+- **THEN** it MUST be editable like any other group-shared dashboard
+- **AND** they MUST be able to modify widgets, rename, reorder, etc.
+
+#### Scenario: Admin UI prevents editing showcase source
+- **GIVEN** the admin UI displaying a showcase card
+- **WHEN** admin tries to click or interact with the source template
+- **THEN** the UI MUST show only "Install" and "Uninstall" buttons
+- **AND** MUST NOT offer "Edit" or "Delete source" options
+
+### Requirement: REQ-DEMO-009 CLI commands for operations
+
+The system MUST expose two Symfony console commands for showcase management.
+
+1. `php occ mydash:demo-showcases:install <showcase-id> [--lang=en|nl]` — installs the specified showcase. Output MUST include the installed dashboard UUID and any skipped widgets.
+2. `php occ mydash:demo-showcases:list` — lists all available showcases with installation status. Output format: table with columns `ID`, `Name`, `Status`, `Language`.
+
+Both commands MUST validate admin role (require Nextcloud admin user credentials or skip if run as web/cron context). Commands MUST be non-interactive and suitable for automation.
+
+#### Scenario: Install via CLI
+- **GIVEN** admin runs `php occ mydash:demo-showcases:install marketing`
+- **WHEN** the command completes
+- **THEN** the system MUST output "Installed dashboard {uuid}"
+- **AND** the dashboard MUST be created and visible to all users
+
+#### Scenario: Install with language via CLI
+- **GIVEN** admin runs `php occ mydash:demo-showcases:install marketing --lang=nl`
+- **WHEN** showcase `marketing-nl.json` exists
+- **THEN** the Dutch variant MUST be installed
+
+#### Scenario: List command shows all showcases
+- **GIVEN** 5 showcases available
+- **WHEN** admin runs `php occ mydash:demo-showcases:list`
+- **THEN** the output MUST show a table with 5 rows
+- **AND** each row MUST include showcase ID, name, and installation status (Installed/Not installed)
+
+#### Scenario: CLI honors the same validation as API
+- **GIVEN** admin tries to install a non-existent showcase via CLI
+- **WHEN** the command runs
+- **THEN** the system MUST output an error "Showcase not found"
+- **AND** exit with code 1

--- a/openspec/changes/demo-data-showcases/specs/demo-data-showcases/spec.md
+++ b/openspec/changes/demo-data-showcases/specs/demo-data-showcases/spec.md
@@ -6,38 +6,104 @@ status: draft
 
 ## Purpose
 
-The `demo-data-showcases` capability provides administrators with one-click installation of pre-built, fully populated example dashboards that illustrate different organizational use cases (marketing, engineering, all-staff, project, community). Showcases are bundled as JSON templates, loaded from disk on demand, and installed as `group_shared` dashboards visible to all users (via REQ-DASH-012 default-group sentinel). The capability includes widget type validation, graceful skip-on-missing for unknown widgets, multi-language support, and idempotent installation via API and CLI commands.
+The `demo-data-showcases` capability provides administrators with one-click installation of pre-built, fully populated example dashboards that illustrate different organizational use cases. Showcases are bundled as ZIP archives containing a machine-readable `export.json` manifest plus per-locale page JSON files and media assets, loaded from disk on demand, and installed as `group_shared` dashboards visible to all users (via REQ-DASH-012 default-group sentinel). The capability includes widget type validation, graceful skip-on-missing for unknown widgets, NL-only localization in v1, and idempotent installation via API and CLI commands.
 
 ## Data Model
 
-Showcases are read-only JSON files stored in `appdata/demo/` with the structure:
+Showcases are stored as ZIP archives under `showcases/{id}/{id}.zip` within the app bundle. Each ZIP contains:
+
+- `export.json` — the canonical machine-readable manifest with full page content
+- `{locale}/` — per-locale directory tree (e.g. `nl/`)
+- `{locale}/home.json` — home page layout and widget definitions
+- `{locale}/navigation.json` — navigation configuration
+- `{locale}/footer.json` — footer configuration
+- `{locale}/_media/*.jpg` — bundled image assets referenced by widget `src` fields
+
+**`export.json` top-level shape:**
 
 ```json
 {
-  "id": "marketing",
-  "name": "Marketing Overview",
-  "description": "Dashboard for marketing campaigns, leads, and ROI tracking",
-  "language": "en",
-  "showcaseTag": "marketing",
-  "gridColumns": 12,
-  "metadataFields": [
-    {"name": "campaignId", "label": "Campaign ID", "type": "text"},
-    {"name": "roi", "label": "ROI %", "type": "number"}
-  ],
-  "widgets": [
+  "exportVersion": "1.3",
+  "schemaVersion": "1.3",
+  "exportDate": "2026-03-07T12:00:00.000Z",
+  "requiresMinVersion": "0.8.11",
+  "language": "nl",
+  "pages": [
     {
-      "type": "welcome",
-      "position": {"x": 0, "y": 0, "w": 12, "h": 2},
-      "config": {"title": "Welcome to Marketing Dashboard"}
-    },
-    {
-      "type": "calendar",
-      "position": {"x": 0, "y": 2, "w": 6, "h": 4},
-      "config": {"showWeekends": true}
+      "_exportPath": "home",
+      "uniqueId": "page-<stable-uuid>",
+      "title": "...",
+      "content": { }
     }
-  ]
+  ],
+  "navigation": { "type": "megamenu", "items": [] },
+  "footer": { "content": "..." },
+  "comments": []
 }
 ```
+
+**Per-page content object shape** (from `{locale}/home.json` or inline in `export.json` pages):
+
+```json
+{
+  "uniqueId": "page-<stable-uuid>",
+  "title": "...",
+  "language": "nl",
+  "layout": {
+    "columns": 1,
+    "rows": [
+      {
+        "columns": 1,
+        "backgroundColor": "",
+        "collapsible": false,
+        "widgets": [
+          {
+            "type": "heading",
+            "column": 1,
+            "order": 1,
+            "content": "Welkom",
+            "level": 2
+          },
+          {
+            "type": "text",
+            "column": 1,
+            "order": 2,
+            "content": "Markdowntekst hier"
+          },
+          {
+            "type": "image",
+            "column": 1,
+            "order": 3,
+            "src": "zorgteam.jpg",
+            "alt": "Het zorgteam",
+            "objectFit": "cover"
+          }
+        ]
+      }
+    ],
+    "sideColumns": {
+      "left":  { "enabled": false, "backgroundColor": "", "widgets": [] },
+      "right": { "enabled": false, "backgroundColor": "", "widgets": [] }
+    }
+  }
+}
+```
+
+Widget objects use **inline flat fields** — there is no `position.{x,y,w,h}` or `config` sub-object. Placement is specified by `column` (integer) and `order` (integer) within a row. The layout is row-based, not grid-coordinate-based.
+
+The 8 widget types used across bundled showcases are:
+
+| Type | Required fields | Notes |
+|---|---|---|
+| `heading` | `content`, `level` (1–5) | |
+| `text` | `content` (markdown) | |
+| `divider` | `style`, `color`, `height` | |
+| `links` | `layout` (`tiles`\|`list`), `columns`, `items[]` | |
+| `image` | `src` (bare filename), `alt`, `objectFit` | `src` resolves relative to `_media/` on install |
+| `file` | `path` (relative), `name` | File may not exist in fresh install; skip-on-missing applies |
+| `news` | `sourcePath`, `layout`, `columns`, `limit`, `sortBy`, `sortOrder`, `showImage`, `showDate`, `showExcerpt`, `autoplayInterval`, `filters` | Runtime resolution — no embedded data |
+| `video` | `provider`, `src` (URL), `title`, `autoplay`, `loop`, `muted` | |
+| `people` | `selectionMode`, `filters`, `layout`, `columns`, `limit`, `sortBy`, `showFields{}` | Queries live user data at render time |
 
 Showcase installations create `group_shared` dashboard records with:
 - `type = 'group_shared'`
@@ -45,44 +111,52 @@ Showcase installations create `group_shared` dashboard records with:
 - `metadata.showcaseId = '{showcase-id}'` (for idempotency tracking)
 - `metadata.sourceLanguage = '{language-code}'`
 
+> **NOTE — MyDash improvement**: Per-showcase idempotency tracking via `metadata.showcaseId` is a MyDash design decision. The reference implementation used a single app-wide boolean flag (`demo_data_imported`) which only works for a single dataset and cannot distinguish between multiple installed showcases. MyDash's per-showcase approach is strictly more correct and is not a port of the reference behavior.
+
 The system maintains a registry of installed showcases by querying existing dashboards with matching showcase ID in metadata.
 
 ## ADDED Requirements
 
-### Requirement: REQ-DEMO-001 Bundled showcase JSON files
+### Requirement: REQ-DEMO-001 Bundled showcase ZIP archives
 
-The system MUST ship with at least 5 showcase JSON files in `appdata/demo/` directory, each defining a complete dashboard template. File naming convention: `{showcase-id}-{lang-code}.json` (e.g., `marketing-en.json`, `marketing-nl.json`). Each file MUST contain:
-- `id`: Unique showcase identifier (immutable)
-- `name`: Human-readable showcase title (localized by filename)
-- `description`: One-sentence description of use case
-- `language`: Language code (`'en'` or `'nl'`)
-- `showcaseTag`: Category tag (`'marketing'`, `'engineering'`, `'all-staff'`, `'project'`, `'community'`)
-- `gridColumns`: Dashboard grid width (integer, typically 12)
-- `metadataFields`: Array of optional custom metadata field definitions
-- `widgets`: Array of pre-configured widget objects with type, position, and config
+The system MUST ship with exactly 5 showcase ZIP archives under `showcases/{id}/{id}.zip`. Each ZIP MUST contain a valid `export.json` manifest plus a `nl/` locale directory tree. Each `export.json` MUST contain:
+- `exportVersion`: Schema version string
+- `schemaVersion`: Schema version string
+- `requiresMinVersion`: Minimum app version required to install
+- `language`: Locale code (`'nl'` for all v1 showcases)
+- `pages`: Array of page objects with `_exportPath`, `uniqueId`, `title`, and `content`
+- `navigation`: Navigation configuration object
+- `footer`: Footer configuration object
 
-The 5 bundled showcases MUST be: `marketing`, `engineering`, `all-staff`, `project`, `community`.
+The 5 bundled showcases MUST be:
+- `de-bron` — healthcare/nursing organization
+- `de-linden` — university
+- `gemeente-duin` — municipality
+- `horizon-labs` — tech startup
+- `van-der-berg` — law firm
 
-#### Scenario: Showcase files exist and load without error
+All 5 showcases are NL-only in v1. Multi-locale support (EN, DE, FR variants) is a v2 goal.
+
+#### Scenario: Showcase ZIP archives exist and load without error
 - **GIVEN** MyDash is installed and enabled
 - **WHEN** the system initializes
-- **THEN** all 5 showcase JSON files MUST be readable from `appdata/demo/`
-- **AND** each file MUST parse as valid JSON with required fields
+- **THEN** all 5 showcase ZIP archives MUST be readable from `showcases/{id}/{id}.zip`
+- **AND** each ZIP MUST contain a valid `export.json` parseable as JSON with required fields
 
-#### Scenario: Localized showcase files are provided
-- **GIVEN** showcase `marketing`
-- **WHEN** admin installs with `lang=en` and separately with `lang=nl`
-- **THEN** the system MUST load `marketing-en.json` for the first request
-- **AND** `marketing-nl.json` for the second request
+#### Scenario: export.json version is checked against minimum app version
+- **GIVEN** showcase `de-bron` with `"requiresMinVersion": "0.8.11"` in `export.json`
+- **WHEN** the running app version is older than `0.8.11`
+- **THEN** the system MUST reject the install with HTTP 422 and a clear version mismatch message
+- **AND** the showcase MUST still appear in the list endpoint with `isInstalled: false`
 
-#### Scenario: Missing localized file falls back to default language
-- **GIVEN** showcase `marketing` has `marketing-en.json` but no `marketing-fr.json`
-- **WHEN** admin installs with `lang=fr`
-- **THEN** the system MUST fall back to `marketing-en.json`
-- **AND** the installed dashboard MUST carry `metadata.sourceLanguage = 'en'` to preserve the fact
+#### Scenario: All showcases are NL-only in v1
+- **GIVEN** showcase `gemeente-duin`
+- **WHEN** admin requests install with any language parameter
+- **THEN** the system MUST always resolve to the `nl/` locale tree
+- **AND** the installed dashboard MUST carry `metadata.sourceLanguage = 'nl'`
 
-#### Scenario: Invalid showcase JSON is rejected
-- **GIVEN** a malformed JSON file in `appdata/demo/`
+#### Scenario: Invalid showcase ZIP is rejected
+- **GIVEN** a showcase ZIP whose `export.json` is malformed or missing
 - **WHEN** the system attempts to load it
 - **THEN** the system MUST log an error
 - **AND** the showcase MUST NOT appear in the available list
@@ -95,18 +169,18 @@ The system MUST expose `GET /api/admin/demo-showcases` returning a JSON array of
 ```json
 [
   {
-    "id": "marketing",
-    "name": "Marketing Overview",
-    "description": "Dashboard for marketing campaigns, leads, and ROI tracking",
-    "thumbnailUrl": "/apps/mydash/appdata/demo/marketing-thumbnail.png",
-    "language": "en",
+    "id": "de-bron",
+    "name": "De Bron",
+    "description": "Intranet dashboard voor een zorginstelling",
+    "thumbnailUrl": "/apps/mydash/showcases/de-bron/thumbnail.png",
+    "language": "nl",
     "isInstalled": true,
     "installedDashboardUuid": "9b2df4a1-2e8c-4a3b-8f1c-5d7e9a1b2c3d"
   }
 ]
 ```
 
-The endpoint MUST be admin-only (HTTP 403 for non-admin users). Response MUST include installation status (`isInstalled` boolean) and UUID if installed. Showcase list MUST be deduplicated by `id` (prefer the user's locale if available, else the first found).
+The endpoint MUST be admin-only (HTTP 403 for non-admin users). Response MUST include installation status (`isInstalled` boolean) and UUID if installed.
 
 #### Scenario: List endpoint requires admin role
 - **GIVEN** a non-admin user
@@ -114,26 +188,26 @@ The endpoint MUST be admin-only (HTTP 403 for non-admin users). Response MUST in
 - **THEN** the system MUST return HTTP 403
 
 #### Scenario: All showcases appear in the list
-- **GIVEN** 5 showcase JSON files in `appdata/demo/`
+- **GIVEN** 5 showcase ZIP archives are present
 - **WHEN** admin calls `GET /api/admin/demo-showcases`
 - **THEN** the response MUST include 5 items
 - **AND** each item MUST have `id`, `name`, `description`, `thumbnailUrl`, `language`, `isInstalled`
 
 #### Scenario: Installation status is accurate
-- **GIVEN** admin has installed showcase `marketing`
+- **GIVEN** admin has installed showcase `de-bron`
 - **WHEN** they call `GET /api/admin/demo-showcases`
-- **THEN** the `marketing` item MUST have `isInstalled: true`
+- **THEN** the `de-bron` item MUST have `isInstalled: true`
 - **AND** MUST include `installedDashboardUuid`
 
 #### Scenario: Installation status is false if not yet installed
-- **GIVEN** showcase `engineering` has never been installed
+- **GIVEN** showcase `horizon-labs` has never been installed
 - **WHEN** admin calls `GET /api/admin/demo-showcases`
-- **THEN** the `engineering` item MUST have `isInstalled: false`
+- **THEN** the `horizon-labs` item MUST have `isInstalled: false`
 - **AND** MUST NOT include `installedDashboardUuid` (or it MUST be null)
 
 ### Requirement: REQ-DEMO-003 Install showcase endpoint
 
-The system MUST expose `POST /api/admin/demo-showcases/{id}/install?lang=en|nl` creating an installed showcase as a `group_shared` dashboard with `groupId = 'default'`. The created dashboard MUST be visible to all users (via REQ-DASH-012). Response format:
+The system MUST expose `POST /api/admin/demo-showcases/{id}/install` creating an installed showcase as a `group_shared` dashboard with `groupId = 'default'`. An optional `?lang=` query parameter is accepted for forward compatibility but always resolves to `nl` in v1. The created dashboard MUST be visible to all users (via REQ-DASH-012). Response format:
 
 ```json
 {
@@ -142,26 +216,27 @@ The system MUST expose `POST /api/admin/demo-showcases/{id}/install?lang=en|nl` 
 }
 ```
 
-If any widget types are unknown at install time, they MUST be silently skipped and listed in `skippedWidgets` array (graceful degradation). The endpoint MUST be admin-only (HTTP 403 for non-admin). Return HTTP 201 on success, HTTP 404 if showcase not found, HTTP 400 if validation fails.
+If any widget types are unknown at install time, they MUST be silently skipped and listed in `skippedWidgets` array (graceful degradation). The endpoint MUST be admin-only (HTTP 403 for non-admin). Return HTTP 201 on success, HTTP 404 if showcase not found, HTTP 422 if version check fails, HTTP 400 if validation fails.
 
 #### Scenario: Install showcase creates visible group-shared dashboard
-- **GIVEN** admin sends `POST /api/admin/demo-showcases/marketing/install`
+- **GIVEN** admin sends `POST /api/admin/demo-showcases/gemeente-duin/install`
 - **WHEN** the installation completes successfully
 - **THEN** the system MUST create a dashboard with `type = 'group_shared'`, `groupId = 'default'`
 - **AND** all users MUST see it in their `GET /api/dashboards/visible` response
 - **AND** the response MUST return HTTP 201 with `installedDashboardUuid`
 
-#### Scenario: Install with language parameter
-- **GIVEN** admin sends `POST /api/admin/demo-showcases/marketing/install?lang=nl`
-- **WHEN** showcase `marketing-nl.json` exists
-- **THEN** the system MUST load the Dutch variant
+#### Scenario: Language parameter is accepted but resolves to NL in v1
+- **GIVEN** admin sends `POST /api/admin/demo-showcases/de-linden/install?lang=en`
+- **WHEN** the installation completes
+- **THEN** the system MUST load the `nl/` locale tree (the only available locale)
 - **AND** the installed dashboard MUST carry `metadata.sourceLanguage = 'nl'`
 
-#### Scenario: Locale fallback if not available
-- **GIVEN** admin sends `POST /api/admin/demo-showcases/marketing/install?lang=fr`
-- **WHEN** `marketing-fr.json` does not exist
-- **THEN** the system MUST fall back to the first available language (typically `marketing-en.json`)
-- **AND** the response MUST include the effective language used
+#### Scenario: Media assets are extracted on install
+- **GIVEN** admin installs showcase `de-bron` which contains `nl/_media/zorgteam.jpg` inside the ZIP
+- **WHEN** the installation completes
+- **THEN** the service MUST extract all files from `nl/_media/` and store them in an accessible location
+- **AND** `image` widgets referencing `"src": "zorgteam.jpg"` MUST resolve correctly at render time
+- **AND** the response MUST not return an error due to missing media
 
 #### Scenario: Unknown showcase returns 404
 - **GIVEN** admin sends `POST /api/admin/demo-showcases/unknown-id/install`
@@ -170,7 +245,7 @@ If any widget types are unknown at install time, they MUST be silently skipped a
 
 #### Scenario: Non-admin user cannot install
 - **GIVEN** a non-admin user
-- **WHEN** they send `POST /api/admin/demo-showcases/marketing/install`
+- **WHEN** they send `POST /api/admin/demo-showcases/de-bron/install`
 - **THEN** the system MUST return HTTP 403
 
 #### Scenario: Widgets with unknown types are skipped
@@ -189,32 +264,34 @@ If any widget types are unknown at install time, they MUST be silently skipped a
 #### Scenario: Showcase metadata preserved for idempotency
 - **GIVEN** an installed showcase dashboard
 - **WHEN** the system queries it by dashboard ID
-- **THEN** the dashboard metadata MUST contain `showcaseId: 'marketing'` (or equivalent tag)
+- **THEN** the dashboard metadata MUST contain `showcaseId: 'de-bron'` (or the relevant showcase ID)
 - **AND** MUST also contain the source language
 
 ### Requirement: REQ-DEMO-004 Idempotent installation
 
 Reinstalling an already-installed showcase MUST return the existing dashboard's UUID without creating a duplicate. The system MUST track installation state by querying existing `group_shared` dashboards with matching `showcaseId` in metadata.
 
+> **NOTE**: The reference implementation tracked idempotency using a single app-wide boolean flag, which only supports one demo dataset. MyDash's per-showcase `metadata.showcaseId` approach is more granular and is the correct design for a multi-showcase system. This is a MyDash improvement, not a port.
+
 #### Scenario: Reinstall returns same UUID
-- **GIVEN** admin has installed showcase `marketing`, receiving UUID `U1`
-- **WHEN** they install `marketing` again
+- **GIVEN** admin has installed showcase `van-der-berg`, receiving UUID `U1`
+- **WHEN** they install `van-der-berg` again
 - **THEN** the system MUST return the same UUID `U1`
 - **AND** no new dashboard MUST be created
 - **AND** the existing dashboard MUST NOT be modified
 
 #### Scenario: Each showcase maintains separate installation state
-- **GIVEN** admin has installed both `marketing` and `engineering`
+- **GIVEN** admin has installed both `de-bron` and `de-linden`
 - **WHEN** they query installation status for both
 - **THEN** both MUST show `isInstalled: true` with different UUIDs
 - **AND** each has its own showcase metadata
 
 ### Requirement: REQ-DEMO-005 Widget type validation and skip-on-missing
 
-At install time, the system MUST validate each widget type in the showcase against the registered widget registry. If a widget type is not registered (unknown), it MUST be silently skipped, recorded in the response, and logged; the installation MUST succeed with valid widgets only.
+At install time, the system MUST validate each widget type in the showcase against the registered widget registry. If a widget type is not registered (unknown), it MUST be silently skipped, recorded in the response, and logged; the installation MUST succeed with valid widgets only. The 8 widget types known to ship in bundled showcases are: `heading`, `text`, `divider`, `links`, `image`, `file`, `news`, `video`, `people`.
 
 #### Scenario: All known widget types are installed
-- **GIVEN** a showcase with widgets of types `welcome`, `calendar`, `recent-activity` (all registered)
+- **GIVEN** a showcase with widgets of types `heading`, `text`, and `image` (all registered)
 - **WHEN** the showcase is installed
 - **THEN** all 3 widgets MUST be created
 - **AND** `skippedWidgets` MUST be empty
@@ -245,14 +322,14 @@ At install time, the system MUST validate each widget type in the showcase again
 The system MUST expose `DELETE /api/admin/demo-showcases/{id}` soft-removing an installed showcase (delete the dashboard and cascade to widget placements). The endpoint MUST be idempotent: calling it twice MUST both return HTTP 204, whether the showcase was installed or not.
 
 #### Scenario: Uninstall deletes the dashboard
-- **GIVEN** admin has installed showcase `marketing`, creating dashboard `D1`
-- **WHEN** they send `DELETE /api/admin/demo-showcases/marketing`
+- **GIVEN** admin has installed showcase `gemeente-duin`, creating dashboard `D1`
+- **WHEN** they send `DELETE /api/admin/demo-showcases/gemeente-duin`
 - **THEN** the system MUST soft-delete dashboard `D1` and all its widget placements
 - **AND** the response MUST return HTTP 204
 - **AND** `GET /api/dashboards/visible` for any user MUST no longer include `D1`
 
 #### Scenario: Uninstall is idempotent
-- **GIVEN** admin sends `DELETE /api/admin/demo-showcases/marketing`
+- **GIVEN** admin sends `DELETE /api/admin/demo-showcases/de-bron`
 - **WHEN** the showcase is not installed (or was already uninstalled)
 - **THEN** the system MUST return HTTP 204 (not 404)
 
@@ -265,40 +342,34 @@ The system MUST expose `DELETE /api/admin/demo-showcases/{id}` soft-removing an 
 
 #### Scenario: Non-admin cannot uninstall
 - **GIVEN** a non-admin user
-- **WHEN** they send `DELETE /api/admin/demo-showcases/marketing`
+- **WHEN** they send `DELETE /api/admin/demo-showcases/de-bron`
 - **THEN** the system MUST return HTTP 403
 
 ### Requirement: REQ-DEMO-007 Localization support
 
-Each showcase MUST support localization via separate JSON files per language. The install endpoint accepts an optional `?lang=en|nl` query parameter to select the desired language variant. If the exact language is not available, the system MUST fall back to the first available variant (typically English). The installed dashboard MUST record its source language in metadata for audit and potential future re-install.
+All v1 bundled showcases are NL-only. Each showcase ZIP contains a single `nl/` locale directory. The install endpoint accepts an optional `?lang=` query parameter for forward compatibility; in v1 this parameter is accepted but always resolves to `nl`. Multi-locale support (EN, DE, FR variants) is a v2 goal. The installed dashboard MUST record its source language in metadata.
 
-#### Scenario: Install with explicit language preference
-- **GIVEN** showcase `marketing` has both `marketing-en.json` and `marketing-nl.json`
-- **WHEN** admin sends `POST /api/admin/demo-showcases/marketing/install?lang=nl`
-- **THEN** the system MUST load and install `marketing-nl.json`
+#### Scenario: Install always uses NL locale in v1
+- **GIVEN** any of the 5 bundled showcases
+- **WHEN** admin installs with or without a `?lang=` parameter
+- **THEN** the system MUST load and install from the `nl/` locale tree
 - **AND** the dashboard metadata MUST record `sourceLanguage: 'nl'`
 
-#### Scenario: Language fallback if not available
-- **GIVEN** showcase `engineering` has only `engineering-en.json`
-- **WHEN** admin requests `?lang=de`
-- **THEN** the system MUST fall back to `engineering-en.json` (first available)
-- **AND** the installed dashboard MUST note the fallback in metadata or logs
-
-#### Scenario: Default language if no parameter given
-- **GIVEN** showcase `marketing` with both EN and NL variants
-- **WHEN** admin sends `POST /api/admin/demo-showcases/marketing/install` (no `?lang` param)
-- **THEN** the system MUST select based on admin's user locale (if available)
-- **OR** fall back to English
+#### Scenario: Language parameter accepted for forward compatibility
+- **GIVEN** admin sends `POST /api/admin/demo-showcases/de-linden/install?lang=en`
+- **WHEN** no `en/` locale exists in the ZIP
+- **THEN** the system MUST fall back to `nl/` (the only available locale)
+- **AND** MUST NOT return an error — graceful fallback is required
 
 #### Scenario: List endpoint includes language code
 - **GIVEN** showcase list response
 - **WHEN** items are returned
-- **THEN** each item MUST include a `language` field (`'en'`, `'nl'`, etc.)
+- **THEN** each item MUST include a `language` field (e.g. `'nl'`)
 - **AND** the frontend MUST display the language to the admin
 
 ### Requirement: REQ-DEMO-008 Read-only showcase source files
 
-Bundled showcase JSON files in `appdata/demo/` are read-only template definitions and MUST NOT be edited or deleted by admins via the admin UI. Only the installed dashboard (a copy in `oc_mydash_dashboards` table) is mutable. The admin UI MUST display showcase templates as non-editable and non-deletable, with "Install" and "Uninstall" buttons for managing installations only.
+Bundled showcase ZIP archives under `showcases/` are read-only template definitions and MUST NOT be edited or deleted by admins via the admin UI. Only the installed dashboard (a copy in `oc_mydash_dashboards` table) is mutable. The admin UI MUST display showcase templates as non-editable and non-deletable, with "Install" and "Uninstall" buttons for managing installations only.
 
 #### Scenario: Showcase source files are not listed in editable templates
 - **GIVEN** admin views the template management or dashboard list
@@ -307,7 +378,7 @@ Bundled showcase JSON files in `appdata/demo/` are read-only template definition
 - **AND** showcase installations (installed dashboards) MUST appear as regular group-shared dashboards
 
 #### Scenario: Installed dashboard is fully editable
-- **GIVEN** admin has installed showcase `marketing`
+- **GIVEN** admin has installed showcase `horizon-labs`
 - **WHEN** they view the installed dashboard
 - **THEN** it MUST be editable like any other group-shared dashboard
 - **AND** they MUST be able to modify widgets, rename, reorder, etc.
@@ -322,21 +393,29 @@ Bundled showcase JSON files in `appdata/demo/` are read-only template definition
 
 The system MUST expose two Symfony console commands for showcase management.
 
-1. `php occ mydash:demo-showcases:install <showcase-id> [--lang=en|nl]` — installs the specified showcase. Output MUST include the installed dashboard UUID and any skipped widgets.
+1. `php occ mydash:demo-showcases:install <showcase-id> [--lang=nl] [--force]` — installs the specified showcase. The `--force` flag bypasses the idempotency guard and reinstalls even if the showcase is already installed (creating a new dashboard). Without `--force`, reinstall returns the existing UUID. Output MUST include the installed dashboard UUID and any skipped widgets.
 2. `php occ mydash:demo-showcases:list` — lists all available showcases with installation status. Output format: table with columns `ID`, `Name`, `Status`, `Language`.
 
 Both commands MUST validate admin role (require Nextcloud admin user credentials or skip if run as web/cron context). Commands MUST be non-interactive and suitable for automation.
 
 #### Scenario: Install via CLI
-- **GIVEN** admin runs `php occ mydash:demo-showcases:install marketing`
+- **GIVEN** admin runs `php occ mydash:demo-showcases:install de-bron`
 - **WHEN** the command completes
 - **THEN** the system MUST output "Installed dashboard {uuid}"
 - **AND** the dashboard MUST be created and visible to all users
 
-#### Scenario: Install with language via CLI
-- **GIVEN** admin runs `php occ mydash:demo-showcases:install marketing --lang=nl`
-- **WHEN** showcase `marketing-nl.json` exists
-- **THEN** the Dutch variant MUST be installed
+#### Scenario: Force reinstall via CLI
+- **GIVEN** showcase `de-bron` is already installed with UUID `U1`
+- **WHEN** admin runs `php occ mydash:demo-showcases:install de-bron --force`
+- **THEN** the command MUST reinstall the showcase, creating a new dashboard
+- **AND** the old dashboard `U1` MUST be removed or superseded
+- **AND** the command MUST output the new UUID
+
+#### Scenario: Install without --force returns existing UUID
+- **GIVEN** showcase `van-der-berg` is already installed with UUID `U1`
+- **WHEN** admin runs `php occ mydash:demo-showcases:install van-der-berg` (no --force)
+- **THEN** the command MUST output the existing UUID `U1` without creating a duplicate
+- **AND** MUST indicate that the showcase was already installed
 
 #### Scenario: List command shows all showcases
 - **GIVEN** 5 showcases available

--- a/openspec/changes/demo-data-showcases/tasks.md
+++ b/openspec/changes/demo-data-showcases/tasks.md
@@ -1,0 +1,148 @@
+# Tasks — demo-data-showcases
+
+## 1. Showcase Data
+
+- [ ] Create `appdata/demo/marketing-en.json` with schema:
+  ```json
+  {
+    "id": "marketing",
+    "name": "Marketing Overview",
+    "description": "Dashboard for marketing campaigns, leads, and ROI tracking",
+    "language": "en",
+    "showcaseTag": "marketing",
+    "gridColumns": 12,
+    "metadataFields": [
+      {"name": "campaignId", "label": "Campaign ID", "type": "text"},
+      {"name": "roi", "label": "ROI %", "type": "number"}
+    ],
+    "widgets": [
+      {"type": "welcome", "position": {"x": 0, "y": 0, "w": 12, "h": 2}, "config": {"title": "Welcome to Marketing Dashboard"}},
+      {"type": "calendar", "position": {"x": 0, "y": 2, "w": 6, "h": 4}, "config": {"showWeekends": true}},
+      {"type": "recent-activity", "position": {"x": 6, "y": 2, "w": 6, "h": 4}, "config": {"limit": 20}}
+    ]
+  }
+  ```
+- [ ] Create `appdata/demo/marketing-nl.json` (Dutch localization of above)
+- [ ] Create `appdata/demo/engineering-en.json` with engineering-focused widgets (architecture docs, sprint tracking, code deployments)
+- [ ] Create `appdata/demo/engineering-nl.json` (Dutch localization)
+- [ ] Create `appdata/demo/all-staff-en.json` with company-wide widgets (news, birthdays, org chart)
+- [ ] Create `appdata/demo/all-staff-nl.json` (Dutch localization)
+- [ ] Create `appdata/demo/project-en.json` with project management widgets (tasks, timeline, team members)
+- [ ] Create `appdata/demo/project-nl.json` (Dutch localization)
+- [ ] Create `appdata/demo/community-en.json` with community engagement widgets (discussions, events, member directory)
+- [ ] Create `appdata/demo/community-nl.json` (Dutch localization)
+- [ ] Create `appdata/demo/marketing-thumbnail.png` (300×200 px PNG preview image)
+- [ ] Create `appdata/demo/engineering-thumbnail.png`, `all-staff-thumbnail.png`, `project-thumbnail.png`, `community-thumbnail.png`
+
+## 2. Backend
+
+- [ ] Create `lib/Service/DemoShowcasesService.php` with methods:
+  - `getAvailableShowcases(): array` — reads `appdata/demo/*-en.json` files, returns `[{id, name, description, language}]`
+  - `loadShowcase(string $id, string $lang = 'en'): array` — loads showcase JSON from disk, falls back to default language if localized version missing
+  - `getShowcaseWithStatus(string $id, string $lang = 'en'): array` — augments showcase with `isInstalled: bool` and `installedDashboardUuid|null`
+  - `installShowcase(string $id, string $lang = 'en'): array` — creates group_shared dashboard with `groupId = 'default'`, stores showcase ID in metadata, validates widget types, skips unknown widgets
+  - `uninstallShowcase(string $id): void` — finds installed dashboard by showcase ID, soft-deletes it (cascade delete widget placements); idempotent
+  - `findInstalledShowcaseDashboard(string $showcaseId): ?Dashboard` — query for existing installation
+  - `validateWidgetTypes(array $widgets): array` — cross-reference each widget type against registered widget registry; return `['valid' => [...], 'skipped' => [...]]`
+  - `getThumbnailUrl(string $id): string` — returns URL to PNG thumbnail
+- [ ] Create `lib/Controller/AdminDemoShowcasesController.php` with routes:
+  - `GET /api/admin/demo-showcases` → calls `getAvailableShowcases()`, returns `[{id, name, description, thumbnailUrl, language, isInstalled}]`
+  - `POST /api/admin/demo-showcases/{id}/install?lang=en|nl` → calls `installShowcase($id, $lang)`, returns `{installedDashboardUuid, skippedWidgets: []|[...]}` HTTP 201
+  - `DELETE /api/admin/demo-showcases/{id}` → calls `uninstallShowcase($id)`, returns HTTP 204 (idempotent)
+- [ ] Require admin role for all three endpoints (check via `IAppManager` or `IUserSession`)
+- [ ] Define typed exceptions: `ShowcaseNotFoundException`, `InvalidWidgetTypeException`, `InvalidLanguageException`
+- [ ] Inject `DashboardService`, `WidgetService`, `WidgetRegistry`, `ILogger` into controller
+
+## 3. Showcase Installation Logic
+
+- [ ] Store showcase metadata in installed dashboard:
+  - Dashboard `title` = showcase name + language suffix (e.g., "Marketing Overview")
+  - Dashboard metadata/tags: add `"showcaseId": "marketing"` and `"sourceLanguage": "en"` to preserve source
+- [ ] Idempotency: check if dashboard with matching `showcaseId` in metadata already exists for this user/group; if yes, return existing UUID
+- [ ] Widget skip mechanism: iterate showcase's `widgets` array, validate each `type` against registry, skip if not found, record in response `skippedWidgets`
+- [ ] Create widget placements for valid widgets with positions and config from JSON
+- [ ] Return response: `{installedDashboardUuid: "...", skippedWidgets: ["unknown-type1", "unknown-type2"]}`
+- [ ] Log each installation and any skipped widgets to `ILogger`
+
+## 4. Frontend
+
+- [ ] Create `src/components/AdminDemoData.vue` Vue 3 SFC:
+  - Fetch `GET /api/admin/demo-showcases` on mount
+  - Display grid of showcase cards, each with:
+    - Thumbnail image
+    - Title
+    - Description
+    - Language badge (EN/NL)
+    - "Install" button (if `!isInstalled`) or "Uninstall" button (if `isInstalled`)
+  - Click "Install" → `POST /api/admin/demo-showcases/{id}/install?lang={currentUserLang}` → show success toast + refresh list
+  - Show warning if any widgets were skipped: "Installed but skipped widgets: [...]"
+  - Click "Uninstall" → `DELETE /api/admin/demo-showcases/{id}` → confirm dialog → remove from list
+  - Handle 404, 403, server errors with user-friendly messages
+  - Disable buttons during loading
+- [ ] Add "Demo data" tab to admin settings page (alongside existing tabs like "Settings", "Templates")
+- [ ] Pagination or lazy load if > 10 showcases (future-proof)
+
+## 5. CLI Commands
+
+- [ ] Create `lib/Command/DemoShowcasesInstallCommand.php` extending `OCP\Console\Command`:
+  - `php occ mydash:demo-showcases:install <id>` — calls `DemoShowcasesService::installShowcase(id)`, outputs "Installed dashboard {uuid}" or error
+  - Accept optional `--lang=en|nl` flag (default user's locale or 'en')
+  - Output installed dashboard UUID on success
+- [ ] Create `lib/Command/DemoShowcasesListCommand.php`:
+  - `php occ mydash:demo-showcases:list` — calls `getAvailableShowcases()`, outputs table: `ID | Name | Status (Installed/Not installed) | Language`
+  - Support `--json` flag for machine parsing
+
+## 6. Tests
+
+- [ ] PHPUnit: `DemoShowcasesService`:
+  - `getAvailableShowcases()` returns all showcase IDs from disk
+  - `loadShowcase()` reads JSON correctly, falls back to default language
+  - `getShowcaseWithStatus()` includes `isInstalled` flag
+  - `installShowcase()` creates group_shared dashboard with `groupId = 'default'`
+  - `installShowcase()` skips unknown widget types, returns `skippedWidgets` array
+  - `installShowcase()` is idempotent: reinstalling returns same UUID
+  - `uninstallShowcase()` soft-deletes dashboard and cascades to widgets; idempotent (no error on second call)
+  - `findInstalledShowcaseDashboard()` returns null if not installed
+  - `validateWidgetTypes()` correctly identifies valid vs. invalid widget types
+
+- [ ] PHPUnit: `AdminDemoShowcasesController`:
+  - `GET /api/admin/demo-showcases` returns HTTP 200 with list of showcases
+  - `POST /api/admin/demo-showcases/{id}/install` returns HTTP 201 with `installedDashboardUuid` and `skippedWidgets`
+  - `POST /api/admin/demo-showcases/{invalid-id}/install` returns HTTP 404
+  - `DELETE /api/admin/demo-showcases/{id}` returns HTTP 204
+  - `DELETE /api/admin/demo-showcases/{id}` called twice is idempotent (204 both times)
+  - Non-admin user gets HTTP 403 on POST/DELETE
+  - `GET /api/admin/demo-showcases` accessible to admin only (HTTP 403 for non-admin)
+
+- [ ] PHPUnit: Showcase JSON schema validation
+  - Valid showcase JSON loads without errors
+  - Invalid showcase JSON (missing required fields) logs error and is skipped
+
+- [ ] Playwright: Admin UI
+  - "Demo data" tab visible in admin settings
+  - Showcase list displays all 5 cards with thumbnails + names
+  - Click "Install" button → loading spinner → success toast → button changes to "Uninstall"
+  - Skip warning shown if widgets are skipped
+  - Click "Uninstall" button → confirm dialog → button changes to "Install"
+  - Error message displayed if install fails (e.g., server error)
+
+## 7. Quality
+
+- [ ] `composer check:strict` passes
+- [ ] OpenAPI schema updated for three new endpoints
+- [ ] Translation entries for all user-facing strings:
+  - Showcase names and descriptions in both EN and NL (from JSON files)
+  - Admin UI button labels ("Install", "Uninstall", "Demo data")
+  - Toast messages ("Successfully installed", "Skipped widgets: ...")
+  - Error messages
+- [ ] Showcase JSON files validate against JSON schema on app install (repair step or onEnable hook)
+- [ ] Thumbnail images (PNG) in `appdata/demo/` are valid and loadable
+- [ ] No raw exception messages returned to client
+- [ ] Demo showcase installations are NOT visible in user's personal dashboard list — they are group-scoped default-group
+
+## 8. Follow-ups (separate changes)
+
+- [ ] `demo-data-showcase-preview` — live preview of showcase widgets before install
+- [ ] `demo-data-showcase-versioning` — support multiple showcase versions (v1, v2) per ID
+- [ ] `demo-data-showcase-export` — export installed dashboard back to template JSON
+- [ ] `demo-data-showcase-custom-upload` — allow admins to create/upload custom showcases via UI

--- a/openspec/changes/divider-widget/design.md
+++ b/openspec/changes/divider-widget/design.md
@@ -1,0 +1,77 @@
+# Design — Divider Widget
+
+## Context
+
+Dashboard layouts benefit from clear visual separation between content areas. Without a
+dedicated separator primitive, admins resort to workarounds such as empty label widgets
+or image placeholders — all of which carry unnecessary semantic weight and break
+accessibility trees.
+
+The divider widget is a pure-presentation element: a horizontal rule rendered with
+configurable thickness, style, and spacing. It carries no data-fetch lifecycle, no
+reactive state, and no backend calls. Its implementation surface is therefore tiny —
+one Vue component, one set of widget-config fields.
+
+Because it is structural rather than informational, special care must be taken to mark
+it correctly for assistive technology so screen readers skip over it as a visual artifact
+rather than treating it as meaningful content.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Render a horizontal separator with configurable visual properties.
+- Expose thickness, line-style, spacing, and color in the widget editor.
+- Satisfy WCAG 2.1 AA for decorative separators.
+
+**Non-Goals:**
+- Vertical orientation (out of scope; layouts handle column separation).
+- Animated or gradient dividers.
+- Responsive thickness changes.
+
+## Decisions
+
+### D1: Thickness enum (`thin | medium | thick`)
+**Decision:** Map to 1 px / 2 px / 4 px via CSS custom property on the element.
+**Alternatives considered:** Free-entry number input (0–20 px).
+**Rationale:** Enum constrains choices to values that look intentional at common screen
+densities; free entry produces one-off values that break visual rhythm across dashboards.
+
+### D2: Line-style enum (`solid | dashed | dotted`)
+**Decision:** Expose all three `border-style` values; default to `solid`.
+**Alternatives considered:** Only `solid` (simpler but limits expressiveness for
+section-break vs. soft-group semantics that admins already request).
+**Rationale:** Three options are universally understood and map 1-to-1 to CSS — zero
+custom rendering logic required.
+
+### D3: Spacing presets (`compact | normal | spacious` → 8/16/32 px)
+**Decision:** Apply chosen value as equal top and bottom margin on the host element.
+**Alternatives considered:** Separate top/bottom inputs; T-shirt sizes but asymmetric.
+**Rationale:** Equal margins keep the divider optically centred between flanking widgets.
+Asymmetric spacing can always be achieved by stacking two dividers.
+
+### D4: Color (custom hex OR theme variable)
+**Decision:** Default to `var(--color-border-dark)`; editor offers a color picker that
+writes a raw hex value when used, or a "use theme" toggle that writes the variable name.
+**Alternatives considered:** Hard-code theme variable only (no custom color).
+**Rationale:** Theme variable is correct for most dashboards; custom hex allows branded
+portals to match a specific brand guideline without overriding global theme tokens.
+
+### D5: Accessibility markup
+**Decision:** Render as `<hr role="separator" aria-orientation="horizontal" aria-hidden="true">`.
+**Alternatives considered:** `<div>` with `role="separator"` (avoids double-role on `<hr>`).
+**Rationale:** `<hr>` has native separator semantics; `aria-hidden="true"` suppresses it
+from the accessibility tree so screen readers treat it as decorative, matching intent.
+
+## Risks / Trade-offs
+
+- `aria-hidden` hides the separator from all AT; if future use-cases need a labelled
+  section boundary, a different widget (e.g. header-widget) is the right tool.
+- Custom hex color bypasses theme contrast guarantees — low risk since it is decorative,
+  but worth noting in editor copy.
+
+## Open follow-ups
+
+- Consider a vertical orientation variant once the grid layout supports column gutters
+  as a placement area.
+- Evaluate whether spacing presets should account for grid row-gap so the divider
+  does not double up whitespace.

--- a/openspec/changes/divider-widget/proposal.md
+++ b/openspec/changes/divider-widget/proposal.md
@@ -1,0 +1,46 @@
+# Divider Widget
+
+## Why
+
+MyDash dashboards with many widgets can feel visually cluttered without clear section breaks. Dashboard creators need lightweight visual separators to organize widgets into logical groups without adding unnecessary content. A simple divider widget provides the minimal component required to break up sections, with options for a thin line, whitespace, or a heading-based divider to hierarchically structure dashboard layouts.
+
+## What Changes
+
+- Register a new dashboard widget with id `mydash_divider` via `OCP\Dashboard\IManager` that appears in the widget picker.
+- Add per-placement configuration stored in `widgetContent JSON` to specify divider style (`line`, `whitespace`, or `heading-break`), line color/thickness/style, whitespace size, and optional heading text.
+- Implement fully client-side Vue 3 SFC `DividerWidget.vue` with three render modes: a thin horizontal line (themeable), a vertical spacer block, or a centered heading with horizontal lines above and below.
+- Support sensible sizing defaults: dividers default to `gridHeight = 1` (minimal footprint) and `gridWidth = full dashboard width` in the widget add modal.
+- Enforce accessibility: line/whitespace dividers use semantic `role="separator"` attributes; heading-break dividers use semantic `<h3>` with aria-label.
+- Provide theme awareness: the default line color follows the active Nextcloud theme via CSS custom property `--color-border`; explicit lineColor config overrides the theme.
+- Ensure print visibility: dividers MUST render on printed dashboards; no `display: none` rules apply in print mode.
+- Provide a minimal edit form with only the four config fields (style, lineColor, lineThickness, lineStyle, whitespaceSize, headingText); no name/icon/click-target inputs to minimize UI noise.
+
+## Capabilities
+
+### New Capabilities
+
+- `divider-widget` — A new MyDash dashboard widget capability providing lightweight visual section breaks and spacing controls for organizing dashboard layouts.
+
+## Impact
+
+**Affected code:**
+
+- `src/components/widgets/DividerWidget.vue` — client-side Vue 3 SFC rendering line, whitespace, or heading-break dividers.
+- `src/components/widgets/config/DividerWidgetConfig.vue` — placement config UI for selecting divider style, line properties, whitespace size, and heading text.
+- `appinfo/routes.php` — no new routes required (divider is fully client-side).
+- No database migrations required (widgetContent JSON is flexible; no schema changes).
+- No backend service classes required.
+
+**Affected APIs:**
+
+- 0 new routes: all rendering is client-side. Widget discovery picks up the widget via Nextcloud's dashboard registration.
+
+**Dependencies:**
+
+- `OCP\Dashboard\IManager` — register the widget on app boot.
+- No new composer or npm dependencies.
+
+**Migration:**
+
+- Zero-impact: no schema changes. Existing dashboards are unaffected; new divider widgets are added via the widget picker with default config.
+- No data backfill required.

--- a/openspec/changes/divider-widget/specs/divider-widget/spec.md
+++ b/openspec/changes/divider-widget/specs/divider-widget/spec.md
@@ -1,0 +1,227 @@
+---
+status: draft
+---
+
+# Divider Widget Specification
+
+## Purpose
+
+The divider widget is a lightweight, configurable visual separator for MyDash dashboards. It enables dashboard creators to break up widget sections into logical groups using minimal UI — a horizontal line, whitespace spacer, or centered heading with dividing lines — all rendered client-side with full theme awareness and print support. This capability adds no backend endpoints or data storage; all configuration is stored in the placement's `widgetContent JSON` blob and rendered in-browser.
+
+## ADDED Requirements
+
+### Requirement: REQ-DIV-001 Register Divider Widget
+
+The system MUST register a divider widget with the Nextcloud Dashboard Widget API so it appears in the widget picker alongside other dashboard widgets.
+
+#### Scenario: Widget appears in discovery
+- GIVEN the MyDash app is installed and enabled
+- WHEN the user opens the "Add Widget" modal on a dashboard
+- THEN the divider widget MUST appear in the widget list with id `mydash_divider`
+- AND the widget MUST have a title (e.g., "Divider") and an icon
+- AND the widget MUST NOT fetch any data on discovery — it is fully client-side
+
+#### Scenario: Widget registration via IManager
+- GIVEN `OCP\Dashboard\IManager` is available in the Nextcloud container
+- WHEN the MyDash app boots (appinfo/app.php or service provider)
+- THEN the app MUST register the divider widget by calling `$manager->registerWidget(new DividerWidgetProvider())`
+- AND the widget provider MUST return widget metadata: id, title, icon URL, and support flag (`supportsV2 = true` for consistency, though no items are loaded)
+
+#### Scenario: Widget appears alongside standard widgets
+- GIVEN the user's Nextcloud has weather_status, notes, and mydash_divider widgets installed
+- WHEN the user opens the widget picker
+- THEN all three widgets MUST be listed and sortable by the user's selection order
+- AND mydash_divider MUST not be marked as requiring special permissions (it is available to all logged-in users)
+
+### Requirement: REQ-DIV-002 Configure Divider Style
+
+The system MUST store placement-level configuration in the `widgetContent JSON` blob to allow dashboard creators to choose between three divider styles: a horizontal line, whitespace spacer, or heading-break.
+
+#### Scenario: Line style configuration
+- GIVEN a divider widget is placed on a dashboard
+- WHEN the user opens the widget's edit form and selects style = `line`
+- THEN the form MUST expose three additional config fields: `lineColor` (color picker or text input, nullable, default theme border color), `lineThickness` (number 1–8 px, default 1), and `lineStyle` (dropdown: solid / dashed / dotted, default solid)
+- AND the config MUST be persisted to `widgetContent` JSON as: `{ "style": "line", "lineColor": null, "lineThickness": 1, "lineStyle": "solid" }`
+
+#### Scenario: Whitespace style configuration
+- GIVEN a divider widget is placed on a dashboard
+- WHEN the user opens the widget's edit form and selects style = `whitespace`
+- THEN the form MUST expose one additional config field: `whitespaceSize` (dropdown: small / medium / large / xlarge, default medium)
+- AND the config MUST map size names to heights: `small = 16px, medium = 32px, large = 64px, xlarge = 128px`
+- AND the config MUST be persisted to `widgetContent` JSON as: `{ "style": "whitespace", "whitespaceSize": "medium" }`
+
+#### Scenario: Heading-break style configuration
+- GIVEN a divider widget is placed on a dashboard
+- WHEN the user opens the widget's edit form and selects style = `heading-break`
+- THEN the form MUST expose one required field: `headingText` (text input, required for this style)
+- AND optionally expose `lineColor` and `lineStyle` to customize the horizontal lines above and below the heading
+- AND the config MUST be persisted to `widgetContent` JSON as: `{ "style": "heading-break", "headingText": "Important Section", "lineColor": null, "lineStyle": "solid" }`
+
+#### Scenario: Edit form is minimal
+- GIVEN the divider widget's config form is open
+- WHEN the user views the form
+- THEN the form MUST contain ONLY the style dropdown and the config fields above (no name, icon, click-target, or other standard widget fields)
+- AND the form MUST provide clear visual labels for each field (e.g., "Style", "Line Color", "Line Thickness", "Whitespace Size", "Heading Text")
+
+### Requirement: REQ-DIV-003 Render Line Divider
+
+The system MUST render a horizontal line divider when style is `line`, respecting color, thickness, and line-style configuration.
+
+#### Scenario: Default line render
+- GIVEN a divider widget with style = `line` and no lineColor specified
+- WHEN the dashboard is rendered
+- THEN a 1-pixel solid horizontal line MUST appear using the theme's `--color-border` CSS custom property
+- AND the line MUST span the full width of the widget container
+
+#### Scenario: Custom line color render
+- GIVEN a divider widget with style = `line`, lineColor = `#ff0000`, lineThickness = 3
+- WHEN the dashboard is rendered
+- THEN a 3-pixel solid red horizontal line MUST appear
+- AND the theme's `--color-border` property MUST be ignored in favour of the explicit color
+
+#### Scenario: Dashed line style
+- GIVEN a divider widget with style = `line`, lineStyle = `dashed`, lineThickness = 2
+- WHEN the dashboard is rendered
+- THEN a 2-pixel dashed horizontal line MUST appear (CSS `border-style: dashed`)
+- AND AND dotted lines MUST also be supported (CSS `border-style: dotted`)
+
+#### Scenario: Line accessibility
+- GIVEN a divider widget with style = `line` is rendered
+- WHEN screen reader accesses the widget
+- THEN the divider MUST have `role="separator"` attribute
+- AND MUST have no text content (purely decorative)
+
+### Requirement: REQ-DIV-004 Render Whitespace Divider
+
+The system MUST render a vertical spacer block when style is `whitespace`, respecting the configured size.
+
+#### Scenario: Default whitespace render
+- GIVEN a divider widget with style = `whitespace` and whitespaceSize = `medium` (default)
+- WHEN the dashboard is rendered
+- THEN a transparent 32-pixel-tall block MUST appear
+- AND the block MUST contribute to grid flow but contain no visible content
+
+#### Scenario: Custom whitespace sizes
+- GIVEN divider widgets with whitespaceSize = small / medium / large / xlarge
+- WHEN the dashboard is rendered
+- THEN the widgets MUST render as 16px / 32px / 64px / 128px tall respectively
+- AND each size MUST scale predictably on responsive layouts
+
+#### Scenario: Whitespace accessibility
+- GIVEN a divider widget with style = `whitespace` is rendered
+- WHEN screen reader accesses the widget
+- THEN the divider MUST have `role="separator"` attribute
+- AND MUST have no text content
+
+### Requirement: REQ-DIV-005 Render Heading-Break Divider
+
+The system MUST render a centered heading with horizontal lines above and below when style is `heading-break`, respecting the optional lineColor configuration.
+
+#### Scenario: Default heading-break render
+- GIVEN a divider widget with style = `heading-break`, headingText = "Key Section"
+- WHEN the dashboard is rendered
+- THEN "Key Section" MUST appear as a centered `<h3>` element between two horizontal lines
+- AND the lines MUST use the theme's `--color-border` CSS custom property by default
+- AND the heading MUST have semantic `<h3>` tag for proper heading hierarchy
+
+#### Scenario: Custom line color on heading-break
+- GIVEN a divider widget with style = `heading-break`, headingText = "Important", lineColor = `#00ff00`
+- WHEN the dashboard is rendered
+- THEN the horizontal lines above and below the heading MUST be green
+- AND the heading text MUST be centered and span the widget width
+- AND padding MUST provide visual breathing room around the heading
+
+#### Scenario: Heading-break accessibility
+- GIVEN a divider widget with style = `heading-break`, headingText = "Summary"
+- WHEN screen reader accesses the widget
+- THEN the `<h3>` element MUST contain the text "Summary"
+- AND the divider MUST have `aria-label="Summary divider"` or similar on a wrapper for redundant clarity
+- AND screen readers MUST announce the heading as a level-3 heading
+
+### Requirement: REQ-DIV-006 Default Widget Sizing
+
+The system MUST set sensible sizing defaults for divider widgets in the widget add modal to minimize their footprint on the dashboard.
+
+#### Scenario: Divider defaults to gridHeight = 1
+- GIVEN the user is adding a new divider widget to a dashboard
+- WHEN the "Add Widget" modal opens and the user selects the divider widget
+- THEN the modal MUST pre-populate `gridHeight = 1` as the default
+- AND the user MAY override this in the placement settings if needed
+
+#### Scenario: Divider defaults to full dashboard width
+- GIVEN the user is adding a new divider widget to a dashboard
+- WHEN the "Add Widget" modal opens and the user selects the divider widget
+- THEN the modal MUST pre-populate `gridWidth = max dashboard width` (typically 4, 8, or 12 depending on dashboard grid configuration)
+- AND the divider MUST span the full available width of the dashboard
+
+#### Scenario: User can override defaults
+- GIVEN the user is configuring a divider widget's sizing
+- WHEN the user modifies `gridHeight` or `gridWidth` in the placement editor
+- THEN the new values MUST be persisted and respected on render
+- AND the system MUST allow gridHeight values down to 1 for minimal dividers
+
+### Requirement: REQ-DIV-007 Theme Awareness and Color Inheritance
+
+The system MUST automatically use the active Nextcloud theme's border color for divider lines by default and MUST support explicit color overrides.
+
+#### Scenario: Default theme color
+- GIVEN a divider widget with style = `line` and no lineColor specified
+- WHEN the dashboard is rendered with the default Nextcloud theme (blue border)
+- THEN the divider line MUST use CSS `border-color: var(--color-border)`
+- AND the line color MUST update automatically if the user switches themes
+
+#### Scenario: Explicit color overrides theme
+- GIVEN a divider widget with style = `line`, lineColor = `#ff9800`
+- WHEN the dashboard is rendered
+- THEN the line MUST use the explicit orange color
+- AND the theme's `--color-border` property MUST be ignored
+
+#### Scenario: Heading-break inherits or overrides line color
+- GIVEN a divider widget with style = `heading-break` and no lineColor specified
+- WHEN the dashboard is rendered
+- THEN the lines above and below the heading MUST use the theme's `--color-border`
+- AND if lineColor is explicitly set, the heading-break lines MUST use that color instead
+
+### Requirement: REQ-DIV-008 Print Support and Visibility
+
+The system MUST ensure divider widgets render visibly on printed dashboards and MUST NOT hide them in print mode.
+
+#### Scenario: Line divider prints
+- GIVEN a divider widget with style = `line` on a dashboard
+- WHEN the user prints or previews the printed dashboard (browser print stylesheet)
+- THEN the line divider MUST be visible on the printed page
+- AND the line MUST NOT have `display: none` or other hide rules in print media
+
+#### Scenario: Whitespace divider prints
+- GIVEN a divider widget with style = `whitespace` on a dashboard
+- WHEN the user prints or previews the printed dashboard
+- THEN the whitespace MUST be visible (rendered as a vertical gap of the configured size)
+- AND the spacing MUST be preserved in the printed layout
+
+#### Scenario: Heading-break divider prints
+- GIVEN a divider widget with style = `heading-break`, headingText = "Section"
+- WHEN the user prints or previews the printed dashboard
+- THEN the heading and its lines MUST be visible
+- AND the heading MUST remain readable with appropriate font size for print
+
+### Requirement: REQ-DIV-009 No Backend Endpoints Required
+
+The system MUST render dividers entirely client-side and MUST NOT require any backend API endpoints beyond standard widget discovery.
+
+#### Scenario: Divider is rendered without API calls
+- GIVEN a divider widget is placed on a dashboard
+- WHEN the dashboard is rendered
+- THEN no custom API endpoints (e.g., `/api/widgets/divider/...`) MUST be called
+- AND the widget MUST use only the `widgetContent` JSON stored in the placement record to configure its render
+
+#### Scenario: Widget discovery works via standard widget API
+- GIVEN the user opens the widget picker
+- WHEN the system calls `IManager::getWidgets()`
+- THEN the divider widget metadata MUST be returned
+- AND no additional backend setup is required
+
+#### Scenario: No migration or schema changes required
+- GIVEN the divider-widget capability is implemented
+- WHEN the MyDash app is upgraded
+- THEN no database migrations MUST be created
+- AND existing placements MUST continue to work without modification

--- a/openspec/changes/divider-widget/tasks.md
+++ b/openspec/changes/divider-widget/tasks.md
@@ -1,0 +1,119 @@
+# Tasks — divider-widget
+
+## 1. Widget Registration
+
+- [ ] 1.1 Create `lib/Dashboard/DividerWidgetProvider.php` implementing `OCP\Dashboard\IWidgetV2` or `IWidget`
+- [ ] 1.2 Implement `getId()` returning `"mydash_divider"`, `getTitle()` returning localized "Divider", `getOrder()` returning appropriate position in widget list
+- [ ] 1.3 Implement `getIconUrl()` returning a divider-themed SVG icon URL
+- [ ] 1.4 Register the widget provider in `appinfo/app.php` or a service provider by injecting `IManager` and calling `registerWidget(new DividerWidgetProvider())`
+- [ ] 1.5 Confirm the divider widget appears in the widget picker when adding widgets to a dashboard
+
+## 2. Frontend Component — DividerWidget.vue
+
+- [ ] 2.1 Create `src/components/widgets/DividerWidget.vue` as a Vue 3 SFC
+- [ ] 2.2 Accept `placement` object as props with structure: `{ widgetContent: { style: string, lineColor: ?string, lineThickness: number, lineStyle: string, whitespaceSize: string, headingText: ?string } }`
+- [ ] 2.3 Implement three conditional render branches by `placement.widgetContent.style`:
+  - [ ] 2.3a **line**: render a horizontal line using `<div style="border-bottom: ${thickness}px ${lineStyle} ${color}; width: 100%; role="separator"" />`
+  - [ ] 2.3b **whitespace**: render a transparent `<div style="height: ${mapSize(whitespaceSize)}px; role="separator"" />`
+  - [ ] 2.3c **heading-break**: render `<div style="display: flex; align-items: center; gap: 1rem;"><hr style="flex: 1; border-color: ${color}"/><h3>${headingText}</h3><hr style="flex: 1; border-color: ${color}"/></div>` with `aria-label` on the wrapper
+- [ ] 2.4 For default lineColor (null), use CSS custom property `--color-border` from the theme
+- [ ] 2.5 Add print-safe CSS: no `display: none` in `@media print` — dividers MUST remain visible
+- [ ] 2.6 Test render on multiple viewport sizes and confirm dividers adapt to widget width
+
+## 3. Frontend Config Component — DividerWidgetConfig.vue
+
+- [ ] 3.1 Create `src/components/widgets/config/DividerWidgetConfig.vue` as a Vue 3 SFC
+- [ ] 3.2 Accept `placement` object as props with `widgetContent` structure
+- [ ] 3.3 Render a minimal edit form with ONLY:
+  - [ ] 3.3a Style selector (dropdown: line / whitespace / heading-break)
+  - [ ] 3.3b Conditional fields based on selected style:
+    - [ ] Line style: lineColor (color picker or text input, label "Line Color"), lineThickness (number input 1–8, label "Thickness (px)"), lineStyle (dropdown: solid / dashed / dotted, label "Line Style")
+    - [ ] Whitespace style: whitespaceSize (dropdown: small / medium / large / xlarge, label "Spacing Size")
+    - [ ] Heading-break style: headingText (required text input, label "Heading Text"), lineColor (optional color picker), lineStyle (optional dropdown)
+- [ ] 3.4 Emit `update:modelValue` with updated `widgetContent` JSON when any field changes
+- [ ] 3.5 No name, icon, click-target, or other standard widget fields — keep the form minimal
+- [ ] 3.6 Provide sensible UI hints (e.g., "Select a divider style to break up dashboard sections")
+
+## 4. Widget Add Modal Defaults
+
+- [ ] 4.1 When user selects the divider widget in the "Add Widget" modal, pre-populate placement defaults:
+  - [ ] 4.1a `gridHeight = 1`
+  - [ ] 4.1b `gridWidth = max dashboard width` (fetch from dashboard's gridColumns or use dashboard's default)
+  - [ ] 4.1c `widgetContent = { style: "line", lineColor: null, lineThickness: 1, lineStyle: "solid" }`
+- [ ] 4.2 Allow user to override these defaults in the placement editor before adding to dashboard
+
+## 5. Theme and CSS
+
+- [ ] 5.1 Ensure `--color-border` custom property is available in the divider render context (inherited from NC theme)
+- [ ] 5.2 Add optional scoped CSS in `DividerWidget.vue` for print media: `@media print { /* divider visibility rules */ }`
+- [ ] 5.3 Confirm dividers render correctly in both light and dark NC themes
+- [ ] 5.4 Test color contrast for dividers: line dividers MUST meet WCAG AA contrast requirements (4.5:1 minimum if used as text separators; visual separators have lower requirements)
+
+## 6. Accessibility
+
+- [ ] 6.1 Line dividers: add `role="separator"` and omit `aria-label` (decorative)
+- [ ] 6.2 Whitespace dividers: add `role="separator"` and omit `aria-label` (decorative)
+- [ ] 6.3 Heading-break dividers: render heading as semantic `<h3>`, add `aria-label="heading_text divider"` on the wrapper, ensure heading inherits correct hierarchy
+- [ ] 6.4 Test with screen reader (e.g., NVDA, JAWS) to confirm dividers are announced correctly or skipped as decorative
+- [ ] 6.5 Ensure font sizes scale appropriately on print for headings and text readability
+
+## 7. Frontend Store Integration
+
+- [ ] 7.1 No special state management required — dividers are fully client-side and use only the `widgetContent` JSON from the placement record
+- [ ] 7.2 Confirm `src/stores/dashboards.js` already serializes placements with `widgetContent` correctly; no changes needed unless divider-specific state is added later
+
+## 8. Routing and Navigation
+
+- [ ] 8.1 No custom routes required — dividers are rendered by standard dashboard page logic
+- [ ] 8.2 Confirm `appinfo/routes.php` does NOT need modification (divider widget uses only widget discovery, not custom endpoints)
+
+## 9. Backend Service Layer
+
+- [ ] 9.1 No service classes required — all logic is client-side
+- [ ] 9.2 If backend state tracking is needed in the future (e.g., divider analytics), deferred to a follow-up change
+
+## 10. i18n / Translations
+
+- [ ] 10.1 Add translation keys for the divider widget:
+  - [ ] `mydash.widget.divider.title` — "Divider"
+  - [ ] `mydash.widget.divider.description` — "A visual section break or spacer for organizing dashboard layouts"
+  - [ ] `mydash.config.divider.style` — "Style"
+  - [ ] `mydash.config.divider.style.line` — "Horizontal Line"
+  - [ ] `mydash.config.divider.style.whitespace` — "Whitespace"
+  - [ ] `mydash.config.divider.style.heading-break` — "Heading with Lines"
+  - [ ] `mydash.config.divider.lineColor` — "Line Color"
+  - [ ] `mydash.config.divider.lineThickness` — "Thickness (pixels)"
+  - [ ] `mydash.config.divider.lineStyle` — "Line Style"
+  - [ ] `mydash.config.divider.lineStyle.solid` — "Solid"
+  - [ ] `mydash.config.divider.lineStyle.dashed` — "Dashed"
+  - [ ] `mydash.config.divider.lineStyle.dotted` — "Dotted"
+  - [ ] `mydash.config.divider.whitespaceSize` — "Spacing Size"
+  - [ ] `mydash.config.divider.whitespaceSize.small` — "Small (16px)"
+  - [ ] `mydash.config.divider.whitespaceSize.medium` — "Medium (32px)"
+  - [ ] `mydash.config.divider.whitespaceSize.large` — "Large (64px)"
+  - [ ] `mydash.config.divider.whitespaceSize.xlarge` — "Extra Large (128px)"
+  - [ ] `mydash.config.divider.headingText` — "Heading Text"
+- [ ] 10.2 Add translations for both `nl` and `en` in `l10n/nl.json` and `l10n/en.json`
+- [ ] 10.3 Reference these keys in Vue components via `$t()` helper
+
+## 11. Quality Gates
+
+- [ ] 11.1 ESLint + Stylelint clean on `src/components/widgets/DividerWidget.vue` and `src/components/widgets/config/DividerWidgetConfig.vue`
+- [ ] 11.2 No unused imports or variables
+- [ ] 11.3 Test divider rendering in Playwright: add a test that places a divider on a dashboard and confirms all three styles render correctly
+- [ ] 11.4 Confirm print layout with Playwright's `page.goto(url, { waitUntil: 'networkidle' }); await page.pdf({ path: 'divider.pdf' })` — dividers MUST be visible in the PDF
+- [ ] 11.5 Confirm no console errors or warnings when rendering dividers (Vue dev tools)
+- [ ] 11.6 SPDX headers on every new PHP file (inside the docblock per the SPDX-in-docblock convention) — gate-spdx must pass
+
+## 12. Documentation and Testing
+
+- [ ] 12.1 Update `.github/docs/widgets.md` (or create if missing) with divider widget usage examples
+- [ ] 12.2 Add Playwright test fixture: create a dashboard with one of each divider style and verify all render correctly
+- [ ] 12.3 Test responsive behaviour: confirm dividers adapt to narrow viewports (mobile) without breaking layout
+- [ ] 12.4 Test dark mode: confirm dividers are visible in both light and dark themes with appropriate color contrast
+
+## 13. Optional Follow-Up
+
+- [ ] 13.1 Consider adding a divider-specific icon/SVG design that matches Nextcloud's icon style
+- [ ] 13.2 Consider adding divider "templates" (preset configs) in a follow-up change for common patterns (e.g., "Section Header", "Subtle Spacer", "Bold Separator")
+- [ ] 13.3 Consider collecting divider usage analytics in a future iteration to inform dashboard layout patterns

--- a/openspec/changes/files-widget/design.md
+++ b/openspec/changes/files-widget/design.md
@@ -1,0 +1,93 @@
+# Design — Files Widget
+
+## Context
+
+The files widget embeds an inline folder browser directly on a MyDash dashboard, allowing users to navigate, open, upload, and delete files without leaving the dashboard context. The widget operates entirely at render time: no background job or pre-cache layer is involved, because file system state changes frequently and a stale listing is worse than the marginal latency of a live read.
+
+Access control is viewer-scoped. Every backend request is evaluated against the viewing user's permissions: files and folders the viewer cannot read are silently absent from the response. Upload and delete actions are similarly gated — the action buttons are rendered only when the placement allows the action AND the viewer holds the required permission on the folder. This means the same widget placement can present differently to different viewers depending on their rights.
+
+Folder navigation within the widget is stateful client-side: sub-folder clicks update the widget's internal navigation stack and trigger a new fetch for the sub-folder's contents. A breadcrumb bar reflects the current path and supports jump-up navigation. The widget never navigates the outer application — all browsing happens within the widget's own viewport.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Provide a live, permission-filtered, paginated folder listing fetched at render time via the server-side file system API.
+- Support click-to-open that deep-links to the standard Files application for preview or editing.
+- Enforce per-viewer ACL silently — no indication to the viewer that hidden files exist.
+- Support cursor-based pagination (50 files per page) for stable navigation across renames.
+- Allow upload and delete actions behind both a placement-level toggle and a per-viewer permission check.
+
+**Non-Goals:**
+- In-widget file preview or editing is out of scope; the widget is a browser, not a viewer.
+- Full-text search across file contents is not provided.
+- Syncing or offline access is not in scope.
+
+## Decisions
+
+### D1: Live fetch at render time — no cache layer
+
+**Decision:** The backend endpoint reads folder contents directly from the server-side file system API on every request. No intermediate cache is used.
+
+**Alternatives considered:** Cache folder listings for a short TTL (e.g., 30 seconds). Reduces file system calls under high concurrency but serves stale data — a file uploaded seconds ago would not appear.
+
+**Rationale:** For a file browser, users expect the listing to reflect reality. Stale data would cause user confusion (e.g., "I just uploaded a file — where is it?"). The small latency of a live read is the correct trade-off here.
+
+### D2: Silent ACL filtering — no indication of hidden files
+
+**Decision:** Files and folders the viewing user cannot read are excluded from the response silently. The API returns the subset the viewer may see; it does not indicate that additional items exist but are hidden.
+
+**Alternatives considered:** Return a placeholder row ("N items hidden — request access") for filtered items. More transparent but leaks existence of restricted files, which may itself be sensitive.
+
+**Rationale:** Standard file-system security convention is to not reveal the existence of inaccessible resources. The silent-omission approach matches expected behaviour in all supported permission models.
+
+### D3: Cursor-based pagination anchored to fileId
+
+**Decision:** Pagination uses a cursor equal to the `fileId` of the last item shown in the current page. The backend resolves the cursor to a position in the sorted listing and returns the next 50 items. Page size is fixed at 50.
+
+**Alternatives considered:** Offset-based pagination (`?offset=50&limit=50`). Simple but unstable: a rename between pages shifts offsets and can cause items to appear twice or be skipped.
+
+**Rationale:** `fileId` is stable across renames and moves within the same folder. Using it as a cursor means "Load more" produces a coherent continuation even if the folder contents changed since the first page was loaded.
+
+### D4: Open-in-Files deep link
+
+**Decision:** Clicking a file opens the standard Files application using `linkToRoute('files.View.index', {dir: parentPath, scrollto: fileId})`. The link opens in the same tab (no `target="_blank"`), taking the user into the full Files experience for preview and editing.
+
+**Alternatives considered:** Open in a new tab to preserve the dashboard context. Splitting context is disorienting when the user intends to work on the file.
+
+**Rationale:** The widget is a convenience entry point, not a replacement for the Files application. Users who need to work with a file should be in the full application. Same-tab navigation is the Nextcloud-native pattern for inter-app linking.
+
+### D5: Folder selection via native path picker dialog
+
+**Decision:** In the widget configuration UI, the folder path is selected using the platform's built-in folder picker dialog (`OC.dialogs.filepicker` with `FILEPICKER_TYPE_CHOOSE_FOLDER` and `modal: true`). The selected folder is stored as an absolute NC path in `widgetContent`.
+
+**Alternatives considered:** Free-text path input. Simpler to implement but error-prone — typos produce silent empty states or wrong-folder displays with no helpful feedback.
+
+**Rationale:** The native picker guarantees the selected path exists at configuration time, provides a familiar UX consistent with the rest of Nextcloud, and avoids an entire class of misconfiguration errors.
+
+### D6: Upload and delete behind dual-gate (placement + ACL)
+
+**Decision:** Upload and delete action buttons are rendered only when (a) the placement config has `allowUpload = true` / `allowDelete = true` AND (b) the viewing user holds write / delete permission on the folder. The backend re-validates both conditions on every write or delete request.
+
+**Alternatives considered:** Placement config alone — show buttons based on `allowUpload` regardless of viewer permission. Simpler but leads to confusing "permission denied" errors after clicking an enabled button.
+
+**Rationale:** Surfacing write/delete actions only when they will succeed prevents confusing error states. The backend re-check on every mutation request is the authoritative permission enforcement; the UI check is a UX convenience, not a security gate.
+
+### D7: Deleted-folder empty state
+
+**Decision:** If the configured folder is no longer accessible (deleted or moved), the widget displays a dedicated "Folder no longer exists" empty state rather than an error banner or crash. A hint directs widget editors to update the configuration.
+
+**Alternatives considered:** Propagate the error as an HTTP 500 or show a generic failure message. Neither communicates to the viewer or editor what action is needed.
+
+**Rationale:** Folder deletion is a foreseeable operational condition. A named empty state with actionable copy ("Update widget settings to choose a new folder") is more helpful than a generic failure.
+
+## Risks / Trade-offs
+
+- **High-frequency renders on large folders** → Every dashboard load hits the file system; conservative default page size (50) limits cost per request.
+- **Cursor stability across concurrent mutations** → A deleted file between pages may invalidate the cursor; fall back to offset-based position when cursor resolution fails.
+- **ACL evaluation latency on large group hierarchies** → No per-request caching is planned; may surface as latency on first load for complex permission setups.
+
+## Open follow-ups
+
+- Define the empty-state copy when the viewer's HTTP 403 is returned for the configured folder root.
+- Evaluate whether a 30-second client-side cache is acceptable on read-heavy dashboards where stale-file risk is low.
+- Confirm whether the tree display mode (hierarchical) is in scope for this iteration or deferred.

--- a/openspec/changes/files-widget/proposal.md
+++ b/openspec/changes/files-widget/proposal.md
@@ -1,0 +1,58 @@
+# Files Widget
+
+## Why
+
+MyDash users frequently need to access files stored in Nextcloud without leaving the dashboard. Currently, they must navigate away to the Files app to browse, preview, or upload files. A files widget embedded directly on the dashboard bridges this gap by providing an inline folder browser with configurable display modes, permission-aware access control, and simple upload/delete capabilities. This reduces context switching and accelerates common file-management workflows.
+
+## What Changes
+
+- Register a new dashboard widget with id `mydash_files` via `OCP\Dashboard\IManager` that appears in the widget picker.
+- Add per-placement configuration stored in `widgetContent JSON` to specify the target folder (via absolute NC path or persistent fileId), display mode (list/grid/tree), filtering options, and access controls (upload/delete).
+- Implement backend `GET /api/widgets/files/{placementId}/contents?cursor=&limit=50` to return paginated directory listings with per-file metadata (name, size, modified, mime type, thumbnails, permissions).
+- Enforce view-time ACL: only files and folders the VIEWING user can read are listed. Return HTTP 403 with `{error: "no_access"}` if the configured folder is unreadable.
+- Support folder navigation: clicking a sub-folder updates the widget's internal navigation state and refetches. Breadcrumb navigation shows the current path with click-to-jump-up.
+- File clicks deep-link to the Nextcloud Files app (`/apps/files/?fileid={fileId}`) to open in the standard viewer/preview.
+- Upload support: when `allowUpload = true` AND the viewer has write permission, an "Upload" button opens a multi-file dropzone. Uploads use Nextcloud's WebDAV / `IRootFolder` API.
+- Delete support: when `allowDelete = true` AND the viewer has delete permission, row-level delete actions appear with confirm modal.
+- Resilience: if the configured folder is deleted, the widget shows "Folder no longer exists" empty state rather than failing.
+- Optional in-widget search: client-side substring filter on folder names (case-insensitive).
+- Empty state: "This folder is empty."
+
+## Capabilities
+
+### New Capabilities
+
+- `files-widget` — A new MyDash dashboard widget capability providing inline Nextcloud Files folder browsing with permission-aware access control, upload/delete, and multiple display modes.
+
+## Impact
+
+**Affected code:**
+
+- `lib/Service/FilesWidgetService.php` — core logic for folder traversal, permission checks, pagination, and file metadata compilation.
+- `lib/Controller/WidgetController.php` — new endpoint `GET /api/widgets/files/{placementId}/contents`.
+- `src/components/widgets/FilesWidget.vue` — main widget component handling folder navigation, display modes, and state.
+- `src/components/widgets/files/FilesList.vue` — list mode renderer.
+- `src/components/widgets/files/FilesGrid.vue` — grid mode renderer with thumbnails.
+- `src/components/widgets/files/FilesTree.vue` — tree/hierarchy mode renderer.
+- `src/components/widgets/files/FileUploader.vue` — drag-drop uploader with progress tracking.
+- `src/components/widgets/files/FileBreadcrumb.vue` — breadcrumb navigation with path jump-up.
+- `src/components/widgets/eventpicker/FilesWidgetConfig.vue` — placement config UI for folder selection, view mode, and access control toggles.
+- `appinfo/routes.php` — register the new files widget contents endpoint.
+- `src/stores/widgets.js` — add widget-specific runtime state for current navigation path and fetch status.
+
+**Affected APIs:**
+
+- 1 new route: `GET /api/widgets/files/{placementId}/contents`
+- 0 changes to existing routes.
+
+**Dependencies:**
+
+- `OCP\Files\IRootFolder` — file system traversal and folder resolution.
+- `OCP\IUserSession` — current user context for permission checks.
+- `OCP\Files\FileInfo` — file metadata (size, mime type, modified time).
+- No new composer or npm dependencies.
+
+**Migration:**
+
+- Zero-impact: app config keys not required. All widget-specific state is stored in placement `widgetContent` JSON.
+- No data backfill required. Existing placements without files widget config simply don't render the widget.

--- a/openspec/changes/files-widget/specs/files-widget/spec.md
+++ b/openspec/changes/files-widget/specs/files-widget/spec.md
@@ -1,0 +1,479 @@
+---
+status: draft
+---
+
+# Files Widget Specification
+
+## ADDED Requirements
+
+### Requirement: REQ-FLS-001 Widget registration
+
+The system MUST register a MyDash dashboard widget with id `mydash_files` via `OCP\Dashboard\IManager::registerWidget()` so it appears in the widget picker alongside other Nextcloud dashboard widgets.
+
+#### Scenario: Widget appears in picker
+
+- GIVEN the files-widget capability is installed and enabled
+- WHEN a user opens the MyDash widget picker dialog
+- THEN the `mydash_files` widget MUST appear in the list with a title (e.g., "Files") and an icon
+- AND the widget MUST be selectable for placement on a dashboard
+
+#### Scenario: Multiple instances allowed
+
+- GIVEN a dashboard already has one files widget placement
+- WHEN the user adds a second files widget to the same dashboard
+- THEN both placements MUST coexist with independent configurations
+- AND each widget MUST track its own current navigation path independently
+
+#### Scenario: Widget registration survives app reload
+
+- GIVEN the widget is registered
+- WHEN Nextcloud cache is cleared or the app is reloaded
+- THEN the `mydash_files` widget MUST still be discoverable in the picker
+
+#### Scenario: Widget registration includes metadata
+
+- GIVEN the widget is registered
+- WHEN the widget picker fetches widget metadata
+- THEN the widget object MUST include at minimum: id, title, icon_url, and v2 API support indication
+
+### Requirement: REQ-FLS-002 Placement configuration
+
+The system MUST store per-placement widget configuration in the `oc_mydash_widget_placements.widgetContent` JSON field, allowing users to specify the target folder, display mode, filtering, and permission settings.
+
+#### Scenario: Config for folder path
+
+- GIVEN a user is configuring a files widget placement
+- WHEN they select a folder via the picker
+- THEN the configuration MUST store either `folderPath: string` (absolute NC path like `/Documents/Marketing`) OR `fileId: number` (persistent folder ID)
+- AND `fileId` is PREFERRED over `folderPath` because it survives folder renames
+- NOTE: Exactly one of `folderPath` or `fileId` MUST be present; they are mutually exclusive
+
+#### Scenario: Config for view mode
+
+- GIVEN a user is configuring a files widget placement
+- WHEN they choose a display mode
+- THEN the configuration MUST store a `viewMode: 'list'|'grid'|'tree'` field
+- AND the default viewMode MUST be `'list'` when not explicitly set
+
+#### Scenario: Config for thumbnails
+
+- GIVEN a user is configuring a files widget placement
+- WHEN they toggle thumbnail display
+- THEN the configuration MUST store a `showThumbnails: boolean` field
+- AND the default value MUST be `true`
+- AND thumbnails only apply in `grid` and `list` modes; `tree` mode ignores this setting
+
+#### Scenario: Config for MIME type filter
+
+- GIVEN a user is configuring a files widget placement
+- WHEN they restrict to specific file types
+- THEN the configuration MUST store a `mimeTypeFilter: string[]` field (empty array = no filter, all files shown)
+- AND valid examples include: `["image/*", "application/pdf", "text/plain"]`
+- NOTE: Empty array or absence of this field means no filtering is applied
+
+#### Scenario: Config for upload and delete permissions
+
+- GIVEN a user is configuring a files widget placement
+- WHEN they enable/disable upload and delete actions
+- THEN the configuration MUST store `allowUpload: boolean` (default `false`) and `allowDelete: boolean` (default `false`)
+- AND these flags are only honored if the VIEWING user has the corresponding permission on the folder
+- NOTE: Presence of the flag in config does NOT grant permission; it only enables the UI if permissions exist
+
+#### Scenario: Config for sorting
+
+- GIVEN a user is configuring a files widget placement
+- WHEN they set sort order
+- THEN the configuration MUST store `sortBy: 'name'|'modified'|'size'|'type'` (default `'name'`) and `sortDescending: boolean` (default `false`)
+
+#### Scenario: Config is JSON-serializable
+
+- GIVEN a placement with files widget config
+- WHEN the placement is fetched from the database
+- THEN the `widgetContent` MUST deserialize cleanly to a JavaScript object
+- AND all array and string fields MUST have no spurious whitespace or encoding issues
+
+### Requirement: REQ-FLS-003 Contents endpoint
+
+The system MUST expose `GET /api/widgets/files/{placementId}/contents?cursor=&limit=50` that returns paginated directory listings with file metadata, respecting the configured folder and user permissions.
+
+#### Scenario: Fetch folder contents
+
+- GIVEN a files widget placement configured with a readable folder
+- AND the requesting user has read permission on that folder
+- WHEN the frontend sends GET /api/widgets/files/{placementId}/contents?cursor=&limit=50
+- THEN the system MUST return HTTP 200 with a JSON object: `{items: [{...}], nextCursor: "..."|null}`
+- AND each item MUST include: fileId (number), name (string), path (string, relative to widget root), mimeType (string), size (number, bytes), modifiedAt (ISO 8601), isFolder (boolean), thumbnailUrl (string, nullable), canEdit (boolean), canDelete (boolean)
+- AND items MUST be sorted according to placement config (sortBy, sortDescending)
+
+#### Scenario: Pagination with cursor
+
+- GIVEN folder contents exceed the limit (e.g., 150 files, limit=50)
+- WHEN the frontend sends GET /api/widgets/files/{placementId}/contents?cursor=&limit=50
+- THEN the response MUST include `nextCursor: "opaque_string_value"` to fetch the next batch
+- AND the frontend MUST send GET /api/widgets/files/{placementId}/contents?cursor=opaque_string_value&limit=50 to fetch the next batch
+- AND the final batch MUST have `nextCursor: null`
+- NOTE: Cursor implementation is opaque to the frontend; the backend may use file ID offsets, timestamps, or other strategies
+
+#### Scenario: Permission-aware item listing
+
+- GIVEN a folder with files: A (user can read), B (user cannot read), C (user can read, can edit), D (user can read, can delete)
+- WHEN the user fetches folder contents
+- THEN items A, C, D MUST appear with accurate `canEdit` and `canDelete` flags
+- AND item B MUST be ABSENT from the list (not disclosed to user without read permission)
+
+#### Scenario: MIME type filter applied
+
+- GIVEN a placement configured with `mimeTypeFilter: ["image/*"]`
+- AND the folder contains: image.png, document.pdf, notes.txt
+- WHEN the frontend fetches folder contents
+- THEN only image.png MUST be returned
+- AND document.pdf and notes.txt MUST be filtered out
+
+#### Scenario: Empty folder
+
+- GIVEN a placement configured with an empty folder
+- WHEN the frontend fetches folder contents
+- THEN the system MUST return HTTP 200 with `{items: [], nextCursor: null}`
+
+#### Scenario: Folder not found
+
+- GIVEN a placement configured with a folder that no longer exists
+- WHEN the frontend fetches folder contents
+- THEN the system MUST return HTTP 404 with `{error: "folder_not_found", message: "The configured folder no longer exists"}`
+
+### Requirement: REQ-FLS-004 View-time access control
+
+The system MUST enforce view-time permission checks: only files and folders the VIEWING user can read are listed. If the configured folder is unreadable, the widget MUST NOT expose its existence or contents.
+
+#### Scenario: User cannot read folder
+
+- GIVEN a placement configured with a folder that the requesting user cannot read
+- AND another user can read that folder
+- WHEN the requesting user fetches folder contents
+- THEN the system MUST return HTTP 403 with `{error: "no_access", message: "You don't have access to this folder"}`
+- AND the widget frontend MUST display an empty-state "You don't have access to this folder."
+- NOTE: No folder metadata (name, structure) is disclosed
+
+#### Scenario: User loses permission after widget creation
+
+- GIVEN a user created a files widget pointing to a folder they could read
+- AND the folder owner later revokes the user's read permission
+- WHEN the user refreshes the dashboard and the widget attempts to fetch contents
+- THEN HTTP 403 `no_access` MUST be returned
+- AND the widget MUST gracefully show the access-denied empty state
+
+#### Scenario: Mixed permissions within folder
+
+- GIVEN a folder with a subfolder that the user cannot read
+- AND other files in the main folder that the user can read
+- WHEN the user fetches folder contents
+- THEN readable files MUST be listed
+- AND the unreadable subfolder MUST be absent from the list (not shown as a grayed-out or inaccessible item)
+
+#### Scenario: Upload/delete checks at action time
+
+- GIVEN a placement with `allowUpload: true` and `allowDelete: true`
+- AND the folder is readable but NOT writable by the user
+- WHEN the widget renders
+- THEN the "Upload" button MUST NOT appear (no upload UI)
+- AND delete actions MUST NOT appear on items
+- AND if the user somehow submits a DELETE request, the backend MUST return HTTP 403
+
+### Requirement: REQ-FLS-005 Breadcrumb navigation and folder traversal
+
+The system MUST support folder navigation: clicking a sub-folder updates the widget's current path (in client state, not config) and refetches. A breadcrumb above the listing shows the current path with click-to-jump-up.
+
+#### Scenario: Breadcrumb displays current path
+
+- GIVEN a user navigates to folder `/Documents/Marketing/Q2`
+- WHEN the widget renders
+- THEN the breadcrumb MUST display: `[root] / Documents / Marketing / Q2`
+- AND each breadcrumb segment MUST be clickable
+
+#### Scenario: Click breadcrumb to jump up
+
+- GIVEN the breadcrumb displays `[root] / Documents / Marketing / Q2`
+- WHEN the user clicks on `Marketing`
+- THEN the widget MUST refetch contents for `/Documents/Marketing`
+- AND the breadcrumb MUST update to `[root] / Documents / Marketing`
+
+#### Scenario: Click folder to descend
+
+- GIVEN the widget displays contents of `/Documents`
+- WHEN the user clicks on a folder named `Marketing`
+- THEN the widget MUST refetch contents for `/Documents/Marketing`
+- AND the breadcrumb MUST update to `[root] / Documents / Marketing`
+- AND sorting and MIME filter MUST be reapplied to the new folder
+
+#### Scenario: Navigation state isolated per widget instance
+
+- GIVEN a dashboard with two files widgets (each pointing to different root folders)
+- WHEN the user navigates in widget A to subfolder `./subfolder`
+- THEN widget B MUST remain at its own root folder
+- AND the two widgets MUST NOT affect each other's current path
+
+#### Scenario: Root folder breadcrumb
+
+- GIVEN a user is viewing the configured root folder
+- WHEN the widget renders the breadcrumb
+- THEN it MUST display at least `[root]` or a home icon
+- AND clicking it MUST not navigate (or reset navigation to the configured root)
+
+### Requirement: REQ-FLS-006 File click deep-linking
+
+When a user clicks on a file, the widget MUST open the standard Nextcloud file viewer/preview by deep-linking to the Nextcloud Files app. The widget MUST NOT attempt to render previews inline.
+
+#### Scenario: Click file to open in Files app
+
+- GIVEN a file with fileId `12345` in the widget listing
+- WHEN the user clicks on the file
+- THEN the widget MUST open `/apps/files/?fileid=12345` in a new tab or window
+- AND the Nextcloud Files app MUST load the file preview/viewer in its standard way
+
+#### Scenario: Click folder does not deep-link
+
+- GIVEN a folder with fileId `12346` in the widget listing
+- WHEN the user clicks on the folder
+- THEN the widget MUST NOT deep-link; instead, it MUST navigate within the widget (see REQ-FLS-005)
+- AND the breadcrumb and contents MUST update
+
+#### Scenario: Deep-link preserves file context
+
+- GIVEN a file `/Documents/Marketing/budget.xlsx` with fileId `555`
+- WHEN the user clicks it in the widget
+- THEN the Files app MUST show the file with full preview/editing capabilities
+- AND the file's location in the Nextcloud file tree MUST be preserved
+
+### Requirement: REQ-FLS-007 Upload capability
+
+When `allowUpload = true` AND the viewer has write permission on the folder, an "Upload" button MUST surface a multi-file dropzone. Uploads MUST go through Nextcloud's standard WebDAV / `IRootFolder` API and show per-file progress.
+
+#### Scenario: Upload button appears when allowed
+
+- GIVEN a placement with `allowUpload: true`
+- AND the viewer has write permission on the configured folder
+- AND the folder is not locked
+- WHEN the widget renders
+- THEN an "Upload" button or drop zone MUST be visible
+
+#### Scenario: Upload button hidden when not allowed
+
+- GIVEN a placement with `allowUpload: false`
+- OR the viewer lacks write permission
+- WHEN the widget renders
+- THEN the "Upload" button MUST NOT appear
+
+#### Scenario: Drag-drop upload multiple files
+
+- GIVEN the upload zone is visible
+- WHEN the user drags 3 files and drops them on the widget
+- THEN the system MUST accept all 3 files for upload
+- AND each file MUST show individual upload progress
+- AND on success, all 3 files MUST appear in the folder listing
+
+#### Scenario: Upload progress indication
+
+- GIVEN a 50 MB file is being uploaded
+- WHEN the upload is in progress
+- THEN the widget MUST display a progress bar or percentage (e.g., "25/50 MB uploaded")
+- AND the user MUST be able to see which files are queued, in progress, or completed
+
+#### Scenario: Upload conflict handling
+
+- GIVEN a user uploads a file `report.pdf` but `report.pdf` already exists in the folder
+- WHEN the upload completes
+- THEN the system MUST follow Nextcloud's standard conflict behavior (rename to `report (1).pdf` or return a conflict prompt via the frontend)
+
+#### Scenario: Upload fails gracefully
+
+- GIVEN a user uploads a 5 GB file to a folder with only 1 GB free space
+- WHEN the upload attempt exceeds available space
+- THEN the backend MUST return an error (e.g., HTTP 507 or 400)
+- AND the widget MUST display the error for that file without blocking other uploads
+- AND the folder listing MUST NOT be corrupted
+
+### Requirement: REQ-FLS-008 Delete capability
+
+When `allowDelete = true` AND the viewer has delete permission on items, row-level delete actions MUST appear with a confirm modal. Deletes MUST respect Nextcloud's trash/recycle bin where applicable.
+
+#### Scenario: Delete button appears when allowed
+
+- GIVEN a placement with `allowDelete: true`
+- AND the viewer has delete permission on a file
+- WHEN the widget renders that file
+- THEN a delete icon or button MUST appear on the item (e.g., trash icon)
+
+#### Scenario: Delete button hidden when not allowed
+
+- GIVEN a placement with `allowDelete: false`
+- OR the viewer lacks delete permission on a file
+- WHEN the widget renders that file
+- THEN the delete button MUST NOT appear for that item
+
+#### Scenario: Delete with confirmation
+
+- GIVEN a file with a delete button visible
+- WHEN the user clicks the delete button
+- THEN a confirmation modal MUST appear with text like "Are you sure you want to delete report.pdf?"
+- AND the user MUST be able to cancel or confirm
+- AND canceling MUST not delete the file
+
+#### Scenario: Delete moves to trash
+
+- GIVEN a file in the configured folder
+- WHEN the user confirms deletion
+- THEN the file MUST be moved to Nextcloud's trash/recycle bin (not permanently deleted)
+- AND the file MUST immediately disappear from the widget listing
+- AND subsequent folder refresh MUST not show the deleted file
+
+#### Scenario: Delete folder recursively
+
+- GIVEN a subfolder within the configured folder
+- WHEN the user confirms deletion of the subfolder
+- THEN the system MUST delete the folder and all its contents (recursively)
+- AND the folder MUST disappear from the breadcrumb and current folder listing
+
+#### Scenario: Delete on permission-denied folder
+
+- GIVEN a widget pointing to a folder
+- AND the user has delete permission on a file, but the folder itself becomes read-only after widget creation
+- WHEN the user attempts to delete
+- THEN the backend MUST return HTTP 403
+- AND the widget MUST display an error (e.g., "You no longer have permission to delete this item")
+
+### Requirement: REQ-FLS-009 Folder-not-found tolerance
+
+If the configured folder is deleted or becomes inaccessible (e.g., share revoked), the widget MUST show an empty-state message rather than an error. The widget MUST NOT expose a 500 error to the user.
+
+#### Scenario: Folder deleted
+
+- GIVEN a placement configured with folder fileId `999`
+- AND the folder is deleted by another user
+- WHEN the current user refreshes the widget
+- THEN the widget MUST display "Folder no longer exists" empty state
+- AND the backend MUST return HTTP 404 with `{error: "folder_not_found"}`
+- AND the widget MUST handle this gracefully (no crash, no stack trace)
+
+#### Scenario: Share revoked after widget creation
+
+- GIVEN a user created a files widget pointing to a shared folder
+- AND the share owner revokes the share
+- WHEN the user refreshes the widget
+- THEN the widget MUST display "You don't have access to this folder" (same as REQ-FLS-004)
+- AND the backend MUST return HTTP 403
+
+#### Scenario: File in configured folder deleted, folder exists
+
+- GIVEN a widget is displaying a folder with 3 files
+- AND another user deletes one of the files
+- WHEN the current user refreshes the folder contents
+- THEN the deleted file MUST NOT appear in the listing
+- AND the other 2 files MUST still appear normally
+
+### Requirement: REQ-FLS-010 MIME type filtering and view modes
+
+The system MUST support MIME type filtering (empty filter = all files) and multiple display modes (list, grid, tree). Filtering MUST be applied server-side in the contents endpoint.
+
+#### Scenario: No MIME filter (all files shown)
+
+- GIVEN a placement with empty or missing `mimeTypeFilter` field
+- WHEN the widget fetches folder contents
+- THEN all files and folders (regardless of type) MUST be returned
+- AND the backend MUST not apply any filtering
+
+#### Scenario: MIME filter by type
+
+- GIVEN a placement with `mimeTypeFilter: ["image/*", "video/*"]`
+- AND the folder contains: photo.jpg, video.mp4, document.pdf, spreadsheet.xlsx
+- WHEN the widget fetches folder contents
+- THEN only photo.jpg and video.mp4 MUST be returned
+- AND document.pdf and spreadsheet.xlsx MUST be filtered out (not disclosed)
+
+#### Scenario: MIME filter by specific MIME type
+
+- GIVEN a placement with `mimeTypeFilter: ["application/pdf"]`
+- AND the folder contains: budget.pdf, report.docx, notes.pdf
+- WHEN the widget fetches folder contents
+- THEN both budget.pdf and notes.pdf MUST be returned
+- AND report.docx MUST be filtered out
+
+#### Scenario: List mode renders rows
+
+- GIVEN a placement with `viewMode: 'list'`
+- WHEN the widget renders
+- THEN items MUST be displayed as rows with columns: icon/thumbnail (if showThumbnails), name, modified date, size
+- AND each row MUST be clickable (file → deep-link; folder → navigate)
+
+#### Scenario: Grid mode with thumbnails
+
+- GIVEN a placement with `viewMode: 'grid'` and `showThumbnails: true`
+- AND the folder contains: image.png, document.pdf, video.mp4
+- WHEN the widget renders
+- THEN each item MUST be displayed as a card/tile with thumbnail image
+- AND thumbnails for images and videos MUST be visible
+- AND document.pdf MUST show a file-type icon (no rendered preview inline)
+
+#### Scenario: Grid mode without thumbnails
+
+- GIVEN a placement with `viewMode: 'grid'` and `showThumbnails: false`
+- WHEN the widget renders
+- THEN each item MUST display as a card/tile with file-type icon (no thumbnail)
+- AND the grid MUST load faster (no thumbnail rendering)
+
+#### Scenario: Tree mode hierarchical display
+
+- GIVEN a placement with `viewMode: 'tree'`
+- AND the folder structure: `root/ > docs/ > 2024/ > [files]` and `root/ > images/ > [files]`
+- WHEN the widget renders
+- THEN a collapsible tree structure MUST be displayed
+- AND clicking expand/collapse on `docs` and `images` MUST show/hide their contents
+- AND the current breadcrumb MUST reflect the deepest navigated folder
+
+#### Scenario: Sort order applied per view mode
+
+- GIVEN a placement with `sortBy: 'modified'` and `sortDescending: true`
+- WHEN the widget renders in list, grid, or tree mode
+- THEN items MUST be sorted by modification date, newest first
+- AND the sort order MUST be consistent across all view modes
+
+### Requirement: REQ-FLS-011 Empty states and in-widget search
+
+The system MUST display appropriate empty states and support optional in-widget client-side search to filter folder contents by name substring (case-insensitive).
+
+#### Scenario: Empty folder state
+
+- GIVEN a widget pointing to an empty folder
+- WHEN the widget renders
+- THEN it MUST display "This folder is empty." message
+- AND no files or folders MUST be listed
+- AND navigation and breadcrumb MUST still function normally
+
+#### Scenario: Empty search results
+
+- GIVEN a folder with files: "budget.pdf", "report.txt", "notes.md"
+- AND the user types "invoice" in an in-widget search field
+- WHEN the search is applied
+- THEN no items MUST be displayed
+- AND a message like "No files matching 'invoice'" MUST appear
+- AND clearing the search MUST restore the full listing
+
+#### Scenario: In-widget search is client-side substring filter
+
+- GIVEN a folder with files: "marketing_budget.xlsx", "budget_2024.xlsx", "Q2_report.pdf"
+- WHEN the user types "budget" in the search field
+- THEN both "marketing_budget.xlsx" and "budget_2024.xlsx" MUST be shown (substring match)
+- AND "Q2_report.pdf" MUST be hidden
+- NOTE: Search is case-insensitive ("BUDGET", "Budget", "budget" all match)
+
+#### Scenario: Search preserves sort order
+
+- GIVEN items sorted by modified date (newest first)
+- WHEN the user applies a search filter
+- THEN matching items MUST remain sorted by modified date
+- AND the sort order MUST not be disrupted by the filter
+
+#### Scenario: Search filters both files and folders
+
+- GIVEN a folder with subfolder "marketing" and file "marketing_plan.pdf"
+- WHEN the user types "market" in the search field
+- THEN both the folder and file MUST be displayed (both match)

--- a/openspec/changes/files-widget/tasks.md
+++ b/openspec/changes/files-widget/tasks.md
@@ -1,0 +1,320 @@
+# Tasks — files-widget
+
+## 1. Widget registration and service layer
+
+- [ ] 1.1 Create `lib/Service/FilesWidgetService.php` with core methods:
+  - `getWidgetInfo(): array` — returns widget metadata (id, title, icon_url, v2 API support)
+  - `getContentsForPlacement(int $placementId, string $currentPath, int $limit, string $cursor): array` — orchestrates folder traversal and permission checks
+  - `traverseFolder(string $path, string $mimeFilter, string $sortBy, bool $sortDescending, int $limit, string $cursor): array` — returns paginated items with metadata
+  - `checkFolderAccess(string $path, string $action): bool` — permission check (read, write, delete) for current user
+  - `buildFileMetadata(FileInfo $file): array` — constructs item object with fileId, name, path, mimeType, size, modifiedAt, isFolder, canEdit, canDelete, thumbnailUrl
+
+- [ ] 1.2 Register the widget in `AppInfo/Bootstrap.php` or lifecycle hook:
+  - Hook into Nextcloud's dashboard widget registration
+  - Call `IManager::registerWidget()` with widget metadata
+  - Widget id: `mydash_files`, title: translatable `app.mydash.files_widget_title`, icon: folder icon URL
+
+- [ ] 1.3 Create PHPUnit tests for `FilesWidgetService`:
+  - `testTraverseFolderSuccess` — mock `IRootFolder`, verify file listing
+  - `testTraverseFolderWithMimeFilter` — filter by `image/*`, verify only matching files returned
+  - `testTraverseFolderPaginated` — verify cursor-based pagination with limit
+  - `testCheckFolderAccessReadPermission` — user can read, verify true
+  - `testCheckFolderAccessDenied` — user cannot read, verify false
+  - `testBuildFileMetadataWithThumbnail` — file supports thumbnail, verify URL present
+
+## 2. Backend controller and routing
+
+- [ ] 2.1 Add endpoint method to `lib/Controller/WidgetController.php`:
+  - `public function filesContents(int $placementId, string $currentPath = '/', int $limit = 50, string $cursor = ''): DataResponse`
+  - Validate placement exists and user can view associated dashboard (return 403 if denied)
+  - Fetch placement config (folderPath, fileId, mimeTypeFilter, sortBy, sortDescending)
+  - Resolve folder via fileId or folderPath (prefer fileId)
+  - Call `FilesWidgetService::getContentsForPlacement()` with filter and sort options
+  - Return HTTP 200 with `{items: [...], nextCursor: "..."|null}`
+  - Return HTTP 403 with `{error: "no_access"}` if folder unreadable
+  - Return HTTP 404 with `{error: "folder_not_found"}` if folder deleted
+  - Decorate with `#[NoCSRFRequired]` and `#[NoAdminRequired]`
+
+- [ ] 2.2 Register route in `appinfo/routes.php`:
+  - `GET /api/widgets/files/{placementId}/contents` → `WidgetController::filesContents()`
+  - Route requirements: placementId (digits), query params: currentPath (string), limit (integer), cursor (string)
+
+- [ ] 2.3 Create PHPUnit tests for controller:
+  - `testFilesContentsSuccess` — mock service, verify HTTP 200 with paginated items
+  - `testFilesContentsFolderNotFound` — return 404 when folder deleted
+  - `testFilesContentsAccessDenied` — return 403 when user cannot read folder
+  - `testFilesContentsWithMimeFilter` — verify filter applied
+  - `testFilesContentsWithSortOrder` — verify sort options respected
+  - `testFilesContentsPagination` — verify cursor and nextCursor fields
+
+## 3. Placement configuration and schema migration
+
+- [ ] 3.1 Add getter/setter methods in `WidgetPlacementService` or factory to safely parse `widgetContent` JSON:
+  - `extractFilesConfig(WidgetPlacement $placement): array` — returns parsed config with defaults (folderPath, fileId, viewMode='list', showThumbnails=true, mimeTypeFilter=[], allowUpload=false, allowDelete=false, sortBy='name', sortDescending=false)
+  - Validate and sanitize config (fileId must be numeric, folderPath must be valid absolute path, mimeTypeFilter entries must be valid MIME patterns)
+
+- [ ] 3.2 Create PHPUnit test for placement config parsing:
+  - `testExtractFilesConfigWithDefaults` — verify all default values applied
+  - `testExtractFilesConfigValidation` — invalid fileId rejected, valid one accepted
+  - `testExtractFilesConfigMimeFilter` — validate MIME type patterns
+
+## 4. Folder traversal, permission checks, and metadata
+
+- [ ] 4.1 Implement in `FilesWidgetService::traverseFolder()`:
+  - Resolve folder via `IRootFolder::getById()` (if fileId) or `IRootFolder::get()` (if path)
+  - Return 404 if folder not found
+  - Check read permission via `FileInfo::isReadable()`
+  - Return 403 if user cannot read folder
+  - Iterate folder children via `DirectoryIterator` or `IRootFolder`
+  - For each child, build file metadata via `buildFileMetadata()`
+  - Apply MIME filter if present: only include children where `$mimeType` matches patterns in filter
+  - Apply sort: use `sortBy` (name/modified/size/type) and `sortDescending` to order results
+  - Apply pagination: skip first N items based on cursor, return up to limit items
+  - Compute nextCursor based on next item index (or null if at end)
+  - Return `{items: [...], nextCursor: ...}`
+
+- [ ] 4.2 Implement `FilesWidgetService::buildFileMetadata()`:
+  - Extract: fileId, name, path (relative to widget root), mimeType, size, modifiedAt
+  - Compute: isFolder, thumbnailUrl (if applicable and showThumbnails enabled)
+  - Check permissions: canEdit (write), canDelete (delete)
+  - Return normalized item object
+
+- [ ] 4.3 Implement `FilesWidgetService::checkFolderAccess()`:
+  - Use `IUserSession::getUser()` to get current user
+  - Use `FileInfo::isReadable()` for read check
+  - Use `FileInfo::isUpdateable()` for write/edit check
+  - Use `FileInfo::isDeletable()` for delete check
+  - Return boolean
+
+- [ ] 4.4 Create PHPUnit tests:
+  - `testTraverseFolderFiltered` — verify MIME filter applied correctly
+  - `testTraverseFolderSorted` — verify items sorted by name/modified/size
+  - `testBuildFileMetadataImage` — image file gets thumbnail URL
+  - `testBuildFileMetadataFolder` — folder marked as isFolder=true
+  - `testCheckFolderAccessMultipleChecks` — test read, write, delete independently
+
+## 5. Folder-not-found and access-denied resilience
+
+- [ ] 5.1 Implement fallback handling in controller:
+  - Catch `NotFoundException` from `IRootFolder::getById()` or `get()` → return HTTP 404
+  - Catch permission exceptions or use `isReadable()` check → return HTTP 403
+  - Log gracefully (INFO level, not ERROR)
+
+- [ ] 5.2 Create PHPUnit tests:
+  - `testFolderDeletedDuringSession` — file existed, is deleted, returns 404
+  - `testShareRevokedDuringSession` — folder was readable, permission revoked, returns 403
+
+## 6. Frontend widget component (Vue 3 SFC)
+
+- [ ] 6.1 Create `src/components/widgets/FilesWidget.vue`:
+  - Props: `placement: object` (with widgetContent config)
+  - Data: `items: []`, `currentPath: '/'`, `loading: false`, `error: null`, `nextCursor: null`, `searchQuery: ''`
+  - Computed: `viewMode`, `showThumbnails`, `mimeTypeFilter`, `allowUpload`, `allowDelete` (from placement config with defaults)
+  - Computed: `filteredItems` — apply client-side search filter to items (substring match, case-insensitive)
+  - Method `fetchContents()`: async call to `GET /api/widgets/files/{placementId}/contents?currentPath=...&limit=50&cursor=...`
+    - Handle loading state, errors, pagination
+  - Method `handleFolderClick(fileId, name)`: update currentPath, call fetchContents()
+  - Method `handleFileClick(fileId)`: open `/apps/files/?fileid={fileId}` in new tab
+  - Method `handleBreadcrumbClick(path)`: navigate to breadcrumb path, call fetchContents()
+  - Method `handleUploadFiles(files)`: emit to FileUploader component or call upload endpoint
+  - Method `handleDeleteFile(fileId, name)`: show confirm modal, call delete endpoint if confirmed
+  - Lifecycle: `onMounted` → `fetchContents()`, optional `watch` on placement config → reset and refetch
+  - Render: router between list/grid/tree components based on viewMode
+  - Render: breadcrumb, search input, empty states, error states, file uploader
+  - Render: loading spinner during fetch
+
+- [ ] 6.2 Create `src/components/widgets/files/FilesList.vue`:
+  - Props: `items: []`, `showThumbnails: boolean`, `allowDelete: boolean`, `sortBy: string`, `sortDescending: boolean`
+  - Emits: `click:file`, `click:folder`, `click:delete`
+  - Render: table with columns: icon/thumbnail, name, modified, size
+  - Each row clickable on name (emit click:file or click:folder)
+  - Delete button on right (if allowDelete and canDelete)
+  - Sort indicators on column headers (current sort highlighted)
+
+- [ ] 6.3 Create `src/components/widgets/files/FilesGrid.vue`:
+  - Props: `items: []`, `showThumbnails: boolean`, `allowDelete: boolean`
+  - Emits: `click:file`, `click:folder`, `click:delete`
+  - Render: CSS grid of file cards
+  - Each card shows: thumbnail (if showThumbnails) or file icon, name (clipped), modified date
+  - Click card → emit click:file or click:folder
+  - Hover card → show delete button (if allowDelete)
+
+- [ ] 6.4 Create `src/components/widgets/files/FilesTree.vue`:
+  - Props: `items: []`, `allowDelete: boolean`, `currentPath: string`
+  - Emits: `click:folder`, `click:file`, `click:delete`
+  - Render: hierarchical tree with expand/collapse
+  - Folder items show expand/collapse arrow
+  - Click folder → emit click:folder with new path
+  - Delete button on hover (if allowDelete)
+
+- [ ] 6.5 Create `src/components/widgets/files/FileBreadcrumb.vue`:
+  - Props: `currentPath: string`
+  - Emits: `navigate:path`
+  - Render: breadcrumb items split by `/` with home icon for root
+  - Each segment clickable → emit navigate:path with that segment
+  - Highlight current last segment
+
+- [ ] 6.6 Create `src/components/widgets/files/FileUploader.vue`:
+  - Props: `placementId: number`, `currentPath: string`, `enabled: boolean` (based on allowUpload && canEdit)
+  - Data: `uploads: []` (track progress per file)
+  - Render: drag-drop zone + "Upload" button
+  - On drop or file select: initiate upload via `PUT /api/widgets/files/{placementId}/upload?currentPath=...`
+  - Send files as multipart/form-data
+  - Emit: `upload:complete` when all done, `upload:error` on failure
+  - Show progress bar per file
+  - Show error message if upload fails
+
+- [ ] 6.7 Create empty-state, error, and failure components:
+  - `EmptyState.vue` — "This folder is empty." or "Folder no longer exists." or "You don't have access to this folder."
+  - `ErrorState.vue` — "Failed to load folder contents" with retry button
+
+- [ ] 6.8 Create Playwright E2E tests:
+  - `testFilesWidgetListView` — widget renders file list with names, sizes, dates
+  - `testFilesWidgetGridView` — widget renders file grid with thumbnails
+  - `testFilesWidgetTreeView` — widget renders collapsible tree, expand/collapse works
+  - `testFilesWidgetFolderNavigation` — click folder → contents update, breadcrumb updates
+  - `testFilesWidgetBreadcrumbJump` — click breadcrumb segment → navigate to that level
+  - `testFilesWidgetFileClick` — click file → opens in new tab with fileid parameter
+  - `testFilesWidgetSearch` — type search → filter items by substring, clear search → restore
+  - `testFilesWidgetUpload` — drag files → upload progress shown, files appear after
+  - `testFilesWidgetDelete` — click delete → confirm modal, file removed after confirm
+  - `testFilesWidgetEmptyState` — empty folder → shows empty message
+  - `testFilesWidgetAccessDenied` — no access to folder → shows access denied message
+
+## 7. Widget configuration UI component
+
+- [ ] 7.1 Create `src/components/widgets/eventpicker/FilesWidgetConfig.vue`:
+  - Used by `WidgetAddEditModal.vue` when configuring a files widget placement
+  - Form sections:
+    - **Folder**: folder picker (loads available folders from user, returns fileId as primary choice, folderPath as secondary)
+    - **View Mode**: radio buttons or dropdown (list, grid, tree)
+    - **Show Thumbnails**: toggle (default true)
+    - **MIME Filter**: multi-input for MIME type patterns (e.g., image/*, text/plain) — add/remove buttons
+    - **Sort By**: dropdown (name, modified, size, type)
+    - **Sort Descending**: toggle
+    - **Allow Upload**: toggle (default false)
+    - **Allow Delete**: toggle (default false)
+  - Validation: fileId or folderPath must be present (exactly one), MIME patterns must be valid format
+  - On save: emit `update:widgetContent` with serialized config object
+
+- [ ] 7.2 Create `src/components/widgets/eventpicker/FolderPicker.vue` (sub-component):
+  - Load available folders from Files API or use a folder selection dialog
+  - Return selected folder with fileId as primary
+  - Show folder name and path
+  - Multi-select or single-select (spec says single root folder per widget)
+
+- [ ] 7.3 Integrate into `WidgetAddEditModal.vue`:
+  - When user selects `mydash_files` widget from picker
+  - Display `FilesWidgetConfig.vue` instead of default generic config panel
+  - Pass selected widget metadata to config component
+
+- [ ] 7.4 Create Playwright test:
+  - `testFilesWidgetConfigUI` — open config modal, select folder, choose view mode, set filters, save
+
+## 8. Upload endpoint
+
+- [ ] 8.1 Add endpoint method to `lib/Controller/WidgetController.php`:
+  - `public function uploadFiles(int $placementId, string $currentPath = '/'): DataResponse`
+  - Validate placement exists and user can view dashboard
+  - Resolve folder via placement config
+  - Check `allowUpload` in config AND user has write permission (403 if not)
+  - Iterate `$_FILES['files']` (or use `IRequest::getUploadedFile()` if available)
+  - For each file, save to folder via `IRootFolder::newFile()` or WebDAV
+  - Return HTTP 200 with list of uploaded file metadata, or HTTP 400 with errors per file
+  - Decorate with `#[NoCSRFRequired]` (for CORS/API use)
+
+- [ ] 8.2 Register route in `appinfo/routes.php`:
+  - `POST /api/widgets/files/{placementId}/upload` → `WidgetController::uploadFiles()`
+
+- [ ] 8.3 Create PHPUnit tests:
+  - `testUploadFilesSuccess` — upload 2 files, verify both appear in folder
+  - `testUploadFilesAccessDenied` — user lacks write permission, return 403
+  - `testUploadFilesConflict` — file exists, renamed to (1), verify new name in response
+  - `testUploadFilesSpaceExceeded` — user quota exceeded, return 507 or 400
+
+## 9. Delete endpoint
+
+- [ ] 9.1 Add endpoint method to `lib/Controller/WidgetController.php`:
+  - `public function deleteFile(int $placementId, int $fileId): DataResponse`
+  - Validate placement exists and user can view dashboard
+  - Resolve file via fileId
+  - Check user has delete permission on file (403 if not)
+  - Call `FileInfo::delete()` or move to trash
+  - Return HTTP 200 on success, or HTTP 403/404 on failure
+  - Decorate with `#[NoCSRFRequired]`
+
+- [ ] 9.2 Register route in `appinfo/routes.php`:
+  - `DELETE /api/widgets/files/{placementId}/files/{fileId}` → `WidgetController::deleteFile()`
+
+- [ ] 9.3 Create PHPUnit tests:
+  - `testDeleteFileSuccess` — file deleted, returns 200
+  - `testDeleteFileAccessDenied` — user lacks delete permission, returns 403
+  - `testDeleteFileNotFound` — file deleted by another user, returns 404
+
+## 10. Internationalization (i18n)
+
+- [ ] 10.1 Add Dutch (nl) and English (en) translation keys:
+  - `app.mydash.files_widget_title` — "Bestanden" / "Files"
+  - `app.mydash.files_empty_state` — "Deze map is leeg." / "This folder is empty."
+  - `app.mydash.files_no_access` — "Je hebt geen toegang tot deze map." / "You don't have access to this folder."
+  - `app.mydash.files_not_found` — "Map bestaat niet meer." / "Folder no longer exists."
+  - `app.mydash.files_loading` — "Map laden…" / "Loading folder…"
+  - `app.mydash.files_error` — "Fout bij laden van mapinhoud." / "Failed to load folder contents."
+  - `app.mydash.files_retry` — "Opnieuw proberen" / "Retry"
+  - `app.mydash.files_upload_button` — "Bestand uploaden" / "Upload File"
+  - `app.mydash.files_delete_button` — "Verwijderen" / "Delete"
+  - `app.mydash.files_delete_confirm` — "Weet je zeker dat je {name} wilt verwijderen?" / "Are you sure you want to delete {name}?"
+  - `app.mydash.files_search_placeholder` — "Zoeken in deze map…" / "Search this folder…"
+
+- [ ] 10.2 Add translation files:
+  - `l10n/nl.json` — Dutch translations
+  - `l10n/en.json` — English translations (fallback)
+
+## 11. Quality gates and testing
+
+- [ ] 11.1 Run `composer check:strict` (PHPCS, PHPMD, Psalm, PHPStan):
+  - Fix any pre-existing issues in touched files
+  - New PHP code must pass all checks
+
+- [ ] 11.2 Run ESLint on all Vue/JS files:
+  - `npm run lint` on `src/components/widgets/`
+  - Fix any warnings or errors
+
+- [ ] 11.3 Run Stylelint on component stylesheets
+
+- [ ] 11.4 Confirm all hydra gates pass locally before opening PR
+
+- [ ] 11.5 Add SPDX-License-Identifier and SPDX-FileCopyrightText headers to every new PHP file (inside docblock)
+
+- [ ] 11.6 PHPUnit test coverage:
+  - Aim for 80%+ line coverage on `FilesWidgetService`
+  - All public methods tested
+  - Edge cases (empty folders, null fields, permission denials) covered
+
+- [ ] 11.7 Playwright E2E test coverage:
+  - Files widget renders in dashboard
+  - All three view modes (list, grid, tree) render correctly
+  - Folder navigation works
+  - Breadcrumb navigation works
+  - File click deep-links to Files app
+  - Upload and delete (if enabled) work
+  - Empty states and error states display correctly
+  - Search filters items
+
+- [ ] 11.8 Manual testing on local Nextcloud instance:
+  - Create a dashboard with files widget
+  - Configure widget with various folder paths and filters
+  - Verify all view modes work
+  - Test upload and delete (if enabled)
+  - Test permission denial scenarios (no access, no write, no delete)
+  - Test folder deletion and share revocation resilience
+
+## 12. Documentation and changelog
+
+- [ ] 12.1 Update `CHANGELOG.md` with:
+  - New feature: "Add files widget for inline Nextcloud folder browsing"
+  - List view modes, MIME filtering, upload/delete features
+
+- [ ] 12.2 Update `README.md` (if applicable) with widget description
+
+- [ ] 12.3 Add code comments to `FilesWidgetService` explaining permission checks, pagination strategy, and resilience logic

--- a/openspec/changes/footer-customization/design.md
+++ b/openspec/changes/footer-customization/design.md
@@ -1,0 +1,106 @@
+# Design — Footer Customization
+
+## Context
+
+The source application stores its footer as a single per-language file (`{lang}/footer.json`) at the language-folder root. `FooterService::getFooter()` and `saveFooter()` accept no `pageId` or `uniqueId` parameter — they operate on the one global footer for the active language. `PageService` explicitly excludes `footer.json` from page listings, confirming it is a system-level file rather than a page attribute. Write access is controlled by `FooterService::canEdit()`, which delegates to `$languageFolder->isUpdateable()` (GroupFolder ACL). There is no per-page footer concept in the source.
+
+MyDash departs from this pattern in two deliberate ways. First, it stores global footer configuration in admin settings rather than the filesystem, because MyDash dashboards have two storage backends (database and GroupFolder) and a filesystem-only path is not a unified fit. Second, it adds a per-dashboard footer override (`dashboardFooterMode`) that does not exist in the source at all. Both departures are intentional MyDash additions.
+
+The global footer supports two authoring modes: raw HTML (max 8 KB, sanitised server-side) and a structured JSON config (`{logoUrl?, organisation?, address?, links?, legal?, copyrightYear?, layoutMode}`). Both modes may carry language-tagged variants (`{en: "...", nl: "..."}`). The footer is off by default; admins explicitly enable it.
+
+Per-dashboard override gives dashboard owners three options: inherit the global footer, suppress it entirely, or supply custom HTML for that dashboard alone. This is primarily useful for branded landing dashboards that need a different footer identity from the instance-wide default.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Provide a global footer toggle and content configuration via admin settings (`mydash.footer_enabled`, `mydash.footer_html`, `mydash.footer_config`, `mydash.footer_background_color`, `mydash.footer_text_color`).
+- Support two authoring modes — raw HTML and structured form-based config — selectable per instance.
+- Allow per-dashboard footer override (`inherit` / `hidden` / `custom`) stored as columns on `oc_mydash_dashboards`.
+- Support multi-language footer variants with a defined fallback chain: viewer NC locale → dashboard primary language → first key in the variant map.
+- Sanitise all HTML through a strict allowlist identical to the text-display widget's allow-list, to avoid duplicating sanitisation rules.
+- Ensure the footer appears in browser print output and PDF exports (`@media print` — no `display: none`).
+- Follow NC theme colours by default; allow admin hex-string overrides.
+
+**Non-Goals:**
+
+- Migrating the source's per-language `footer.json` filesystem layout to MyDash — admin settings is the single storage path.
+- Implementing per-row HTML upload via image-widget-style file attachments — footer assets are referenced by URL only.
+- Real-time footer push after an admin edit — the updated footer appears on next page load.
+- Supporting a GroupFolder ACL model for footer write permission — admin-role check via the `admin-roles` capability covers it.
+- Multi-language variants on the per-dashboard `dashboardFooterHtml` field in the initial release (deferred; see Open Follow-ups).
+
+## Decisions
+
+### D1: Global footer storage — admin settings, not filesystem
+
+**Decision**: Global footer config lives in five admin settings keys: `mydash.footer_enabled`, `mydash.footer_html`, `mydash.footer_config`, `mydash.footer_background_color`, `mydash.footer_text_color`. Stored and retrieved via the existing `admin-settings` capability.
+
+**Alternatives considered:**
+
+- **Source's `{lang}/footer.json` filesystem-per-language pattern**: rejected because MyDash dashboards can be stored in either the database or a GroupFolder, so a filesystem path is not a universal anchor. Admin settings provide a single authoritative store regardless of the active storage backend.
+
+**Source evidence**:
+
+- `intravox-source/lib/Service/FooterService.php:81-168` — single global `footer.json` per language; no `pageId` argument.
+- `intravox-source/lib/Controller/FooterController.php` — `get()` and `save()` take no `pageId` or `uniqueId` parameter.
+- `intravox-source/lib/Service/PageService.php:564,1973` — `footer.json` at the language root explicitly excluded from page listings.
+
+**Rationale**: Admin settings is already the established pattern for MyDash instance-wide configuration. Reusing it keeps the bootstrap path simple, avoids filesystem permission complexity, and makes the footer values available via `IAppConfig` without mounting any GroupFolder.
+
+### D2: Per-dashboard override — MyDash addition
+
+**Decision**: Each dashboard MAY carry a footer override via two new columns on `oc_mydash_dashboards`: `dashboardFooterMode VARCHAR(16)` (values: `inherit`, `hidden`, `custom`; default `inherit`) and `dashboardFooterHtml MEDIUMTEXT NULL` (populated only when mode is `custom`). When mode is `inherit`, the dashboard renders the global footer. When `hidden`, no footer renders. When `custom`, the dashboard's own HTML renders (sanitised identically to global HTML).
+
+**Source evidence**: None — this is entirely a MyDash addition. The source has no per-page footer concept.
+
+**Rationale**: Branded landing dashboards and departmental dashboards often need different footer identities. Storing the override on the dashboard row keeps the resolution logic local to `DashboardService::resolveEffectiveFooter()` and avoids a separate override table. The invariant (mode=`custom` requires non-NULL, non-empty HTML; all other modes require NULL) is enforced at the service layer.
+
+### D3: Multi-language fallback — viewer NC locale → dashboard primary language → first key
+
+**Decision**: When footer content (HTML mode or structured mode fields) is a language-tagged map (`{en: "...", nl: "..."}`), the render selects the variant by:
+
+1. Viewer's NC locale, retrieved via `getUserValue($uid, 'core', 'lang')`.
+2. Dashboard's primary language variant (per the `dashboard-language-content` capability's `primaryLanguage` field), if the viewer's locale is absent from the map.
+3. First key in the map, if neither of the above yields a match.
+
+**Rationale**: The footer is read by the viewer, so the viewer's own locale is the strongest signal. Falling through to the dashboard's primary language handles the common case where a mono-lingual dashboard was authored in one language and the viewer's locale is simply not present in a partially-translated footer. First-key fallback gives deterministic output over an arbitrary locale miss.
+
+### D4: HTML sanitisation — shared allow-list with text-display widget
+
+**Decision**: HTML-mode footer content and per-dashboard `dashboardFooterHtml` both pass through the same allow-list used by the text-display widget: `<a>` (href only), `<p>`, `<strong>`, `<em>`, `<br>`, `<ul>`, `<ol>`, `<li>`, `<img>` (src only, no `srcset`, no `onerror`, no data URIs). External `<a>` tags automatically receive `rel="noopener noreferrer"`. All other tags and attributes are stripped before storage.
+
+**Rationale**: Using one canonical allow-list prevents the two surfaces from drifting apart and avoids duplication of sanitisation logic. The footer allow-list is intentionally not extended with `<table>` or `<div>` — layout is left to the structured config's columns/inline modes.
+
+### D5: Print stylesheet — footer prints by default
+
+**Decision**: The `DashboardFooter.vue` component does not apply `display: none` in `@media print`. The footer participates in NC's print stylesheet and appears in PDF exports of a dashboard.
+
+**Source evidence**: No explicit print handling found in the source footer implementation — this is a MyDash addition.
+
+**Rationale**: Organizations printing or exporting dashboards for archiving or compliance typically need the footer (copyright, legal disclaimers, contact) to appear in the export. Opt-out printing would require admins to discover a non-obvious CSS override.
+
+### D6: Theme awareness — NC variables with optional hex overrides
+
+**Decision**: Footer background and text colours follow NC theme CSS variables (`--color-main-background`, `--color-main-text`) by default. If `mydash.footer_background_color` or `mydash.footer_text_color` are set (valid CSS hex strings), those override the theme variables inline on the root footer element.
+
+**Rationale**: Theme-first keeps the footer consistent with NC's dark/high-contrast modes without additional work. Per-instance overrides allow organizations with strict brand colour requirements to pin exact hex values without needing a custom NC theme.
+
+### D7: Off by default
+
+**Decision**: `mydash.footer_enabled` defaults to `false`. A fresh MyDash installation renders no footer until an admin explicitly enables it via the admin settings UI or API.
+
+**Rationale**: An empty or placeholder footer on day one is visually awkward and may confuse end users. Defaulting to off means the footer only appears once the admin has configured meaningful content, matching the principle of safe defaults across MyDash admin settings.
+
+## Spec Changes Implied
+
+- **REQ-FTR-001** (storage): add a NOTE confirming that `footer_enabled` and companion keys live in admin settings, not in the source's `{lang}/footer.json` filesystem pattern, and cite D1.
+- **REQ-FTR-006** (per-dashboard override): add a NOTE marking this requirement as a MyDash addition with no source counterpart, citing D2. Confirm storage as `dashboardFooterMode VARCHAR(16)` + `dashboardFooterHtml MEDIUMTEXT NULL` on `oc_mydash_dashboards`.
+- **REQ-FTR-007** (multi-language): pin the three-step fallback chain from D3 (viewer NC locale → dashboard primary language → first key). Update the "Locale fallback" scenario to reflect step 2 before step 3.
+- **REQ-FTR-005** (sanitisation): add a cross-reference to the text-display widget's allow-list to make the shared definition explicit; note that the footer does not extend the list with `<table>` or `<div>`.
+
+## Open Follow-ups
+
+- Whether `dashboardFooterHtml` should support language-tagged variants (`{en: "...", nl: "..."}`) — likely yes, using the same shape as global config; deferred to a follow-up to keep the initial schema simple.
+- Whether the structured-mode `logoUrl` field should accept NC file-ID references (e.g., `fileId:12345`) in addition to plain URLs — this would align with the `header-widget`'s `backgroundImageFileId` pattern.
+- Whether the public-share render path includes the footer — the expected answer is yes (preserves branding for external viewers), but this depends on the `dashboard-public-share` capability's rendering context and should be confirmed before implementation.

--- a/openspec/changes/footer-customization/proposal.md
+++ b/openspec/changes/footer-customization/proposal.md
@@ -1,0 +1,65 @@
+# Footer Customization
+
+## Why
+
+MyDash currently has no branded footer mechanism. Organizations need to display copyright, legal links, contact information, and custom branding (logos, organization name, address) below the dashboard content. Without a configurable footer, instances lack a professional closure and legal disclaimers, forcing admins to inject HTML at the reverse-proxy level or rely on Nextcloud theme customizations that don't directly integrate with the dashboard surface.
+
+## What Changes
+
+- Add two global admin settings: `mydash.footer_enabled` (boolean, default `false`) and `mydash.footer_html` (sanitised HTML string, max 8KB).
+- Add structured configuration alternative: `mydash.footer_config` (JSON object) with schema `{logoUrl?, organisation?, address?, links: [{label, url}]?, legal?, copyrightYear?, layoutMode: 'columns'|'inline'}` — use when admin prefers form-based input over raw HTML.
+- Add admin UI in MyDash settings: tabbed "HTML Mode" vs "Structured Mode" with live preview.
+- Add Vue 3 SFC `DashboardFooter.vue` mounted by `App.vue` below the dashboard grid. Renders nothing when `footer_enabled = false`.
+- HTML sanitisation: allow `<a>`, `<p>`, `<strong>`, `<em>`, `<br>`, `<ul>`, `<ol>`, `<li>`, `<img>` (src-only); strip everything else; force `rel="noopener noreferrer"` on external links.
+- Structured mode rendering: `columns` layout = 3-column flex grid (logo+org / address / links+legal); `inline` layout = single row with separators.
+- Per-dashboard override: dashboard owner MAY set `dashboardFooterMode: 'inherit'|'hidden'|'custom'` on their dashboard object. `inherit` = use global; `hidden` = no footer; `custom` = render dashboard's own `dashboardFooterHtml` field (sanitised identically).
+- Print support: footer prints in PDFs (survives export).
+- Theme awareness: footer text + background colours follow NC theme variables; admin MAY override with `mydash.footer_background_color` and `mydash.footer_text_color` settings.
+- Multi-language support: HTML/structured config MAY contain language-tagged variants `{en: "...", nl: "..."}`. Render picks matching variant based on viewer's NC locale; falls back to first key if no match.
+
+## Capabilities
+
+### New Capabilities
+
+- `footer-customization` — standalone capability covering all footer configuration, rendering, and override mechanisms.
+
+### Modified Capabilities
+
+- `dashboards` — extends with per-dashboard footer mode and HTML field (`dashboardFooterMode`, `dashboardFooterHtml`), but no breaking changes to existing REQ-DASH-001..010.
+
+## Impact
+
+**Affected code:**
+
+- `lib/Db/AdminSettings.php` — add three new settings keys + getter/setter chain
+- `lib/Db/Dashboard.php` — add `dashboardFooterMode` and `dashboardFooterHtml` fields (nullable, entity layer)
+- `lib/Service/AdminSettingsService.php` — getters/setters for footer settings, HTML sanitisation logic
+- `lib/Service/DashboardService.php` — inherit footer config on dashboard mutations (override precedence logic)
+- `lib/Controller/AdminSettingsController.php` — new endpoints to read/write footer settings
+- `lib/Migration/VersionXXXXDate2026...AddFooterColumns.php` — schema migration
+- `src/components/DashboardFooter.vue` — new SFC, columns/inline layout rendering, language variant selection
+- `src/views/App.vue` — mount DashboardFooter below grid
+- `src/views/AdminSettings.vue` — extend with footer tab (HTML/structured mode selector, live preview)
+- `src/stores/dashboards.js` — track footer config in store state
+- `appinfo/routes.php` — register new admin footer endpoints
+
+**Affected APIs:**
+
+- 2 new admin endpoints: `GET|PUT /api/admin/footer-settings` (auth: admin)
+- Existing `GET|PUT /api/dashboard/{uuid}` extended to include `dashboardFooterMode` and `dashboardFooterHtml` fields (backward compatible)
+
+**Dependencies:**
+
+- `OCP\Constants::HTML5` or similar; otherwise custom sanitiser (no new composer/npm deps)
+- Nextcloud theme CSS variable access (already available)
+
+**Migration:**
+
+- Zero-impact: schema adds nullable columns; no backfill needed. Existing dashboards get `dashboardFooterMode = 'inherit'` and `dashboardFooterHtml = NULL` by default.
+
+## Risks
+
+- **Injection vector**: unsanitised HTML from admin allows XSS. Mitigation: strict allowlist in sanitiser (no script, no event handlers, no data URIs).
+- **PDF rendering**: footer may not print correctly if CSS relies on modern layout (Grid, custom properties). Mitigation: test print output; use fallback inline styles.
+- **Locale fallback**: if user locale is not present in language variants, which key is picked? Mitigation: explicit ordering (first key is fallback).
+- **Performance**: rendering three-column layout may cause reflow. Mitigation: lazy-load footer; use CSS containment.

--- a/openspec/changes/footer-customization/specs/footer-customization/spec.md
+++ b/openspec/changes/footer-customization/specs/footer-customization/spec.md
@@ -1,0 +1,389 @@
+---
+status: draft
+---
+
+# Footer Customization Specification
+
+## Purpose
+
+Footer Customization provides per-instance branding, legal disclaimers, and contact information rendered below the dashboard surface. Administrators configure global footer content (HTML or structured form), with optional per-dashboard overrides. The footer respects theme colors, supports multi-language variants, and prints correctly in PDF exports.
+
+## Data Model
+
+### Admin Footer Settings (oc_mydash_admin_settings extended)
+
+Settings are stored as key-value pairs:
+- **footer_enabled**: Boolean (default: `false`) — global master toggle
+- **footer_html**: String, max 8KB (default: empty) — raw HTML mode; sanitised server-side
+- **footer_config**: JSON object (default: empty) — structured mode; schema `{logoUrl?, organisation?, address?, links: [{label, url}]?, legal?, copyrightYear?, layoutMode: 'columns'|'inline'}`
+- **footer_background_color**: Nullable hex string (default: NULL) — override background colour; falls back to theme variable
+- **footer_text_color**: Nullable hex string (default: NULL) — override text colour; falls back to theme variable
+
+Each footer setting MAY contain language-tagged variants as a nested map: `{en: "...", nl: "..."}`. Render logic selects matching viewer locale; falls back to first key if no match.
+
+### Dashboard Footer Fields (oc_mydash_dashboards extended)
+
+Extend `oc_mydash_dashboards` table with:
+- **dashboardFooterMode**: VARCHAR(16), default `'inherit'` — values: `inherit`, `hidden`, `custom`
+- **dashboardFooterHtml**: LONGTEXT, nullable — dashboard-specific footer HTML (only used if mode='custom'); sanitised identically to global HTML
+
+Invariant: if `dashboardFooterMode = 'custom'`, then `dashboardFooterHtml` MUST be non-NULL and non-empty after trim. If mode is `inherit` or `hidden`, `dashboardFooterHtml` MUST be NULL.
+
+## ADDED Requirements
+
+### Requirement: REQ-FTR-001 Global Footer Enable/Disable
+
+Administrators MUST be able to globally enable or disable the footer on all dashboards via the `footer_enabled` setting.
+
+#### Scenario: Footer disabled by default
+- GIVEN a fresh MyDash installation
+- WHEN any user views a dashboard
+- THEN the footer MUST NOT be rendered
+- AND `footer_enabled` MUST default to `false` in the settings table
+
+#### Scenario: Admin enables footer
+- GIVEN the admin sets `footer_enabled = true` via `PUT /api/admin/footer-settings`
+- WHEN a user views a dashboard
+- THEN the footer MUST be rendered (assuming no per-dashboard override = `hidden`)
+- AND the change MUST take effect immediately on next page load
+
+#### Scenario: Disabling footer hides it everywhere
+- GIVEN `footer_enabled = true` and footers are visible on all dashboards
+- WHEN the admin sets `footer_enabled = false`
+- THEN all dashboards MUST hide the footer
+- AND per-dashboard custom footers (mode='custom') are exempted: they MUST still render
+
+#### Scenario: Non-admin cannot toggle footer
+- GIVEN a regular user "alice"
+- WHEN she sends `PUT /api/admin/footer-settings` with body `{"footerEnabled": false}`
+- THEN the system MUST return HTTP 403 (Forbidden)
+- AND no setting MUST be modified
+
+### Requirement: REQ-FTR-002 HTML Mode — Raw HTML Input and Sanitisation
+
+Administrators MUST be able to provide raw HTML for the footer, which is sanitised server-side before storage and rendering.
+
+#### Scenario: Admin provides valid HTML
+- GIVEN the admin sends `PUT /api/admin/footer-settings` with `{"footerHtml": "<p>Copyright 2026</p>"}`
+- WHEN the setting is stored
+- THEN the HTML MUST be sanitised: allowed tags (`<a>`, `<p>`, `<strong>`, `<em>`, `<br>`, `<ul>`, `<ol>`, `<li>`, `<img>`) pass through; all others stripped
+- AND the footer MUST render with the sanitised HTML when `footer_enabled = true`
+
+#### Scenario: HTML injection attempt blocked
+- GIVEN the admin sends `{"footerHtml": "<p onclick='alert()'>Click me</p>"}`
+- WHEN the setting is stored
+- THEN the `onclick` attribute MUST be stripped
+- AND the stored result MUST be sanitised to `<p>Click me</p>`
+
+#### Scenario: Script tag stripped
+- GIVEN the admin sends `{"footerHtml": "<p>Text <script>alert('xss')</script> here</p>"}`
+- WHEN the setting is stored
+- THEN the `<script>` tag and its content MUST be removed entirely
+- AND the result MUST be sanitised to `<p>Text  here</p>`
+
+#### Scenario: External links get rel attribute
+- GIVEN the admin sends `{"footerHtml": "<a href='https://example.com'>Link</a>"}`
+- WHEN the setting is stored
+- THEN the link MUST automatically have `rel="noopener noreferrer"` and `target="_blank"` added
+- AND the rendered HTML MUST include both attributes
+
+#### Scenario: Data URIs stripped from img
+- GIVEN the admin sends `{"footerHtml": "<img src='data:image/png;base64,...' />"}`
+- WHEN the setting is stored
+- THEN the `src` attribute MUST be stripped (data URIs not allowed)
+- AND the tag MUST either be removed or rendered as empty
+
+#### Scenario: Oversized HTML rejected
+- GIVEN the admin sends a footer HTML string of 9000 bytes (exceeds 8KB limit)
+- WHEN the `PUT /api/admin/footer-settings` is processed
+- THEN the system MUST return HTTP 413 (Payload Too Large)
+- AND the setting MUST NOT be updated
+
+#### Scenario: Allowed tags list enforcement
+- GIVEN the admin sends `{"footerHtml": "<div>Not allowed</div><p>Allowed</p>"}`
+- WHEN the setting is stored
+- THEN the `<div>` MUST be stripped (not in allowlist)
+- AND the `<p>` MUST be preserved
+- AND the result MUST be `Allowed paragraph text only`
+- NOTE: Allowed tags are: `<a>`, `<p>`, `<strong>`, `<em>`, `<br>`, `<ul>`, `<ol>`, `<li>`, `<img>` (src-only)
+
+### Requirement: REQ-FTR-003 Structured Mode — Form-Based Configuration
+
+Administrators MUST be able to configure footer content via a structured JSON schema, avoiding raw HTML.
+
+#### Scenario: Admin sets structured footer config
+- GIVEN the admin sends `PUT /api/admin/footer-settings` with:
+  ```json
+  {
+    "footerConfig": {
+      "logoUrl": "https://example.com/logo.png",
+      "organisation": "ACME Corp",
+      "address": "Main Street 123\n1234 AB Amsterdam",
+      "links": [{"label": "Privacy", "url": "https://example.com/privacy"}],
+      "legal": "All rights reserved",
+      "copyrightYear": 2026,
+      "layoutMode": "columns"
+    }
+  }
+  ```
+- WHEN the setting is stored
+- THEN the system MUST validate the schema (all keys match expected structure, no extra keys)
+- AND the JSON MUST be stored in `footer_config` setting
+
+#### Scenario: Structured config schema validation
+- GIVEN the admin sends a `footerConfig` with an unexpected key `"unknownField": "value"`
+- WHEN the `PUT /api/admin/footer-settings` is processed
+- THEN the system MUST reject the request with HTTP 400 (Bad Request)
+- AND the error message MUST indicate which keys are allowed
+
+#### Scenario: Partial structured config (optional fields)
+- GIVEN the admin sends `{"footerConfig": {"organisation": "ACME", "layoutMode": "inline"}}`
+- WHEN the setting is stored
+- THEN the system MUST accept the partial object (all fields except `organisation`, `layoutMode`, and `links` are optional)
+- AND the footer renderer MUST skip missing fields gracefully
+
+#### Scenario: Links array in structured config
+- GIVEN the admin sends `{"footerConfig": {"links": [{"label": "Privacy", "url": "https://..."}, {"label": "Contact", "url": "https://..."}]}}`
+- WHEN the setting is stored
+- THEN the links array MUST be stored as-is
+- AND the footer renderer MUST iterate the array and render each link with proper HTML anchors
+
+### Requirement: REQ-FTR-004 Footer Rendering — Global Content
+
+The footer MUST be rendered below the dashboard grid when enabled globally and not overridden at the dashboard level.
+
+#### Scenario: Footer renders with enabled global footer
+- GIVEN `footer_enabled = true` and `footer_html = "<p>Copyright 2026</p>"`
+- WHEN a user views a dashboard with `dashboardFooterMode = 'inherit'` (or NULL)
+- THEN the footer MUST appear below the dashboard grid
+- AND the content MUST be the stored `footer_html` text
+
+#### Scenario: Footer is not rendered when disabled
+- GIVEN `footer_enabled = false`
+- WHEN a user views any dashboard
+- THEN the footer MUST NOT be rendered
+- AND no footer element MUST be visible in the DOM
+
+#### Scenario: Footer renders structured content in columns layout
+- GIVEN `footer_config = {logoUrl: "...", organisation: "...", address: "...", links: [...], legal: "...", layoutMode: "columns"}`
+- WHEN a user views a dashboard
+- THEN the footer MUST render as a 3-column CSS grid:
+  - Column 1: logo image and organisation name
+  - Column 2: address text (split by newlines)
+  - Column 3: links list (ul/li) and legal text below
+- AND columns MUST be evenly spaced with gap of ~2rem
+
+#### Scenario: Footer renders structured content in inline layout
+- GIVEN `footer_config = {..., layoutMode: "inline"}`
+- WHEN a user views a dashboard
+- THEN the footer MUST render as a single horizontal row
+- AND items (logo, organisation, address, links, legal) MUST be separated by vertical bars or dots (CSS ::before pseudo-element)
+- AND the row MUST wrap on narrow screens (mobile-responsive)
+
+### Requirement: REQ-FTR-005 HTML Sanitisation Rules
+
+HTML MUST be sanitised according to a strict allowlist before storage and rendering.
+
+#### Scenario: Sanitiser strips forbidden attributes
+- GIVEN input HTML: `<p class='danger' data-value='test'>Text</p>`
+- WHEN sanitised
+- THEN the `class` and `data-value` attributes MUST be stripped
+- AND the result MUST be `<p>Text</p>`
+
+#### Scenario: Style attributes not allowed
+- GIVEN input: `<p style='color: red;'>Text</p>`
+- WHEN sanitised
+- THEN the `style` attribute MUST be stripped
+- AND the result MUST be `<p>Text</p>`
+
+#### Scenario: Images with src-only
+- GIVEN input: `<img src='https://example.com/logo.png' alt='logo' />`
+- WHEN sanitised
+- THEN the `src` attribute MUST be preserved
+- AND the `alt` attribute MUST be stripped (not in allowlist)
+- AND the result MUST be `<img src='https://example.com/logo.png' />`
+
+#### Scenario: Nested tags
+- GIVEN input: `<strong><em>Bold and italic</em></strong>`
+- WHEN sanitised
+- THEN both tags MUST be preserved (both are allowed)
+- AND nesting MUST work correctly
+- NOTE: Do NOT strip nesting; allow reasonable HTML structure
+
+### Requirement: REQ-FTR-006 Per-Dashboard Footer Override
+
+Dashboard owners MUST be able to override the global footer on their own dashboard using three modes: inherit (global), hidden (no footer), or custom (dashboard-specific HTML).
+
+#### Scenario: Dashboard with inherit mode (default)
+- GIVEN a dashboard with `dashboardFooterMode = 'inherit'` (or NULL)
+- WHEN `footer_enabled = true` globally with `footer_html = "..."` 
+- THEN the dashboard MUST render the global footer
+- AND the dashboard's own `dashboardFooterHtml` field MUST be ignored (must be NULL)
+
+#### Scenario: Dashboard with hidden mode
+- GIVEN a dashboard with `dashboardFooterMode = 'hidden'`
+- WHEN `footer_enabled = true` globally
+- THEN the dashboard MUST NOT render any footer
+- AND the footer MUST be hidden even though global footer is enabled
+
+#### Scenario: Dashboard with custom mode
+- GIVEN a dashboard with `dashboardFooterMode = 'custom'` and `dashboardFooterHtml = "<p>Custom footer</p>"`
+- WHEN any user views the dashboard
+- THEN the dashboard MUST render the custom footer (NOT the global footer)
+- AND the custom HTML MUST be sanitised identically to global HTML
+
+#### Scenario: Custom mode requires HTML
+- GIVEN the dashboard owner sends `PUT /api/dashboard/{uuid}` with `dashboardFooterMode = 'custom'` but no `dashboardFooterHtml`
+- WHEN the request is processed
+- THEN the system MUST return HTTP 400
+- AND the error message MUST indicate that custom mode requires footer HTML
+
+#### Scenario: Mode change clears stale HTML
+- GIVEN a dashboard with `dashboardFooterMode = 'custom'` and `dashboardFooterHtml = "<p>Old footer</p>"`
+- WHEN the dashboard owner sends `PUT /api/dashboard/{uuid}` with `dashboardFooterMode = 'inherit'` (no `dashboardFooterHtml` in request)
+- THEN the system MUST update mode to `inherit`
+- AND the `dashboardFooterHtml` MUST be cleared to NULL
+- AND subsequent renders MUST use the global footer
+
+#### Scenario: Only dashboard owner can set custom footer
+- GIVEN a dashboard owned by "alice" with `dashboardFooterMode = 'view_only'` permission for user "bob"
+- WHEN "bob" sends `PUT /api/dashboard/{uuid}` with `dashboardFooterMode = 'custom'`
+- THEN the system MUST return HTTP 403 (Forbidden)
+- AND the setting MUST NOT be modified (only the owner can override)
+
+### Requirement: REQ-FTR-007 Multi-Language Support
+
+Footer content MUST support language-tagged variants. The footer renderer MUST select the matching variant based on the viewer's Nextcloud locale.
+
+#### Scenario: Single-language footer (default)
+- GIVEN `footer_html = "<p>Welcome</p>"` (plain string, not a map)
+- WHEN a user with NC locale `nl` views the dashboard
+- THEN the footer MUST render the plain HTML (no variant selection needed)
+
+#### Scenario: Language-tagged footer variants
+- GIVEN `footer_html = {en: "<p>Welcome</p>", nl: "<p>Welkom</p>"}`
+- WHEN a user with NC locale `nl` views the dashboard
+- THEN the footer MUST render the `nl` variant: `<p>Welkom</p>`
+
+#### Scenario: Locale fallback (no match)
+- GIVEN `footer_html = {en: "<p>English</p>", fr: "<p>Français</p>"}`
+- WHEN a user with NC locale `de` (no matching key) views the dashboard
+- THEN the footer MUST fall back to the first key in the map (language order is implementation-defined; typically `en`)
+
+#### Scenario: Language variants in structured config
+- GIVEN `footer_config = {organisation: {en: "ACME", nl: "ACME NL"}, layoutMode: "columns"}`
+- WHEN a user with NC locale `nl` views the dashboard
+- THEN the footer renderer MUST select the `nl` variant for the organisation field
+- AND the footer MUST display "ACME NL"
+
+#### Scenario: Admin i18n editor in settings UI
+- GIVEN the admin visits the footer settings tab
+- WHEN the admin sets `footer_html` as a language-tagged map
+- THEN the UI MUST show tabs for each language variant (e.g., "English", "Dutch")
+- AND the admin can edit and preview each variant independently
+- NOTE: This is a UI requirement; spec does not mandate exact UI behavior, only that variants can be configured and rendered correctly
+
+### Requirement: REQ-FTR-008 Print Support and CSS
+
+The footer MUST be visible and properly styled when the dashboard is exported to PDF or printed.
+
+#### Scenario: Footer prints in PDF
+- GIVEN a dashboard with `footer_enabled = true` and `footer_html = "<p>Copyright 2026</p>"`
+- WHEN a user prints the dashboard to PDF (via browser print dialog)
+- THEN the footer MUST appear on the PDF output
+- AND the footer styling MUST be printer-friendly (no fixed positioning, readable in grayscale)
+
+#### Scenario: Print-specific CSS
+- GIVEN the DashboardFooter component has a `@media print { ... }` rule
+- WHEN the page is printed
+- THEN the footer MUST be visible and properly formatted
+- AND background colours and images MUST render in the PDF (if color printing is enabled)
+
+#### Scenario: Footer does not break layout on print
+- GIVEN a dashboard with content that fills the page and a footer below
+- WHEN printed to PDF
+- THEN the footer MUST not push content off the page; it MUST be on a new page or bottom of the current page
+- AND page breaks MUST not cause the footer to be duplicated
+
+### Requirement: REQ-FTR-009 Theme Awareness and Color Customisation
+
+The footer MUST use Nextcloud theme colors by default, with optional admin override via color settings.
+
+#### Scenario: Footer inherits theme colors
+- GIVEN `footer_background_color = NULL` and `footer_text_color = NULL` (not overridden)
+- WHEN the page renders with NC theme (e.g., dark theme)
+- THEN the footer background MUST use the NC theme's primary background colour (CSS var `--primary-background-color`)
+- AND the footer text MUST use the NC theme's primary text colour (CSS var `--primary-text-color`)
+
+#### Scenario: Admin overrides footer colors
+- GIVEN the admin sets `footer_background_color = "#1a1a1a"` and `footer_text_color = "#ffffff"`
+- WHEN the page renders
+- THEN the footer background MUST be `#1a1a1a`
+- AND the footer text MUST be `#ffffff`
+- AND the theme colours MUST be ignored in favor of the overrides
+
+#### Scenario: Color override fallback
+- GIVEN `footer_background_color = "#1a1a1a"` and `footer_text_color = NULL`
+- WHEN the page renders
+- THEN the background MUST be `#1a1a1a`
+- AND the text MUST fall back to the NC theme's primary text colour (override only applies to background, text is theme-driven)
+
+#### Scenario: Invalid color values rejected
+- GIVEN the admin sends `PUT /api/admin/footer-settings` with `{"footerBackgroundColor": "not-a-color"}`
+- WHEN the request is processed
+- THEN the system MUST return HTTP 400
+- AND the error message MUST indicate that color values must be valid hex strings
+
+### Requirement: REQ-FTR-010 API Endpoints
+
+The system MUST provide two new admin-only API endpoints to manage footer settings.
+
+#### Scenario: Get footer settings
+- GIVEN an admin user
+- WHEN she sends `GET /api/admin/footer-settings`
+- THEN the system MUST return HTTP 200 with a JSON object:
+  ```json
+  {
+    "footerEnabled": true,
+    "footerHtml": "...",
+    "footerConfig": {...},
+    "footerBackgroundColor": "#...",
+    "footerTextColor": "#..."
+  }
+  ```
+- AND all five keys MUST be present in the response
+
+#### Scenario: Update footer settings
+- GIVEN an admin user
+- WHEN she sends `PUT /api/admin/footer-settings` with body:
+  ```json
+  {
+    "footerEnabled": true,
+    "footerHtml": "<p>New content</p>"
+  }
+  ```
+- THEN the system MUST update the two settings
+- AND the response MUST return HTTP 200 with `{"status": "ok"}` (simple success response)
+- AND untouched settings (not in the PATCH) MUST retain their previous values
+
+#### Scenario: Non-admin rejects GET
+- GIVEN a regular user "alice"
+- WHEN she sends `GET /api/admin/footer-settings`
+- THEN the system MUST return HTTP 403 (Forbidden)
+- AND the response body MUST NOT expose any footer settings
+
+#### Scenario: Non-admin rejects PUT
+- GIVEN a regular user "alice"
+- WHEN she sends `PUT /api/admin/footer-settings` with any body
+- THEN the system MUST return HTTP 403 (Forbidden)
+- AND no setting MUST be modified
+
+#### Scenario: Dashboard API returns effective footer
+- GIVEN a user requests `GET /api/dashboard/{uuid}`
+- WHEN the response is returned
+- THEN the dashboard object MUST include:
+  - `dashboardFooterMode` (string: `inherit`, `hidden`, or `custom`)
+  - `dashboardFooterHtml` (nullable string)
+- AND if the dashboard has an active global footer or custom override, an optional `effectiveFooter` field MAY be included with the resolved footer content
+- NOTE: The `effectiveFooter` field is optional for API backward compatibility; recommended but not strictly required
+

--- a/openspec/changes/footer-customization/specs/footer-customization/spec.md
+++ b/openspec/changes/footer-customization/specs/footer-customization/spec.md
@@ -35,6 +35,8 @@ Invariant: if `dashboardFooterMode = 'custom'`, then `dashboardFooterHtml` MUST 
 
 Administrators MUST be able to globally enable or disable the footer on all dashboards via the `footer_enabled` setting.
 
+> NOTE (MyDash vs source — D1): The source application stores footer content as a single per-language file (`{lang}/footer.json`) on the filesystem. MyDash deliberately departs from this pattern: all five footer settings (`footer_enabled`, `footer_html`, `footer_config`, `footer_background_color`, `footer_text_color`) are stored as admin settings keys, not in the filesystem. This is because MyDash dashboards may be backed by either the database or a GroupFolder; a filesystem-only path is not a universal anchor. Admin settings provide a single authoritative store regardless of the active storage backend (source-confirmed: `FooterService.php:81-168` takes no `pageId` argument and operates on one global footer per language).
+
 #### Scenario: Footer disabled by default
 - GIVEN a fresh MyDash installation
 - WHEN any user views a dashboard
@@ -184,6 +186,8 @@ The footer MUST be rendered below the dashboard grid when enabled globally and n
 
 HTML MUST be sanitised according to a strict allowlist before storage and rendering.
 
+> NOTE (shared allow-list — D4): The sanitisation allow-list used for footer HTML is the same list used by the text-display widget — it is a single canonical definition, not duplicated. This means the footer allow-list is intentionally narrow: `<a>` (href only), `<p>`, `<strong>`, `<em>`, `<br>`, `<ul>`, `<ol>`, `<li>`, `<img>` (src only, no `srcset`, no `onerror`, no data URIs). Layout tags `<table>` and `<div>` are NOT added to the footer allow-list; layout is provided by the structured config's `layoutMode` field instead. External `<a>` tags automatically receive `rel="noopener noreferrer"`.
+
 #### Scenario: Sanitiser strips forbidden attributes
 - GIVEN input HTML: `<p class='danger' data-value='test'>Text</p>`
 - WHEN sanitised
@@ -213,6 +217,8 @@ HTML MUST be sanitised according to a strict allowlist before storage and render
 ### Requirement: REQ-FTR-006 Per-Dashboard Footer Override
 
 Dashboard owners MUST be able to override the global footer on their own dashboard using three modes: inherit (global), hidden (no footer), or custom (dashboard-specific HTML).
+
+> NOTE (MyDash addition — D2): This entire requirement is a MyDash-original feature with no counterpart in the source. The source application has no per-page footer concept; `FooterController.php` `get()` and `save()` accept no `pageId` or `uniqueId` parameter, and `PageService.php` explicitly excludes `footer.json` from page listings. The two new columns (`dashboardFooterMode VARCHAR(16)` default `'inherit'`, `dashboardFooterHtml MEDIUMTEXT NULL`) are stored on `oc_mydash_dashboards`. Write permission for the override is controlled by dashboard ownership (not GroupFolder ACL — the source's `$languageFolder->isUpdateable()` ACL pattern does not apply here because MyDash write permission is governed by the `admin-roles` capability for global settings and dashboard ownership for per-dashboard fields).
 
 #### Scenario: Dashboard with inherit mode (default)
 - GIVEN a dashboard with `dashboardFooterMode = 'inherit'` (or NULL)
@@ -253,7 +259,13 @@ Dashboard owners MUST be able to override the global footer on their own dashboa
 
 ### Requirement: REQ-FTR-007 Multi-Language Support
 
-Footer content MUST support language-tagged variants. The footer renderer MUST select the matching variant based on the viewer's Nextcloud locale.
+Footer content MUST support language-tagged variants. The footer renderer MUST select the matching variant using a three-step fallback chain (D3):
+
+1. Viewer's NC locale, retrieved via `getUserValue($uid, 'core', 'lang')`.
+2. Dashboard's primary language (the `primaryLanguage` field from the `dashboard-language-content` capability), if the viewer's locale key is absent from the variant map.
+3. First key in the variant map, if neither step 1 nor step 2 yields a match.
+
+> NOTE (source-confirmed fallback — D3): The source application stores a single `footer.json` per language root with no multi-language variant map inside it. The three-step fallback chain above is therefore a MyDash addition. Steps 1–3 are the authoritative resolution order; implementations MUST NOT skip step 2 and fall directly to step 3.
 
 #### Scenario: Single-language footer (default)
 - GIVEN `footer_html = "<p>Welcome</p>"` (plain string, not a map)
@@ -265,10 +277,21 @@ Footer content MUST support language-tagged variants. The footer renderer MUST s
 - WHEN a user with NC locale `nl` views the dashboard
 - THEN the footer MUST render the `nl` variant: `<p>Welkom</p>`
 
-#### Scenario: Locale fallback (no match)
+#### Scenario: Locale fallback — step 2 then step 3
 - GIVEN `footer_html = {en: "<p>English</p>", fr: "<p>Français</p>"}`
-- WHEN a user with NC locale `de` (no matching key) views the dashboard
-- THEN the footer MUST fall back to the first key in the map (language order is implementation-defined; typically `en`)
+- AND the dashboard has `primaryLanguage = "fr"` (from the `dashboard-language-content` capability)
+- WHEN a user with NC locale `de` (no matching key in the map) views the dashboard
+- THEN the footer MUST first check step 2: the dashboard's primary language (`fr`) IS present in the map
+- AND the footer MUST render the `fr` variant: `<p>Français</p>`
+- NOTE: Step 3 (first-key fallback) is only reached when BOTH the viewer's locale (step 1) AND the dashboard's primary language (step 2) are absent from the variant map
+
+#### Scenario: Locale fallback — step 3 (first key)
+- GIVEN `footer_html = {fr: "<p>Français</p>", nl: "<p>Welkom</p>"}`
+- AND the dashboard has `primaryLanguage = "de"` (not present in the variant map)
+- WHEN a user with NC locale `ja` (also not present) views the dashboard
+- THEN step 1 (`ja`) misses, step 2 (`de`) misses
+- AND the footer MUST render the first key in the map: `<p>Français</p>`
+- AND the result MUST be deterministic (first key in insertion order)
 
 #### Scenario: Language variants in structured config
 - GIVEN `footer_config = {organisation: {en: "ACME", nl: "ACME NL"}, layoutMode: "columns"}`

--- a/openspec/changes/footer-customization/tasks.md
+++ b/openspec/changes/footer-customization/tasks.md
@@ -1,0 +1,158 @@
+# Tasks — footer-customization
+
+## 1. Schema migration
+
+- [ ] 1.1 Create `lib/Migration/VersionXXXXDate2026...AddFooterColumns.php` adding `dashboardFooterMode VARCHAR(16)` and `dashboardFooterHtml LONGTEXT` to `oc_mydash_dashboards`
+- [ ] 1.2 Add default constraint `dashboardFooterMode = 'inherit'` (all existing rows get this value)
+- [ ] 1.3 Add index on `dashboardFooterMode` for fast filtering if needed in future
+- [ ] 1.4 Confirm migration is reversible (drop columns in `postSchemaChange` rollback path)
+- [ ] 1.5 Run migration locally against sqlite, mysql, and postgres; verify schema applied cleanly each time
+
+## 2. Admin settings domain model
+
+- [ ] 2.1 Add three new settings keys to `AdminSettings` entity: `footer_enabled` (bool, default false), `footer_html` (string, max 8KB, default empty), `footer_config` (JSON, default empty object)
+- [ ] 2.2 Add theme override settings: `footer_background_color` (hex string, nullable) and `footer_text_color` (hex string, nullable)
+- [ ] 2.3 Each setting MUST have getter/setter in `AdminSettingsService` for consistent read/write
+
+## 3. Dashboard domain model
+
+- [ ] 3.1 Add `dashboardFooterMode` field to `Dashboard` entity: enum values `inherit`, `hidden`, `custom` (default: `inherit`)
+- [ ] 3.2 Add `dashboardFooterHtml` field to `Dashboard` entity (nullable LONGTEXT)
+- [ ] 3.3 Both fields MUST include getter/setter following Entity `__call` pattern (no named args)
+- [ ] 3.4 Update `Dashboard::jsonSerialize()` to include both fields in API responses
+
+## 4. HTML sanitisation layer
+
+- [ ] 4.1 Create `lib/Service/HtmlSanitiserService.php` that implements allowlist-based HTML sanitisation
+- [ ] 4.2 Allowed tags: `<a>` (href, title only), `<p>`, `<strong>`, `<em>`, `<br>`, `<ul>`, `<ol>`, `<li>`, `<img>` (src only)
+- [ ] 4.3 Force all `<a>` tags to have `rel="noopener noreferrer"` and `target="_blank"` on external URLs (scheme check: http, https)
+- [ ] 4.4 Strip all other tags, attributes, event handlers, data URIs, style attributes
+- [ ] 4.5 Max input size: 8192 bytes (reject oversized inputs with HTTP 413)
+- [ ] 4.6 PHPUnit test: sanitiser preserves allowed tags, strips forbidden ones, handles edge cases (nested tags, empty tags, malformed HTML)
+
+## 5. Admin settings endpoints + service layer
+
+- [ ] 5.1 Add `AdminSettingsService::getFooterSettings(): array` returning all five footer settings as flat object
+- [ ] 5.2 Add `AdminSettingsService::updateFooterSettings(array $patch): void` that validates/sanitises inputs before save
+- [ ] 5.3 In `updateFooterSettings()`, if `footer_html` is provided, pass it through `HtmlSanitiserService::sanitise()`
+- [ ] 5.4 If `footer_config` is provided, validate schema (keys match expected structure, no extra keys) before save
+- [ ] 5.5 Add controller method `AdminSettingsController::getFooterSettings()` mapped to `GET /api/admin/footer-settings` (admin-only)
+- [ ] 5.6 Add controller method `AdminSettingsController::updateFooterSettings()` mapped to `PUT /api/admin/footer-settings` (admin-only, calls service + sanitiser)
+- [ ] 5.7 Both endpoints MUST carry admin auth attribute (#[RequireUserRole] or equivalent); return HTTP 403 for non-admin
+- [ ] 5.8 Update `appinfo/routes.php` with both new routes
+
+## 6. Dashboard footer override logic
+
+- [ ] 6.1 In `DashboardService::updateDashboard()`, when `dashboardFooterMode` is set, validate it's one of `inherit`, `hidden`, `custom`
+- [ ] 6.2 If mode is `custom`, require `dashboardFooterHtml` to be present (non-null, non-empty after trim)
+- [ ] 6.3 If mode is `custom`, sanitise the provided `dashboardFooterHtml` via `HtmlSanitiserService`
+- [ ] 6.4 If mode is `inherit` or `hidden`, clear `dashboardFooterHtml` to NULL on save (to avoid stale data)
+- [ ] 6.5 Add `DashboardService::resolveFooterForDashboard(Dashboard $dashboard): ?array` that returns `{mode, html, colors}` or NULL if footer disabled
+  - If dashboard mode = `hidden`: return NULL
+  - If dashboard mode = `custom`: return `{mode: 'custom', html: sanitised dashboardFooterHtml, colors: ...}`
+  - If dashboard mode = `inherit` (or NULL): check global `footer_enabled`; if false return NULL; if true return `{mode: 'global', html: footer_html or rendered footer_config, colors: ...}`
+- [ ] 6.6 Propagate resolved footer to frontend via dashboard API response (new optional field `effectiveFooter`)
+
+## 7. Footer rendering component (Vue 3)
+
+- [ ] 7.1 Create `src/components/DashboardFooter.vue` SFC with props `{footer: Object, layoutMode: String}`
+- [ ] 7.2 If `footer` is null/undefined, render nothing (v-if guard)
+- [ ] 7.3 Parse language variants: if footer.html is an object (map), select variant matching user's NC locale (use `useI18n().locale.value`); fall back to first key if no match
+- [ ] 7.4 Render HTML mode: v-html directive on sanitised HTML (server-sanitised, but double-check client-side strip of any `<script>`)
+- [ ] 7.5 Render structured mode (layoutMode='columns' or 'inline'):
+  - **columns**: 3-column CSS grid (gap 2rem)
+    - Column 1: logo (img tag), organisation name
+    - Column 2: address (rendered as lines)
+    - Column 3: links list (ul/li with a tags), legal text
+  - **inline**: single row, items separated by vertical bar or dot (use CSS ::before pseudo-element)
+- [ ] 7.6 Apply theme-aware colours: use CSS custom properties --primary-text-color, --primary-background-color by default; if admin set overrides, use those (fallback to theme vars)
+- [ ] 7.7 Make footer sticky or absolutely positioned at page bottom (clarify UX: is it sticky or fixed-height section?)
+- [ ] 7.8 Add print stylesheet: `@media print { footer { ... } }` to ensure footer is visible in PDF exports
+
+## 8. Admin UI for footer settings
+
+- [ ] 8.1 Extend `src/views/AdminSettings.vue` with a new tab "Footer" alongside existing tabs
+- [ ] 8.2 Add toggle "Enable footer" (controls `footer_enabled` setting)
+- [ ] 8.3 Add tabs "HTML Mode" vs "Structured Mode" (controls which setting path is saved: `footer_html` vs `footer_config`)
+- [ ] 8.4 HTML Mode UI:
+  - Textarea for raw HTML (max 8KB)
+  - "Info" box showing allowed tags + sanitisation rules
+  - Live preview pane rendering the sanitised HTML
+- [ ] 8.5 Structured Mode UI:
+  - Form fields: Logo URL (input), Organisation (input), Address (textarea), Links (repeating rows: label/url pairs), Legal text (textarea), Copyright year (number input), Layout mode dropdown (columns/inline)
+  - Save button serialises to JSON and stores in `footer_config`
+  - Live preview pane showing rendered columns/inline layout with sample data
+- [ ] 8.6 Add "Color overrides" section: two color pickers for background and text (optional, labeled "Advanced")
+- [ ] 8.7 Multi-language support in UI:
+  - If `footer_html` or any `footer_config` field is a language-tagged object, show tabs for each language variant
+  - Allow editing en and nl variants separately
+  - Fallback indicator showing which language is the default
+- [ ] 8.8 Save button calls `PUT /api/admin/footer-settings` with sanitised payload
+- [ ] 8.9 On load, call `GET /api/admin/footer-settings` and populate UI accordingly
+
+## 9. Dashboard-level footer override UI
+
+- [ ] 9.1 Extend dashboard edit/settings form with a "Footer" section
+- [ ] 9.2 Add dropdown "Footer mode": inherit / hidden / custom
+- [ ] 9.3 If mode='custom', show textarea for dashboard-specific footer HTML
+- [ ] 9.4 When mode changes away from 'custom', clear the textarea (optional; suggest to user)
+- [ ] 9.5 Live preview of final footer (inherited or custom) below the form
+- [ ] 9.6 Save button includes `dashboardFooterMode` and `dashboardFooterHtml` in dashboard PATCH payload
+
+## 10. Frontend store wiring
+
+- [ ] 10.1 Extend `src/stores/dashboards.js` to cache footer settings from `GET /api/admin/footer-settings` in module state
+- [ ] 10.2 Add `footerSettings` getter that returns cached settings (with fallback to `{footer_enabled: false}`)
+- [ ] 10.3 Add `resolveFooterForDashboard(dashboard)` action that applies override logic (inherit → global, hidden → null, custom → dashboard HTML)
+- [ ] 10.4 When dashboard list is fetched, populate each dashboard's `effectiveFooter` from backend (or compute client-side if backend doesn't return it)
+- [ ] 10.5 Subscribe to settings changes: after `PUT /api/admin/footer-settings`, refresh cached footer state
+
+## 11. DashboardFooter mount in App.vue
+
+- [ ] 11.1 In `src/views/App.vue`, add `<DashboardFooter :footer="dashboardFooter" />` component below the main dashboard grid
+- [ ] 11.2 Bind `dashboardFooter` to store getter that returns effective footer for active dashboard
+- [ ] 11.3 Ensure DashboardFooter is mounted even on lazy-loaded dashboards (use watch or computed to track active dashboard UUID)
+
+## 12. i18n strings
+
+- [ ] 12.1 Add i18n keys for all new UI strings: "Enable footer", "HTML Mode", "Structured Mode", "Footer settings", "Logo URL", "Organisation name", "Address", "Links", "Legal text", "Copyright year", "Layout mode", "Color overrides", "Footer mode", "Inherit global footer", "Hide footer on this dashboard", "Custom footer for this dashboard", "Allowed HTML tags", "Sanitisation applied", etc.
+- [ ] 12.2 Provide translations for `nl` and `en` in `translationfiles/` or `i18n/` directory
+- [ ] 12.3 All error messages (oversize HTML, invalid schema, etc.) MUST have i18n keys in both languages
+
+## 13. PHPUnit tests
+
+- [ ] 13.1 `HtmlSanitiserServiceTest` — test allowlist enforcement, event handler stripping, external link rel-tagging
+- [ ] 13.2 `AdminSettingsServiceTest::testFooterSettingsRoundTrip` — save and retrieve footer settings, verify JSON encoding/decoding
+- [ ] 13.3 `AdminSettingsServiceTest::testFooterHtmlSanitisation` — confirm malicious input is stripped before save
+- [ ] 13.4 `DashboardServiceTest::testResolveFooterForDashboard` — test all mode combinations (inherit, hidden, custom with/without global enabled)
+- [ ] 13.5 `DashboardServiceTest::testDashboardFooterOverrideValidation` — mode must be one of three values; custom mode requires HTML; inherit/hidden clear HTML
+- [ ] 13.6 `AdminSettingsControllerTest` — auth enforcement (non-admin gets 403), valid/invalid payloads, size limits
+- [ ] 13.7 Dashboard API test: verify `dashboardFooterMode`, `dashboardFooterHtml`, `effectiveFooter` fields round-trip correctly
+
+## 14. End-to-end Playwright tests
+
+- [ ] 14.1 Admin user enables footer, sets HTML mode with sample content, verifies footer appears on dashboard
+- [ ] 14.2 Admin switches to structured mode, fills form (logo, org, address, links), verifies columns layout renders
+- [ ] 14.3 Admin sets footer_enabled = false, verifies footer disappears from dashboard
+- [ ] 14.4 Dashboard owner overrides footer with custom mode, edits text, verifies override is visible on their dashboard only
+- [ ] 14.5 Multi-language: admin sets en and nl variants, verify user sees correct language based on NC locale
+- [ ] 14.6 Print test: export dashboard to PDF, verify footer is included in PDF (manual or via headless browser screenshot)
+- [ ] 14.7 Theme awareness: change NC theme, verify footer colours respond to theme variables (or admin overrides if set)
+
+## 15. Quality gates
+
+- [ ] 15.1 `composer check:strict` (PHPCS, PHPMD, Psalm, PHPStan) passes — fix any pre-existing issues encountered along the way
+- [ ] 15.2 ESLint + Stylelint clean on all touched Vue/JS files
+- [ ] 15.3 Update OpenAPI spec / Postman collection with new endpoints
+- [ ] 15.4 All i18n keys for both nl and en (per i18n requirement)
+- [ ] 15.5 SPDX headers on every new PHP file (inside docblock per SPDX-in-docblock convention)
+- [ ] 15.6 Run all hydra gates locally before opening PR
+- [ ] 15.7 Verify no hardcoded "footer-customization" or "footer" feature-flag references; if toggling is needed, use generic mechanism (e.g., `footer_enabled` setting is the toggle, no separate feature flag)
+
+## 16. Documentation
+
+- [ ] 16.1 Add admin guide section to `.github/docs/` describing footer setup (HTML mode, structured mode, overrides, multi-language)
+- [ ] 16.2 Include screenshots of admin UI and live preview
+- [ ] 16.3 Note sanitisation rules and security best practices (e.g., avoid user-supplied URLs in structured mode)
+- [ ] 16.4 Document per-dashboard override feature and use cases
+

--- a/openspec/changes/groupfolder-storage-backend/design.md
+++ b/openspec/changes/groupfolder-storage-backend/design.md
@@ -1,0 +1,91 @@
+# Design — GroupFolder storage backend
+
+## Context
+
+MyDash is introducing a two-backend storage architecture (DB and GroupFolder) built directly on the pattern proven by the reference implementation, which uses a GroupFolder as its sole persistence layer. The reference implementation provides the ground truth for how a Nextcloud app should behave when its GroupFolder is unreachable, missing, or not yet set up.
+
+The critical open question is what happens when an administrator switches `mydash.content_storage` from one backend to the other without first running the one-time migration command. Half the dashboard records then live in the old backend while the new backend is active. Two strategies are possible: (a) hard-fail every read that misses in the new backend, or (b) transparently fall back to the old backend for reads.
+
+The reference implementation sheds light on this because it has exactly one backend and must deal with the same class of failure: GroupFolder unreachable, app uninstalled, or setup never completed. Its choices reveal the operational tradeoff between fail-closed safety and read continuity.
+
+A key structural fact from the reference app is that its `intravox_page_index` table stores only metadata — `unique_id`, `title`, `path`, `language`, `status`, `modified_at`, `parent_id`, `file_id` — and carries **no cached body/content**. The DB is never a content fallback; it is only a lookup index. Page bodies always require a live filesystem read. This is the architectural anchor for the decision below.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Pick exactly one behaviour for REQ-GFSB-009 and encode it in the spec with concrete scenarios.
+- Ensure the chosen behaviour is consistent with the reference app's fail-closed philosophy.
+- Document the specific conditions that trigger HTTP 503 vs. HTTP 404.
+
+**Non-Goals:**
+
+- Choosing a fallback strategy for **reads within a single backend** (e.g., locale fallback inside GroupFolderContentStorage — that is REQ-GFSB-004 and already partially resolved).
+- Designing the migration command itself (REQ-GFSB-008 is fully specced).
+- Changing any other requirement.
+
+## Decisions
+
+### D1: Backend-switch behaviour — hard-fail vs. dual-read
+
+**Decision**: **Hard-fail (option a).** When `mydash.content_storage` is switched to a new backend without running the migration, read operations for dashboards that exist only in the old backend MUST return HTTP 503 with error key `dashboard_content_storage_unavailable`. The API MUST NOT attempt to read from the inactive backend.
+
+**Alternatives considered:**
+
+- **Dual-read (option b)**: try the active backend, fall back to the inactive one if not found. Rejected because (1) it requires both backends to remain live and queryable at all times, making backend decommissioning impossible without data loss risk; (2) it makes the `exists()` semantics ambiguous — callers cannot know which backend holds the authoritative copy; (3) the reference app explicitly does not implement any cross-backend fallback even for its much simpler single-backend case.
+
+**Rationale**: The reference implementation's error handling is consistently fail-closed. When `getSharedFolder()` fails — because the GroupFolder is missing or the `groupfolders` app is uninstalled — the resulting exception propagates as HTTP 500 (internal server error) rather than silently degrading. The list endpoint is the one exception: it deliberately returns an empty array instead of an error when the folder is not found (`intravox-source/lib/Controller/ApiController.php:209-214`), but this is scoped to the *listing* operation only, where an empty result is semantically valid. Single-page reads throw the exception straight through to a 404/500. The reference app never attempts a cross-store lookup because it has nowhere else to look — but the design choice is clear: known-bad state surfaces immediately rather than being papered over.
+
+For MyDash the consequence is equally clear: an operator who switches backends without migrating has made an incomplete operational change. Surfacing HTTP 503 immediately is the correct signal — it is unambiguous, monitorable, and tells the operator exactly what to do (run the migration command). Silent dual-read would hide the incomplete migration indefinitely and could cause split-brain writes (new dashboards going to the new backend, old ones silently read from the old one, no indication that migration is needed).
+
+The `groupfolder_setup_required` distinction (GroupFolder app not installed vs. GroupFolder folder not yet created) also informs this: the reference app (`intravox-source/lib/Service/SetupService.php:79-89`) returns a typed error key (`groupfolders_app_not_enabled`) immediately — it does not substitute a different storage mechanism. MyDash should mirror this granularity.
+
+**Source evidence**:
+
+- `intravox-source/lib/Controller/ApiController.php:209-214` — listing endpoint catches `"IntraVox folder not found"` and returns `[]` rather than an error, but this is the list path only; all other endpoints propagate the exception as 404 or 500.
+- `intravox-source/lib/Service/PageService.php:441-445` — `getIntraVoxFolder()` throws a plain `\Exception("IntraVox folder not found…")` with no fallback; caller in `getPage()` maps it to HTTP 404 (`ApiController:258-263`).
+- `intravox-source/lib/Service/SetupService.php:79-89` — `setupSharedFolder()` returns `['success' => false, 'error' => 'groupfolders_app_not_enabled']` immediately when the app is absent; no alternative path attempted.
+- `intravox-source/lib/Service/SetupService.php:562-569` — `isSetupComplete()` is a boolean predicate (`try { getSharedFolder(); return true; } catch { return false; }`); callers treat `false` as a blocking condition (see `DemoDataService:570-572` which runs setup first, not a different content source).
+- `intravox-source/lib/Migration/Version001300Date20260420000000.php:25-76` — `intravox_page_index` schema: only `unique_id`, `title`, `path`, `language`, `status`, `modified_at`, `parent_id`, `file_id`. **No `body` or `content` column.** The DB is purely a metadata index; there is nothing to fall back to for content even if dual-read were desired.
+- `intravox-source/lib/Service/PermissionService.php:129-131` — **surprising exception**: when no GroupFolder is found, `calculatePermissions()` returns `PERMISSION_ALL` as a fallback ("Fallback if groupfolders not setup"). This is a deliberate open-door for pre-setup state, but it applies only to permission checks, not to content reads. Content reads have no equivalent fallback.
+
+### D2: Pre-setup hard-fail vs. auto-create on first GroupFolder write
+
+**Decision**: The GroupFolder backend MUST attempt auto-creation (`ensureMyDashGroupFolder()`) on the first write when no "MyDash" GroupFolder exists. It MUST NOT auto-create on reads. A read against a non-existent GroupFolder returns HTTP 503.
+
+**Rationale**: The reference app auto-creates its GroupFolder during the explicit `setupSharedFolder()` step (triggered via the repair step on install, `intravox-source/lib/Migration/SetupDemoData.php:34-48`). It does not auto-create on demand during page reads; `getSharedFolder()` throws if the folder does not exist. For writes the reference app delegates creation to the setup flow, not to the write path. MyDash will differ slightly because its GroupFolder backend can be activated by an admin mid-lifecycle rather than only at install. Putting `ensureMyDashGroupFolder()` in the write path (REQ-GFSB-003 already specifies this) matches the spirit of the reference implementation while accommodating the mid-lifecycle activation case.
+
+**Source evidence**:
+
+- `intravox-source/lib/Migration/SetupDemoData.php:34-48` — setup runs before any content operations; if it fails, the repair step returns early with a warning, not by falling back to a different store.
+- `intravox-source/lib/Service/SetupService.php:269-297` — `getSharedFolder()` throws `\Exception("Groupfolder '…' not accessible")` with no auto-create; auto-create is only in `setupSharedFolder()` → `createOrGetGroupfolderByName()`.
+
+### D3: Migration retention — delete DB copy after migration or keep it
+
+**Decision**: Keep DB records after migration (option B from REQ-GFSB-008's optional decision point). The migration command MUST NOT delete the source DB content. Deletion can be triggered by a separate `--prune-source` flag.
+
+**Rationale**: The reference app never destroys content on migration — its `migrateResourcesFolders()` and `migrateTemplatesFolders()` helpers only create new structures; they never delete old ones. Given that rolling back from GroupFolder to DB is as simple as flipping `mydash.content_storage` back, keeping DB records gives operators a zero-downtime rollback path. Destroying them would make rollback require restoring from backup.
+
+**Source evidence**:
+
+- `intravox-source/lib/Service/SetupService.php:625-703` — both migration helpers (`migrateResourcesFolders`, `migrateTemplatesFolders`) are purely additive; no removal of existing data after creating new structures.
+
+## Spec changes implied
+
+Changes to apply to `specs/groupfolder-storage-backend/spec.md`:
+
+1. **REQ-GFSB-009 Scenario 1 (database-backed dashboard readable during GroupFolder transition)**: Replace the "NOTE" text and the "decide during implementation" hedge with a firm ruling: the system MUST return HTTP 503 with `dashboard_content_storage_unavailable` when the active backend is GroupFolder and the requested dashboard does not exist in the GroupFolder (even if it exists in the DB). Remove the dual-read option from the scenario entirely.
+
+2. **REQ-GFSB-009 — add new scenario**: "Pre-switch migration required" — GIVEN `mydash.content_storage` is about to be switched AND dashboards exist in the current backend, the admin-facing error message in HTTP 503 responses MUST include a reference to the migration command (`mydash:storage:migrate-to-groupfolder`). This ensures the 503 is actionable, not just a raw failure.
+
+3. **REQ-GFSB-008 Scenario "Retention policy after migration"**: Change from open decision to resolved: option B (keep DB records). Add: the command MUST accept a `--prune-source` flag that, when passed, deletes the DB content for successfully migrated dashboards. The default (no flag) MUST NOT delete.
+
+4. **REQ-GFSB-003 — add scenario**: "GroupFolder auto-creation does not occur on read" — GIVEN the "MyDash" GroupFolder does not exist AND `mydash.content_storage = 'groupfolder'`, WHEN a read operation is attempted, THEN the system MUST return HTTP 503 without attempting to create the GroupFolder.
+
+5. **REQ-GFSB-005 Scenario "GroupFolders app becomes unavailable mid-operation"**: Remove the phrase "NOT silently fall back to the database backend" — this already aligns with the decision but the current wording implies fallback is a live option being rejected; after this design is applied, the wording should state the positive: "MUST throw `DashboardContentStorageException` propagated as HTTP 503."
+
+## Open follow-ups
+
+- **PermissionService `PERMISSION_ALL` fallback**: The reference app grants full permissions when no GroupFolder is found (`intravox-source/lib/Service/PermissionService.php:129-131`). This is an open-door for pre-setup state. MyDash's `PermissionService` equivalent should explicitly NOT grant full permissions when the GroupFolder backend is configured but the GroupFolder is missing — that state is HTTP 503 territory, not open-door territory. This is a design detail that needs a spec scenario under REQ-GFSB-005 or a new REQ-GFSB-011.
+
+- **Listing endpoint semantics during transition**: The reference app returns `[]` (empty array) for the page list when the folder is not found. Should MyDash's `GET /api/dashboards` (or `/visible`) return `[]` or HTTP 503 when the active backend is GroupFolder but the folder is unreachable? The current spec says fail-closed (503) for all operations. The reference app makes a list-vs-detail distinction. A separate micro-decision is needed here before implementation starts.

--- a/openspec/changes/groupfolder-storage-backend/proposal.md
+++ b/openspec/changes/groupfolder-storage-backend/proposal.md
@@ -1,0 +1,73 @@
+# GroupFolder Storage Backend
+
+## Why
+
+Today MyDash dashboard content (widgets, layout, metadata) is stored exclusively in the database. This creates a scalability ceiling for large deployments and limits the ability to sync dashboard content across multiple Nextcloud instances or to back up dashboards as versioned files. Administrators need the option to store dashboard content in managed, versioned, access-controlled GroupFolders alongside other Nextcloud documents. This change abstracts the storage layer so dashboard content can transparently live in either the database (current default) or a dedicated GroupFolder (new option), with no changes to the dashboard API or user experience.
+
+## What Changes
+
+- Introduce a `DashboardContentStorage` interface with two implementations: `DbContentStorage` (current behaviour, default) and `GroupFolderContentStorage` (new).
+- Add an admin setting `mydash.content_storage` with values `db` (default) or `groupfolder`.
+- Auto-create a GroupFolder named "MyDash" on first GroupFolder-backed write or via explicit admin trigger, with ACL rules restricting access to intended dashboard members.
+- Persist each dashboard's content (widget tree, layout, metadata) as a single JSON file at `<MyDash>/<locale-or-empty>/<dashboard-uuid>.json`.
+- Read/write via Nextcloud's `IRootFolder` API — never direct filesystem paths.
+- Provide a one-time migration command `mydash:storage:migrate-to-groupfolder` that copies all existing dashboards from the DB to the GroupFolder, idempotent and safe to re-run.
+- Fail closed: if the GroupFolder backend is unreachable (deleted, ACL stripped), the API returns HTTP 503 with a clear error, never silently falling back.
+- Require the `groupfolders` Nextcloud app to be installed; surface a clear admin error if not available.
+
+## Capabilities
+
+### New Capabilities
+
+- `groupfolder-storage-backend`: abstraction layer for pluggable dashboard content storage, supporting database and managed-folder backends with automatic failover protection and migration tooling.
+
+### Modified Capabilities
+
+- `admin-settings`: adds one new setting key `mydash.content_storage` (enum: `db` or `groupfolder`, default `db`).
+- `dashboards`: no API changes; existing dashboard read/write endpoints transparently use the configured storage backend.
+
+## Impact
+
+**Affected code:**
+
+- `lib/Service/DashboardContentStorage/DashboardContentStorageInterface.php` — new interface defining `read()`, `write()`, `delete()` operations
+- `lib/Service/DashboardContentStorage/DbContentStorage.php` — refactored current DB logic into storage layer
+- `lib/Service/DashboardContentStorage/GroupFolderContentStorage.php` — new implementation for GroupFolder persistence
+- `lib/Service/DashboardContentStorageFactory.php` — factory that instantiates the correct backend based on admin setting
+- `lib/Service/DashboardService.php` — inject `DashboardContentStorageFactory`, call `getStorage()->read/write/delete()` instead of direct queries
+- `lib/Db/Dashboard.php` — content field becomes virtual (not persisted in DB for GroupFolder-backed dashboards); `jsonSerialize()` still returns it
+- `lib/Migration/VersionXXXXDate2026...php` — nullable migration: adds `groupfolder` app dependency check; does NOT alter existing schema
+- `lib/Command/MigrateStorageToGroupFolder.php` — new CLI command for one-time migration
+- `lib/Command/ToggleStorageSetting.php` — optional admin helper to change `mydash.content_storage` setting with validation
+- `appinfo/info.xml` — add `groupfolders` as a (soft) dependency; version bump
+- `src/stores/dashboards.js` — no changes (store already handles serialized content from API)
+
+**Affected APIs:**
+
+- `POST /api/dashboard` — transparently writes to the configured storage backend
+- `GET /api/dashboard/{uuid}` — transparently reads from the configured storage backend
+- `PUT /api/dashboard/{uuid}` — transparently updates the configured storage backend
+- `DELETE /api/dashboard/{uuid}` — transparently deletes from the configured storage backend
+- `GET /api/dashboards/visible` (if implemented from multi-scope-dashboards) — transparently reads from the configured backend
+
+**New CLI commands:**
+
+- `mydash:storage:migrate-to-groupfolder` — idempotent bulk migration from DB to GroupFolder
+- `mydash:storage:toggle-backend {db|groupfolder}` — change the admin setting (optional, for convenience)
+
+**Dependencies:**
+
+- `OCP\Files\IRootFolder` — already available in Nextcloud
+- `groupfolders` Nextcloud app — must be installed (checked at runtime; graceful error if missing)
+- No new composer or npm dependencies
+
+**Migration:**
+
+- Zero-impact by default — all existing dashboards remain in the DB (`mydash.content_storage = 'db'` is default).
+- Operators opt-in via the admin setting or the CLI migration command.
+- Idempotent: re-running the migration command is safe; it skips dashboards already in the GroupFolder.
+- Rollback: if an operator switches `mydash.content_storage` back to `db`, the DB records are still present (migration does not delete them).
+
+**Breaking changes:**
+
+- None — existing code and clients work unchanged.

--- a/openspec/changes/groupfolder-storage-backend/specs/groupfolder-storage-backend/spec.md
+++ b/openspec/changes/groupfolder-storage-backend/specs/groupfolder-storage-backend/spec.md
@@ -1,0 +1,375 @@
+---
+status: draft
+---
+
+# GroupFolder Storage Backend Specification
+
+## Purpose
+
+The GroupFolder Storage Backend is an abstraction layer that decouples dashboard content persistence from the database, enabling administrators to choose between database storage (current default) and managed GroupFolder storage (new option). This capability provides a scalable, versioned, and backup-friendly alternative for storing dashboard widget trees, layout configurations, and metadata, while maintaining complete backward compatibility with existing deployments.
+
+## Data Model
+
+Dashboard content storage is mediated by the `DashboardContentStorage` interface with two implementations:
+
+### DbContentStorage (Database Backend)
+
+Persists dashboard content in the `oc_mydash_dashboards` table:
+- **content**: JSON-encoded string containing the full widget tree, layout metadata, and display settings
+- **Backend**: reads from and writes directly to the dashboard entity via `DashboardMapper`
+- **Default**: used when `mydash.content_storage` admin setting is `'db'` or unset
+
+### GroupFolderContentStorage (Managed Folder Backend)
+
+Persists dashboard content as JSON files in a managed Nextcloud GroupFolder named "MyDash":
+- **File structure**: `MyDash/<locale-or-empty>/<dashboard-uuid>.json` (e.g., `MyDash/nl/abc123.json`)
+- **Locale**: optional; empty string or language code; allows future multi-language dashboard content separation
+- **Permissions**: GroupFolder ACL restricts access to administrators; dashboard-level permissions (from the `dashboards` capability) control user visibility
+- **Access**: via Nextcloud `IRootFolder` API, never direct filesystem paths
+- **Availability check**: runtime validation that the `groupfolders` app is installed; HTTP 503 error if not available
+
+### Admin Setting
+
+A single setting controls the active backend:
+- **Key**: `mydash.content_storage`
+- **Type**: string enum
+- **Valid values**: `'db'` (default) or `'groupfolder'`
+- **Behavior**: all read/write operations use the configured backend; existing dashboards remain readable in their original backend during a transition period
+
+## ADDED Requirements
+
+### Requirement: REQ-GFSB-001 Storage Interface Abstraction
+
+The system MUST provide a unified `DashboardContentStorage` interface that abstracts the physical storage mechanism from the dashboard service layer. The interface MUST define three core operations: read, write, and delete.
+
+#### Scenario: Read dashboard content from active backend
+
+- GIVEN a dashboard with UUID "dash-001" exists in the active storage backend
+- WHEN `DashboardService::getDashboard("dash-001")` is called
+- THEN the system MUST delegate to `getStorage()->read("dash-001")` to fetch the content
+- AND the content (widgets array, layout metadata) MUST be returned as a parsed PHP array
+- AND the HTTP response MUST include the full content in the `content` field
+
+#### Scenario: Write dashboard content to active backend
+
+- GIVEN a user creates or updates a dashboard with new widget placements
+- WHEN `DashboardService::createDashboard()` or `updateDashboard()` is called with a content array
+- THEN the system MUST delegate to `getStorage()->write(uuid, $content)` to persist the content
+- AND the operation MUST be idempotent (rewriting identical content produces no error)
+- AND the HTTP response MUST return HTTP 201 (create) or HTTP 200 (update)
+
+#### Scenario: Delete dashboard content from active backend
+
+- GIVEN a user deletes a dashboard
+- WHEN `DashboardService::deleteDashboard(uuid)` is called
+- THEN the system MUST delegate to `getStorage()->delete(uuid)` to remove the content
+- AND the dashboard entity MUST also be deleted from the database via the mapper
+- AND the HTTP response MUST return HTTP 204
+
+#### Scenario: Check existence without raising exception
+
+- GIVEN a dashboard UUID "unknown" does not exist in any backend
+- WHEN `getStorage()->exists("unknown")` is called
+- THEN the system MUST return `false` without raising an exception
+- AND the caller can use this for optional-read patterns
+
+### Requirement: REQ-GFSB-002 Database Backend Default Behavior
+
+The database backend MUST implement the storage interface using the existing `oc_mydash_dashboards` table, preserving all current behavior for operators who do not opt-in to GroupFolder storage.
+
+#### Scenario: Database backend is the default
+
+- GIVEN a fresh MyDash installation
+- AND no `mydash.content_storage` admin setting has been explicitly configured
+- WHEN any dashboard operation occurs
+- THEN the system MUST use `DbContentStorage` automatically
+- AND dashboard content MUST be read from and written to the `content` field in `oc_mydash_dashboards`
+- AND no GroupFolder dependency is invoked
+
+#### Scenario: Database backend reads existing dashboards
+
+- GIVEN the database contains a dashboard with UUID "dash-legacy" and content `{"widgets": [...]}`
+- WHEN `DbContentStorage::read("dash-legacy")` is called
+- THEN the system MUST fetch the dashboard entity via `DashboardMapper::findByUuid()`
+- AND the `content` field MUST be JSON-decoded and returned as a PHP array
+- AND the operation MUST not create a GroupFolder or depend on the `groupfolders` app
+
+#### Scenario: Database backend handles missing dashboard gracefully
+
+- GIVEN a dashboard UUID "dash-missing" does not exist in the database
+- WHEN `DbContentStorage::read("dash-missing")` is called
+- THEN the system MUST throw `DashboardNotFoundException` (extending `DashboardContentStorageException`)
+- AND the exception message MUST be descriptive and logged for debugging
+
+#### Scenario: Database backend writes and overwrites
+
+- GIVEN a dashboard entity exists in the database
+- WHEN `DbContentStorage::write(uuid, {"widgets": [...], "new": true})` is called
+- THEN the system MUST update the dashboard entity's `content` field
+- AND call `DashboardMapper::update()` to persist the change
+- AND rewriting with identical content MUST not raise an error
+
+### Requirement: REQ-GFSB-003 GroupFolder Backend Auto-Creation and ACL
+
+The GroupFolder backend MUST automatically create a managed GroupFolder named "MyDash" on first use, with restrictive ACL rules ensuring only administrators have file-level access.
+
+#### Scenario: GroupFolder is auto-created on first write
+
+- GIVEN the `mydash.content_storage` setting is `'groupfolder'`
+- AND no "MyDash" GroupFolder yet exists
+- WHEN `GroupFolderContentStorage::write(uuid, {...})` is called for the first time
+- THEN the system MUST create a GroupFolder named "MyDash" via the `groupfolders` app API
+- AND the GroupFolder MUST be created with ACL rules:
+  - Administrators: read, write, delete
+  - All other users: no default access (dashboard permissions mediate visibility)
+- AND the write operation MUST proceed to store the content in the newly created folder
+
+#### Scenario: Subsequent writes reuse existing GroupFolder
+
+- GIVEN the "MyDash" GroupFolder already exists with correct ACL rules
+- WHEN `GroupFolderContentStorage::write(uuid, {...})` is called
+- THEN the system MUST NOT attempt to create the GroupFolder again
+- AND the write MUST proceed directly to persisting the content
+
+#### Scenario: GroupFolder creation is idempotent
+
+- GIVEN `ensureMyDashGroupFolder()` is called twice in rapid succession
+- THEN the system MUST return the same GroupFolder ID both times
+- AND no duplicate GroupFolder MUST be created
+- AND the operation MUST be thread-safe (atomic read-or-create pattern)
+
+#### Scenario: ACL isolation from user dashboard permissions
+
+- GIVEN a GroupFolder with administrator-only file access
+- AND a non-administrator user "alice" has `view_full` permission on a dashboard (from the `dashboards` capability)
+- WHEN alice's browser calls `GET /api/dashboard/{uuid}` to read the dashboard content
+- THEN the system MUST:
+  - Check alice's dashboard permission via `PermissionService`
+  - If authorized, fetch the content via `GroupFolderContentStorage`
+  - Never expose filesystem-level GroupFolder ACL to the user
+- AND alice MUST NOT be able to directly access the GroupFolder via the Files API (file-level ACL is restrictive)
+
+### Requirement: REQ-GFSB-004 GroupFolder File Structure and Multi-Locale Support
+
+The GroupFolder backend MUST organize dashboard content as JSON files in a structured directory hierarchy that supports optional locale-based separation, enabling future multi-language dashboard configurations.
+
+#### Scenario: File path resolution without locale
+
+- GIVEN a dashboard UUID "abc-123-def-456" exists
+- AND the system has no locale preference set (or locale is empty)
+- WHEN `GroupFolderContentStorage` resolves the file path
+- THEN the path MUST be `MyDash/abc-123-def-456.json`
+- AND reading this file MUST return the full dashboard content object
+
+#### Scenario: File path resolution with locale
+
+- GIVEN a dashboard UUID "abc-123-def-456" and a locale preference "nl" (Dutch)
+- WHEN `GroupFolderContentStorage` resolves the file path
+- THEN the path MUST be `MyDash/nl/abc-123-def-456.json`
+- AND the system MUST create the `MyDash/nl/` directory if it does not exist
+- AND reading this file MUST return the locale-specific dashboard content
+
+#### Scenario: Fallback when locale-specific file is missing
+
+- GIVEN a dashboard UUID with a locale preference "nl" but no `MyDash/nl/{uuid}.json` file exists
+- AND a fallback file `MyDash/{uuid}.json` exists
+- WHEN `GroupFolderContentStorage::read()` is called
+- THEN the system MUST:
+  - Attempt to read `MyDash/nl/{uuid}.json` first
+  - Fall back to `MyDash/{uuid}.json` if the locale-specific file does not exist
+  - OR raise `DashboardNotFoundException` if neither exists (decision: implement fallback if operationally useful; document choice)
+- NOTE: Fallback behavior is optional; current implementation can skip this and always require exact locale match
+
+#### Scenario: Content is JSON-encoded on write
+
+- GIVEN a dashboard content array `{"widgets": [...], "layout": {...}}`
+- WHEN `GroupFolderContentStorage::write(uuid, $content)` is called
+- THEN the system MUST JSON-encode the array via `json_encode($content, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES)`
+- AND write the JSON string to the file at the resolved path
+- AND the file MUST be human-readable for manual inspection by administrators
+
+### Requirement: REQ-GFSB-005 Dependency Check and Error Handling
+
+The system MUST verify that the `groupfolders` Nextcloud app is installed before attempting GroupFolder operations, and MUST fail with a clear, actionable error if the app is not available.
+
+#### Scenario: GroupFolders app is required but missing
+
+- GIVEN a MyDash instance with `mydash.content_storage = 'groupfolder'`
+- AND the `groupfolders` Nextcloud app is not installed
+- WHEN a dashboard read/write/delete operation is attempted
+- THEN the system MUST throw `GroupFoldersNotInstalledException` extending `DashboardContentStorageException`
+- AND the exception message MUST be: "The 'groupfolders' Nextcloud app is required for GroupFolder storage backend but is not installed. Please install it via the app store or contact your administrator."
+- AND the HTTP response MUST return HTTP 503 (Service Unavailable)
+
+#### Scenario: GroupFolders app becomes unavailable mid-operation
+
+- GIVEN `GroupFolderContentStorage` is in use and the app was previously installed
+- AND the `groupfolders` app is suddenly disabled or uninstalled
+- WHEN a read/write operation encounters a failure related to the missing app
+- THEN the system MUST catch the underlying error
+- AND throw `DashboardContentStorageException` with HTTP 503 status
+- AND log the error at WARN level with full context
+- AND NOT silently fall back to the database backend
+
+#### Scenario: All I/O errors are wrapped in storage exception
+
+- GIVEN any I/O operation on the GroupFolder fails (permission denied, disk full, network error for remote storage)
+- WHEN `GroupFolderContentStorage` encounters the error
+- THEN the system MUST catch the underlying exception
+- AND throw or re-throw `DashboardContentStorageException` with a descriptive message including the operation (read/write/delete) and the dashboard UUID
+- AND HTTP 503 MUST be returned to the client with error key `dashboard_content_storage_unavailable`
+
+### Requirement: REQ-GFSB-006 Admin Setting for Backend Selection
+
+The system MUST provide an admin-accessible setting that controls which storage backend is used for all dashboard operations. The setting MUST be persistent and validated on update.
+
+#### Scenario: Retrieve current storage backend setting
+
+- GIVEN an administrator navigates to MyDash admin settings
+- WHEN the admin fetches `GET /api/admin/settings`
+- THEN the response MUST include `{"mydash.content_storage": "db"}` (or `"groupfolder"` if changed)
+- AND the response MUST include all other admin settings unchanged
+
+#### Scenario: Change storage backend setting
+
+- GIVEN the current setting is `mydash.content_storage = "db"`
+- WHEN the admin sends `PUT /api/admin/settings` with body `{"mydash.content_storage": "groupfolder"}`
+- THEN the system MUST validate the value (enum: `db` or `groupfolder`)
+- AND persist the new setting in the admin settings table
+- AND return HTTP 200 with the updated setting
+- AND all subsequent dashboard operations MUST use the new backend
+
+#### Scenario: Invalid storage backend value is rejected
+
+- GIVEN the admin sends a PUT request with `{"mydash.content_storage": "redis"}`
+- WHEN the endpoint processes the request
+- THEN the system MUST reject the value as invalid
+- AND return HTTP 400 with error message `"Invalid value for mydash.content_storage. Must be 'db' or 'groupfolder'."`
+- AND the setting MUST NOT be changed
+
+#### Scenario: Non-admin cannot change backend setting
+
+- GIVEN a regular user "alice" (non-administrator)
+- WHEN she sends `PUT /api/admin/settings` with body `{"mydash.content_storage": "..."}` (any value)
+- THEN the system MUST return HTTP 403 (Forbidden)
+- AND the setting MUST NOT be changed
+
+### Requirement: REQ-GFSB-007 Fail-Closed Guarantee and No Silent Fallback
+
+The system MUST never silently fall back from a configured backend to a different one. If the configured backend is unavailable, the operation MUST fail with a clear error and not attempt to use an alternative backend.
+
+#### Scenario: GroupFolder backend is unavailable, no fallback to database
+
+- GIVEN `mydash.content_storage = 'groupfolder'` is configured
+- AND the GroupFolder is deleted or becomes unreachable (ACL stripped, Nextcloud storage issue)
+- WHEN a user attempts to read or write a dashboard
+- THEN the system MUST NOT attempt to fall back to database storage
+- AND MUST return HTTP 503 with error key `dashboard_content_storage_unavailable`
+- AND the error message MUST indicate the configured backend is unavailable
+
+#### Scenario: Database backend failure does not trigger GroupFolder attempt
+
+- GIVEN `mydash.content_storage = 'db'` is configured
+- AND a database error occurs (e.g., connection lost, table locked)
+- WHEN a dashboard operation fails
+- THEN the system MUST NOT attempt to use GroupFolder as a fallback
+- AND MUST return HTTP 503 or appropriate database error
+- AND the failure MUST be logged with full context
+
+#### Scenario: Fail-closed behavior is tested and enforced
+
+- GIVEN the tests for storage layer exception handling
+- WHEN a configured backend throws an exception
+- THEN the system MUST NOT mask it or attempt fallback
+- AND the exception MUST propagate to the controller with HTTP 503
+
+### Requirement: REQ-GFSB-008 One-Time Migration Command
+
+The system MUST provide a console command that migrates all existing dashboards from the database backend to the GroupFolder backend in a single operation, with idempotent semantics allowing safe re-execution.
+
+#### Scenario: Migration command copies all dashboards
+
+- GIVEN a MyDash instance with 10 dashboards stored in the database
+- WHEN an administrator runs `mydash:storage:migrate-to-groupfolder` via the console
+- THEN the system MUST:
+  - Query all dashboard records via `DashboardMapper::findAll()`
+  - For each dashboard, read its content from the database
+  - Write the content to the GroupFolder backend via `GroupFolderContentStorage`
+  - Log progress (e.g., "Migrated 5/10 dashboards")
+- AND the command MUST exit with code 0 on success
+- AND the console output MUST confirm the total count migrated
+
+#### Scenario: Migration skips already-migrated dashboards
+
+- GIVEN some dashboards have already been migrated to GroupFolder
+- WHEN the migration command is run again
+- THEN the system MUST detect that the content already exists in GroupFolder (via `exists()` check)
+- AND skip re-copying it without raising an error
+- AND log a message like "Dashboard {uuid} already migrated, skipping"
+- AND the command MUST remain idempotent and exit with code 0
+
+#### Scenario: Migration handles errors gracefully
+
+- GIVEN a migration is in progress and encounters a write error on dashboard 7 of 10
+- WHEN the error occurs (e.g., GroupFolder permission issue)
+- THEN the system MUST:
+  - Log the error with the dashboard UUID and details
+  - Continue processing remaining dashboards (not fail-fast)
+  - Output a summary at the end: "Migrated 6/10, 1 error"
+  - Return exit code 1 to signal partial failure
+- AND the operator can re-run the command to retry failed dashboards
+
+#### Scenario: Retention policy after migration (optional decision point)
+
+- GIVEN migration has completed successfully
+- THEN either:
+  - (A) The system deletes the content from the database (clean cutover), OR
+  - (B) The system leaves the database content in place for rollback safety
+- NOTE: Decision is implementation-specific; document the choice in the command help text and release notes. Recommended: option (A) with a dry-run flag to preview changes.
+
+### Requirement: REQ-GFSB-009 Transparent Backend Switching During Transition
+
+Existing dashboards MUST remain readable from their original backend during a transition period, allowing operators to gradually migrate content without service disruption.
+
+#### Scenario: Database-backed dashboard is readable during GroupFolder transition
+
+- GIVEN `mydash.content_storage = 'db'` and dashboard "D1" with content in the database
+- WHEN the operator switches the setting to `mydash.content_storage = 'groupfolder'` but does not run the migration command
+- AND a user requests `GET /api/dashboard/D1`
+- THEN the system MUST still read from the database (the configured backend is now GroupFolder, but D1 has not been migrated yet)
+- NOTE: This scenario requires the API to attempt both backends in order (try configured, fall back to alternate for read-only). Decide during implementation whether to support this or require migration before switching.
+
+#### Scenario: Create new dashboards with the currently configured backend
+
+- GIVEN `mydash.content_storage = 'groupfolder'` is now configured
+- AND a user creates a new dashboard "D2" after switching
+- WHEN the new dashboard is created
+- THEN the system MUST persist its content to the GroupFolder backend, not the database
+- AND existing dashboards remain in their original backend until explicitly migrated
+
+### Requirement: REQ-GFSB-010 No API Changes Required
+
+The storage backend MUST be transparent to all existing API clients. Dashboard read/write/delete endpoints MUST not change their contracts, error codes (except for the new HTTP 503 case), or response formats.
+
+#### Scenario: API response format is unchanged
+
+- GIVEN a client calls `GET /api/dashboard/{uuid}`
+- AND the dashboard content is stored in either backend
+- WHEN the endpoint returns a response
+- THEN the response format MUST be identical: same JSON structure, same field names, same HTTP status codes
+- AND the client MUST not be able to determine which backend was used
+
+#### Scenario: Create endpoint response is unchanged
+
+- GIVEN a client calls `POST /api/dashboard` with widget content
+- WHEN the system uses the configured backend (db or groupfolder)
+- THEN the response MUST return HTTP 201 and the full dashboard object
+- AND the response format MUST be identical to the current implementation
+
+#### Scenario: New error response for unavailable storage backend
+
+- GIVEN the configured backend is unavailable
+- WHEN any dashboard operation is attempted
+- THEN the system MUST return HTTP 503 (Service Unavailable)
+- AND the response body MUST include `{"error": "dashboard_content_storage_unavailable", "message": "..."}`
+- AND this is the ONLY new error code; all other HTTP codes remain as they are today

--- a/openspec/changes/groupfolder-storage-backend/tasks.md
+++ b/openspec/changes/groupfolder-storage-backend/tasks.md
@@ -1,0 +1,121 @@
+# Tasks — groupfolder-storage-backend
+
+## 1. Core storage interface
+
+- [ ] 1.1 Create `lib/Service/DashboardContentStorage/DashboardContentStorageInterface.php` with methods: `read(string $dashboardUuid): array`, `write(string $dashboardUuid, array $content): void`, `delete(string $dashboardUuid): void`, `exists(string $dashboardUuid): bool`
+- [ ] 1.2 Each method throws `DashboardContentStorageException` on I/O failure with a descriptive message
+- [ ] 1.3 The `read()` method returns the dashboard content object (widgets array, layout metadata, etc.) as a parsed PHP array; if file does not exist, throw `DashboardNotFoundException` (extend `DashboardContentStorageException`)
+- [ ] 1.4 The `write()` method accepts the content array and persists it; it MUST be idempotent (overwriting an existing file is safe)
+- [ ] 1.5 All methods include PHPDoc with type hints and exception docs
+
+## 2. Database storage implementation
+
+- [ ] 2.1 Create `lib/Service/DashboardContentStorage/DbContentStorage.php` implementing `DashboardContentStorageInterface`
+- [ ] 2.2 Inject `DashboardMapper` and `DashboardFactory` in the constructor
+- [ ] 2.3 `read()` method: fetch the dashboard entity via mapper, extract the content field (deserialised JSON), return as array; throw `DashboardNotFoundException` if mapper throws DoesNotExistException
+- [ ] 2.4 `write()` method: fetch the existing dashboard, update its content field, call `mapper->update()`
+- [ ] 2.5 `delete()` method: fetch dashboard, set content to `null` or empty array, call `mapper->update()`
+- [ ] 2.6 `exists()` method: attempt to fetch via mapper, return boolean (no exception thrown if not found)
+- [ ] 2.7 Add PHPUnit tests for DbContentStorage: read existing, read non-existent, write, delete, exists checks
+
+## 3. GroupFolder storage implementation
+
+- [ ] 3.1 Create `lib/Service/DashboardContentStorage/GroupFolderContentStorage.php` implementing `DashboardContentStorageInterface`
+- [ ] 3.2 Inject `IRootFolder`, `IGroupManager`, `IAppManager` (to check if `groupfolders` is installed), `ILogger` in the constructor
+- [ ] 3.3 Constructor MUST validate that the `groupfolders` app is installed; if not, throw `GroupFoldersNotInstalledException` (extend `DashboardContentStorageException`)
+- [ ] 3.4 Add private method `ensureMyDashGroupFolder(): int` — creates or fetches the "MyDash" GroupFolder, returns its folder ID; if creation fails, log warning and throw exception
+- [ ] 3.5 Add private method `resolvePath(string $dashboardUuid, ?string $locale = null): string` returning `MyDash/<locale-or-empty>/<uuid>.json` (e.g., `MyDash/nl/abc123.json` or `MyDash/abc123.json` if no locale)
+- [ ] 3.6 `read()` method: call `ensureMyDashGroupFolder()`, navigate via `IRootFolder` to the resolved file path, read and `json_decode()` the content, return array; throw `DashboardNotFoundException` if file not found
+- [ ] 3.7 `write()` method: call `ensureMyDashGroupFolder()`, create parent directories if needed, write `json_encode($content)` to the resolved path, return (no exception on overwrite)
+- [ ] 3.8 `delete()` method: call `ensureMyDashGroupFolder()`, delete the file at the resolved path; do not throw if file does not exist (idempotent)
+- [ ] 3.9 `exists()` method: attempt to open file at resolved path, return boolean (no exception)
+- [ ] 3.10 All I/O errors (permissions, disk full, etc.) MUST be caught and wrapped in `DashboardContentStorageException` with HTTP 503 status hint
+- [ ] 3.11 Add PHPUnit tests for GroupFolderContentStorage: read existing, read non-existent, write, delete, exists; test with and without locale; test groupfolder creation
+
+## 4. Storage factory and dependency injection
+
+- [ ] 4.1 Create `lib/Service/DashboardContentStorage/DashboardContentStorageFactory.php` with method `getStorage(): DashboardContentStorageInterface`
+- [ ] 4.2 Inject `IConfig` (for admin settings) and both implementations in the constructor
+- [ ] 4.3 `getStorage()` method reads the `mydash.content_storage` admin setting; returns `DbContentStorage` if `db` (or unset), `GroupFolderContentStorage` if `groupfolder`
+- [ ] 4.4 Add PHPUnit test for factory: verify correct implementation returned based on setting value
+
+## 5. Domain model updates
+
+- [ ] 5.1 Update `lib/Db/Dashboard.php` entity — keep the `content` field (column) for backward compatibility, but document that it may be unused if GroupFolder backend is active
+- [ ] 5.2 Add optional GUID parameter `locale` to the entity for multi-language support; default to empty string
+- [ ] 5.3 Update `jsonSerialize()` to always include the `content` field in the response (the storage layer reads it; the API client sees it regardless of backend)
+- [ ] 5.4 No database schema changes needed for the entity itself
+
+## 6. Service layer integration
+
+- [ ] 6.1 Update `lib/Service/DashboardService.php` — inject `DashboardContentStorageFactory` in the constructor
+- [ ] 6.2 Refactor `getDashboard($uuid)` to: call `dashboardMapper->findByUuid()` to get the entity, then call `getStorage()->read($uuid)` to fetch content, merge into response object
+- [ ] 6.3 Refactor `createDashboard()` to: create entity via factory, call `getStorage()->write()` with the initial widget tree, then persist the entity
+- [ ] 6.4 Refactor `updateDashboard($uuid, $patch)` to: fetch entity, call `getStorage()->write()` with the merged content, update entity metadata (name, description) via mapper
+- [ ] 6.5 Refactor `deleteDashboard($uuid)` to: call `getStorage()->delete($uuid)` first, then delete the entity via mapper
+- [ ] 6.6 Catch `DashboardContentStorageException` in all methods and re-throw as `\Exception` with a user-friendly message; include the underlying error in logs
+- [ ] 6.7 Add PHPUnit tests for DashboardService integration: verify it calls the correct storage backend based on factory output
+
+## 7. Migration command
+
+- [ ] 7.1 Create `lib/Command/MigrateStorageToGroupFolder.php` extending `Command`
+- [ ] 7.2 Register in `appinfo/info.xml` or bootstrap (depending on app structure) as a console command
+- [ ] 7.3 Command MUST:
+  - [ ] 7.3.1 Query all dashboards from DB via `DashboardMapper->findAll()`
+  - [ ] 7.3.2 For each dashboard: read its content from DB, write to GroupFolder via `GroupFolderContentStorage`, delete from DB (optional; see 7.4 below)
+  - [ ] 7.3.3 Skip dashboards already in GroupFolder (check via `exists()` on GroupFolder storage)
+  - [ ] 7.3.4 Log progress and any errors
+  - [ ] 7.3.5 Return exit code 0 on success, non-zero on error
+- [ ] 7.4 Decide on retention: EITHER delete DB content after migration (recommended for cleanup) OR leave it in place for safety. Document the choice.
+- [ ] 7.5 Make the command idempotent — re-running it MUST not cause errors or data loss
+- [ ] 7.6 Add output options (verbose, quiet) for automation-friendly logging
+- [ ] 7.7 PHPUnit test: mock both storages, verify migration copies all records and skips duplicates
+
+## 8. Error handling and failover
+
+- [ ] 8.1 Create exception hierarchy: `DashboardContentStorageException` (base), `DashboardNotFoundException`, `GroupFoldersNotInstalledException` extending it
+- [ ] 8.2 In the controller (DashboardController), catch `DashboardContentStorageException` and return HTTP 503 with a JSON error body: `{"error": "dashboard_content_storage_unavailable", "message": "The dashboard content store is unreachable. Please contact your administrator."}`
+- [ ] 8.3 Log all storage exceptions at WARN level with full context (dashboard UUID, storage type, underlying error)
+- [ ] 8.4 NEVER silently fall back from GroupFolder to DB — fail closed with an explicit error
+- [ ] 8.5 PHPUnit test: mock storage to throw exception, verify controller returns 503
+
+## 9. Admin settings integration
+
+- [ ] 9.1 Update `lib/Db/AdminSetting.php` (or equivalent admin settings entity) to include `mydash.content_storage` as a recognized setting key
+- [ ] 9.2 Add to `admin-settings` spec: `mydash.content_storage` with type `string`, enum values `["db", "groupfolder"]`, default `"db"`
+- [ ] 9.3 Update the admin settings controller to include this setting in GET/POST responses
+- [ ] 9.4 Add validation: POST to the admin settings endpoint with invalid `mydash.content_storage` value returns HTTP 400
+- [ ] 9.5 PHPUnit test: retrieve, update, and validate the setting
+
+## 10. GroupFolder ACL and auto-creation
+
+- [ ] 10.1 When the GroupFolder is first created, set ACL rules:
+  - [ ] 10.1.1 Administrators: full access (read, write, delete)
+  - [ ] 10.1.2 All other users: no default access (ACL is restrictive by default)
+  - [ ] 10.1.3 Dashboard access is mediated by the API layer (the storage layer does not enforce per-dashboard ACL — that is the responsibility of the dashboard permission layer)
+- [ ] 10.2 Document the GroupFolder creation process in a README or inline comment so operators understand the structure
+- [ ] 10.3 PHPUnit test: verify GroupFolder creation includes correct ACL rules
+
+## 11. CLI helper command (optional)
+
+- [ ] 11.1 Create `lib/Command/ToggleStorageSetting.php` to allow admins to change the setting via CLI
+- [ ] 11.2 Command signature: `mydash:storage:toggle-backend {db|groupfolder}`
+- [ ] 11.3 Validate the argument, update the setting, confirm to the user
+- [ ] 11.4 Output a warning if switching away from `groupfolder`: "Note: dashboards already in the GroupFolder will not be automatically copied back to the DB"
+
+## 12. Quality gates and testing
+
+- [ ] 12.1 `composer check:strict` (PHPCS, PHPMD, Psalm, PHPStan) passes — fix any pre-existing issues encountered
+- [ ] 12.2 All new PHP files include SPDX headers inside the docblock (per SPDX-in-docblock convention)
+- [ ] 12.3 PHPUnit test coverage: aim for 85%+ on the storage layer (interface, implementations, factory)
+- [ ] 12.4 E2E test (Playwright): create a dashboard via API, verify it appears in GroupFolder when backend is `groupfolder`; switch backend to `db` and verify fallback read still works
+- [ ] 12.5 Integration test: run migration command, verify all dashboards are copied and the API still reads them correctly
+- [ ] 12.6 i18n: all error messages and CLI output in both `nl` and `en` (error keys: `dashboard_content_storage_unavailable`, `groupfolder_not_installed`, etc.)
+- [ ] 12.7 Update OpenAPI spec / Postman collection if it documents error responses
+
+## 13. Documentation
+
+- [ ] 13.1 Add a "Storage Backend" section to the MyDash admin documentation explaining the two backends, when to use each, and the migration process
+- [ ] 13.2 Include example GroupFolder structure and ACL rules
+- [ ] 13.3 Document the CLI commands and their options
+- [ ] 13.4 Add a changelog entry noting the new capability, the default behaviour (unchanged), and the opt-in migration path

--- a/openspec/changes/header-widget/design.md
+++ b/openspec/changes/header-widget/design.md
@@ -1,0 +1,85 @@
+# Design — Header Widget
+
+## Context
+
+Many intranet dashboards open with a branded banner: an organisation name, a welcome
+headline, an optional background image, and a primary call-to-action button. Today this
+is approximated by combining an image widget with a label widget, but the two can drift
+out of alignment and neither carries the correct heading semantics.
+
+The header widget is a full-width banner component. It owns title, optional image, and
+optional CTA button in a single cohesive unit. Three layout modes cover the main
+compositional patterns: text-only, image-beside-text, and image-as-background with
+text overlay.
+
+Because a page may already carry an `<h1>` from the application chrome, the widget must
+let the admin choose the heading level for the title so they can avoid duplicate `<h1>`
+landmarks — a WCAG 2.1 AA requirement.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Render a full-width banner with title, optional image, and optional CTA button.
+- Support three layout modes with a single config toggle.
+- Allow the admin to choose heading level (h1/h2/h3).
+- Enforce an image URL allow-list configurable by the administrator.
+
+**Non-Goals:**
+- Files-picker integration (deferred — reuse `image-widget-media-picker` pattern later).
+- CreateFile or action-ID CTA types (deferred to keep initial scope tight).
+- Animated or video backgrounds.
+
+## Decisions
+
+### D1: Image source — URL only
+**Decision:** Image source is a plain URL field. The allow-list of permitted hosts is
+controlled by an admin setting (`mydash.header_widget_allowed_image_hosts`); empty list
+means all hosts are permitted.
+**Alternatives considered:** Files picker (deferred); data-URL inline upload.
+**Rationale:** URL-only keeps the widget stateless and avoids file-storage coupling in
+the first iteration. The allow-list prevents admins from inadvertently embedding tracking
+pixels from arbitrary third-party hosts.
+
+### D2: CTA action types — URL and internal route only
+**Decision:** CTA button supports a URL (external, opens new tab) or an internal route
+string (same-tab navigation within the app). No action_id or createFile hooks.
+**Alternatives considered:** Full action registry (createFile, share, etc.).
+**Rationale:** URL + internal route covers 90% of observed use-cases. Action registry
+adds significant complexity and should be designed holistically across all widgets that
+need it, not first in the header widget.
+
+### D3: Layout modes (`image-bg-text-overlay | image-side-text-side | text-only`)
+**Decision:** Expose three layout modes; default to `text-only` so the widget is
+usable without an image URL configured.
+**Alternatives considered:** Two modes only (overlay and side-by-side); free CSS input.
+**Rationale:** Three named modes map to distinct CSS templates and cover the cases
+present in existing intranet implementations. Free CSS input is a maintenance hazard.
+
+### D4: Heading level enum (h1/h2/h3)
+**Decision:** Admin selects heading level from a dropdown; rendered as the corresponding
+HTML element. Default is `h2`.
+**Alternatives considered:** Always `h1`; always `div` with font styling only.
+**Rationale:** Allowing `h1` is necessary for dashboards where the banner IS the page
+title; `h2` is the correct default for dashboards that already have an application-level
+`h1`. Hardcoding either breaks one scenario. `div` with font styling breaks heading
+navigation for AT users.
+
+### D5: Background image allow-list admin setting
+**Decision:** Admin config key `mydash.header_widget_allowed_image_hosts` holds a
+newline-separated list of permitted hostnames. Empty = all permitted. Checked server-side
+on config save.
+**Alternatives considered:** Same-origin only; no allow-list (open).
+**Rationale:** Open default matches existing image-widget behaviour. The allow-list is
+opt-in restriction, not default restriction — the practical balance for on-premises.
+
+## Risks / Trade-offs
+
+- Text overlay requires sufficient contrast; editor should warn when the combination is
+  likely to fail AA.
+- Deferring the Files picker means admins must host images on an accessible URL.
+
+## Open follow-ups
+
+- Files picker integration reusing `image-widget-media-picker` allow-list pattern.
+- Contrast checker in editor for `image-bg-text-overlay` mode.
+- Extend CTA types to action_id once the cross-widget action registry is designed.

--- a/openspec/changes/header-widget/proposal.md
+++ b/openspec/changes/header-widget/proposal.md
@@ -1,0 +1,53 @@
+# Header Widget
+
+## Why
+
+MyDash dashboards often need prominent visual headers to contextualize content—a banner with a title, subtitle, background imagery, and optional call-to-action. Currently, this requires custom styling of regular widgets or ad-hoc design. A dedicated header widget provides a first-class, configurable banner component that can be placed at the top of any dashboard, replacing the legacy "header row" concept with a reusable, flexible widget that supports images, overlays, text alignment, and accessibility.
+
+## What Changes
+
+- Register a new dashboard widget with id `mydash_header` via `OCP\Dashboard\IManager` that appears in the widget picker.
+- Add per-placement configuration stored in `widgetContent JSON` to specify title, optional subtitle, background image (URL or NC file ID), overlay color/mode, text styling, sizing, and optional CTA button.
+- Image sources: support external URLs with an allow-list (`mydash.header_widget_allowed_image_domains`), and internal Nextcloud file IDs (via NC Files preview route) with file-read ACL checks.
+- Image-load failures gracefully fall back to solid background color (no error UI in header context).
+- Overlay modes: `none` (solid background only), `tint` (semi-transparent color overlay), `gradient-bottom` (linear gradient).
+- Height presets: `small` (120px), `medium` (200px), `large` (320px), `xlarge` (480px).
+- Render: Vue 3 SFC `HeaderWidget.vue` using CSS `background-image` for images and absolute-positioned overlay div for tint/gradient.
+- Text styling: configurable color, alignment (left/center/right), vertical alignment (top/middle/bottom).
+- CTA button: optional link with configurable style (primary/secondary/ghost) and target (new tab for external URLs, same tab for internal).
+- Accessibility: title as `<h2>`, subtitle as `<p>`, CTA with proper ARIA labels.
+- Default sizing: headers fill the full dashboard width by default.
+
+## Capabilities
+
+### New Capabilities
+
+- `header-widget` — A new MyDash dashboard widget capability providing full-width banners with images, overlays, text, and CTA buttons.
+
+## Impact
+
+**Affected code:**
+
+- `lib/Service/HeaderWidgetService.php` — core logic for validating image sources, allow-list checks, file ACL validation.
+- `lib/Controller/WidgetController.php` — no new endpoints required (fully client-side).
+- `src/components/widgets/HeaderWidget.vue` — widget render component.
+- `src/components/widgets/headerpicker/HeaderWidgetConfig.vue` — placement config UI for editing title, subtitle, image, overlay, text, and CTA.
+- `appinfo/routes.php` — no new routes required.
+- `lib/Migration/VersionXXXXDate2026...AddHeaderWidgetSettings.php` — schema migration adding app config setting `mydash.header_widget_allowed_image_domains` (JSON array; empty = all allowed).
+- `src/stores/widgets.js` — optional: widget-specific runtime state for image load status.
+
+**Affected APIs:**
+
+- 0 new routes (fully client-side widget with standard NC image routes).
+
+**Dependencies:**
+
+- `OCP\Files\IRootFolder` — file read ACL check for `backgroundImageFileId`.
+- `OCP\IAppConfig` — admin setting for allow-list.
+- No new composer or npm dependencies.
+
+**Migration:**
+
+- Zero-impact: app config key created on demand via IAppConfig getter.
+- No schema changes required beyond optional settings.
+- No data backfill required.

--- a/openspec/changes/header-widget/specs/header-widget/spec.md
+++ b/openspec/changes/header-widget/specs/header-widget/spec.md
@@ -1,0 +1,465 @@
+---
+capability: header-widget
+status: draft
+---
+
+# Header Widget Specification
+
+## ADDED Requirements
+
+### Requirement: REQ-HDR-001 Widget registration
+
+The system MUST register a MyDash dashboard widget with id `mydash_header` via `OCP\Dashboard\IManager::registerWidget()` so it appears in the widget picker alongside other Nextcloud dashboard widgets.
+
+#### Scenario: Widget appears in picker
+
+- GIVEN the header-widget app is installed and enabled
+- WHEN a user opens the MyDash widget picker dialog
+- THEN the `mydash_header` widget MUST appear in the list with a title (e.g., "Header Banner") and an icon
+- AND the widget MUST be selectable for placement on a dashboard
+
+#### Scenario: Multiple instances allowed
+
+- GIVEN a dashboard already has one header widget placement
+- WHEN the user adds a second header widget to the same dashboard
+- THEN both placements MUST coexist with independent configurations
+- AND the system MUST treat them as separate instances
+
+#### Scenario: Widget registration survives app reload
+
+- GIVEN the widget is registered
+- WHEN Nextcloud cache is cleared or the app is reloaded
+- THEN the `mydash_header` widget MUST still be discoverable in the picker
+
+#### Scenario: Widget registration includes metadata
+
+- GIVEN the widget is registered
+- WHEN the widget picker fetches widget metadata
+- THEN the widget object MUST include at minimum: id, title, icon_url
+
+### Requirement: REQ-HDR-002 Placement configuration structure
+
+The system MUST store per-placement widget configuration in the `oc_mydash_widget_placements.widgetContent` JSON field, allowing users to specify content, styling, image source, and optional CTA.
+
+#### Scenario: Config for title and subtitle
+
+- GIVEN a user is configuring a header widget placement
+- WHEN they set the title and optional subtitle
+- THEN the configuration MUST store a `title: string` field (required)
+- AND a `subtitle: string|null` field (optional, default null)
+
+#### Scenario: Config for background image URL
+
+- GIVEN a user is configuring a header widget placement
+- WHEN they provide an external image URL
+- THEN the configuration MUST store a `backgroundImageUrl: string|null` field
+- AND each URL MUST be HTTP/HTTPS
+- AND the URL is subject to allow-list validation (see REQ-HDR-005)
+
+#### Scenario: Config for background image file ID
+
+- GIVEN a user is configuring a header widget placement
+- WHEN they select an image from Nextcloud Files
+- THEN the configuration MUST store a `backgroundImageFileId: number|null` field
+- AND the file ID MUST be validated for file-read ACL at render time (see REQ-HDR-006)
+
+#### Scenario: Config for background color
+
+- GIVEN a user is configuring a header widget placement
+- WHEN they set a solid background color
+- THEN the configuration MUST store a `backgroundColor: string|null` field
+- AND the color MUST be a valid CSS color string (hex, rgb, or named)
+
+#### Scenario: Config for overlay mode
+
+- GIVEN a user is configuring a header widget placement
+- WHEN they choose an overlay effect
+- THEN the configuration MUST store an `overlayMode: 'none'|'tint'|'gradient-bottom'` field
+- AND the default value MUST be `'tint'` if backgroundImageUrl or backgroundImageFileId is set, otherwise `'none'`
+
+#### Scenario: Config for overlay opacity
+
+- GIVEN a user is configuring a header widget placement
+- WHEN they adjust the overlay opacity
+- THEN the configuration MUST store an `overlayOpacity: number` field
+- AND the default value MUST be `0.4`
+- AND the value MUST be in the range [0.0, 1.0]
+
+#### Scenario: Config for text color
+
+- GIVEN a user is configuring a header widget placement
+- WHEN they set the text color
+- THEN the configuration MUST store a `textColor: string|null` field
+- AND the default behavior (when null) MUST auto-derive contrast-safe text color from backgroundColor or image
+- AND if explicitly set, MUST be a valid CSS color string
+
+#### Scenario: Config for text and vertical alignment
+
+- GIVEN a user is configuring a header widget placement
+- WHEN they choose text positioning
+- THEN the configuration MUST store:
+  - `textAlign: 'left'|'center'|'right'` (default `'center'`)
+  - `verticalAlign: 'top'|'middle'|'bottom'` (default `'middle'`)
+
+#### Scenario: Config for height preset
+
+- GIVEN a user is configuring a header widget placement
+- WHEN they choose a height
+- THEN the configuration MUST store a `height: 'small'|'medium'|'large'|'xlarge'` field
+- AND the default value MUST be `'medium'`
+- AND the heights MUST map to: small=120px, medium=200px, large=320px, xlarge=480px
+
+#### Scenario: Config for CTA button
+
+- GIVEN a user is configuring a header widget placement
+- WHEN they optionally add a call-to-action button
+- THEN the configuration MUST store a `cta: {label: string, url: string, style: 'primary'|'secondary'|'ghost'}|null` field
+- AND the cta field MUST be optional (default null)
+- AND if present, all three properties (label, url, style) MUST be non-empty strings
+
+#### Scenario: Config is JSON-serializable
+
+- GIVEN a placement with header widget config
+- WHEN the placement is fetched from the database
+- THEN the `widgetContent` MUST deserialize cleanly to a JavaScript object
+- AND all required fields MUST be present with no spurious whitespace or encoding issues
+
+### Requirement: REQ-HDR-003 Image source precedence
+
+When both `backgroundImageFileId` and `backgroundImageUrl` are present in the configuration, the system MUST apply the following precedence: file ID takes priority over URL.
+
+#### Scenario: File ID overrides URL when both set
+
+- GIVEN a placement with both backgroundImageFileId (123) and backgroundImageUrl ("https://example.com/image.jpg")
+- WHEN the widget renders
+- THEN the file preview route MUST be used
+- AND the URL MUST be ignored
+
+#### Scenario: URL used when file ID is null
+
+- GIVEN a placement with backgroundImageFileId=null and backgroundImageUrl="https://example.com/image.jpg"
+- WHEN the widget renders
+- THEN the external URL MUST be fetched and displayed
+
+#### Scenario: Neither set defaults to background color
+
+- GIVEN a placement with backgroundImageFileId=null and backgroundImageUrl=null
+- WHEN the widget renders
+- THEN the widget MUST display backgroundColor only (no image)
+
+### Requirement: REQ-HDR-004 Overlay rendering modes
+
+The system MUST support three overlay modes for controlling how background images are layered with colors.
+
+#### Scenario: Overlay mode none (no overlay)
+
+- GIVEN a placement with overlayMode='none'
+- WHEN the widget renders
+- THEN no color overlay MUST be applied
+- AND the background image (if present) MUST display at full opacity
+- AND backgroundColor (if set) MUST be ignored
+
+#### Scenario: Overlay mode tint (semi-transparent color)
+
+- GIVEN a placement with overlayMode='tint', overlayOpacity=0.4, and backgroundColor='#000000'
+- WHEN the widget renders
+- THEN a semi-transparent black overlay with 40% opacity MUST be positioned absolutely over the background image
+- AND text MUST be positioned above the overlay div
+
+#### Scenario: Overlay mode gradient-bottom (linear gradient)
+
+- GIVEN a placement with overlayMode='gradient-bottom' and backgroundColor='#000000'
+- WHEN the widget renders
+- THEN a linear gradient overlay MUST be applied: top=transparent, bottom=backgroundColor
+- AND the gradient MUST transition from 50% down to 100% of widget height
+
+#### Scenario: Default overlay mode based on image presence
+
+- GIVEN a placement with backgroundImageUrl set but overlayMode not explicitly set
+- WHEN the widget renders
+- THEN overlayMode MUST default to 'tint'
+- AND when no image is present, overlayMode MUST default to 'none'
+
+### Requirement: REQ-HDR-005 External image allow-list
+
+The system MUST enforce an allow-list of external image hostnames via admin setting `mydash.header_widget_allowed_image_domains` to prevent loading from untrusted sources.
+
+#### Scenario: Allow-list enabled with allowed domain
+
+- GIVEN mydash.header_widget_allowed_image_domains="[\"images.example.com\", \"cdn.trusted.org\"]"
+- WHEN a placement is configured with backgroundImageUrl="https://images.example.com/banner.jpg"
+- THEN the image MUST be allowed and loaded
+
+#### Scenario: Allow-list enabled with disallowed domain
+
+- GIVEN mydash.header_widget_allowed_image_domains="[\"images.example.com\"]"
+- WHEN a placement is configured with backgroundImageUrl="https://untrusted-site.com/image.jpg"
+- THEN the image MUST NOT load
+- AND the widget MUST fall back to backgroundColor only
+- AND no error UI MUST be displayed
+
+#### Scenario: Empty allow-list allows all domains
+
+- GIVEN mydash.header_widget_allowed_image_domains=null or []
+- WHEN a placement is configured with any external backgroundImageUrl
+- THEN the image MUST be loaded without restriction
+- AND this is the default behavior (zero-config = all allowed)
+
+#### Scenario: Same-origin URLs bypass allow-list
+
+- GIVEN the dashboard is loaded from localhost:3000
+- WHEN a placement is configured with backgroundImageUrl="http://localhost:3000/images/banner.jpg"
+- THEN the URL MUST be loaded regardless of allow-list setting
+- AND same-origin is determined by protocol, hostname, and port
+
+#### Scenario: Allow-list hostname matching is case-insensitive
+
+- GIVEN mydash.header_widget_allowed_image_domains="[\"Images.Example.COM\"]"
+- WHEN a placement is configured with backgroundImageUrl="https://images.example.com/banner.jpg"
+- THEN the image MUST be allowed (case-insensitive match)
+
+### Requirement: REQ-HDR-006 File ID image with ACL validation
+
+The system MUST validate file read permissions when `backgroundImageFileId` is set, falling back to backgroundColor if the user cannot read the file.
+
+#### Scenario: User can read file
+
+- GIVEN a placement with backgroundImageFileId=123
+- AND the requesting user has read access to file 123
+- WHEN the widget renders
+- THEN the file preview route MUST be constructed
+- AND the image MUST load successfully
+
+#### Scenario: User cannot read file
+
+- GIVEN a placement with backgroundImageFileId=123
+- AND the requesting user CANNOT read file 123 (permission denied or file deleted)
+- WHEN the widget renders
+- THEN the file preview route returns 404 or 403
+- AND the widget MUST fall back to backgroundColor only
+- AND no error message or icon MUST be displayed
+
+#### Scenario: File ID converted to preview URL
+
+- GIVEN a placement with backgroundImageFileId=42
+- WHEN the widget renders
+- THEN the frontend MUST construct a preview URL: `linkToRoute('files.api.v1.resources', {fileId: 42})`
+- OR equivalent NC file preview route pattern
+
+### Requirement: REQ-HDR-007 Image load failure graceful fallback
+
+The system MUST gracefully handle image load failures (404, timeout, invalid URL) by falling back to backgroundColor and continuing to render the widget without error UI.
+
+#### Scenario: External image returns 404
+
+- GIVEN a placement with backgroundImageUrl="https://example.com/nonexistent.jpg"
+- WHEN the widget renders and the image fails to load
+- THEN the widget MUST display backgroundColor only
+- AND the title, subtitle, and CTA MUST still be visible
+- AND no broken-image icon, error message, or placeholder MUST be shown
+
+#### Scenario: Image load timeout
+
+- GIVEN a placement with backgroundImageUrl pointing to a slow/unresponsive server
+- WHEN the image fails to load within browser timeout
+- THEN the widget MUST fall back to backgroundColor
+- AND continue rendering normally
+
+#### Scenario: Invalid image MIME type
+
+- GIVEN a placement with backgroundImageUrl pointing to a non-image file (e.g., .txt)
+- WHEN the browser detects invalid image format
+- THEN the widget MUST fall back to backgroundColor
+- AND the widget MUST render successfully
+
+### Requirement: REQ-HDR-008 Text rendering and styling
+
+The system MUST render title and subtitle with semantic HTML and configurable styling (color, alignment, vertical positioning).
+
+#### Scenario: Title rendered as h2
+
+- GIVEN a placement with title="Welcome"
+- WHEN the widget renders
+- THEN an `<h2>` tag MUST contain the title text
+- AND the heading hierarchy MUST be proper for page structure
+
+#### Scenario: Subtitle rendered as paragraph
+
+- GIVEN a placement with subtitle="Explore our dashboard"
+- WHEN the widget renders
+- THEN a `<p>` tag MUST contain the subtitle text
+- AND no subtitle tag MUST appear if subtitle is null or empty
+
+#### Scenario: Text alignment applied correctly
+
+- GIVEN a placement with textAlign='right'
+- WHEN the widget renders
+- THEN the title and subtitle MUST be right-aligned
+- AND text-align: right MUST apply to the content container
+
+#### Scenario: Vertical alignment applied correctly
+
+- GIVEN a placement with verticalAlign='top'
+- WHEN the widget renders
+- THEN the title and subtitle MUST be positioned at the top of the widget
+- AND this MUST use absolute positioning or flexbox justify-content
+
+#### Scenario: Text color applied with contrast fallback
+
+- GIVEN a placement with backgroundColor='#ffffff' and textColor=null
+- WHEN the widget renders
+- THEN the system MUST apply a dark text color (e.g., #000000) for readability
+- AND when textColor is explicitly set, that color MUST be used instead
+
+### Requirement: REQ-HDR-009 Height presets and responsive sizing
+
+The system MUST support four height presets (small, medium, large, xlarge) that map to fixed pixel values, and default widgets to full dashboard width.
+
+#### Scenario: Height small (120px)
+
+- GIVEN a placement with height='small'
+- WHEN the widget renders
+- THEN the widget height MUST be 120px
+- AND the widget MUST span the full dashboard width
+
+#### Scenario: Height medium (200px)
+
+- GIVEN a placement with height='medium'
+- WHEN the widget renders
+- THEN the widget height MUST be 200px
+- AND this is the default when height is not set
+
+#### Scenario: Height large (320px)
+
+- GIVEN a placement with height='large'
+- WHEN the widget renders
+- THEN the widget height MUST be 320px
+
+#### Scenario: Height xlarge (480px)
+
+- GIVEN a placement with height='xlarge'
+- WHEN the widget renders
+- THEN the widget height MUST be 480px
+
+#### Scenario: Default grid sizing for header widget
+
+- GIVEN a header widget is added to a dashboard
+- WHEN the placement is created
+- THEN gridWidth MUST default to the full dashboard width (gridColumns value)
+- AND gridHeight MUST be auto-calculated from the height preset and grid row size
+
+### Requirement: REQ-HDR-010 Call-to-action button rendering and navigation
+
+The system MUST render an optional CTA button with configurable style and handle navigation to internal or external URLs.
+
+#### Scenario: CTA button with primary style
+
+- GIVEN a placement with cta={label: "Sign up", url: "https://example.com/signup", style: "primary"}
+- WHEN the widget renders
+- THEN a button with primary styling MUST appear with text "Sign up"
+- AND clicking the button MUST navigate to https://example.com/signup
+
+#### Scenario: CTA button with secondary style
+
+- GIVEN a placement with cta={label: "Learn more", url: "/internal/docs", style: "secondary"}
+- WHEN the widget renders
+- THEN a button with secondary styling MUST appear
+- AND clicking MUST navigate to /internal/docs in the same tab (internal URL)
+
+#### Scenario: CTA button with ghost style
+
+- GIVEN a placement with cta={label: "Dismiss", url: "#", style: "ghost"}
+- WHEN the widget renders
+- THEN a button with ghost (outline/minimal) styling MUST appear
+
+#### Scenario: External URL opens in new tab
+
+- GIVEN a placement with cta={label: "Visit", url: "https://example.com", style: "primary"}
+- WHEN the user clicks the CTA button
+- THEN the URL MUST open in a new tab
+- AND the link MUST have `target="_blank"` and `rel="noopener noreferrer"`
+
+#### Scenario: Internal URL opens in same tab
+
+- GIVEN a placement with cta={label: "Go to settings", url: "/settings", style: "primary"}
+- WHEN the user clicks the CTA button
+- THEN the URL MUST navigate in the current tab
+- AND `target` and `rel` MUST NOT be set
+
+#### Scenario: No CTA button when cta is null
+
+- GIVEN a placement with cta=null
+- WHEN the widget renders
+- THEN no button MUST appear
+- AND the widget MUST render with title, subtitle, and background only
+
+### Requirement: REQ-HDR-011 Accessibility for header widgets
+
+The system MUST ensure header widgets are accessible to keyboard navigation and screen readers, with proper ARIA labels and semantic HTML.
+
+#### Scenario: Title is keyboard-navigable
+
+- GIVEN a header widget is rendered on a dashboard
+- WHEN a keyboard user presses Tab
+- THEN the widget MUST be reachable in the tab order
+- AND the widget's heading (`<h2>`) MUST be focusable or part of the widget's accessible region
+
+#### Scenario: CTA button is keyboard accessible
+
+- GIVEN a header widget with a CTA button
+- WHEN a keyboard user presses Tab to reach the button
+- THEN the button MUST be focusable
+- AND pressing Enter or Space MUST trigger the navigation action
+
+#### Scenario: CTA button has accessible label
+
+- GIVEN a placement with cta={label: "Sign up", url: "https://example.com/signup"}
+- WHEN a screen reader user encounters the widget
+- THEN the button MUST have an accessible label
+- AND the label SHOULD combine button text and destination (e.g., "Sign up, opens in new tab" for external)
+
+#### Scenario: Subtitle accessible to screen readers
+
+- GIVEN a placement with subtitle="Explore our dashboard"
+- WHEN a screen reader parses the widget
+- THEN the subtitle MUST be read as a paragraph or descriptive text
+- AND it MUST NOT be hidden from assistive technology (no aria-hidden)
+
+#### Scenario: Image alt text or absence
+
+- GIVEN a header widget with a background image
+- WHEN a screen reader encounters the widget
+- THEN if the image is decorative (background-image CSS), it MUST NOT have an alt attribute or MUST be aria-hidden
+- AND the semantic content (title, subtitle, CTA) MUST be independent of the image for understanding
+
+### Requirement: REQ-HDR-012 Print-friendly rendering
+
+The system MUST render header widgets visibly when printed, including background images and colors, subject to the user's "print backgrounds" browser setting.
+
+#### Scenario: Header widget prints with background image
+
+- GIVEN a header widget with a background image on a dashboard
+- WHEN the user prints the page (Ctrl+P or browser print menu)
+- THEN the widget MUST appear with its background image visible
+- AND this is subject to the user's browser "Print backgrounds" setting
+
+#### Scenario: Header widget prints with overlay and text
+
+- GIVEN a header widget with overlayMode='tint', backgroundColor, and text
+- WHEN the page is printed
+- THEN the overlay, background color, and all text MUST be visible in the print
+- AND text color MUST have sufficient contrast for print readability
+
+## Non-Functional Requirements
+
+- **Performance**: Header widgets MUST render and display images within 500ms, even with large background images.
+- **Image loading**: External image fetch MUST timeout after 10 seconds; local file previews after 5 seconds.
+- **Compatibility**: The widget MUST support all modern browsers (Chrome, Firefox, Safari, Edge) and gracefully degrade on older browsers (fallback to solid color).
+- **Data integrity**: Placement deletion MUST not leave orphaned config data; widgetContent JSON MUST validate on save.
+- **Accessibility**: Header widgets MUST meet WCAG 2.1 AA standards for color contrast, keyboard navigation, and screen reader compatibility.
+- **Localization**: Widget configuration labels and defaults MUST support English and Dutch.
+
+### Current Implementation Status
+
+**Not yet implemented:**
+- REQ-HDR-001 through REQ-HDR-012: All requirements are new with this change proposal.

--- a/openspec/changes/header-widget/tasks.md
+++ b/openspec/changes/header-widget/tasks.md
@@ -1,0 +1,218 @@
+# Tasks — header-widget
+
+## 1. Widget registration and service layer
+
+- [ ] 1.1 Create `lib/Service/HeaderWidgetService.php` with core methods:
+  - `getWidgetInfo(): array` — returns widget metadata (id, title, icon_url, v2 API support)
+  - `validateImageSource(string $url, string $fileId): bool` — checks allow-list for external URLs, file ACL for file IDs
+  - `checkAllowList(string $url): bool` — checks hostname against allow-list setting
+  - `canReadFile(int $fileId, string $userId): bool` — verifies file read ACL via `IRootFolder`
+- [ ] 1.2 Register the widget in a boot/lifecycle hook or service provider:
+  - Hook into Nextcloud's dashboard widget registration (e.g., in `AppInfo/Bootstrap.php` or a listener on `IManager`)
+  - Call `IManager::registerWidget()` with widget metadata
+  - Widget id: `mydash_header`, title: translatable `app.mydash.header_widget_title`, icon: header icon URL
+- [ ] 1.3 Create fixture-based PHPUnit tests for `HeaderWidgetService`:
+  - `testCheckAllowListMatching` — hostname match, mismatch, case-insensitivity
+  - `testCanReadFileSuccess` — user can read file, returns true
+  - `testCanReadFileAccessDenied` — user cannot read file, returns false
+
+## 2. Widget configuration UI component
+
+- [ ] 2.1 Create `src/components/widgets/headerpicker/HeaderWidgetConfig.vue`:
+  - Used by `WidgetAddEditModal.vue` when configuring a header widget placement
+  - Form sections:
+    - **Title** (required): text input
+    - **Subtitle** (optional): text input
+    - **Background Image**: choice of external URL OR NC file picker (via `FilePicker`)
+    - **Overlay Mode**: radio buttons (none, tint, gradient-bottom)
+    - **Overlay Color & Opacity**: color picker + slider (default 0.4)
+    - **Text Color**: color picker (with auto-contrast option)
+    - **Text Alignment**: radio buttons (left, center, right; default center)
+    - **Vertical Alignment**: radio buttons (top, middle, bottom; default middle)
+    - **Height**: dropdown (small/medium/large/xlarge; default medium)
+    - **CTA Button** (optional): label + URL + style (primary/secondary/ghost)
+  - Validation: URLs must be HTTP/HTTPS; colors must be valid CSS; overlay opacity 0..1
+  - On save: emit `update:widgetContent` with serialized config object
+- [ ] 2.2 Integrate into `WidgetAddEditModal.vue`:
+  - When user selects `mydash_header` widget from picker
+  - Display `HeaderWidgetConfig.vue` instead of default generic config panel
+
+## 3. Placement configuration and schema migration
+
+- [ ] 3.1 Create `lib/Migration/VersionXXXXDate2026...AddHeaderWidgetSettings.php`:
+  - Add app config table entry for `mydash.header_widget_allowed_image_domains` (default `null` or `[]`)
+  - NOTE: All per-placement config stored in `oc_mydash_widget_placements.widgetContent` JSON
+- [ ] 3.2 Add getter method in `WidgetPlacementService` or factory to safely parse `widgetContent` JSON:
+  - `extractHeaderConfig(WidgetPlacement $placement): array` — returns parsed config with defaults (title required; subtitle, backgroundImageUrl, backgroundImageFileId, backgroundColor, overlayMode, overlayOpacity, textColor, textAlign, verticalAlign, height, cta all optional with sensible defaults)
+  - Validate and sanitize config (URLs must be HTTP/HTTPS, colors valid CSS, opacity 0..1, heights in [small, medium, large, xlarge], alignments in [left, center, right], verticalAlignments in [top, middle, bottom], overlayModes in [none, tint, gradient-bottom])
+- [ ] 3.3 Create PHPUnit test for placement config parsing:
+  - `testExtractHeaderConfigWithDefaults` — verify default values are applied
+  - `testExtractHeaderConfigValidation` — invalid URLs/colors rejected, valid ones accepted
+
+## 4. Image source validation and allow-list
+
+- [ ] 4.1 Implement in `HeaderWidgetService::validateImageSource()`:
+  - Input: `backgroundImageUrl` (string, nullable) and `backgroundImageFileId` (int, nullable)
+  - If `backgroundImageFileId` is set:
+    - Call `canReadFile($fileId, $userId)` to verify ACL
+    - Return true if file is readable, false otherwise
+    - No error UI — frontend falls back to backgroundColor
+  - If `backgroundImageUrl` is set and not same-origin:
+    - Call `checkAllowList($url)` to verify hostname
+    - Return true if allowed, false otherwise
+    - Return true if same-origin (always allowed)
+  - Return true if both are null (valid state)
+- [ ] 4.2 Implement `HeaderWidgetService::checkAllowList()`:
+  - Read `mydash.header_widget_allowed_image_domains` from `IAppConfig::getValueString()`
+  - If empty or null, return true (all allowed by default)
+  - Otherwise, parse URL, extract hostname (case-insensitive)
+  - Check for exact match in allow-list (no wildcard subdomain expansion)
+  - Return boolean
+- [ ] 4.3 Implement `HeaderWidgetService::canReadFile()`:
+  - Use `IRootFolder::getUserFolder($userId)` to get user's file root
+  - Try to fetch file by ID via file search or direct path resolution
+  - Return true if file exists and is readable, false otherwise
+  - On exception (file deleted, permission denied), return false silently
+- [ ] 4.4 Create PHPUnit tests:
+  - `testValidateImageSourceWithFileId` — file readable, returns true
+  - `testValidateImageSourceWithFileIdAccessDenied` — file not readable, returns false
+  - `testValidateImageSourceWithUrlAllowListAllowed` — URL in allow-list, returns true
+  - `testValidateImageSourceWithUrlAllowListDisallowed` — URL not in allow-list, returns false
+  - `testValidateImageSourceWithUrlSameOrigin` — same-origin URL, returns true (no allow-list check)
+
+## 5. Frontend widget component (Vue 3 SFC)
+
+- [ ] 5.1 Create `src/components/widgets/HeaderWidget.vue`:
+  - Props: `placement: object` (with widgetContent config)
+  - Data: `imageLoaded: false`, `imageError: null`
+  - Computed properties:
+    - `headerConfig`: extract + validate placement config with defaults
+    - `headerStyles`: generate inline CSS for wrapper (height, background, etc.)
+    - `overlayStyles`: generate CSS for overlay div (color, opacity, gradient)
+    - `textStyles`: generate CSS for title/subtitle (color, alignment, vertical-align)
+    - `buttonClasses`: generate button classes based on CTA style
+  - Methods:
+    - `onImageLoad()`: set imageLoaded = true
+    - `onImageError()`: set imageLoaded = false, maintain backgroundColor fallback
+    - `handleCtaClick()`: navigate to cta.url (target=_blank for external, same tab for internal)
+  - Template:
+    - Root div with headerStyles
+    - Conditional `<img>` or `background-image` CSS for image
+    - Overlay div (if overlayMode !== 'none') with overlayStyles
+    - Absolute-positioned content area with title (`<h2>`), subtitle (`<p>`), and CTA button
+    - CTA button with `rel="noopener noreferrer"` if target=_blank
+    - ARIA labels on button combining text + destination
+  - Lifecycle: onMounted → validate config, set up image loading
+  - No data fetching (fully client-side, images load via standard NC preview routes)
+- [ ] 5.2 Handle image-load failure gracefully:
+  - Listen for `@error` on image element
+  - If image fails, clear `background-image` and display backgroundColor instead
+  - No error icon or message in header (falls back silently)
+  - Subtitle and CTA still render normally
+- [ ] 5.3 Handle file ID image source:
+  - Frontend constructs preview URL: `linkToRoute('files.api.v1.resources', {fileid: fileId, preview: true})`
+  - OR use standard NC file preview URL pattern: `/index.php/apps/files/api/v1/files/{fileId}?preview=true`
+  - Pass URL to image element same as external URLs
+  - ACL is handled server-side (invalid file IDs/no ACL → 404 from file preview route)
+- [ ] 5.4 Create Playwright E2E tests:
+  - `testHeaderWidgetRendersTitleAndSubtitle` — widget displays title and subtitle correctly
+  - `testHeaderWidgetWithBackgroundImage` — widget renders image (mocked via preview route)
+  - `testHeaderWidgetWithOverlay` — widget applies tint/gradient overlay
+  - `testHeaderWidgetWithCTA` — CTA button renders and navigates on click
+  - `testHeaderWidgetImageFailureWithColorFallback` — image 404 → backgroundColor only
+  - `testHeaderWidgetHeightPresetsResponsive` — height presets render correctly
+
+## 6. Accessibility
+
+- [ ] 6.1 Ensure semantic HTML:
+  - Title rendered as `<h2>` (proper heading hierarchy)
+  - Subtitle rendered as `<p>` (semantic paragraph)
+  - CTA rendered as `<a href>` or `<button>` with proper labels
+- [ ] 6.2 Add ARIA labels:
+  - CTA button with `aria-label` combining button text and link destination if button text is icon-only
+  - Title and subtitle with proper role/lang attributes if multilingual
+- [ ] 6.3 Keyboard navigation:
+  - CTA button focusable and clickable via Enter/Space
+  - Header widget navigable via Tab in dashboard grid
+- [ ] 6.4 Color contrast:
+  - Auto-contrast logic: detect background brightness and pick white or black text (default if no textColor set)
+  - Manual textColor override supported
+
+## 7. Internationalization (i18n)
+
+- [ ] 7.1 Add Dutch (nl) and English (en) translation keys:
+  - `app.mydash.header_widget_title` — "Kopbanner" / "Header Banner"
+  - `app.mydash.header_config_title` — "Titel" / "Title"
+  - `app.mydash.header_config_subtitle` — "Ondertitel (optioneel)" / "Subtitle (optional)"
+  - `app.mydash.header_config_image` — "Achtergrondafbeelding" / "Background Image"
+  - `app.mydash.header_config_image_url` — "Afbeeldings-URL" / "Image URL"
+  - `app.mydash.header_config_image_file` — "Bestand uit Nextcloud" / "File from Nextcloud"
+  - `app.mydash.header_config_overlay_mode` — "Overlay-modus" / "Overlay Mode"
+  - `app.mydash.header_config_overlay_color` — "Overlay-kleur" / "Overlay Color"
+  - `app.mydash.header_config_overlay_opacity` — "Doorzichtigheid (0-1)" / "Opacity (0-1)"
+  - `app.mydash.header_config_text_color` — "Tekstkleur" / "Text Color"
+  - `app.mydash.header_config_text_align` — "Tekstuitlijning" / "Text Alignment"
+  - `app.mydash.header_config_vertical_align` — "Verticale uitlijning" / "Vertical Alignment"
+  - `app.mydash.header_config_height` — "Hoogte" / "Height"
+  - `app.mydash.header_config_cta` — "Call-to-Action knop (optioneel)" / "Call-to-Action Button (optional)"
+  - `app.mydash.header_config_cta_label` — "Knoptekst" / "Button Text"
+  - `app.mydash.header_config_cta_url` — "Doel-URL" / "Target URL"
+  - `app.mydash.header_config_cta_style` — "Knopstijl" / "Button Style"
+  - `app.mydash.header_config_overlay_none` — "Geen" / "None"
+  - `app.mydash.header_config_overlay_tint` — "Gekleurde overlay" / "Tinted Overlay"
+  - `app.mydash.header_config_overlay_gradient` — "Gradient aan onderkant" / "Gradient Bottom"
+  - `app.mydash.header_config_height_small` — "Klein (120px)" / "Small (120px)"
+  - `app.mydash.header_config_height_medium` — "Gemiddeld (200px)" / "Medium (200px)"
+  - `app.mydash.header_config_height_large` — "Groot (320px)" / "Large (320px)"
+  - `app.mydash.header_config_height_xlarge` — "Extra groot (480px)" / "Extra Large (480px)"
+  - `app.mydash.header_config_text_align_left` — "Links" / "Left"
+  - `app.mydash.header_config_text_align_center` — "Gecentreerd" / "Center"
+  - `app.mydash.header_config_text_align_right` — "Rechts" / "Right"
+  - `app.mydash.header_config_vertical_align_top` — "Boven" / "Top"
+  - `app.mydash.header_config_vertical_align_middle` — "Midden" / "Middle"
+  - `app.mydash.header_config_vertical_align_bottom` — "Onder" / "Bottom"
+  - `app.mydash.header_config_cta_style_primary` — "Primair" / "Primary"
+  - `app.mydash.header_config_cta_style_secondary` — "Secundair" / "Secondary"
+  - `app.mydash.header_config_cta_style_ghost` — "Transparant" / "Ghost"
+- [ ] 7.2 Add translation files:
+  - `l10n/nl.json` — Dutch translations
+  - `l10n/en.json` — English translations (fallback)
+
+## 8. Quality gates and testing
+
+- [ ] 8.1 Run `composer check:strict` (PHPCS, PHPMD, Psalm, PHPStan):
+  - Fix any pre-existing issues in touched files
+  - New PHP code must pass all checks
+- [ ] 8.2 Run ESLint on all Vue/JS files:
+  - `npm run lint` on `src/components/widgets/`
+  - Fix any warnings or errors
+- [ ] 8.3 Run Stylelint on component stylesheets
+- [ ] 8.4 Confirm all hydra-gates pass locally before opening PR
+- [ ] 8.5 Add SPDX-License-Identifier and SPDX-FileCopyrightText headers to every new PHP file (inside docblock)
+- [ ] 8.6 PHPUnit test coverage:
+  - Aim for 80%+ line coverage on `HeaderWidgetService`
+  - All public methods tested
+  - Edge cases (null fields, invalid URLs, file not found) covered
+- [ ] 8.7 Playwright E2E test coverage:
+  - Header widget renders in dashboard
+  - All height presets render correctly
+  - Image loading (external URL and file ID) works
+  - All overlay modes render correctly
+  - CTA button navigates correctly
+  - Image load failure gracefully falls back to backgroundColor
+  - Accessibility: title navigable via keyboard, ARIA labels present
+- [ ] 8.8 Manual testing on local Nextcloud instance:
+  - Create a dashboard with header widget
+  - Configure title, subtitle, background image (external + NC file)
+  - Test each overlay mode and height preset
+  - Test CTA button navigation (internal and external)
+  - Test image load failure (404)
+  - Test file ACL (try with file user cannot read)
+
+## 9. Documentation and changelog
+
+- [ ] 9.1 Update `CHANGELOG.md` with:
+  - New feature: "Add header widget for full-width banners with images, overlays, and CTA"
+  - List features: overlay modes, height presets, image allow-list, file ACL
+- [ ] 9.2 Update `README.md` (if applicable) with widget description
+- [ ] 9.3 Add code comments to `HeaderWidgetService` explaining allow-list logic and file ACL validation

--- a/openspec/changes/image-widget-media-picker/design.md
+++ b/openspec/changes/image-widget-media-picker/design.md
@@ -1,0 +1,76 @@
+# Design — Image Widget Media Picker
+
+## Context
+
+The image-widget capability (currently in `openspec/changes/`, not yet promoted) supports two image sources: a direct URL string and a file uploaded via the resource-uploads endpoint. Both paths store a URL in `content.url`. Authors who already have images in their Nextcloud Files do not want to download and re-upload them; they want a native file picker. This change adds a third source, `nc-file`, that opens the platform's built-in file picker and stores a `fileId` instead of a URL, so the image is resolved at render time against the viewer's own file permissions.
+
+The key design constraint is that the file picker produces a `fileId`, not a URL. A `fileId` is opaque to external consumers and cannot be handed to a plain `<img src>`. The renderer must exchange the `fileId` for a time-limited or permission-respecting URL at view time, and must degrade gracefully when the referenced file has been deleted or is inaccessible to the viewer.
+
+This spec extends `image-widget` and depends on it being in place. It does not modify the URL or upload paths.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Add a "Choose from Nextcloud" button to the image-widget edit form that opens the platform file picker.
+- Store the selected file as `{source: 'nc-file', fileId: number}` on the placement.
+- Resolve the `fileId` to a serving URL at render time, checking the viewer's read permission.
+- Render the broken-image placeholder when the file is deleted or inaccessible.
+- Enforce a MIME-type allow-list at pick time; reject non-image files.
+
+**Non-Goals:**
+- Picking files from external storage providers or federated shares.
+- Serving image content directly from the MyDash backend (the platform's own file-serving URL is used).
+- Permanent public sharing of the picked file (the image is only visible to users who can already read it).
+- Editing or cropping the picked image.
+
+## Decisions
+
+### D1: Storage discriminator — `source` field on the placement
+**Decision**: The placement content gains a `source: 'url' | 'upload' | 'nc-file'` discriminator; the `fileId` field is only present when `source === 'nc-file'`; existing `url`-source placements are unaffected.
+**Alternatives considered**:
+- Store the serving URL derived from `fileId` instead of the `fileId` itself — rejected: serving URLs can expire or change; `fileId` is stable.
+- Overload `content.url` with a `ncfile://` scheme — rejected: fragile, requires a custom scheme parser, breaks the existing renderer's plain `<img src>`.
+**Rationale**: A discriminator field makes the rendering branch explicit and avoids any ambiguity about how to interpret the `url` field.
+
+### D2: File picker integration — platform built-in dialog
+**Decision**: Clicking "Choose from Nextcloud" invokes the platform's built-in file picker dialog, which returns the selected file's node ID.
+**Alternatives considered**:
+- A custom file browser built inside the MyDash edit modal — rejected: duplicates existing platform functionality and requires ongoing maintenance.
+**Rationale**: The built-in picker is already available to all Nextcloud apps, handles federated and local files uniformly, and is familiar to users.
+
+### D3: Permission-respecting render via server-side check
+**Decision**: At view time, the renderer calls `IRootFolder` to verify the current viewer can read the file before returning a serving URL; if the check fails, the broken-image placeholder is shown.
+**Alternatives considered**:
+- Serve all `nc-file` images without a permission check and rely on Nextcloud's file-serving to reject unauthorised requests — rejected: exposes the existence of the file (the browser makes a request that returns 403, leaking the fileId is in use).
+- Cache permission results — rejected: caching introduces staleness if file permissions change between renders.
+**Rationale**: A server-side check is the only way to avoid both information leakage and broken-image noise for users who legitimately cannot see the file.
+
+### D4: MIME-type allow-list
+**Decision**: The picker is constrained to `image/jpeg`, `image/png`, `image/gif`, `image/webp`, and `image/svg+xml`; SVG is only allowed if the admin SVG-sanitiser setting is enabled.
+**Alternatives considered**:
+- Allow any MIME type and rely on `<img>` to refuse non-image content — rejected: exposes the broken-image fallback UX for valid files that happen to not be images; also allows SVG without sanitisation.
+- Exclude SVG entirely — rejected: SVG is a common logo/icon format and admins who have enabled the sanitiser should be able to use it.
+**Rationale**: Restricting the picker MIME list prevents user confusion and closes the SVG XSS vector by linking it to the admin-controlled setting.
+
+### D5: File deletion handling — broken-image placeholder plus admin orphan cleanup
+**Decision**: When the `fileId` no longer exists or the viewer cannot read it, the renderer shows the same broken-image placeholder as the existing `@error` handler; a background admin job identifies dangling `fileId` values in placements.
+**Alternatives considered**:
+- Automatically remove the placement when the file is deleted — rejected: deleting a widget silently is destructive and confusing for the dashboard owner.
+- Show a specific "file deleted" message instead of the generic placeholder — rejected: leaks information about why the image is missing to viewers who may not have had access.
+**Rationale**: The placeholder is already the fallback for broken URLs; reusing it keeps the viewer experience consistent. The admin cleanup job is an operational backstop, not a correctness requirement.
+
+### D6: No change to the URL or upload source paths
+**Decision**: The `url` and `upload` source paths remain exactly as specified in `image-widget`; this change is purely additive.
+**Alternatives considered**: none
+**Rationale**: Additivity prevents regression and allows the media picker to be released independently of or after the base `image-widget` change.
+
+## Risks / Trade-offs
+
+- **Serving URL stability** → The URL returned by `IRootFolder` for a given `fileId` may change if the file is moved. Mitigation: resolve the URL on every render rather than caching it in the placement.
+- **SVG sanitiser dependency** → Admins who enable the SVG MIME type without enabling the sanitiser may be surprised when SVG is still blocked. Mitigation: the UI shows a tooltip explaining the dependency.
+
+## Open follow-ups
+
+- Decide whether the broken-image placeholder for inaccessible `nc-file` images should be distinguishable from a genuinely broken URL to the dashboard owner (but not to plain viewers).
+- Define the cadence and scope of the admin orphan-cleanup job — on-demand, nightly, or triggered by file deletion events.
+- Confirm whether the platform file picker can be constrained to a specific MIME list programmatically or only by post-selection validation.

--- a/openspec/changes/image-widget-media-picker/proposal.md
+++ b/openspec/changes/image-widget-media-picker/proposal.md
@@ -1,0 +1,60 @@
+# Image Widget Media Picker
+
+## Why
+
+The existing image-widget capability (REQ-IMG-001..005) supports two image sources: direct URL paste and direct file upload to the app's resource storage. Neither source leverages the user's existing Nextcloud Files, which creates friction: images the user already has stored in Files must be either downloaded, re-uploaded, or their URL pasted manually. This capability adds a third source path via Nextcloud's native file picker, allowing users to reference images already stored in their Nextcloud instance without re-uploading or manual URL entry.
+
+## What Changes
+
+- Extend the image-widget to track a `sourceType ENUM('url','upload','files')` field on the placement's widget config, stored alongside existing image-widget settings.
+- When `sourceType = 'files'`, the widget edit modal surfaces a "Pick from Files" button that opens the Nextcloud file picker (`@nextcloud/dialogs` or `OCA.Files.FilePicker`) restricted to image MIME types.
+- Selected files are referenced by their Nextcloud file ID and path (stored as `fileId BIGINT` and `filePath VARCHAR(2048)` on the placement).
+- At render time, the widget generates a preview URL using `IURLGenerator::linkToRoute('files_sharing.PublicPreview.getPreview')` or the `core.preview.getPreview` route (depending on viewer-vs-owner access scenario).
+- Viewer-side access checks: if the viewer cannot read the referenced file, the widget shows the same broken-image fallback as URL-mode (REQ-IMG-004) — never throws 500.
+- File deletion: when the source NC file is deleted, the widget keeps its `fileId` reference and shows "image unavailable" rather than silently emptying.
+- Existing URL-mode widgets (REQ-IMG-001..005) continue unchanged.
+- The widget edit form gains a third radio option: "Pick from Files" with the file picker button and resolved file path display.
+- SVG sources (`image/svg+xml`) must be sanitised via the separate `svg-sanitisation` capability before render (referenced but not implemented here).
+
+## Capabilities
+
+### New Capability
+
+- `image-widget-media-picker`: adds REQ-IMP-001..008 to extend the existing `image-widget` with a third media source (Nextcloud Files picker).
+
+### Modified Capability
+
+- `image-widget`: implicitly modified by `image-widget-media-picker` (the picker feature extends the form and widget config). The parent spec is not changed in this capability; changes to `image-widget/spec.md` will follow as a separate delta-style update once both capabilities are approved.
+
+## Impact
+
+**Affected code:**
+
+- `lib/Db/WidgetPlacement.php` — add optional `fileId` and `filePath` fields (nullable BIGINT and VARCHAR) for file-mode placements.
+- `lib/Service/ImageWidgetService.php` — new `resolveFilePreviewUrl()` method using `IURLGenerator` to generate preview URLs respecting viewer access.
+- `src/components/widgets/ImageWidget.vue` — extend form to include `sourceType` radio group and conditional file-picker button; add `@nextcloud/dialogs` or vanilla `OCA.Files.FilePicker` integration.
+- `src/components/widgets/ImageWidgetForm.vue` — handle `sourceType = 'files'` branch with file path display and picker invocation.
+- Migration to schema: add `fileId` (BIGINT NULL) and `filePath` (VARCHAR(2048) NULL) columns to `oc_mydash_widget_placements`.
+
+**Affected APIs:**
+
+- Existing `/api/resources` (URL/upload) endpoints unchanged.
+- New internal service method: `ImageWidgetService::resolveFilePreviewUrl(int $fileId, string $filePath): string`.
+- No new public API endpoints (all logic stays within the widget and forms).
+
+**Dependencies:**
+
+- `@nextcloud/dialogs` (file picker dialogue — already used in Nextcloud UI layer) OR `OCP\Files\IMimeTypeDetector` and `OCA.Files.FilePicker` (existing NC JS).
+- `IURLGenerator` (already available in Nextcloud).
+- No new composer dependencies.
+
+**Migration:**
+
+- Non-breaking: adds two nullable columns to `oc_mydash_widget_placements`. Existing image-widget placements get `fileId = NULL` and `filePath = NULL`; they continue to work via the `url` field and `sourceType` defaults to `'url'`.
+
+## Handover Notes
+
+- File picker MIME type filtering: restrict to `image/png`, `image/jpeg`, `image/gif`, `image/webp`, `image/svg+xml`.
+- SVG handling: SVG sources pass through to the separate `svg-sanitisation` capability for XSS protection before final render (the change proposal references but does not implement sanitisation).
+- Broken image fallback: reuse the existing empty-URL placeholder + message from REQ-IMG-004.
+- UI responsivity: the file picker integration should gracefully handle network delays (file picker may be async on slow connections).

--- a/openspec/changes/image-widget-media-picker/specs/image-widget-media-picker/spec.md
+++ b/openspec/changes/image-widget-media-picker/specs/image-widget-media-picker/spec.md
@@ -1,0 +1,245 @@
+---
+status: draft
+---
+
+# Image Widget Media Picker — New Capability
+
+## ADDED Requirements
+
+### Requirement: REQ-IMP-001 SourceType field for image-widget config
+
+The image widget placement MUST store a `sourceType` field (ENUM: `'url'`, `'upload'`, `'files'`) in the placement's widget config. This field MUST default to `'url'` for backward compatibility with existing image widgets. The field MUST persist across widget updates and MUST be serialized in the placement API response.
+
+#### Scenario: New image widget defaults to URL source
+
+- GIVEN a user creates a new image widget placement with no `sourceType` explicitly set
+- WHEN the placement is saved
+- THEN the placement's config MUST have `sourceType: 'url'`
+
+#### Scenario: SourceType persists across updates
+
+- GIVEN a placement with `sourceType: 'files'` referencing a file
+- WHEN the user updates the widget's title via PUT /api/widgets/{id}
+- THEN the `sourceType` field MUST remain `'files'` after the update
+
+#### Scenario: SourceType included in API response
+
+- GIVEN a placement with `sourceType: 'upload'`
+- WHEN the user fetches the placement via GET /api/widgets/{id}
+- THEN the JSON response MUST include `"sourceType": "upload"`
+
+#### Scenario: Invalid sourceType rejected on input
+
+- GIVEN a user attempts to set `sourceType: 'clipboard'` (not a valid enum value)
+- WHEN the placement is saved
+- THEN the system MUST return HTTP 400 with a validation error
+- AND the `sourceType` value MUST NOT change
+
+### Requirement: REQ-IMP-002 File picker invocation
+
+When the image widget edit form has `sourceType = 'files'`, the form MUST display a "Pick from Files" button that opens Nextcloud's native file picker. The file picker MUST be restricted to image MIME types: `image/png`, `image/jpeg`, `image/gif`, `image/webp`, `image/svg+xml`. The picker MUST support only single-file selection, not multi-select.
+
+#### Scenario: File picker button visible for files source
+
+- GIVEN the user selects `sourceType: 'files'` in the image widget form
+- WHEN the form renders
+- THEN a "Pick from Files" button MUST be visible
+- AND the URL input field MUST be hidden (only the file picker UI is shown for this source type)
+
+#### Scenario: File picker opens on button click
+
+- GIVEN the user clicks the "Pick from Files" button
+- WHEN the file picker opens
+- THEN it MUST display the user's Nextcloud Files directory
+- AND MIME type filtering MUST be applied (only image files visible)
+
+#### Scenario: File picker filters to image MIME types
+
+- GIVEN the file picker is open
+- WHEN the user navigates to a folder containing 10 files (3 images, 7 documents)
+- THEN only the 3 image files MUST be selectable
+- AND the 7 documents MUST appear disabled or hidden
+
+#### Scenario: Single-file selection only
+
+- GIVEN the file picker is open
+- WHEN the user attempts to select multiple files (shift-click, Ctrl+click)
+- THEN only the last file clicked MUST be selected
+- AND the picker MUST NOT allow a multi-selection mode
+
+### Requirement: REQ-IMP-003 File reference storage
+
+When a file is selected via the file picker, the placement MUST store two fields: `fileId` (BIGINT) and `filePath` (VARCHAR, max 2048 bytes). Both MUST be persisted on the placement record in the database. The `filePath` MUST be the display path shown to the user (e.g. `/Photos/vacation.jpg`), suitable for human reading in edit forms and error messages.
+
+#### Scenario: Selected file stores both ID and path
+
+- GIVEN the user selects `/Photos/sunset.png` from the file picker
+- WHEN the widget is saved
+- THEN the placement MUST store:
+  - `fileId: 12345` (the Nextcloud file ID)
+  - `filePath: '/Photos/sunset.png'` (the human-readable path)
+
+#### Scenario: File path survives widget title and style updates
+
+- GIVEN a placement with `fileId: 12345` and `filePath: '/Photos/sunset.png'`
+- WHEN the user updates the widget's custom title via PUT /api/widgets/{id}
+- THEN both `fileId` and `filePath` MUST remain unchanged
+
+#### Scenario: FilePath max length enforced
+
+- GIVEN a user attempts to save a file with an extremely long path (>2048 bytes)
+- WHEN validation occurs
+- THEN the system MUST return HTTP 400 with a validation error
+- AND the placement MUST NOT be saved
+
+### Requirement: REQ-IMP-004 Preview URL generation for file-mode widgets
+
+At render time, the widget MUST generate a preview image URL for the referenced Nextcloud file using the appropriate Nextcloud preview service. The system MUST use `IURLGenerator::linkToRoute()` to generate a URL that respects the viewer's access permissions to the file. The preview URL MUST support both scenarios: files owned by the viewer and files shared with the viewer.
+
+#### Scenario: Viewer can access file, generates preview URL
+
+- GIVEN a placement with `sourceType: 'files'`, `fileId: 12345`, and the viewer owns the file
+- WHEN the widget renders
+- THEN the system MUST call `IURLGenerator::linkToRoute('core.preview.getPreview', ['fileId' => 12345, ...])`
+- AND the generated URL MUST point to a valid preview image
+
+#### Scenario: Viewer cannot access file, returns null
+
+- GIVEN a placement with `fileId: 999999` (a file the viewer has no permission to read)
+- WHEN the widget renders and attempts to generate the preview URL
+- THEN the URL generation service MUST return `null`
+- AND the widget MUST fall back to the broken-image fallback (REQ-IMP-005)
+
+#### Scenario: Shared file preview URL uses public share route
+
+- GIVEN a file is shared with the viewer via a share link
+- AND the placement references the file ID
+- WHEN the widget renders
+- THEN the preview URL MUST be generated using the appropriate shared-file preview route
+- AND the image MUST display correctly without requiring additional authentication
+
+#### Scenario: Preview URL handles file not found gracefully
+
+- GIVEN a placement references a file ID that no longer exists in Nextcloud
+- WHEN the widget renders and attempts to generate the preview URL
+- THEN the URL generation MUST not throw an exception
+- AND the widget MUST proceed to the broken-image fallback
+
+### Requirement: REQ-IMP-005 Broken-image fallback for file-mode widgets
+
+When a file-mode image widget's referenced file is inaccessible (deleted, permissions revoked, or network failure), the widget MUST display the same broken-image placeholder as REQ-IMG-004 (from the base image-widget capability): a 48 px camera icon plus the translated message `t('Image failed to load')`, centered. The widget MUST NOT crash, unmount, or throw a 500 HTTP error. The broken-image fallback MUST be identical regardless of source type (`url`, `upload`, or `files`).
+
+#### Scenario: Deleted file shows broken-image fallback
+
+- GIVEN a placement with `sourceType: 'files'` referencing a file that was deleted from Nextcloud
+- WHEN the widget renders
+- THEN the `<img>` element's `error` event fires (broken image from preview URL 404)
+- AND the widget MUST swap to the empty-URL placeholder with text `'Image failed to load'`
+
+#### Scenario: Permission revoked shows fallback without crash
+
+- GIVEN a file was previously accessible, then the viewer's permissions were revoked
+- WHEN the widget renders on the next page load
+- THEN the preview URL will fail to load
+- AND the `error` event handler MUST catch this gracefully
+- AND the grid and surrounding widgets MUST remain fully functional
+
+#### Scenario: Broken-image state persists until file is restored
+
+- GIVEN a widget is in broken-image fallback state
+- WHEN the file is restored to Nextcloud with the same ID
+- THEN the user must refresh the page to re-attempt loading the preview
+- NOTE: Re-validation on a schedule is out of scope for this change
+
+### Requirement: REQ-IMP-006 File deletion handling
+
+When the referenced Nextcloud file is deleted, the widget MUST retain its `fileId` and `filePath` reference on the placement (the placement is NOT auto-deleted). This allows the widget to show a clear "image unavailable" state (the broken-image fallback) rather than silently clearing the placement or showing a generic empty state. The broken-image fallback (REQ-IMP-005) provides the appropriate user feedback.
+
+#### Scenario: Deleted file retains placement metadata
+
+- GIVEN a placement with `sourceType: 'files'`, `fileId: 12345`, and `filePath: '/Photos/sunset.png'`
+- WHEN the file with ID 12345 is deleted from Nextcloud
+- THEN the placement record MUST still exist with unchanged `fileId` and `filePath`
+- AND the widget MUST render the broken-image fallback on next page load
+
+#### Scenario: Admin can clear orphaned reference manually
+
+- GIVEN a placement with a deleted file's orphaned reference
+- WHEN the widget editor form opens
+- THEN the user CAN click "Pick from Files" to select a new file
+- OR the user CAN switch `sourceType` back to `'url'` to set a new URL
+- AND the orphaned fields (`fileId`, `filePath`) MUST be cleared on save
+
+### Requirement: REQ-IMP-007 Widget form source type UI
+
+The image widget edit form MUST display a "Source Type" radio group with three mutually exclusive options: "URL/Link", "Upload", and "Pick from Files". Only the input fields relevant to the selected source type MUST be visible. Switching between source types MUST NOT erase previously entered values for other source types (values MUST be retained in component state, allowing the user to switch back without re-entering).
+
+#### Scenario: Radio group shows all three source options
+
+- GIVEN the image widget edit form opens
+- WHEN the form renders
+- THEN a radio group MUST be visible with labels: "URL/Link", "Upload", "Pick from Files"
+- AND one option MUST be pre-selected based on the current placement's `sourceType`
+
+#### Scenario: URL form fields shown only for URL source
+
+- GIVEN the user selects the "URL/Link" radio option
+- WHEN the form updates
+- THEN the URL input field and link input field MUST be visible
+- AND the file upload input and file picker button MUST be hidden
+
+#### Scenario: Upload form fields shown only for upload source
+
+- GIVEN the user selects the "Upload" radio option
+- WHEN the form updates
+- THEN the file `<input type="file">` MUST be visible
+- AND the URL/link inputs and file picker button MUST be hidden
+
+#### Scenario: File picker shown only for files source
+
+- GIVEN the user selects the "Pick from Files" radio option
+- WHEN the form updates
+- THEN the "Pick from Files" button and file path display MUST be visible
+- AND the URL input and file upload input MUST be hidden
+
+#### Scenario: Switching sources retains previous values
+
+- GIVEN the user enters a URL in the URL field, then switches to "Upload"
+- WHEN the user switches back to "URL/Link"
+- THEN the previously entered URL MUST still be in the input field
+- AND no data loss MUST occur
+
+### Requirement: REQ-IMP-008 SVG source handoff to sanitisation
+
+When a file-mode image widget references an SVG file (`image/svg+xml`), the widget MUST NOT render the SVG as a raw `<img>` element before sanitisation. Instead, the SVG file reference MUST be passed to the separate `svg-sanitisation` capability (a sibling change) for XSS protection. This capability specifies the handoff point; the actual SVG sanitisation is implemented in the `svg-sanitisation` change.
+
+#### Scenario: SVG file triggers sanitisation handoff
+
+- GIVEN a placement with `sourceType: 'files'` and the selected file has MIME type `image/svg+xml`
+- WHEN the widget edit form saves the placement
+- THEN the `fileId` and `filePath` MUST be stored as normal
+- AND the widget rendering layer MUST route the SVG reference to the `svg-sanitisation` capability
+- AND the raw file content MUST NOT be served directly as an `<img>` src before sanitisation
+
+#### Scenario: Non-SVG images bypass sanitisation requirement
+
+- GIVEN a placement with a PNG file (`image/png`)
+- WHEN the widget renders
+- THEN the image MUST be displayed directly via the preview URL
+- AND the `svg-sanitisation` capability is NOT invoked
+
+#### Scenario: SVG from URL source also requires sanitisation
+
+- GIVEN a placement with `sourceType: 'url'` pointing to an external SVG file
+- WHEN the widget renders
+- THEN the URL MUST be routed through the `svg-sanitisation` capability
+- NOTE: This requirement applies equally to both `url` and `files` sources; it documents the hand-off point for SVG handling
+
+## Non-Functional Requirements
+
+- **Backward Compatibility**: Existing image widgets with `sourceType: 'url'` (default) MUST continue to render unchanged. No breaking changes to REQ-IMG-001..005.
+- **Performance**: File picker invocation (opening) MUST complete within 1 second. Preview URL generation MUST not block rendering; if generation fails, fallback to broken-image state within 500 ms.
+- **Access Control**: Preview URL generation MUST respect Nextcloud's file ACLs; viewers without permission MUST receive `null` URL, not a 403 error. The widget gracefully falls back (REQ-IMP-005).
+- **Data Integrity**: `fileId` and `filePath` MUST be stored transactionally with the placement; an incomplete save MUST not leave orphaned references.
+- **Localization**: All new form labels ("Pick from Files", "Select image file", etc.) and error messages MUST be available in English and Dutch (nl/en) per the i18n requirement.
+- **Accessibility**: The "Pick from Files" button MUST be keyboard-accessible and have an appropriate `aria-label`. The file picker dialog MUST follow Nextcloud's accessibility guidelines.

--- a/openspec/changes/image-widget-media-picker/tasks.md
+++ b/openspec/changes/image-widget-media-picker/tasks.md
@@ -1,0 +1,86 @@
+# Tasks — image-widget-media-picker
+
+## 1. Schema migration
+
+- [ ] 1.1 Create `lib/Migration/VersionXXXXDate2026...AddFilePickerColumns.php` adding `fileId BIGINT NULL` and `filePath VARCHAR(2048) NULL` to `oc_mydash_widget_placements`
+- [ ] 1.2 Migration is reversible (drop columns in `postSchemaChange` rollback path)
+- [ ] 1.3 Run migration locally against sqlite, mysql, and postgres; verify schema applied cleanly each time
+
+## 2. Domain model
+
+- [ ] 2.1 Add `fileId` field to `WidgetPlacement` entity (nullable BIGINT, getter/setter with Entity `__call` pattern — no named args)
+- [ ] 2.2 Add `filePath` field to `WidgetPlacement` entity (nullable VARCHAR(2048), getter/setter)
+- [ ] 2.3 Update `WidgetPlacement::jsonSerialize()` to include both fields (null in output when not a file-mode placement)
+
+## 3. Service layer
+
+- [ ] 3.1 In `ImageWidgetService`, add new method `resolveFilePreviewUrl(int $fileId, string $filePath, ?string $userId = null): ?string` that:
+  - Accepts an optional `$userId` (defaults to current auth user)
+  - Uses `IURLGenerator::linkToRoute()` to generate a preview URL
+  - For shared files, prefers `files_sharing.PublicPreview.getPreview` if viewer lacks direct read access
+  - Falls back to `core.preview.getPreview` for files the viewer owns or has access to
+  - Returns `null` if the file cannot be resolved or is inaccessible (widget will show broken-image fallback)
+- [ ] 3.2 In `ImageWidgetService::renderImage()` (or equivalent render method), add logic to:
+  - Check `placement.sourceType` — if `'files'`, call `resolveFilePreviewUrl()` instead of using `placement.url`
+  - On `null` return, fall back to the broken-image placeholder as per REQ-IMG-004
+- [ ] 3.3 Add PHPUnit test covering: file found and user has access (returns valid URL), file not found (returns null), user lacks access (returns null)
+
+## 4. Frontend widget form
+
+- [ ] 4.1 In `src/components/widgets/ImageWidgetForm.vue` (or the AddWidgetModal's image sub-form):
+  - Add a radio group for `sourceType` with three options: "URL/Link", "Upload", "Pick from Files"
+  - Conditional rendering: only show the corresponding input group for the selected source type
+- [ ] 4.2 For `sourceType = 'url'`: keep existing URL and link inputs as-is (REQ-IMG-005 unchanged)
+- [ ] 4.3 For `sourceType = 'upload'`: keep existing file `<input type="file">` and resource-uploads POST pipeline as-is (REQ-IMG-005 unchanged)
+- [ ] 4.4 For `sourceType = 'files'`: add:
+  - A "Pick from Files" button that opens the Nextcloud file picker (`@nextcloud/dialogs` or `OCA.Files.FilePicker`)
+  - File picker restricted to MIME types: `image/png`, `image/jpeg`, `image/gif`, `image/webp`, `image/svg+xml`
+  - Display the selected file's path (e.g. `/Photos/vacation.jpg`) below the button, read-only
+  - Store selected file's `fileId` and `filePath` in the placement config on save
+- [ ] 4.5 File picker error handling: if picker fails or is cancelled, keep the current selection; show inline error message only on picker failure (not on user cancel)
+- [ ] 4.6 Validation: form still requires either `url` (for url/upload modes) or `filePath` (for files mode) — return validation error if both are empty after selection
+
+## 5. Preview URL handling
+
+- [ ] 5.1 At render time, the widget's URL resolution logic (in `ImageWidget.vue` or renderer) checks:
+  - If `sourceType = 'files'` and `fileId` is set: call the backend `resolveFilePreviewUrl()` API (or backend resolves on load and sends `previewUrl` in the placement payload)
+  - Otherwise, use `url` field as-is
+- [ ] 5.2 For backend-resolved approach: add `GET /api/widgets/{placementId}/preview-url` endpoint that returns `{"url": "..."}` (unauthenticated or uses viewer's permissions to check file access)
+- [ ] 5.3 If viewer cannot access the file, the endpoint returns HTTP 404 or `{"url": null}`; frontend falls back to broken-image placeholder per REQ-IMG-004
+
+## 6. SVG sanitisation handoff
+
+- [ ] 6.1 When `sourceType = 'files'` and selected MIME type is `image/svg+xml`, the widget MUST NOT render the SVG directly
+- [ ] 6.2 Instead, pass the `fileId` and `filePath` to the separate `svg-sanitisation` capability (implementation deferred to that change)
+- [ ] 6.3 Note in the spec and tasks that SVG-from-files MUST be sanitised before render to prevent XSS
+
+## 7. Frontend store
+
+- [ ] 7.1 Ensure `src/stores/dashboards.js` (or widget placement store) includes `fileId` and `filePath` in the placement object serialisation/deserialisation
+- [ ] 7.2 No additional getters/actions needed — the existing placement update flow handles file-mode placements transparently
+
+## 8. PHPUnit tests
+
+- [ ] 8.1 `ImageWidgetServiceTest::testResolveFilePreviewUrl` — file exists and user has access (returns valid preview URL)
+- [ ] 8.2 `ImageWidgetServiceTest::testResolveFilePreviewUrlFileNotFound` — file ID is invalid (returns null)
+- [ ] 8.3 `ImageWidgetServiceTest::testResolveFilePreviewUrlAccessDenied` — user lacks read permission (returns null)
+- [ ] 8.4 `WidgetPlacementMapperTest::roundTripFileFields` — `fileId` and `filePath` persist and are retrieved correctly
+- [ ] 8.5 `ImageWidgetRendererTest::testRenderWithFileSource` — when `sourceType = 'files'`, renderer uses file preview URL, not `url` field
+
+## 9. Playwright E2E tests
+
+- [ ] 9.1 User opens image widget edit modal, selects "Pick from Files" radio
+- [ ] 9.2 "Pick from Files" button opens the file picker and filters to image MIME types
+- [ ] 9.3 User selects a file from their Nextcloud Files; modal displays the file path
+- [ ] 9.4 Form saves; widget renders the selected file as a preview
+- [ ] 9.5 File is later deleted in Nextcloud; widget shows broken-image fallback (no 500 error)
+- [ ] 9.6 URL-mode widget (REQ-IMG-001..005) still works unchanged
+- [ ] 9.7 SVG file selected; widget does NOT render raw SVG (awaits svg-sanitisation capability)
+
+## 10. Quality gates
+
+- [ ] 10.1 `composer check:strict` (PHPCS, PHPMD, Psalm, PHPStan) passes — fix any pre-existing issues encountered along the way
+- [ ] 10.2 ESLint + Stylelint clean on all touched Vue/JS files
+- [ ] 10.3 i18n keys for all new UI strings ("Pick from Files", "Select image file", etc.) in both `nl` and `en` per the i18n requirement
+- [ ] 10.4 SPDX headers on every new PHP file (inside the docblock per the SPDX-in-docblock convention) — gate-spdx must pass
+- [ ] 10.5 Run all 10 `hydra-gates` locally before opening PR

--- a/openspec/changes/link-button-widget-list-mode/design.md
+++ b/openspec/changes/link-button-widget-list-mode/design.md
@@ -1,0 +1,84 @@
+# Design — Link Button Widget List Mode
+
+## Context
+
+The link-button-widget capability (currently in `openspec/changes/`, not yet promoted) renders a single styled button that opens a URL, invokes a named internal action, or creates a file. Dashboard authors who want a navigation panel or a set of related quick-links currently place multiple single-link widgets side by side, consuming a proportionally large number of grid cells. This change extends the widget with a `displayMode: 'list'` that consolidates multiple links into one cell, rendered either as a vertical stack or as horizontal pill buttons.
+
+The design preserves full backward compatibility: existing placements have no `displayMode` field, which the renderer treats as `'button'` (the original single-link mode). The `links` array is only populated in `'list'` mode; the single-link fields (`url`, `label`, `icon`, `actionType`, `backgroundColor`, `textColor`) remain the source of truth in `'button'` mode. Each entry in the `links` array follows the same per-link schema as the parent `link-button-widget` single-link config.
+
+This spec depends on `link-button-widget` being in place. It does not modify the single-link rendering path.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Add `displayMode: 'button' | 'list'` to the placement config, defaulting to `'button'`.
+- In `'list'` mode, render a sequence of links from a `links: array` field using the parent widget's per-link schema.
+- Support `orientation: 'vertical' | 'horizontal'` for the list layout.
+- Reuse the parent's URL sanitisation (reject `javascript:` and `data:`) on every list entry.
+- Provide a Vue list-editor component with drag-to-reorder and per-row edit using the parent's single-link form.
+
+**Non-Goals:**
+- Replacing the existing single-link button with the list mode (both coexist under `displayMode`).
+- Nested lists or grouped sections within a single list widget.
+- Per-link background colour in `'list'` mode (the widget background applies to the whole cell).
+- A maximum link count beyond the grid cell's natural height limit.
+
+## Decisions
+
+### D1: Schema additivity — `displayMode` defaults to `'button'`
+**Decision**: `displayMode` is absent on all existing placements; the renderer treats absence as `'button'` and uses the single-link fields, unchanged.
+**Alternatives considered**:
+- Migrate existing placements to explicit `displayMode: 'button'` — rejected: unnecessary database churn with no user-visible benefit.
+**Rationale**: Zero-migration additivity is the lowest-risk extension path. All existing widget behaviour is preserved without a data migration.
+
+### D2: Per-link schema — reuse parent's single-link config shape
+**Decision**: Each entry in `links[]` carries `{label, url, icon, actionType}` — the same fields as the parent's single-link config minus the widget-level `backgroundColor` and `textColor`.
+**Alternatives considered**:
+- A simplified per-link schema with only `label` and `url` — rejected: authors who want an internal action or createFile entry in a list cannot do so.
+- Include `backgroundColor` and `textColor` per link — rejected: inconsistent visual rhythm within the list; widget-level colour applies uniformly.
+**Rationale**: Reusing the parent schema means the per-row edit form is the parent's `LinkButtonForm.vue` with the colour fields hidden, reducing code duplication.
+
+### D3: Per-link icon resolution — same dual-mode as parent REQ-LBN-002
+**Decision**: Each list entry resolves its `icon` using the same MDI-name / uploaded-resource-URL dual-mode as the parent widget's `IconRenderer`.
+**Alternatives considered**:
+- Icon-only for list entries — rejected: some entries need text labels without icons; some need both.
+- No icons in list mode — rejected: unnecessarily restricts functionality that already exists.
+**Rationale**: Reusing the existing `IconRenderer` keeps both modes visually consistent and avoids a separate icon-resolution code path.
+
+### D4: List orientation — `vertical` flex-column vs `horizontal` flex-row pills
+**Decision**: `orientation: 'vertical' | 'horizontal'` on the list config; `'vertical'` renders a `flex-column` stack, `'horizontal'` renders `flex-row` pills with wrapping.
+**Alternatives considered**:
+- Grid layout — rejected: overkill for a one-dimensional link list.
+- Orientation inferred from the grid cell aspect ratio — rejected: auto-inference would surprise authors when they resize the cell.
+**Rationale**: An explicit boolean-equivalent choice is the simplest UX. Authors pick the orientation once when configuring the widget and it does not change unless they edit it.
+
+### D5: List editor UX — drag-to-reorder with per-row edit panel
+**Decision**: A `LinkListEditorForm.vue` component shows a draggable list of entries; clicking a row opens the parent's `LinkButtonForm.vue` as an inline panel with colour fields hidden.
+**Alternatives considered**:
+- Inline editing directly in the list row — rejected: insufficient horizontal space for six fields in a single row.
+- A separate modal per link — rejected: too many modal layers given the list editor is already inside the widget edit modal.
+**Rationale**: An inline slide-down panel provides enough space for all fields without additional modal nesting, and reuses the existing form without modification.
+
+### D6: URL sanitisation applied per list entry
+**Decision**: The same `javascript:` and `data:` scheme rejection applied to the single-link widget's `url` field is applied to each `links[].url` on save.
+**Alternatives considered**:
+- Sanitise only at render time (omit the link if the scheme is rejected) — rejected: silent data loss on save is worse than a validation error.
+**Rationale**: Validation at save time returns a clear error to the author; render-time silencing produces invisible broken links.
+
+### D7: List entry count — no hard limit beyond HTTP payload limits
+**Decision**: No explicit maximum number of list entries is enforced at the API level; the editor soft-caps at 20 entries via a disabled "Add" button.
+**Alternatives considered**:
+- Hard cap of 10 entries — rejected: some navigation panels legitimately exceed 10 items.
+- No soft cap in the editor — rejected: an unbounded list editor degrades usability for very long lists.
+**Rationale**: The dashboard grid cell provides a natural visual limit. A soft cap at 20 covers the vast majority of use cases; authors who need more can split across multiple list widgets.
+
+## Risks / Trade-offs
+
+- **Reorder state loss** → If the author drags entries and then navigates away without saving, the reorder is lost. Mitigation: the edit modal already has an unsaved-changes guard from the parent widget infrastructure.
+- **Horizontal overflow** → In `'horizontal'` orientation with many long labels, pills may overflow the cell. Mitigation: `flex-wrap` is enabled; overflowing pills wrap to the next row rather than clipping.
+
+## Open follow-ups
+
+- Decide whether `displayMode` should be togglable after creation without losing the `links` array when switching back to `'button'` (preserve `links` in storage but ignore it in `'button'` mode).
+- Determine whether the per-link `actionType: 'createFile'` makes sense inside a list (each click would prompt for a filename separately); consider restricting `actionType` to `'external' | 'internal'` in list mode.
+- Confirm drag-to-reorder library availability — check whether the existing Vue dependency set already includes a sortable list component before adding a new one.

--- a/openspec/changes/link-button-widget-list-mode/proposal.md
+++ b/openspec/changes/link-button-widget-list-mode/proposal.md
@@ -1,0 +1,63 @@
+# Link-Button Widget List Mode
+
+## Why
+
+The existing link-button widget renders a single clickable button per placement, suitable for "one primary action" UI patterns. However, many dashboards need to present multiple related links grouped together in a single widget cell — e.g., "Quick Links" showing Navigation, Help, Settings; or a "Downloads" widget with links to Report 1, Report 2, Report 3. Currently, users must either (a) place multiple single-button widgets side by side (consuming grid space inefficiently) or (b) leave links unmapped in other widget types.
+
+This change extends the link-button widget with an optional "list" display mode, allowing administrators to configure a single widget placement that renders a vertical or horizontal list of multiple links. The change is purely additive — existing single-button placements remain unchanged and function identically.
+
+## What Changes
+
+- Add `displayMode ENUM('button','list')` field to widget-placement config (default: `'button'` for backward compatibility)
+- Add `links JSON` field to widget-placement, typed as an array of link objects (empty or null for button mode; non-empty array for list mode)
+- Each link object reuses the three action-type schema from the parent link-button capability (external URL, internal action_id, or createFile)
+- Add `listOrientation ENUM('vertical','horizontal')` (default: `'vertical'`) to control list layout direction
+- Add `listItemGap ENUM('compact','normal','spacious')` (default: `'normal'`) to control inter-item spacing
+- Extend the edit form with a display-mode toggle and a list editor (reusing the existing single-link form for each entry)
+- Preserve full backward compatibility: placements without `displayMode` or `links` fields remain valid and render using legacy single-link fields
+
+## Capabilities
+
+### New Capabilities
+
+NEW capability: `link-button-widget-list-mode` (NOT a modification of the parent `link-button-widget` capability, because the parent is not yet promoted to `openspec/specs/`; once the parent is promoted, this change will be merged into it via a follow-up delta change)
+
+### Modified Capabilities
+
+- (none — this is a new capability)
+
+## Impact
+
+**Affected code:**
+
+- `lib/Db/WidgetPlacement.php` — add `displayMode` and `links` fields with getters/setters
+- `lib/Db/WidgetPlacementMapper.php` — if list-mode metadata requires indexing, add indexes (initially, no new indexes needed; `links` is fully contained in the placement record)
+- `lib/Service/PlacementService.php` — validation for list-mode invariants (non-empty links array when displayMode='list')
+- `src/components/widgets/LinkButtonWidget.vue` — extend renderer to detect `displayMode` and conditionally render list or single-button layout
+- `src/components/widgets/LinkButtonEditForm.vue` — add display-mode toggle, list editor UI, and drag-to-reorder handler
+- `src/stores/placements.js` — if a dedicated placement store exists, ensure it serialises the new fields correctly
+
+**Affected APIs:**
+
+- No new routes — all changes are to the widget placement's config structure (existing `PUT /api/widgets/{placementId}` handles the new fields)
+- Existing `GET /api/widgets` and `GET /api/dashboard/{id}/widgets` continue to work unchanged; responses now MAY include `displayMode` and `links` fields on placements that have them
+
+**Dependencies:**
+
+- No new Composer or npm dependencies
+- Reuses existing `IconRenderer`, modal components, drag-drop libraries already in the codebase
+
+**Migration:**
+
+- Zero-impact: existing placements without the new fields remain valid (implicit `displayMode = 'button'`)
+- No database schema migration required (JSON fields can be empty/null)
+- No data backfill needed
+- Frontend form auto-detects legacy vs. new format and presents the appropriate UI
+
+## Timeline & Ownership
+
+**Scope:** Widget placement configuration extension + frontend rendering + edit form UI
+
+**Complexity:** Medium — three requirements per link (action type, icon resolution, styling) replicate existing single-button logic; list rendering is straightforward flexbox + role attributes
+
+**Risk:** Low — fully backward compatible; no data migration; no schema changes

--- a/openspec/changes/link-button-widget-list-mode/specs/link-button-widget-list-mode/spec.md
+++ b/openspec/changes/link-button-widget-list-mode/specs/link-button-widget-list-mode/spec.md
@@ -1,0 +1,297 @@
+---
+status: draft
+---
+
+# Link-Button Widget List Mode
+
+## ADDED Requirements
+
+### Requirement: REQ-LBLM-001 Display mode configuration
+
+The link-button widget MUST support a `displayMode ENUM('button','list')` field on its widget-config record. The field MUST default to `'button'` to preserve backward compatibility with existing single-button placements. When `displayMode = 'button'`, the widget renders a single button using only the first entry from the `links` array (or legacy single-link fields). When `displayMode = 'list'`, the widget renders a full vertical or horizontal list of multiple links per the list rendering requirements.
+
+#### Scenario: Display mode field exists with button default
+- GIVEN a new link-button-widget placement is created without specifying `displayMode`
+- WHEN the placement is retrieved via API
+- THEN the placement MUST have `displayMode = 'button'`
+
+#### Scenario: Existing placements remain valid without displayMode
+- GIVEN a placement created before list-mode support exists (no `displayMode` field in data)
+- WHEN the placement is retrieved via API
+- THEN the system MUST treat it as `displayMode = 'button'` implicitly
+- AND the widget MUST render correctly using legacy single-link fields
+
+#### Scenario: Display mode can be set to list
+- GIVEN a placement update includes `displayMode = 'list'`
+- WHEN the update is saved
+- THEN the placement MUST have `displayMode = 'list'`
+
+### Requirement: REQ-LBLM-002 Links array schema
+
+The widget placement MUST support a `links JSON` field typed as an array of link objects. Each link object MUST contain:
+
+```json
+{
+  "label": "string (required)",
+  "url": "string (required)",
+  "icon": "string (optional, name or URL)",
+  "actionType": "enum: 'url' | 'action_id' | 'createFile' (required)",
+  "value": "string (optional, populated only for createFile)"
+}
+```
+
+When `displayMode = 'button'`, only the first entry in the `links` array is used, preserving existing single-button behaviour. When `displayMode = 'list'`, all entries in the array are rendered. The `links` field MAY be empty or null for `displayMode = 'button'` placements (legacy single-link fields take precedence); it MUST be a non-empty array for `displayMode = 'list'`.
+
+#### Scenario: Links array stored on placement
+- GIVEN a placement with `displayMode = 'list'` and `links = [{label: 'Docs', url: '...', actionType: 'url', ...}, ...]`
+- WHEN the placement is retrieved
+- THEN the full `links` array MUST be present in the response
+
+#### Scenario: Single-button mode ignores links array
+- GIVEN a placement with `displayMode = 'button'`, a populated `links` array, AND legacy single-link fields (`url`, `icon`)
+- WHEN the widget renders
+- THEN the legacy fields MUST be used
+- AND the `links` array MUST NOT be rendered
+
+#### Scenario: Links array can be empty for button mode
+- GIVEN a placement with `displayMode = 'button'` and `links = []`
+- WHEN the widget renders
+- THEN the system MUST fall back to legacy single-link fields
+- AND no error MUST occur
+
+### Requirement: REQ-LBLM-003 Action type reuse for list items
+
+Each link entry in the `links` array MUST follow the same three action-type specification as the existing single-button widget (from REQ-LBN-001):
+
+1. `'url'` — External link: `window.open(url, '_blank', 'noopener,noreferrer')`
+2. `'action_id'` — Internal action: resolved against the internal action registry and invoked if registered
+3. `'createFile'` — File creation: opens a filename-prompt modal (per REQ-LBN-003) and creates a new file via `POST /api/files/create`
+
+For `'createFile'` actions, the `value` field MUST contain the file extension (e.g., `'docx'`, `'txt'`). Per-link click handlers MUST respect the dashboard edit-mode suppression (no actions fire when `canEdit === true` and `isAdmin === true`).
+
+#### Scenario: List item with external link
+- GIVEN a list item with `actionType: 'url'` and `url: 'https://example.com'`
+- WHEN the user clicks the list item (not in edit mode)
+- THEN the system MUST open the URL in a new tab
+
+#### Scenario: List item with internal action
+- GIVEN a list item with `actionType: 'action_id'` and `url: 'open-files'` (a registered internal action)
+- WHEN the user clicks the list item
+- THEN the system MUST invoke the registered function for `'open-files'`
+
+#### Scenario: List item with createFile action
+- GIVEN a list item with `actionType: 'createFile'`, `label: 'New Report'`, and `value: 'docx'`
+- WHEN the user clicks the list item
+- THEN the system MUST open the createFile modal (per REQ-LBN-003)
+- AND on success, create a file with `.docx` extension
+
+#### Scenario: List item click suppressed in edit mode
+- GIVEN a widget in a dashboard with `canEdit === true` and `isAdmin === true`
+- AND the widget is rendering in list mode
+- WHEN the user clicks any list item
+- THEN no action MUST fire
+
+### Requirement: REQ-LBLM-004 Icon resolution per list item
+
+Each link entry's `icon` field MUST follow the same dual-mode convention as REQ-LBN-002:
+
+- A URL (starts with `/` or `http`) MUST render as `<img>` 
+- A bare name MUST render via the shared `IconRenderer` (MDI component)
+- An empty or null value MUST render no icon
+
+Icon size MUST be consistent across all list items (24 px square for list mode; 48 px for compact/normal/spacious variants may adjust padding but not icon size). The icon MUST appear inline (left of the label in vertical mode, above in horizontal mode per list orientation).
+
+#### Scenario: Custom icon URL in list item
+- GIVEN a list item with `icon: '/apps/mydash/icons/report.png'` and `label: 'Q4 Report'`
+- WHEN the widget renders in list mode
+- THEN the item MUST show the custom image followed by the label text
+
+#### Scenario: Icon name in list item
+- GIVEN a list item with `icon: 'folder'` (an MDI icon name) and `label: 'Browse files'`
+- WHEN the widget renders
+- THEN the item MUST display the MDI folder icon followed by the label
+
+#### Scenario: No icon in list item
+- GIVEN a list item with `icon: ''` and `label: 'Click here'`
+- WHEN the widget renders
+- THEN no icon MUST appear
+- AND only the label MUST be visible
+
+### Requirement: REQ-LBLM-005 List orientation and spacing
+
+The widget MUST support `listOrientation ENUM('vertical','horizontal')` (default: `'vertical'`) and `listItemGap ENUM('compact','normal','spacious')` (default: `'normal'`) configuration fields on the placement.
+
+Vertical mode MUST render the list as `<ul role="list">` with each item as `<li>`, stacked vertically using flexbox. Horizontal mode MUST render as `<div role="list">` with each item as `<div role="listitem">`, laid out inline as horizontal pills with flex wrapping.
+
+The `listItemGap` values control inter-item spacing:
+- `'compact'` — 0.5 rem gap
+- `'normal'` — 1 rem gap
+- `'spacious'` — 1.5 rem gap
+
+#### Scenario: Vertical list orientation
+- GIVEN a widget with `displayMode: 'list'`, `listOrientation: 'vertical'`, and 3 links
+- WHEN the widget renders
+- THEN the items MUST be stacked vertically
+- AND the HTML MUST use `<ul role="list">` as the container
+
+#### Scenario: Horizontal list orientation
+- GIVEN a widget with `displayMode: 'list'`, `listOrientation: 'horizontal'`, and 3 links
+- WHEN the widget renders
+- THEN the items MUST be laid out inline (horizontally)
+- AND the HTML MUST use `<div role="list">` as the container
+- AND the container MUST have flex wrapping enabled
+
+#### Scenario: List item spacing
+- GIVEN a widget with `listItemGap: 'spacious'`
+- WHEN the widget renders
+- THEN the gap between items MUST be 1.5 rem (CSS `gap: 1.5rem`)
+
+#### Scenario: Orientation and gap default to vertical and normal
+- GIVEN a placement with `displayMode: 'list'` but no `listOrientation` or `listItemGap` fields
+- WHEN the placement is retrieved
+- THEN `listOrientation` MUST default to `'vertical'`
+- AND `listItemGap` MUST default to `'normal'`
+
+### Requirement: REQ-LBLM-006 Edit form integration
+
+The edit form for a link-button-widget placement MUST gain:
+
+1. A "Display mode" toggle/select switching between `'button'` and `'list'`
+2. A list editor UI (only visible when `displayMode = 'list'`) with:
+   - A drag-to-reorder handle for each link
+   - An "Add link" button to append a new entry
+   - An "Edit" button per link opening a modal with the existing single-link form (label, url, actionType, icon, backgroundColor, textColor)
+   - A "Remove" button per link to delete that entry
+
+The single-link form MUST be reused unchanged inside the list editor modal for consistency. When editing in button mode, only the first link's fields are exposed; the full links array remains hidden to the user.
+
+#### Scenario: Display mode toggle in edit form
+- GIVEN the edit form for a link-button-widget placement
+- WHEN the user toggles display mode from `'button'` to `'list'`
+- THEN the form MUST show the list editor section
+- AND the legacy single-link fields MUST be hidden or disabled
+
+#### Scenario: Add link button appends to array
+- GIVEN the list editor with 2 existing links
+- WHEN the user clicks "Add link"
+- THEN a new empty entry MUST be appended to the `links` array
+- AND a form modal MUST open for the user to fill in the new link's details
+
+#### Scenario: Edit link reuses single-link form
+- GIVEN the list editor with 3 links
+- WHEN the user clicks "Edit" on the second link
+- THEN the existing single-link form modal MUST open pre-populated with that link's values
+
+#### Scenario: Remove link deletes from array
+- GIVEN the list editor with 3 links
+- WHEN the user clicks "Remove" on the first link
+- THEN the first link MUST be deleted from the `links` array
+- AND the remaining 2 links MUST shift down in order
+
+#### Scenario: Drag to reorder list items
+- GIVEN the list editor with 3 links A, B, C
+- WHEN the user drags B above A
+- THEN the `links` array order MUST become [B, A, C]
+
+### Requirement: REQ-LBLM-007 Validation and constraints
+
+The system MUST enforce the following validation rules:
+
+- When `displayMode = 'list'`, the `links` field MUST be a non-empty array; if the user tries to save without any links, the form MUST show an error `'At least one link is required for list mode'`.
+- Each link in the `links` array MUST have non-empty `label` and `url` fields; if either is empty, the form MUST prevent saving.
+- When `displayMode = 'button'`, the `links` field MAY be empty or contain up to one entry; if `links` is empty, the legacy single-link fields (URL, icon) MUST be used.
+- The invariant `displayMode = 'button' XOR links is non-empty array` MUST NOT be enforced by the backend — the frontend form ensures this before submission.
+
+#### Scenario: List mode requires non-empty links array
+- GIVEN a placement with `displayMode: 'list'` and `links: []`
+- WHEN the user attempts to save
+- THEN the form MUST display an error message
+- AND the save MUST be prevented
+
+#### Scenario: Each link requires label and url
+- GIVEN a list editor with a link missing the `label` field
+- WHEN the user attempts to save
+- THEN the form MUST show an error
+- AND highlight the offending link
+
+#### Scenario: Button mode with empty links falls back to legacy fields
+- GIVEN a placement with `displayMode: 'button'`, `links: []`, and `url: 'https://example.com'`, `icon: 'external'`
+- WHEN the widget renders
+- THEN the button MUST open the URL from the legacy field
+- AND no error MUST occur
+
+### Requirement: REQ-LBLM-008 Rendering semantics
+
+The list-mode renderer MUST:
+
+1. Wrap the list in `<ul role="list">` (vertical) or `<div role="list">` (horizontal)
+2. Render each link as a `<li>` (vertical) or `<div role="listitem">` (horizontal)
+3. Inside each item, use the same button styling primitives as the single-button mode (background color, text color, hover lift effect, 2 px up translation)
+4. Preserve accessibility: each item MUST have a semantic label derived from its `label` field
+5. Inline styles MUST use CSS variables and inline `style` attributes; no hardcoded colours in the HTML
+
+When icon + label are present, the layout MUST be: icon (left, inline) followed by label text (no wrapping). Icon size MUST be 24 px in list mode. Label text MUST be left-aligned.
+
+#### Scenario: Vertical list renders as ul with li
+- GIVEN a widget with `displayMode: 'list'`, `listOrientation: 'vertical'`, and 2 links
+- WHEN the widget renders
+- THEN the HTML structure MUST be:
+  ```html
+  <ul role="list">
+    <li><!-- item 1 --></li>
+    <li><!-- item 2 --></li>
+  </ul>
+  ```
+
+#### Scenario: Horizontal list renders as div with flex
+- GIVEN a widget with `displayMode: 'list'`, `listOrientation: 'horizontal'`
+- WHEN the widget renders
+- THEN the HTML MUST be:
+  ```html
+  <div role="list" style="display: flex; flex-wrap: wrap; gap: ...">
+    <div role="listitem"><!-- item 1 --></div>
+    <div role="listitem"><!-- item 2 --></div>
+  </div>
+  ```
+
+#### Scenario: List item uses button styling
+- GIVEN a list item with `backgroundColor: '#0066cc'` and `textColor: '#ffffff'`
+- WHEN the item renders
+- THEN the CSS MUST apply `background-color: #0066cc` and `color: #ffffff` via inline styles
+
+#### Scenario: Hover effect applies to list items
+- GIVEN a list item is hovered
+- WHEN the user hovers the pointer over it
+- THEN the item MUST translate up by 2 px
+- AND a soft drop shadow MUST be applied (matching single-button hover)
+
+### Requirement: REQ-LBLM-009 Backward compatibility migration
+
+Existing widget placements created before list-mode support MUST remain valid and render correctly without data migration. Placements lacking a `displayMode` field MUST be treated as `displayMode = 'button'` implicitly. Placements lacking a `links` field MUST use the legacy single-link fields (`url`, `icon`) for rendering.
+
+No schema migration is required — the system MUST support both the old (single-link fields) and new (links array + displayMode) representations side-by-side. The frontend form MUST detect which representation a placement uses and offer the appropriate edit interface: single-link form for `displayMode = 'button'` with no `links` array, list editor for `displayMode = 'list'`.
+
+#### Scenario: Pre-list-mode placement renders with legacy fields
+- GIVEN a placement created before list-mode support, with fields: `{url: 'https://example.com', icon: 'external', label: 'Go'}`
+- AND no `displayMode` or `links` fields
+- WHEN the widget renders
+- THEN the button MUST show using the legacy fields
+- AND the widget MUST function identically to before
+
+#### Scenario: Edit form detects legacy format
+- GIVEN a placement in legacy format (no `displayMode` or `links`)
+- WHEN the edit form opens
+- THEN the system MUST present the single-link form
+- AND NOT the list editor
+
+#### Scenario: Upgrade from button to list preserves existing link
+- GIVEN a placement in legacy format with `url: 'https://example.com'`
+- WHEN the user toggles `displayMode` to `'list'` in the edit form
+- THEN the system MUST create a `links` array with the first entry populated from the legacy fields
+- AND the placement MUST save successfully
+
+#### Scenario: No schema change needed
+- GIVEN the app schema at version N (before list-mode support)
+- WHEN the app is updated to version N+1 (with list-mode support)
+- THEN no Nextcloud migration step MUST run
+- AND existing placements MUST continue to work without re-saving

--- a/openspec/changes/link-button-widget-list-mode/tasks.md
+++ b/openspec/changes/link-button-widget-list-mode/tasks.md
@@ -1,0 +1,98 @@
+# Tasks — link-button-widget-list-mode
+
+## 1. Domain model
+
+- [ ] 1.1 Add `displayMode` field to `WidgetPlacement` entity with getter/setter; default `'button'`
+- [ ] 1.2 Add `links` field to `WidgetPlacement` entity (JSON, nullable) with getter/setter
+- [ ] 1.3 Add `listOrientation` field to `WidgetPlacement` entity; default `'vertical'`
+- [ ] 1.4 Add `listItemGap` field to `WidgetPlacement` entity; default `'normal'`
+- [ ] 1.5 Update `WidgetPlacement::jsonSerialize()` to include all four new fields (with null checks for backward compat)
+
+## 2. Service validation layer
+
+- [ ] 2.1 In `PlacementService::updatePlacement()`, add validation: when `displayMode = 'list'`, the `links` field MUST be a non-empty array
+- [ ] 2.2 Add validation: when `displayMode = 'button'`, `links` MAY be empty, null, or have one entry
+- [ ] 2.3 Return HTTP 400 with error message `'At least one link is required for list mode'` if validation fails
+- [ ] 2.4 Each link in the `links` array MUST have non-empty `label` and `url` fields; return HTTP 400 if either is missing
+- [ ] 2.5 Add fixture-based PHPUnit test covering: button mode with empty links, button mode with one link, list mode with multiple links, list mode with zero links (error case)
+
+## 3. Frontend — renderer component
+
+- [ ] 3.1 In `LinkButtonWidget.vue`, detect `displayMode` from the placement config
+- [ ] 3.2 When `displayMode = 'button'` or `displayMode` is missing, render the existing single-button layout (no changes to existing code path)
+- [ ] 3.3 When `displayMode = 'list'`, render a list container:
+  - Vertical: `<ul role="list">` with `<li>` items, `display: flex; flex-direction: column`
+  - Horizontal: `<div role="list">` with `<div role="listitem">` items, `display: flex; flex-wrap: wrap`
+- [ ] 3.4 For each link in the `links` array, render a clickable item with:
+  - Icon (24 px, left of label, or omitted if empty)
+  - Label (left-aligned text)
+  - Click handler dispatching to the appropriate action type (URL, action_id, or createFile per REQ-LBN-001)
+  - Styling: background color (from link entry or theme default), text color (from link entry or theme default)
+  - Hover effect: translate up 2 px, add soft drop shadow (matching single-button)
+- [ ] 3.5 Apply `listItemGap` spacing via CSS `gap` property (compact 0.5rem, normal 1rem, spacious 1.5rem)
+- [ ] 3.6 Suppress all click handlers when in edit mode (`isAdmin === true` AND dashboard `canEdit === true`)
+- [ ] 3.7 Reuse existing icon-resolution logic (REQ-LBN-002 + REQ-LBLM-004): URL-based icons render as `<img>`, name-based render via `IconRenderer`, empty/null render as no icon
+- [ ] 3.8 Add unit test: vertical list with 3 links renders correct HTML structure
+- [ ] 3.9 Add unit test: horizontal list with 2 links renders correct HTML structure
+- [ ] 3.10 Add unit test: click handlers dispatch correctly for external URL, action_id, and createFile action types
+- [ ] 3.11 Add unit test: click is suppressed in edit mode
+
+## 4. Frontend — edit form component
+
+- [ ] 4.1 In `LinkButtonEditForm.vue` (or a wrapper/modal), add a "Display mode" toggle/select with options `'button'` and `'list'`
+- [ ] 4.2 When `displayMode = 'button'` (or missing), show the existing single-link form (label, url, actionType, icon, backgroundColor, textColor)
+- [ ] 4.3 When `displayMode = 'list'`, show a list editor UI with:
+  - A table/list of existing links with columns: [icon/label, drag handle, edit button, remove button]
+  - An "Add link" button to append a new empty entry
+- [ ] 4.4 For each link in the list editor, "Edit" button opens a modal with the existing single-link form pre-populated with that link's values
+- [ ] 4.5 Implement drag-to-reorder for list items (reorder the `links` array based on user drag)
+- [ ] 4.6 "Remove" button deletes a link from the array (splice at index)
+- [ ] 4.7 Add form validation: when `displayMode = 'list'`, prevent saving if `links` is empty; show error `'At least one link is required'`
+- [ ] 4.8 Add form validation: each link MUST have non-empty `label` and `url`; highlight the offending row if validation fails
+- [ ] 4.9 When editing a placement in legacy format (no `displayMode` or `links`), pre-populate the single-link form from the legacy fields
+- [ ] 4.10 When user toggles `displayMode` from `'button'` to `'list'` in an existing placement, auto-populate the first `links` entry from the legacy single-link fields (if present)
+- [ ] 4.11 Add integration test: user creates a button-mode placement, edits it to switch to list mode with 2 links, saves, and the placement stores correctly
+- [ ] 4.12 Add integration test: user creates a list-mode placement with 3 links, drags one to reorder, removes one, adds another, and the final array is correct
+
+## 5. Frontend — store integration
+
+- [ ] 5.1 Verify the placement store (`src/stores/placements.js` or wherever placements are tracked) serialises the new fields correctly
+- [ ] 5.2 If the store manually reconstructs placement objects, update the reconstruction logic to include `displayMode`, `links`, `listOrientation`, `listItemGap`
+- [ ] 5.3 No schema change to the store state; the new fields are already included in the placement object from the API
+
+## 6. PHPUnit tests
+
+- [ ] 6.1 `PlacementServiceTest::testListModeRequiresNonEmptyLinks` — list mode with empty links array returns error
+- [ ] 6.2 `PlacementServiceTest::testListModeWithValidLinks` — list mode with multiple valid link entries saves correctly
+- [ ] 6.3 `PlacementServiceTest::testButtonModeBackwardCompat` — button mode placement without `displayMode` field is treated as button mode
+- [ ] 6.4 `PlacementServiceTest::testEachLinkRequiresLabelAndUrl` — link entry missing `label` or `url` returns error
+- [ ] 6.5 Test all 3 `listOrientation` values (vertical, horizontal, missing/default)
+- [ ] 6.6 Test all 3 `listItemGap` values (compact, normal, spacious, missing/default)
+
+## 7. E2E Playwright tests
+
+- [ ] 7.1 Create a link-button-widget placement in button mode, verify it renders a single button
+- [ ] 7.2 Edit the placement to switch to list mode with 2 links, verify the list renders vertically with both links
+- [ ] 7.3 Change `listOrientation` to horizontal, verify the list renders inline
+- [ ] 7.4 Change `listItemGap` to spacious, verify the spacing increases (visual or DOM inspection)
+- [ ] 7.5 Click a link with `actionType: 'url'`, verify it opens in a new tab (mock `window.open`)
+- [ ] 7.6 Click a link with `actionType: 'action_id'`, verify the registered action is invoked
+- [ ] 7.7 Click a link with `actionType: 'createFile'`, verify the modal opens and file is created
+- [ ] 7.8 In edit mode, click a list item, verify no action fires (edit-mode suppression)
+- [ ] 7.9 Verify a pre-list-mode placement (legacy format) still renders with legacy fields
+
+## 8. Quality gates
+
+- [ ] 8.1 `composer check:strict` passes (PHPCS, PHPMD, Psalm, PHPStan)
+- [ ] 8.2 ESLint + Stylelint clean on all Vue/JS files
+- [ ] 8.3 Test coverage for new code ≥ 75% (PHPUnit + Playwright combined)
+- [ ] 8.4 i18n keys added for all user-facing strings (error messages, button labels, field labels) in both `nl` and `en`
+- [ ] 8.5 SPDX-License-Identifier header added to any new PHP files (inside the docblock per convention)
+- [ ] 8.6 Update OpenAPI spec / Postman collection if the placement schema is documented there
+- [ ] 8.7 Run all hydra-gates locally before opening PR
+
+## 9. Documentation
+
+- [ ] 9.1 Update the link-button-widget capability documentation (or parent `widgets` docs) to reference the new list-mode capability
+- [ ] 9.2 Add a note in the changelog: "Link-button widget now supports a 'list' display mode for rendering multiple links in a single widget placement"
+- [ ] 9.3 If there is an admin guide or widget configuration guide, add a section explaining how to configure list mode and the available options (orientation, spacing)

--- a/openspec/changes/links-widget/design.md
+++ b/openspec/changes/links-widget/design.md
@@ -1,0 +1,80 @@
+# Design — Links Widget
+
+## Context
+
+Intranet dashboards frequently need a curated, multi-section list of links — think
+"Finance", "HR", and "IT" each with five to ten destination URLs. This is distinct from
+the single-button `link-button-widget` and from `quicklinks-widget` (a flat icon grid).
+The links widget groups links under labelled sections and supports multiple columns so
+the full set fits without excessive vertical scrolling.
+
+Section headings give the grid semantic structure that benefits both sighted users
+(scannable at a glance) and screen reader users (can jump by heading). Each link carries
+an optional icon, a label, and a destination URL.
+
+The widget is editor-managed: admins build and reorder sections and individual links via
+an inline drag-and-drop interface. No backend API is involved at read time — the full
+data set is stored in the widget config and rendered client-side.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Render N sections, each with a heading and a list of labelled links.
+- Support 1–4 column layouts with responsive CSS grid collapse.
+- Provide drag-to-reorder for both sections and individual links.
+- Sanitise all URLs before storage and render.
+
+**Non-Goals:**
+- Dynamic link sources (RSS, search results, external directory).
+- Per-user personalisation of link visibility.
+- Nested sub-sections.
+
+## Decisions
+
+### D1: Data shape
+**Decision:** `sections: [{ heading: string, links: [{ label, url, icon? }] }]` stored
+in widget config JSON.
+**Alternatives considered:** Flat array with a `section` foreign-key field.
+**Rationale:** Nested structure mirrors the render tree, simplifies drag-to-reorder
+scope, and is the natural shape for JSON config storage.
+
+### D2: Column count (`cols: 1|2|3|4`)
+**Decision:** Admin sets `cols`; CSS grid wraps sections into that many columns. On
+narrow viewports (< 600 px), always collapse to 1 column.
+**Alternatives considered:** `auto` flow (sections fill naturally without a hard count).
+**Rationale:** Explicit column count gives the admin predictable layout control; auto
+flow can produce uneven last rows that look unintentional.
+
+### D3: Section ordering via drag-to-reorder
+**Decision:** Sections and their links are each reorderable via drag handles in the
+editor; final order is the array order persisted to config.
+**Alternatives considered:** Alphabetical sort; fixed order with manual index fields.
+**Rationale:** Array-order is the simplest representation for arbitrary sort; drag
+handles are the established pattern in the widget editor for reordering items.
+
+### D4: URL sanitisation
+**Decision:** On save, reject any URL whose scheme is not `http`, `https`, `mailto`, or
+`tel`. Store a validation error on the offending link; block save until resolved.
+**Alternatives considered:** Client-side warn but allow save; server-side only.
+**Rationale:** `javascript:` and `data:` URIs are XSS vectors. Blocking at save (both
+client and server) is the correct defence-in-depth approach.
+
+### D5: Edit UX — inline per-section editor with drag handles
+**Decision:** Each section expands to an inline editor showing heading input and a
+draggable link list; a "+ Add section" button appends a new section at the bottom.
+**Alternatives considered:** Modal editor per section; side-panel editor.
+**Rationale:** Inline editing keeps context visible; admins can see the full layout
+while editing any section, reducing layout surprises.
+
+## Risks / Trade-offs
+
+- Large link sets (10+ sections × 10 links) will produce a long editor panel — consider
+  a collapse-all/expand-all affordance in a follow-up.
+- Drag-to-reorder requires accessible keyboard alternatives (arrow-key reorder) to meet
+  WCAG 2.1 AA; this must be included in implementation, not deferred.
+
+## Open follow-ups
+
+- Add a "link count badge" on collapsed sections in the editor for at-a-glance density.
+- Consider a dynamic source mode (URL returning JSON link list) once the links widget
+  reaches steady adoption.

--- a/openspec/changes/links-widget/proposal.md
+++ b/openspec/changes/links-widget/proposal.md
@@ -1,0 +1,60 @@
+# Links Widget
+
+## Why
+
+MyDash users often need to organize and present collections of related links (e.g., to tools, documents, external resources, or internal app shortcuts) in a curated, visually grouped manner. The existing link-button-widget handles single action buttons; the upcoming link-button-widget-list-mode extends that widget with a simple list view. This proposal adds a NEW widget type optimized for "link directory" layouts: a multi-column grid of link cards organized into named sections, with configurable icons, descriptions, and display styles. Users need this capability to create organized link hubs on their dashboards without resorting to external iframes or multiple single-button widgets.
+
+## What Changes
+
+- Register a new dashboard widget with id `mydash_links` via `OCP\Dashboard\IManager` that appears in the widget picker.
+- Add per-placement configuration stored in `widgetContent JSON` to specify sections (each with title and array of links), column layout, and display mode preferences.
+- Implement fully static rendering (no backend data endpoint required — all configuration is provided at placement edit time).
+- Provide Vue 3 SFC `LinksWidget.vue` with three link layout modes: `card` (icon + label + description), `inline` (flat rows of icon + label), and `icon-only` (grid of icons with hover tooltips).
+- Support configurable icon resolution: Nextcloud built-in icon names (e.g., `icon-files`), custom URLs (via `<img>`), or fall back to generic link icon.
+- Implement tabular edit form with drag-to-reorder for both sections and links within each section.
+- Guard against empty sections: sections with zero links are hidden at render time but retained in config for later editing.
+- Display empty widget state ("No links yet — click the gear icon to add some.") when no sections or links exist.
+- Render via CSS Grid with configurable column count (1–6, default 3).
+- Enforce URL sanitisation on save: reject non-HTTP(S) and non-relative URLs; return HTTP 400 on invalid input.
+- Handle navigation correctly: external URLs use `rel="noopener noreferrer"`, internal URLs (same NC instance) preserve `window.opener` for cross-tab messaging. Optionally open in new tab based on configuration.
+
+## Capabilities
+
+### New Capabilities
+
+- `links-widget` — A new MyDash dashboard widget capability providing a multi-column curated link grid organized into named sections with configurable layout, icon resolution, and edit UI.
+
+## Impact
+
+**Affected code:**
+
+- `src/components/widgets/LinksWidget.vue` — main render component with three layout modes (card, inline, icon-only), CSS Grid layout, and navigation handling.
+- `src/components/widgets/links/LinksWidgetConfig.vue` — tabular edit form with drag-to-reorder for sections and links; URL validation.
+- `src/components/widgets/links/SectionEditor.vue` — sub-component for editing a single section (title + nested link rows).
+- `src/components/widgets/links/LinkEditor.vue` — sub-component for editing a single link (label, url, icon, description).
+- `src/stores/widgets.js` — no new store methods required; widget uses placement config directly.
+- No migration or schema changes required.
+
+**Affected APIs:**
+
+- 0 new routes (fully static, no backend data endpoint).
+- 0 changes to existing routes.
+
+**Dependencies:**
+
+- No new composer or npm dependencies.
+- Uses standard Nextcloud icon classes (MDI via shared NC components).
+- Standard HTML5 `<a>` elements and CSS Grid for layout.
+
+**Migration:**
+
+- Zero-impact: no schema changes, no data migrations, no app config required.
+- Existing dashboards are unaffected; users opt-in by adding the widget to a dashboard.
+
+## Definitions
+
+- **Section**: A named group of links rendered as a labelled container. Empty sections (zero links) are hidden at render time but retained in config.
+- **Link**: A single navigation target with label, URL, optional icon, and optional description.
+- **Layout mode**: How individual links are rendered: `card` (icon + label + description in a compact card), `inline` (flat list of icon+label rows), or `icon-only` (grid of icons with hover tooltip).
+- **Icon resolution**: The process of determining how to render an `icon` field: if it's a Nextcloud built-in name, use MDI class; if it's a URL, render `<img>`; if blank, fall back to generic icon.
+- **URL sanitisation**: Validation that rejects non-HTTP(S) and non-relative URLs (e.g., `javascript:`, `data:`, `file://`).

--- a/openspec/changes/links-widget/specs/links-widget/spec.md
+++ b/openspec/changes/links-widget/specs/links-widget/spec.md
@@ -1,0 +1,445 @@
+---
+capability: links-widget
+status: draft
+---
+
+# Links Widget Specification
+
+## ADDED Requirements
+
+### Requirement: REQ-LNKS-001 Widget registration
+
+The system MUST register a MyDash dashboard widget with id `mydash_links` via `OCP\Dashboard\IManager::registerWidget()` so it appears in the widget picker alongside other Nextcloud dashboard widgets.
+
+#### Scenario: Widget appears in picker
+
+- GIVEN the links-widget app is installed and enabled
+- WHEN a user opens the MyDash widget picker dialog
+- THEN the `mydash_links` widget MUST appear in the list with a title (e.g., "Links") and an icon
+- AND the widget MUST be selectable for placement on a dashboard
+
+#### Scenario: Multiple instances allowed
+
+- GIVEN a dashboard already has one links widget placement
+- WHEN the user adds a second links widget to the same dashboard
+- THEN both placements MUST coexist with independent configurations
+- AND each placement MUST render its own sections and links separately
+
+#### Scenario: Widget registration survives reload
+
+- GIVEN the widget is registered
+- WHEN Nextcloud cache is cleared or the app is reloaded
+- THEN the `mydash_links` widget MUST still be discoverable in the picker
+
+#### Scenario: Widget metadata is complete
+
+- GIVEN the widget is registered
+- WHEN the widget picker fetches widget metadata
+- THEN the widget object MUST include at minimum: id, title, icon_url
+
+### Requirement: REQ-LNKS-002 Placement configuration schema
+
+The system MUST store per-placement widget configuration in the `oc_mydash_widget_placements.widgetContent` JSON field, allowing users to specify sections with links, layout preferences, and display options.
+
+#### Scenario: Config stores sections array
+
+- GIVEN a user is configuring a links widget placement
+- WHEN they add sections and links
+- THEN the configuration MUST store a `sections: [{title: string, links: [...]}, ...]` field
+- AND each section MUST have a title string and an array of link objects
+- AND the config MUST serialize and deserialize cleanly as JSON
+
+#### Scenario: Config stores column count
+
+- GIVEN a user is configuring a links widget placement
+- WHEN they set the number of columns
+- THEN the configuration MUST store a `columns: number` field
+- AND the value MUST be in the range 1–6
+- AND the default value MUST be 3
+
+#### Scenario: Config stores link layout mode
+
+- GIVEN a user is configuring a links widget placement
+- WHEN they select a display mode
+- THEN the configuration MUST store a `linkLayout: 'card'|'inline'|'icon-only'` field
+- AND the default value MUST be `'card'`
+
+#### Scenario: Config stores icon size preference
+
+- GIVEN a user is configuring a links widget placement
+- WHEN they set icon size
+- THEN the configuration MUST store an `iconSize: 'small'|'medium'|'large'` field
+- AND the default value MUST be `'medium'`
+- AND the size MUST map to pixel dimensions: small=24px, medium=40px, large=64px
+
+#### Scenario: Config stores open-in-new-tab preference
+
+- GIVEN a user is configuring a links widget placement
+- WHEN they toggle the new-tab behavior
+- THEN the configuration MUST store an `openInNewTab: boolean` field
+- AND the default value MUST be `true`
+
+#### Scenario: Config stores section visibility preference
+
+- GIVEN a user is configuring a links widget placement
+- WHEN they toggle section title visibility
+- THEN the configuration MUST store a `showSectionTitles: boolean` field
+- AND the default value MUST be `true`
+
+#### Scenario: Config stores description visibility preference
+
+- GIVEN a user is configuring a links widget placement
+- WHEN they toggle description visibility
+- THEN the configuration MUST store a `showLinkDescriptions: boolean` field
+- AND the default value MUST be `true`
+- AND the value MUST only affect the `'card'` layout mode (other modes ignore descriptions)
+
+### Requirement: REQ-LNKS-003 Link data structure
+
+The system MUST support a link object with label, URL, icon, and optional description, and MUST allow zero or more links per section.
+
+#### Scenario: Link has required fields
+
+- GIVEN a link in a section
+- WHEN the widget configuration is saved
+- THEN each link MUST have at minimum: `label: string` and `url: string`
+- AND the label MUST be a non-empty string
+- AND the url MUST be non-empty after sanitisation
+
+#### Scenario: Link has optional icon field
+
+- GIVEN a link in a section
+- WHEN the widget configuration is saved
+- THEN the link MAY have an `icon: string` field (can be empty, a Nextcloud icon name, or a URL)
+- AND if present, the icon MUST be resolved per REQ-LNKS-004
+
+#### Scenario: Link has optional description field
+
+- GIVEN a link in a section
+- WHEN the widget configuration is saved
+- THEN the link MAY have a `description: string` field (empty or text)
+- AND the description MUST only be displayed in `'card'` layout mode (REQ-LNKS-006)
+
+#### Scenario: Empty sections are hidden at render time
+
+- GIVEN a section with title but zero links
+- WHEN the widget renders
+- THEN the section MUST NOT appear in the DOM
+- AND the section MUST remain in the stored config (for user convenience)
+- NOTE: Users can add links later without reconfiguring the section
+
+### Requirement: REQ-LNKS-004 Icon resolution precedence
+
+The system MUST resolve the `icon` field of a link using the following precedence:
+
+1. If `icon` is empty or null, render a generic link icon (stock Nextcloud icon).
+2. Else if `icon` matches a known Nextcloud icon name pattern (bare word, no slashes; e.g., `icon-files`, `icon-download`), render it via the shared IconRenderer as an MDI `<svg>` class.
+3. Else if `icon` is a URL (starts with `/` or `http`), render it as an `<img>` element with `src` set to the URL.
+4. Else (unrecognized format), fall back to the generic link icon.
+
+#### Scenario: Nextcloud icon name resolved to SVG class
+
+- GIVEN link config `{label: 'Files', url: '/apps/files', icon: 'icon-files'}`
+- WHEN the widget renders
+- THEN the system MUST render an `<svg>` with class `icon-icon-files` (or equivalent Nextcloud MDI class)
+- AND the icon MUST display at the configured iconSize (24/40/64 px)
+
+#### Scenario: URL icon resolved to img element
+
+- GIVEN link config `{label: 'Custom', url: 'https://example.com', icon: 'https://example.com/logo.png'}`
+- WHEN the widget renders
+- THEN the system MUST render `<img src="https://example.com/logo.png" alt="Custom">`
+- AND the img size MUST match the configured iconSize
+
+#### Scenario: Empty icon defaults to generic link icon
+
+- GIVEN link config `{label: 'Document', url: '/docs/readme.pdf', icon: ''}`
+- WHEN the widget renders
+- THEN the system MUST render a generic link icon (e.g., `icon-link` or similar)
+
+#### Scenario: Unrecognized icon format defaults gracefully
+
+- GIVEN link config `{label: 'Bad Icon', url: 'https://example.com', icon: 'not-a-real-icon-name'}`
+- WHEN the widget renders
+- THEN the system MUST fall back to the generic link icon (not crash)
+
+### Requirement: REQ-LNKS-005 Three link layout modes
+
+The system MUST support three distinct layout modes for rendering links, controlled by the `linkLayout` config field.
+
+#### Scenario: Card layout with full details
+
+- GIVEN config `{linkLayout: 'card', showLinkDescriptions: true}`
+- WHEN the widget renders
+- THEN each link MUST display in a card container with:
+  - Icon (resolved per REQ-LNKS-004)
+  - Label text (bold or prominent)
+  - Description text (if present in config and showLinkDescriptions=true)
+  - Visual card border/padding/hover effect
+- AND cards MUST be arranged in the CSS Grid (REQ-LNKS-007)
+
+#### Scenario: Inline layout without descriptions
+
+- GIVEN config `{linkLayout: 'inline'}`
+- WHEN the widget renders
+- THEN each link MUST display as a flat row:
+  - Icon (resolved per REQ-LNKS-004)
+  - Label text beside the icon
+  - Description MUST NOT appear (even if present in config)
+- AND rows MUST NOT have card styling (no border, minimal padding)
+
+#### Scenario: Icon-only layout with hover tooltip
+
+- GIVEN config `{linkLayout: 'icon-only'}`
+- WHEN the widget renders
+- THEN each link MUST display as:
+  - Icon (resolved per REQ-LNKS-004) only
+  - No visible label
+  - Label appears on hover as a tooltip
+- AND icons MUST be arranged in a grid (CSS Grid with equal-sized cells)
+- AND description MUST NOT appear
+
+#### Scenario: Description visibility toggle
+
+- GIVEN a widget in `'card'` layout with showLinkDescriptions=false
+- WHEN the widget renders
+- THEN the description MUST NOT be displayed for any link
+- AND the card MUST not expand to show description space
+
+### Requirement: REQ-LNKS-006 Multi-column grid layout
+
+The system MUST render sections and links using a CSS Grid layout with a configurable column count, allowing responsive multi-column link organization.
+
+#### Scenario: Grid renders with configured columns
+
+- GIVEN config `{columns: 3}`
+- WHEN the widget renders
+- THEN the system MUST generate a CSS Grid with `grid-template-columns: repeat(3, 1fr)`
+- AND all link cards/items MUST flow left-to-right, wrapping to the next row
+- AND all items MUST have equal width
+
+#### Scenario: Column count respects bounds
+
+- GIVEN a user enters columns=7 (out of valid range 1–6)
+- WHEN the config is saved
+- THEN the system MUST reject the input (HTTP 400 or validation error)
+- OR silently clamp to 6 and warn the user
+
+#### Scenario: Single-column layout
+
+- GIVEN config `{columns: 1}`
+- WHEN the widget renders
+- THEN links MUST be displayed as a single vertical list
+
+#### Scenario: Six-column layout
+
+- GIVEN config `{columns: 6}`
+- WHEN the widget renders
+- THEN links MUST be arranged in 6 columns (for compact dense display)
+
+#### Scenario: Responsive behavior on mobile
+
+- GIVEN the widget on a small viewport (mobile phone)
+- WHEN the CSS Grid renders
+- THEN the layout MUST adapt responsively:
+  - Either wrap columns or collapse to single column (CSS media queries)
+  - OR the grid respects the configured columns and horizontal scroll if needed
+- NOTE: The specific responsive behavior is implementation-detail; requirement is that it MUST be usable on mobile
+
+### Requirement: REQ-LNKS-007 URL sanitisation and validation
+
+The system MUST validate and sanitise all URLs in the links configuration to reject malicious or malformed inputs.
+
+#### Scenario: Valid HTTPS URL accepted
+
+- GIVEN a link config with `url: 'https://example.com/page'`
+- WHEN the config is saved
+- THEN the URL MUST be accepted and stored
+- AND the system MUST NOT reject it
+
+#### Scenario: Valid HTTP URL accepted
+
+- GIVEN a link config with `url: 'http://example.com/page'`
+- WHEN the config is saved
+- THEN the URL MUST be accepted and stored
+
+#### Scenario: Valid relative URL accepted
+
+- GIVEN a link config with `url: '/apps/files/list'` or `url: '../other'`
+- WHEN the config is saved
+- THEN relative URLs (starting with `/` or `../`) MUST be accepted
+- AND path traversal (multiple `../` chains) MUST be rejected
+- NOTE: Simple relative paths are for internal Nextcloud navigation
+
+#### Scenario: JavaScript URL rejected
+
+- GIVEN a link config with `url: 'javascript:alert("xss")'`
+- WHEN the config is saved
+- THEN the system MUST return HTTP 400 with error message
+- AND the URL MUST NOT be stored
+- AND the user MUST see validation feedback (e.g., "Invalid URL")
+
+#### Scenario: Data URL rejected
+
+- GIVEN a link config with `url: 'data:text/html,...'`
+- WHEN the config is saved
+- THEN the system MUST reject with HTTP 400
+
+#### Scenario: File URL rejected
+
+- GIVEN a link config with `url: 'file:///etc/passwd'`
+- WHEN the config is saved
+- THEN the system MUST reject with HTTP 400
+
+#### Scenario: Empty URL rejected
+
+- GIVEN a link config with `url: ''` or `url: null`
+- WHEN the config is saved
+- THEN the system MUST reject with HTTP 400 and error message
+- AND a label "Link URL is required" MUST be shown to the user
+
+### Requirement: REQ-LNKS-008 Edit form with drag-to-reorder
+
+The system MUST provide an interactive configuration UI allowing users to add/edit/delete sections and links, and reorder them via drag-and-drop.
+
+#### Scenario: Add a new section
+
+- GIVEN the configuration form is open
+- WHEN the user clicks "Add Section"
+- THEN a new section row MUST be appended with:
+  - Editable title text field (placeholder "Section title")
+  - A nested links table (initially empty)
+  - A delete button for the section
+
+#### Scenario: Edit section title
+
+- GIVEN a section exists in the form
+- WHEN the user clicks the title field and types a new name
+- THEN the title MUST update in the rendered config
+- AND the widget preview (if any) MUST update
+
+#### Scenario: Add link to section
+
+- GIVEN a section is open in the form
+- WHEN the user clicks "Add Link" under that section
+- THEN a new link row MUST be appended with:
+  - Label input
+  - URL input
+  - Icon input (with icon preview)
+  - Description input (collapsible or conditional)
+  - Delete button
+
+#### Scenario: Edit link details
+
+- GIVEN a link row is displayed
+- WHEN the user edits any field (label, url, icon, description)
+- THEN the config MUST update in real-time
+- AND the widget preview (if any) MUST re-render
+
+#### Scenario: Delete link
+
+- GIVEN a link row is displayed
+- WHEN the user clicks the delete button
+- THEN the link MUST be removed from the section
+- AND if the section becomes empty, it MUST still exist (per REQ-LNKS-003)
+
+#### Scenario: Delete section
+
+- GIVEN a section row is displayed
+- WHEN the user clicks the delete button
+- THEN the section MUST be removed from the config
+- AND all links in that section are deleted
+
+#### Scenario: Drag to reorder sections
+
+- GIVEN the configuration form displays multiple sections
+- WHEN the user drags the drag handle (⋮⋮) of a section upward or downward
+- THEN the section MUST move to the new position
+- AND the order MUST persist in the config JSON
+- NOTE: Drag handle visibility/affordance is implementation detail
+
+#### Scenario: Drag to reorder links within a section
+
+- GIVEN a section with multiple links
+- WHEN the user drags the drag handle of a link up or down
+- THEN the link MUST move to the new position within that section
+- AND links in other sections MUST NOT be affected
+- AND the order MUST persist in the config JSON
+
+#### Scenario: Icon preview in edit form
+
+- GIVEN the link editor displays an icon input field
+- WHEN the user enters a Nextcloud icon name (e.g., `icon-files`)
+- THEN a small preview MUST display the resolved icon (SVG)
+- AND when the user enters a URL (e.g., `https://example.com/logo.png`)
+- THEN the preview MUST show the `<img>` (or a placeholder if URL is not yet valid)
+
+### Requirement: REQ-LNKS-009 Empty widget state
+
+The system MUST display a user-friendly empty-state message when the widget has no links to display.
+
+#### Scenario: Empty state appears with no sections
+
+- GIVEN a links widget with empty config `{sections: []}`
+- WHEN the widget renders
+- THEN a message MUST appear: "No links yet — click the gear icon to add some."
+- AND no links grid MUST be visible
+- AND no sections MUST appear
+
+#### Scenario: Empty state appears when all sections are empty
+
+- GIVEN a links widget with `{sections: [{title: 'Tools', links: []}]}`
+- WHEN the widget renders
+- THEN the section MUST be hidden (per REQ-LNKS-003)
+- AND the empty-state message MUST appear (since no visible sections remain)
+
+#### Scenario: Gear icon navigates to edit
+
+- GIVEN the empty-state message is displayed
+- WHEN the user clicks "gear icon" (or clickable edit affordance)
+- THEN the widget edit modal MUST open (if supported by the dashboard UI)
+- OR the dashboard MUST switch to edit mode (platform dependent)
+
+### Requirement: REQ-LNKS-010 Navigation handling and rel attributes
+
+The system MUST correctly handle link navigation, distinguishing between external and internal URLs, and set appropriate `rel` attributes to prevent security issues and preserve cross-tab messaging where needed.
+
+#### Scenario: External URL uses rel="noopener noreferrer"
+
+- GIVEN a link config with `url: 'https://example.com'` (external)
+- WHEN the user clicks the link
+- AND openInNewTab=true
+- THEN the system MUST call `window.open(url, '_blank', 'noopener,noreferrer')`
+- OR render an `<a>` element with `rel="noopener noreferrer"` and `target="_blank"`
+- NOTE: This prevents the external site from accessing `window.opener`
+
+#### Scenario: Internal URL preserves window.opener
+
+- GIVEN a link config with `url: '/apps/files'` (relative, internal to same NC instance)
+- WHEN the user clicks the link
+- AND openInNewTab=true
+- THEN the system MUST allow `window.opener` to be accessible (no `noopener`)
+- AND the link MUST open in a new tab
+- NOTE: This allows the new tab to communicate back to the dashboard if needed
+
+#### Scenario: Same-window navigation
+
+- GIVEN a link config with `url: 'https://example.com'` and openInNewTab=false
+- WHEN the user clicks the link
+- THEN the system MUST navigate the same window (no new tab)
+- AND `rel="noopener noreferrer"` is not applicable (no new window)
+
+#### Scenario: Internal link in same window
+
+- GIVEN a link config with `url: '/apps/mydash/dashboard/1'` and openInNewTab=false
+- WHEN the user clicks the link
+- THEN the system MUST navigate to the URL in the same window
+- AND no `rel` attribute is needed
+
+#### Scenario: Click handler does not fire in edit mode
+
+- GIVEN the widget is in edit mode (dashboard edit UI is open)
+- WHEN the user clicks a link
+- THEN the click handler MUST be suppressed (no navigation)
+- AND the link MUST remain editable (not navigated away)
+

--- a/openspec/changes/links-widget/tasks.md
+++ b/openspec/changes/links-widget/tasks.md
@@ -1,0 +1,235 @@
+# Tasks — links-widget
+
+## 1. Widget registration
+
+- [ ] 1.1 Register the widget in `AppInfo/Bootstrap.php` or via a listener on Nextcloud's widget discovery:
+  - Call `IManager::registerWidget()` (or equivalent discovery hook) with widget id `mydash_links`
+  - Provide widget metadata: title (translatable `app.mydash.links_widget_title`), icon URL
+- [ ] 1.2 Create PHPUnit test:
+  - `testLinksWidgetIsRegistered` — verify widget appears in `IManager::getWidgets()`
+
+## 2. Placement configuration schema and parsing
+
+- [ ] 2.1 Define canonical configuration structure in placement `widgetContent JSON`:
+  ```json
+  {
+    "sections": [
+      {
+        "title": "string",
+        "links": [
+          {
+            "label": "string",
+            "url": "string (HTTP(S) or relative)",
+            "icon": "string (empty, Nextcloud icon name, or URL)",
+            "description": "string (optional)"
+          }
+        ]
+      }
+    ],
+    "columns": number (1-6, default 3),
+    "linkLayout": "card" | "inline" | "icon-only" (default "card"),
+    "iconSize": "small" | "medium" | "large" (default "medium", maps to 24/40/64 px),
+    "openInNewTab": boolean (default true),
+    "showSectionTitles": boolean (default true),
+    "showLinkDescriptions": boolean (default true, only honoured in "card" layout)
+  }
+  ```
+- [ ] 2.2 Add helper function in `WidgetPlacementService` or config parser:
+  - `extractLinksConfig(WidgetPlacement $placement): array` — deserialize `widgetContent` with defaults
+  - Validate schema: sections is array, each section has title+links, links have label+url, columns in range 1–6, layout is valid enum, iconSize is valid enum, booleans are booleans
+  - Return parsed config or throw validation exception
+- [ ] 2.3 Create PHPUnit test:
+  - `testExtractLinksConfigWithDefaults` — verify defaults applied
+  - `testExtractLinksConfigInvalidColumns` — columns > 6 rejected
+  - `testExtractLinksConfigEmptySections` — empty sections array is valid
+
+## 3. URL sanitisation (backend validation on config save)
+
+- [ ] 3.1 Add URL validator in `WidgetPlacementService::validateLinksConfig()`:
+  - For each link in each section, validate `url`:
+    - If starts with `/`, must not be path traversal (no `..`); accept relative
+    - If starts with `http://` or `https://`, parse and accept
+    - If any other scheme (javascript, data, file, etc.), reject with HTTP 400
+    - Empty URLs are rejected
+  - Return validation error with HTTP 400 if any URL invalid
+- [ ] 3.2 Call this validator on PUT/PATCH placement to prevent bad URLs at save time
+- [ ] 3.3 Create PHPUnit test:
+  - `testValidateUrlHttps` — https://example.com accepted
+  - `testValidateUrlRelative` — /apps/myapp/doc accepted
+  - `testValidateUrlJavascript` — javascript:alert(...) rejected
+  - `testValidateUrlData` — data:text/html rejected
+  - `testValidateUrlEmpty` — empty string rejected
+
+## 4. Frontend widget component (Vue 3 SFC)
+
+- [ ] 4.1 Create `src/components/widgets/LinksWidget.vue`:
+  - Props: `placement: object` (with widgetContent config)
+  - Computed: `config` (parsed from placement widgetContent with defaults)
+  - Computed: `visibleSections` — filter to sections with > 0 links
+  - Computed: `columnCount` — layout CSS variable
+  - Data: none (fully static, no API calls)
+  - Template: 
+    - Empty state if no visible sections
+    - Else: `<div style="display: grid; grid-template-columns: repeat(var(--cols), 1fr);">`
+    - For each visible section: section header (if showSectionTitles) + list of links
+    - For each link: render based on linkLayout mode (card, inline, or icon-only)
+  - CSS: CSS Grid, responsive column fallback for mobile, no hardcoded colors (use CSS variables for nldesign)
+- [ ] 4.2 Create `src/components/widgets/links/LinkCard.vue` (sub-component, card mode):
+  - Props: `link: object`, `iconSize: string`, `showDescription: boolean`, `openInNewTab: boolean`
+  - Template: card container with icon + label + description
+  - Icon resolution: call `resolveIcon()` helper (see 4.5)
+  - Click handler: sanitize URL, determine `rel` attribute based on URL type, call `navigateTo()`
+  - CSS: card border, padding, hover effect, responsive for small screens
+- [ ] 4.3 Create `src/components/widgets/links/LinkInline.vue` (sub-component, inline mode):
+  - Props: `link: object`, `iconSize: string`, `openInNewTab: boolean`
+  - Template: flat list item with icon + label only (description ignored)
+  - Click handler: same as LinkCard
+- [ ] 4.4 Create `src/components/widgets/links/LinkIconOnly.vue` (sub-component, icon-only mode):
+  - Props: `link: object`, `iconSize: string`, `openInNewTab: boolean`
+  - Template: icon grid item with `<img>` or `<svg>` (size from iconSize)
+  - Hover: show tooltip with link label
+  - Click handler: same as LinkCard
+- [ ] 4.5 Create helper function `resolveIcon(iconField: string): {type: 'svg'|'img', src?: string, class?: string}`:
+  - If `iconField` is empty or null: return `{type: 'svg', class: 'icon-link'}` (generic link icon)
+  - Else if `iconField` matches Nextcloud icon pattern (bare word, no slashes): return `{type: 'svg', class: 'icon-' + iconField}`
+  - Else if `iconField` starts with `/` or `http`: return `{type: 'img', src: iconField}`
+  - Else: default to generic link icon
+- [ ] 4.6 Create helper function `navigateTo(url: string, openInNewTab: boolean, isExternal: boolean)`:
+  - Determine `rel` attribute:
+    - If external: `rel="noopener noreferrer"`
+    - If internal (same NC instance): no `rel` or `rel=""` (preserve `window.opener`)
+  - If `openInNewTab`: `window.open(url, '_blank', 'noopener,noreferrer')` (for external) or `window.open(url, '_blank')` (for internal)
+  - Else: `window.location.href = url`
+  - Note: for `<a>` elements, set `rel` and `target` attributes instead of using JavaScript
+- [ ] 4.7 Create Playwright E2E tests:
+  - `testLinksWidgetRenderCard` — widget renders links as cards with all fields visible
+  - `testLinksWidgetRenderInline` — widget renders links as flat list (no description)
+  - `testLinksWidgetRenderIconOnly` — widget renders icon grid with tooltips on hover
+  - `testLinksWidgetEmptyState` — no sections or no links → empty state message
+  - `testLinksWidgetExternalLinkOpensNewTab` — click external link → opens new tab with noopener
+  - `testLinksWidgetInternalLinkSameWindow` — click internal link (relative URL) → navigates same window or new tab per config
+  - `testLinksWidgetHiddenSections` — section with zero links not rendered, but still in config
+  - `testLinksWidgetResponsiveColumns` — column count matches config, grid reflows on resize
+
+## 5. Widget configuration UI component
+
+- [ ] 5.1 Create `src/components/widgets/links/LinksWidgetConfig.vue`:
+  - Used by `WidgetAddEditModal.vue` when configuring a links widget placement
+  - Sections editor:
+    - Render array of sections, one per row
+    - Each row has: title text input, delete button, drag handle (⋮⋮)
+    - Click "Add Section" button to append empty section
+    - Links sub-editor per section (see 5.2)
+  - Global options panel:
+    - `columns`: number input (1–6, default 3)
+    - `linkLayout`: radio or dropdown (card, inline, icon-only; default card)
+    - `iconSize`: radio or dropdown (small, medium, large; default medium)
+    - `openInNewTab`: checkbox (default true)
+    - `showSectionTitles`: checkbox (default true)
+    - `showLinkDescriptions`: checkbox (default true, disabled if linkLayout !== 'card')
+  - Validation on save:
+    - All section titles non-empty
+    - Each section has ≥ 1 link (or warn user)
+    - All link URLs valid (call backend validator or do client-side check)
+    - Columns in range 1–6
+  - On save: call backend URL sanitisation endpoint, collect errors, emit `update:widgetContent` with serialized config
+- [ ] 5.2 Create `src/components/widgets/links/SectionEditor.vue` (sub-component):
+  - Props: `section: object` (with title+links), `index: number`
+  - Events: `update:section`, `delete`, `reorder-links`
+  - Template:
+    - Title input field
+    - Delete section button
+    - Links table below (rows of links in that section)
+    - "Add Link" button to append empty link row
+  - Link rows:
+    - Drag handle (⋮⋮), label input, URL input, icon input, description input (collapsible/optional)
+    - Delete button per link
+    - Drag-to-reorder links within section
+- [ ] 5.3 Create `src/components/widgets/links/LinkEditor.vue` (sub-component):
+  - Props: `link: object` (label, url, icon, description), `index: number`, `showDescriptionField: boolean`
+  - Events: `update:link`, `delete`, `reorder`
+  - Template:
+    - Row with inputs: label, url, icon (text input with icon preview), optional description
+    - Delete button, drag handle
+    - Inline validation feedback (URL format check)
+  - Icon preview: show resolved icon (SVG or img) in a small preview area
+- [ ] 5.4 Integrate into `WidgetAddEditModal.vue`:
+  - When user selects `mydash_links` widget from picker
+  - Display `LinksWidgetConfig.vue` instead of default generic config panel
+  - Pass placement config to component, listen for `update:widgetContent` to update form state
+- [ ] 5.5 Create Playwright test:
+  - `testLinksWidgetConfigAddSection` — open config, add section, add links, verify structure
+  - `testLinksWidgetConfigDragReorderSection` — drag section to different position, verify order in config
+  - `testLinksWidgetConfigDragReorderLink` — drag link to different position within section, verify order
+  - `testLinksWidgetConfigDeleteLink` — delete link, verify it's removed from config
+  - `testLinksWidgetConfigValidateUrl` — enter invalid URL, see error, fix it, can save
+  - `testLinksWidgetConfigIconPreview` — enter Nextcloud icon name, see preview; enter image URL, see img preview
+
+## 6. Internationalization (i18n)
+
+- [ ] 6.1 Add Dutch (nl) and English (en) translation keys:
+  - `app.mydash.links_widget_title` — "Links" / "Links"
+  - `app.mydash.links_empty_state` — "Geen links gedefinieerd — klik op het tandwielpictogram om er enkele toe te voegen." / "No links yet — click the gear icon to add some."
+  - `app.mydash.links_column_count` — "Kolommen" / "Columns"
+  - `app.mydash.links_link_layout` — "Lay-out" / "Layout"
+  - `app.mydash.links_icon_size` — "Pictogramgrootte" / "Icon size"
+  - `app.mydash.links_open_new_tab` — "In nieuw tabblad openen" / "Open in new tab"
+  - `app.mydash.links_show_titles` — "Sectietitels weergeven" / "Show section titles"
+  - `app.mydash.links_show_descriptions` — "Beschrijvingen weergeven" / "Show descriptions"
+  - `app.mydash.links_add_section` — "Sectie toevoegen" / "Add section"
+  - `app.mydash.links_add_link` — "Link toevoegen" / "Add link"
+  - `app.mydash.links_section_title` — "Sectietitel" / "Section title"
+  - `app.mydash.links_link_label` — "Label" / "Label"
+  - `app.mydash.links_link_url` — "URL" / "URL"
+  - `app.mydash.links_link_icon` — "Pictogram (naam of URL)" / "Icon (name or URL)"
+  - `app.mydash.links_link_description` — "Beschrijving (optioneel)" / "Description (optional)"
+  - `app.mydash.links_invalid_url` — "Ongeldige URL — gebruik HTTP(S) of relatieve paden." / "Invalid URL — use HTTP(S) or relative paths."
+  - `app.mydash.links_layout_card` — "Kaart" / "Card"
+  - `app.mydash.links_layout_inline` — "Inline" / "Inline"
+  - `app.mydash.links_layout_icon_only` — "Alleen pictogram" / "Icon only"
+  - `app.mydash.links_icon_size_small` — "Klein (24 px)" / "Small (24 px)"
+  - `app.mydash.links_icon_size_medium` — "Normaal (40 px)" / "Medium (40 px)"
+  - `app.mydash.links_icon_size_large` — "Groot (64 px)" / "Large (64 px)"
+- [ ] 6.2 Add translation files:
+  - `l10n/nl.json` — Dutch translations
+  - `l10n/en.json` — English translations (fallback)
+
+## 7. Quality gates and testing
+
+- [ ] 7.1 Run `npm run lint` on all Vue/JS files:
+  - `src/components/widgets/LinksWidget.vue`
+  - `src/components/widgets/links/*.vue`
+  - Fix any warnings or errors
+- [ ] 7.2 Run Stylelint on component stylesheets
+- [ ] 7.3 Run `composer check:strict` if any PHP code is touched (validator, registration)
+- [ ] 7.4 Confirm all hydra-gates pass locally before opening PR
+- [ ] 7.5 Add SPDX headers to every new file
+- [ ] 7.6 PHPUnit test coverage:
+  - Aim for 80%+ line coverage on URL validator logic (if in PHP service)
+  - All validation scenarios covered (valid/invalid URLs, schema validation)
+- [ ] 7.7 Playwright E2E test coverage:
+  - Widget renders in all three layout modes
+  - Empty state displays correctly
+  - Config UI allows add/edit/delete/reorder
+  - Navigation works (external opens new tab, internal same/new per config)
+  - Drag-to-reorder works for sections and links
+- [ ] 7.8 Manual testing:
+  - Create a dashboard
+  - Add links widget
+  - Configure sections and links with various icon types (name, URL, blank)
+  - Test all three layout modes (card, inline, icon-only)
+  - Test all icon sizes (small, medium, large)
+  - Verify responsive layout on desktop and mobile
+  - Test external link opens with noopener
+  - Test internal link (relative URL) preserves window.opener if not openInNewTab
+  - Hide/show descriptions, section titles, verify UI updates
+
+## 8. Documentation and changelog
+
+- [ ] 8.1 Update `CHANGELOG.md` with:
+  - "Add links-widget: curated multi-column link grid with sections, three layout modes, and drag-to-reorder editor"
+- [ ] 8.2 Add code comments to `LinksWidget.vue` explaining:
+  - Icon resolution strategy and precedence
+  - Why empty sections are retained in config (user convenience)
+  - URL sanitisation expectations (enforced at save time)
+  - Internal vs. external link navigation strategy

--- a/openspec/changes/menu-widget/design.md
+++ b/openspec/changes/menu-widget/design.md
@@ -1,0 +1,85 @@
+# Design — Menu Widget
+
+## Context
+
+Larger intranet dashboards increasingly need in-page navigation between sections or
+sub-pages. The application sidebar handles app-level navigation; the menu widget handles
+page-level or section-level navigation that is relevant only within a specific dashboard.
+These two roles must remain clearly separated — the widget renders its own nav tree,
+not a mirror of the sidebar.
+
+The widget supports up to three levels of hierarchy. Beyond three levels, navigation
+trees become cognitively expensive and collapse poorly on mobile. Depth is capped at the
+data layer, not merely the UI, so the limit is enforced regardless of how the config is
+loaded.
+
+Keyboard navigation is a first-class concern: users navigating entirely by keyboard must
+be able to open, traverse, and close every level without reaching for a pointer.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Render a hierarchical navigation tree up to 3 levels deep.
+- Support three open-styles (flyout, dropdown, accordion).
+- Open external URLs in a new tab; keep internal/relative URLs in-tab.
+- Meet WCAG 2.1 AA keyboard navigation requirements.
+
+**Non-Goals:**
+- Mega-menu layouts (marketing-style full-width panels).
+- Dynamic population from a sitemap API.
+- Per-user item visibility based on group membership.
+
+## Decisions
+
+### D1: Tree depth cap at 3 levels
+**Decision:** Enforce a maximum depth of 3 in the widget config schema; a 4th level is
+rejected with a validation error.
+**Alternatives considered:** Cap at 2 (insufficient for observed IA depths); unlimited
+depth with a UX warning.
+**Rationale:** 3 levels is the practical maximum before usability degrades sharply.
+Schema-level enforcement prevents data drift that would break render components.
+
+### D2: Data shape
+**Decision:** `items: [{ label, url, icon?, children?: [...] }]` nested up to 2 child
+levels (3 total), stored in widget config JSON.
+**Alternatives considered:** Adjacency-list with parent_id (harder to render and reorder).
+**Rationale:** Nested arrays match the render tree, simplify recursive components, and
+terminate naturally at the depth limit.
+
+### D3: Open-style enum (`flyout | dropdown | accordion`)
+**Decision:** Admin selects one open-style. `flyout` opens on hover to the right;
+`dropdown` opens on click below the parent; `accordion` expands inline (mobile-friendly).
+**Alternatives considered:** Auto-select based on viewport (makes admin preview unreliable).
+**Rationale:** Explicit choice keeps admin preview consistent with production. Responsive
+adaptation within each style can be added as a follow-up without changing the data model.
+
+### D4: External vs. internal URL detection
+**Decision:** A URL is external if it has a scheme and its host differs from `window.location.host`.
+External links open with `target="_blank" rel="noopener noreferrer"`. All other URLs
+(relative, same-host absolute) open in the same tab.
+**Alternatives considered:** Always open in same tab; always open in new tab; admin
+toggles per link.
+**Rationale:** Automatic detection matches user expectation with zero per-link config.
+`rel="noopener noreferrer"` is the current best practice for new-tab links.
+
+### D5: Keyboard navigation
+**Decision:** Tab moves focus between top-level items. Enter/Space opens a sub-menu.
+Arrow keys navigate within it. Escape collapses the nearest open level; focus returns to
+the triggering item.
+**Alternatives considered:** Tab through all items including children (too many Tab
+presses to exit a long tree).
+**Rationale:** Tab-to-top-item + arrow-within-submenu is the ARIA Authoring Practices
+Guide pattern for navigation menus; familiar to AT users and keeps tab order manageable.
+
+## Risks / Trade-offs
+
+- Flyout style is pointer-dependent by default; a companion keyboard trigger (Enter to
+  open flyout) is required for WCAG compliance and must not be deferred.
+- Depth-cap enforcement at schema write time means existing configs with greater depth
+  (imported from another system) will be rejected — a migration note is needed.
+
+## Open follow-ups
+
+- Responsive fallback: auto-switch to accordion below a configurable breakpoint.
+- Per-group item visibility once the roles/permissions spec is stabilised.
+- Icon picker integration consistent with `link-button-widget` icon source pattern.

--- a/openspec/changes/menu-widget/proposal.md
+++ b/openspec/changes/menu-widget/proposal.md
@@ -1,0 +1,53 @@
+# Menu widget
+
+## Why
+
+MyDash dashboards need a flexible, hierarchical navigation widget to surface contextual links. Users should be able to publish "links to other places" as a structured menu (up to 3 levels deep) with multiple visual styles — dropdown, megamenu, or tree. This is distinct from the application-chrome navigation. The widget must support both internal navigation (same-page routes) and external URLs, with live active-item highlighting based on the current page URL. The widget MUST be fully static (no backend API calls) with server-side validation of nesting depth.
+
+## What Changes
+
+- Introduce a new widget `type: 'menu'` registered in `widgetRegistry.js` with default content `{items: [], style: 'dropdown', orientation: 'horizontal', showIcons: true, expandedByDefault: false, activeItemHighlight: 'underline'}`.
+- Add a strict JSON schema for menu items: 3-level nesting maximum (top-level + 2 child levels), each item has `label`, optional `url`, optional `icon`, optional `children` array.
+- Implement renderer `MenuWidget.vue` with three visual styles:
+  - `dropdown`: top-level items in a horizontal bar; level-2 in a popover on hover/focus; level-3 in a flyout to the side
+  - `megamenu`: top-level in horizontal bar; opening any one shows a full-width panel with all level-2 items grouped and level-3 inline
+  - `tree`: vertical hierarchical list with expand/collapse carets
+- Add active-item detection: any item whose URL matches the current page URL is highlighted; ancestors are highlighted as "in current path".
+- Keyboard navigation: Tab through top-level; arrow keys open and traverse children; Esc closes dropdowns. Conform to WAI-ARIA Menu/Menubar or Disclosure patterns.
+- External URL handling: links to external hosts open in a new tab with `rel="noopener noreferrer"`.
+- Edit form: drag-and-drop tree editor; max-depth validation indicator; per-item icon picker (reuse `link-button-widget`'s icon resolution from REQ-LBN-002).
+- Empty state: "No menu items yet — click the gear icon to add some."
+- Server-side depth validation: HTTP 400 if any item nests deeper than 3 levels on placement save.
+
+## Capabilities
+
+### New Capabilities
+
+- `menu-widget` — adds REQ-MENU-001 (widget registration), REQ-MENU-002 (config schema & depth validation), REQ-MENU-003 (dropdown style), REQ-MENU-004 (megamenu style), REQ-MENU-005 (tree style), REQ-MENU-006 (active item detection), REQ-MENU-007 (keyboard navigation), REQ-MENU-008 (external link handling), REQ-MENU-009 (edit form), REQ-MENU-010 (icon resolution), REQ-MENU-011 (empty state).
+
+### Modified Capabilities
+
+(none — this change is fully additive)
+
+## Impact
+
+**Affected code:**
+
+- `src/components/Widgets/Renderers/MenuWidget.vue` — new renderer supporting dropdown, megamenu, and tree styles
+- `src/components/Widgets/Forms/MenuForm.vue` — new add/edit sub-form with drag-and-drop tree editor and depth validation
+- `src/constants/widgetRegistry.js` — register `type: 'menu'` with default content shape
+- `lib/Service/WidgetService.php` — server-side depth validation in `validateWidgetContent()` before placement save
+- `l10n/en.js`, `l10n/nl.js` — translation strings for all visible labels and empty state
+
+**Affected APIs:**
+
+- 0 new routes — fully static rendering via existing placement API
+
+**Dependencies:**
+
+- No new composer or npm dependencies; uses existing Nextcloud CSS variables and Vue 3 SFC composables
+
+**Migration:**
+
+- Zero schema changes — menu shape lives inside the existing `content` JSON blob on widget placements.
+- Existing dashboards continue to work unchanged; the `menu` type only appears once an admin explicitly adds a Menu widget.

--- a/openspec/changes/menu-widget/specs/menu-widget/spec.md
+++ b/openspec/changes/menu-widget/specs/menu-widget/spec.md
@@ -1,0 +1,403 @@
+---
+capability: menu-widget
+delta: true
+status: draft
+---
+
+# Menu Widget — Delta from change `menu-widget`
+
+## ADDED Requirements
+
+### Requirement: REQ-MENU-001 Widget registration and default structure
+
+The system MUST register a widget `type: 'menu'` in `widgetRegistry.js` with default `widgetContent` shape:
+
+```json
+{
+  "items": [],
+  "style": "dropdown",
+  "orientation": "horizontal",
+  "showIcons": true,
+  "expandedByDefault": false,
+  "activeItemHighlight": "underline"
+}
+```
+
+The `items` array MUST support objects with:
+- `label` (string, required): display text
+- `url` (string, optional): destination URL (internal route or external URL)
+- `icon` (string, optional): icon identifier (MDI name or URL, follows REQ-MENU-010)
+- `children` (array of items, optional): up to 2 levels of nesting allowed
+
+#### Scenario: Widget registers with default config
+
+- GIVEN the widget system initializes
+- WHEN a dashboard creator opens the Add Widget modal
+- THEN the menu widget MUST appear in the widget picker
+- AND selecting it MUST populate `widgetContent` with the default shape above
+
+#### Scenario: Hierarchical item structure
+
+- GIVEN content `{items: [{label: 'Parent', url: 'https://example.com', children: [{label: 'Child', url: '/route'}]}]}`
+- WHEN the widget renders
+- THEN the parent and child items MUST both display
+- AND the child MUST be nested under the parent visually and in the DOM tree
+
+### Requirement: REQ-MENU-002 Config schema and depth validation
+
+The `items` array MUST allow up to 3 levels of nesting (top-level + 2 child levels). Any item with `children` deeper than 2 levels MUST be rejected at placement-save time with HTTP 400 `{error: 'Menu items can nest at most 3 levels deep'}`.
+
+Server-side validation MUST recursively check all items in the saved placement's `widgetContent.items` and reject the placement if depth > 3.
+
+Valid field values:
+- `style` ∈ {`'dropdown'`, `'megamenu'`, `'tree'`} (default `'dropdown'`)
+- `orientation` ∈ {`'horizontal'`, `'vertical'`} (default `'horizontal'` for dropdown/megamenu; forced `'vertical'` for tree)
+- `showIcons` ∈ {`true`, `false`} (default `true`)
+- `expandedByDefault` ∈ {`true`, `false`} (default `false`; only meaningful for tree style)
+- `activeItemHighlight` ∈ {`'background'`, `'underline'`, `'left-bar'`, `'none'`} (default `'underline'`)
+
+#### Scenario: Depth validation rejects 4-level nesting
+
+- GIVEN placement content with `items: [{label: 'L1', children: [{label: 'L2', children: [{label: 'L3', children: [{label: 'L4'}]}]}]}]`
+- WHEN the user saves the placement
+- THEN the API MUST return HTTP 400 with `{error: 'Menu items can nest at most 3 levels deep'}`
+- AND the placement MUST NOT be saved
+
+#### Scenario: Three-level nesting is valid
+
+- GIVEN the same structure but with `children` at L3 empty or absent
+- WHEN the user saves
+- THEN the placement MUST save successfully
+
+#### Scenario: Invalid style value rejected in form validation
+
+- GIVEN the form has `style: 'invalid-style'` before save
+- WHEN the form validates
+- THEN it MUST reject the submission and show an error
+- NOTE: Schema enforcement prevents invalid styles at the API level; form must also catch it client-side
+
+### Requirement: REQ-MENU-003 Dropdown style
+
+When `style === 'dropdown'`, the renderer MUST:
+
+- Render top-level items in a horizontal bar (or vertical if `orientation === 'vertical'`).
+- Open a popover dropdown below (or beside, depending on space) when a top-level item with children is clicked or focused.
+- Render level-2 items in the dropdown as clickable; clicking MUST navigate to their `url` or expand their children in a flyout to the right.
+- Render level-3 items inline under their parent level-2 item in the flyout.
+- Close the dropdown and flyout when Esc is pressed.
+- Close dropdowns and move focus to the next top-level item when Tab is pressed.
+
+#### Scenario: Dropdown opens on click
+
+- GIVEN content `{style: 'dropdown', items: [{label: 'Menu', children: [{label: 'Item 1', url: '/path1'}]}]}`
+- WHEN the user clicks the "Menu" item
+- THEN a dropdown MUST appear below it
+- AND "Item 1" MUST be visible and clickable inside
+
+#### Scenario: Level-2 with children opens flyout
+
+- GIVEN the same structure but Item 1 has `children: [{label: 'Sub', url: '/sub'}]`
+- AND the user has clicked "Menu" to open the main dropdown
+- WHEN the user hovers over or focuses "Item 1"
+- THEN a flyout MUST appear to the right
+- AND "Sub" MUST be visible inside
+
+#### Scenario: Esc closes dropdown and flyout
+
+- GIVEN the dropdown and flyout are open
+- WHEN the user presses Esc
+- THEN both MUST close
+- AND focus MUST return to the "Menu" button
+
+#### Scenario: Tab closes and moves focus
+
+- GIVEN the dropdown is open with focus on an item
+- WHEN the user presses Tab
+- THEN the dropdown MUST close
+- AND focus MUST move to the next top-level menu item (or off the widget if last)
+
+### Requirement: REQ-MENU-004 Megamenu style
+
+When `style === 'megamenu'`, the renderer MUST:
+
+- Render top-level items in a horizontal bar.
+- Open a full-width panel below the bar when any top-level item is clicked, containing all level-2 items grouped by their parent top-level item.
+- Display each level-2 item's label and its level-3 children inline as a list.
+- Navigate to the item's URL when a level-2 or level-3 item is clicked.
+- Switch the panel content to a different section when another top-level item is clicked.
+- Close the panel when Esc is pressed.
+
+#### Scenario: Megamenu panel opens full-width
+
+- GIVEN content `{style: 'megamenu', items: [{label: 'Products', children: [{label: 'Widget', url: '/widgets'}, {label: 'Gadget', url: '/gadgets'}]}]}`
+- WHEN the user clicks "Products"
+- THEN a full-width panel MUST appear below the bar
+- AND both "Widget" and "Gadget" MUST be visible and organized in the panel
+
+#### Scenario: Panel switches on top-level click
+
+- GIVEN the panel is open showing Products items
+- AND there is another top-level item "Services" with its own children
+- WHEN the user clicks "Services"
+- THEN the panel content MUST switch to show Services items
+- AND Products items MUST no longer be visible
+
+#### Scenario: Level-3 items render inline under level-2
+
+- GIVEN Products > Widget > [FAQ, Docs] (level-3 children)
+- WHEN the panel is open
+- THEN "Widget" MUST be a clickable item
+- AND "FAQ" and "Docs" MUST appear as an inline list below or beside "Widget"
+
+#### Scenario: Esc closes megamenu
+
+- GIVEN the megamenu panel is open
+- WHEN the user presses Esc
+- THEN the panel MUST close
+
+### Requirement: REQ-MENU-005 Tree style
+
+When `style === 'tree'`, the renderer MUST:
+
+- Render items as a vertical hierarchical list.
+- Render top-level items without children as clickable links; items with children MUST show a caret to the left.
+- Expand or collapse children when the caret is clicked or the right arrow key is pressed.
+- Expand all children on initial render when `expandedByDefault === true`.
+- Render level-2 items with a caret if they have level-3 children; clicking the caret MUST expand the level-3 items.
+- Render level-3 items as always-leaf nodes (no caret) that are clickable links or labels.
+
+#### Scenario: Tree renders with collapsed children by default
+
+- GIVEN content `{style: 'tree', items: [{label: 'Parent', children: [{label: 'Child'}]}], expandedByDefault: false}`
+- WHEN the widget renders
+- THEN "Parent" MUST show a closed caret (or right-pointing arrow)
+- AND "Child" MUST NOT be visible initially
+
+#### Scenario: Tree expands on caret click
+
+- GIVEN the same structure with the caret visible
+- WHEN the user clicks the caret
+- THEN the caret MUST rotate or change appearance (to open/down-pointing)
+- AND "Child" MUST become visible
+
+#### Scenario: expandedByDefault expands all on load
+
+- GIVEN the same structure but `expandedByDefault: true`
+- WHEN the widget renders
+- THEN all children at all levels MUST be visible
+- AND all carets MUST be in the open position
+
+#### Scenario: Tree with mixed click targets
+
+- GIVEN a structure where Parent has a URL and children: `{label: 'Parent', url: '/parent', children: [...]}`
+- WHEN the widget renders
+- THEN the caret MUST be separate from the label
+- AND clicking the label MUST navigate to `/parent`
+- AND clicking the caret MUST only expand/collapse the children (no navigation)
+
+### Requirement: REQ-MENU-006 Active item detection and highlighting
+
+The renderer MUST detect the active item based on the current page URL and highlight it and its ancestors. The `activeItemHighlight` field controls the style:
+
+- `'underline'`: bottom border on the active item and ancestor items
+- `'background'`: light background colour on the active item and ancestor items
+- `'left-bar'`: left border (4-6 px wide) on the active item and ancestor items
+- `'none'`: no visual highlighting
+
+An item is "active" if its `url` matches the current window location (exact match or route prefix match for internal routes). An item is "in current path" if it is an ancestor of an active item.
+
+#### Scenario: Exact URL match highlights active item
+
+- GIVEN items with `{label: 'Reports', url: '/reports'}`
+- AND the current page is `http://localhost:3000/reports`
+- WHEN the widget renders
+- THEN the "Reports" item MUST be highlighted with the configured style
+- AND its ancestors MUST also be highlighted
+
+#### Scenario: Route prefix match for internal routes
+
+- GIVEN items with `{label: 'Users', url: '/users'}` and children `{label: 'Alice', url: '/users/alice'}`
+- AND the current page is `/users/alice/profile`
+- WHEN the widget renders
+- THEN "Alice" MUST be highlighted as active
+- AND "Users" MUST be highlighted as "in current path"
+
+#### Scenario: External URLs don't auto-highlight
+
+- GIVEN items with `{label: 'External', url: 'https://example.com'}`
+- AND the current page is not example.com
+- WHEN the widget renders
+- THEN the item MUST NOT be highlighted
+- NOTE: External URLs are unlikely to match window.location; highlighting is skipped
+
+#### Scenario: activeItemHighlight='left-bar' renders left border
+
+- GIVEN content with `activeItemHighlight: 'left-bar'`
+- AND an active item
+- WHEN the widget renders
+- THEN the active item MUST have a left border
+- AND the width MUST be 4-6 px
+
+### Requirement: REQ-MENU-007 Keyboard navigation
+
+The renderer MUST support keyboard navigation conforming to WAI-ARIA Menu/Menubar pattern:
+
+- **Tab**: move focus to the next top-level item; if at the last item, move focus out of the widget. Close any open dropdowns/flyouts.
+- **Shift+Tab**: move focus to the previous top-level item; if at the first item, move focus out of the widget. Close any open dropdowns.
+- **Enter/Space**: on a top-level item with children, open the dropdown/submenu. On a leaf item, navigate to its URL.
+- **ArrowDown**: on a top-level item with children, open the dropdown and move focus to the first child. In an open dropdown, move focus to the next child.
+- **ArrowUp**: in an open dropdown, move focus to the previous child.
+- **ArrowRight**: on a level-2 item with level-3 children, open the flyout. In tree style, expand the item's children.
+- **ArrowLeft**: close the current dropdown/flyout. In tree style, collapse the item's children.
+- **Esc**: close any open dropdowns and return focus to the top-level item that opened them.
+
+#### Scenario: Tab moves focus between top-level items
+
+- GIVEN a dropdown menu with 3 top-level items and focus on the first item
+- WHEN the user presses Tab
+- THEN focus MUST move to the second item
+- AND any open dropdown MUST close
+
+#### Scenario: Enter opens dropdown and Space navigates
+
+- GIVEN a top-level item with children and focus on it
+- WHEN the user presses Enter
+- THEN the dropdown MUST open
+- AND focus MUST move to the first child
+- NOTE: This assumes Enter behaves like ArrowDown for menu items; if Space should also open, that is implementation-dependent
+
+#### Scenario: Esc closes and returns focus
+
+- GIVEN an open dropdown with focus on a child item
+- WHEN the user presses Esc
+- THEN the dropdown MUST close
+- AND focus MUST return to the parent top-level item
+
+#### Scenario: ArrowRight expands tree node
+
+- GIVEN a tree-style menu with a collapsed item and focus on it
+- WHEN the user presses ArrowRight
+- THEN the item MUST expand
+- AND focus MAY move to the first child (implementation detail)
+
+### Requirement: REQ-MENU-008 External link handling
+
+When an item's `url` starts with `http://` or `https://`, it is treated as an external URL. Clicking an external URL MUST:
+
+1. Open the link in a new tab via `window.open(url, '_blank', 'noopener,noreferrer')`
+2. Apply `rel="noopener noreferrer"` to any fallback `<a>` tag for progressive enhancement
+
+Internal URLs (starting with `/` or no protocol) MUST use `router.push()` or a same-tab `<a>` href.
+
+#### Scenario: External URL opens in new tab
+
+- GIVEN content `{label: 'GitHub', url: 'https://github.com'}`
+- WHEN the user clicks the item
+- THEN the system MUST call `window.open('https://github.com', '_blank', 'noopener,noreferrer')`
+- AND a new tab MUST open
+
+#### Scenario: Internal URL uses router.push
+
+- GIVEN content `{label: 'Dashboard', url: '/dashboard'}`
+- WHEN the user clicks the item
+- THEN the system MUST call `router.push('/dashboard')`
+- AND navigation MUST occur in the same tab
+
+#### Scenario: Fallback <a> tag has rel attribute
+
+- GIVEN an item with `url: 'https://external.com'`
+- AND fallback rendering for JavaScript-disabled scenarios
+- WHEN the HTML is inspected
+- THEN the `<a>` MUST have `rel="noopener noreferrer"`
+
+### Requirement: REQ-MENU-009 Add/edit form with drag-and-drop editor
+
+The menu sub-form for `AddWidgetModal` MUST include:
+
+1. A **Config section** with dropdowns for `style`, `orientation` (disabled for tree), `activeItemHighlight`, and toggles for `showIcons` and `expandedByDefault` (only shown for tree).
+2. A **Tree editor** for building the `items` array:
+   - Drag-and-drop reordering of items at all levels
+   - Add/remove/edit buttons for each item
+   - Validation: reject drops that would create depth > 3 levels
+   - Depth indicator showing current nesting level (e.g., "Level 3 - max reached" for items with 2 ancestors)
+   - Per-item inline fields: `label`, `url`, `icon` (via icon picker reusing REQ-MENU-010), optional "add children" button
+
+When editing an existing widget, all fields MUST pre-fill from `editingWidget.content`.
+
+#### Scenario: Config section controls all fields
+
+- GIVEN the form is open
+- THEN there MUST be dropdowns to select style, orientation, activeItemHighlight
+- AND toggles for showIcons and expandedByDefault (tree only)
+- AND changes MUST update the content before save
+
+#### Scenario: Drag-and-drop reorders items
+
+- GIVEN a tree editor with two top-level items [A, B]
+- WHEN the user drags A below B
+- THEN the order in `items` MUST reverse to [B, A]
+
+#### Scenario: Depth validation prevents overly nested drops
+
+- GIVEN an item that already has 2 ancestors
+- WHEN the user tries to add children to it
+- THEN the UI MUST show "Level 3 - max reached"
+- AND the form MUST prevent adding children (disable the "add children" button)
+
+#### Scenario: Icon picker per item
+
+- GIVEN the tree editor with an item selected
+- WHEN the user clicks the icon field
+- THEN an icon picker MUST appear (reusing link-button-widget's icon resolution)
+- AND the user MUST be able to select or upload an icon
+
+### Requirement: REQ-MENU-010 Icon resolution
+
+The `icon` field of a menu item MUST follow the same dual-mode convention as `link-button-widget` (REQ-LBN-002):
+
+- A custom URL (starts with `/` or `http`) MUST render as `<img>` inside the menu item
+- A bare name MUST render via the shared `IconRenderer` (built-in MDI component)
+- An empty or null value MUST render no icon (label-only)
+
+Icon size MUST be 16-24 px (smaller than REQ-LBN-002's 48 px, to fit in a menu list). The icon MUST appear to the left of the label in horizontal layouts and to the left in vertical/tree layouts.
+
+#### Scenario: MDI icon in dropdown
+
+- GIVEN content `{style: 'dropdown', items: [{label: 'Settings', icon: 'mdiCog'}]}`
+- WHEN the widget renders
+- THEN the item MUST display the settings icon to the left of "Settings"
+
+#### Scenario: Custom URL icon in tree
+
+- GIVEN content `{style: 'tree', items: [{label: 'Custom', icon: '/apps/mydash/icons/custom.svg'}]}`
+- WHEN the widget renders
+- THEN the item MUST display the custom SVG icon to the left of "Custom"
+
+### Requirement: REQ-MENU-011 Empty state
+
+When the `items` array is empty or not provided, the renderer MUST display a placeholder message: **"No menu items yet — click the gear icon to add some."**
+
+The gear icon in the message MUST be clickable and open the edit form if the user is an admin/dashboard editor. For non-editors, the message MUST be non-interactive.
+
+#### Scenario: Empty menu shows placeholder
+
+- GIVEN content `{items: []}`
+- AND the user is viewing the dashboard (not editing)
+- WHEN the widget renders
+- THEN the message "No menu items yet — click the gear icon to add some." MUST appear
+- AND the gear icon MUST be visible
+
+#### Scenario: Edit mode enables gear icon click
+
+- GIVEN the same empty menu
+- AND the user is in edit mode
+- WHEN the user clicks the gear icon
+- THEN the edit form MUST open
+- AND they can add items
+
+#### Scenario: Non-empty menu hides placeholder
+
+- GIVEN content `{items: [{label: 'Item', url: '/path'}]}`
+- WHEN the widget renders
+- THEN the placeholder message MUST NOT appear
+- AND the menu MUST be rendered normally

--- a/openspec/changes/menu-widget/tasks.md
+++ b/openspec/changes/menu-widget/tasks.md
@@ -1,0 +1,166 @@
+# Tasks — menu-widget
+
+## 1. Server-side validation
+
+- [ ] 1.1 Create `lib/Service/MenuService.php::validateMenuItems(array $items): void`
+- [ ] 1.2 Recursively validate nesting depth; reject if any item nests > 3 levels deep
+- [ ] 1.3 Throw `BadRequestException` with message `'Menu items can nest at most 3 levels deep'`
+- [ ] 1.4 Integrate validation into `lib/Service/WidgetService.php::validateWidgetContent()` before placement save
+- [ ] 1.5 Validate that `style` field is one of `dropdown`, `megamenu`, `tree`
+- [ ] 1.6 Validate that `activeItemHighlight` is one of `background`, `underline`, `left-bar`, `none`
+
+## 2. Dropdown renderer
+
+- [ ] 2.1 Create `src/components/Widgets/Renderers/MenuWidget.vue` with style handler
+- [ ] 2.2 Implement dropdown layout: top-level items in horizontal bar (or vertical if `orientation: 'vertical'`)
+- [ ] 2.3 Implement popover dropdown on click/focus of top-level items with children
+- [ ] 2.4 Implement flyout for level-2 items with level-3 children, appearing to the right on hover
+- [ ] 2.5 Close dropdown on Esc key press
+- [ ] 2.6 Close dropdown when Tab moves focus away
+- [ ] 2.7 Render level-2 and level-3 items clickable or navigable (REQ-MENU-008)
+
+## 3. Megamenu renderer
+
+- [ ] 3.1 Implement megamenu layout: top-level items in horizontal bar
+- [ ] 3.2 On top-level click, open full-width panel below showing all level-2 items grouped by parent
+- [ ] 3.3 Display level-3 items inline as a list under/beside their level-2 parent
+- [ ] 3.4 Switch panel content when user clicks another top-level item
+- [ ] 3.5 Close panel on Esc key press
+
+## 4. Tree renderer
+
+- [ ] 4.1 Implement tree layout: vertical hierarchical list with carets for expandable items
+- [ ] 4.2 Show closed caret (right-pointing) for items with children; open caret (down-pointing) when expanded
+- [ ] 4.3 Toggle expand/collapse on caret click or ArrowRight/ArrowLeft keys
+- [ ] 4.4 When `expandedByDefault: true`, expand all items on initial render
+- [ ] 4.5 Separate caret from label: caret toggles children, label is clickable if item has URL
+- [ ] 4.6 Indent level-2 and level-3 items appropriately (e.g., 20-24 px per level)
+
+## 5. Active item detection
+
+- [ ] 5.1 Implement `isActiveItem(itemUrl, currentLocation): boolean` helper
+- [ ] 5.2 Match item URL against `window.location.pathname` (exact match or prefix for internal routes)
+- [ ] 5.3 Skip matching for external URLs (http/https)
+- [ ] 5.4 Recursively mark ancestors of active items as "in current path"
+- [ ] 5.5 Render active items and ancestors with appropriate highlight style from `activeItemHighlight` field:
+  - [ ] 5.5a `underline`: bottom border (3-4 px solid, use primary color)
+  - [ ] 5.5b `background`: light background color (use primary at 10% opacity)
+  - [ ] 5.5c `left-bar`: left border (4-6 px solid, use primary color)
+  - [ ] 5.5d `none`: no visual change
+
+## 6. Keyboard navigation
+
+- [ ] 6.1 Implement Tab/Shift+Tab to move focus between top-level items; close dropdowns
+- [ ] 6.2 Implement Enter/Space on top-level item with children to open dropdown
+- [ ] 6.3 Implement ArrowDown to open dropdown or move focus to next child
+- [ ] 6.4 Implement ArrowUp to move focus to previous child in open dropdown
+- [ ] 6.5 Implement ArrowRight to open flyout (dropdown/megamenu) or expand tree node
+- [ ] 6.6 Implement ArrowLeft to close flyout or collapse tree node
+- [ ] 6.7 Implement Esc to close all open dropdowns/flyouts and return focus to triggering item
+- [ ] 6.8 Set `aria-haspopup="menu"` on top-level items with children
+- [ ] 6.9 Set `role="menubar"` on the top-level item container
+- [ ] 6.10 Set `role="menu"` on dropdown/flyout containers; `role="menuitem"` on items
+- [ ] 6.11 Manage `aria-expanded` attribute on top-level items (true when dropdown open)
+
+## 7. External link handling
+
+- [ ] 7.1 Detect external URLs: check if `url` starts with `http://` or `https://`
+- [ ] 7.2 For external URLs, call `window.open(url, '_blank', 'noopener,noreferrer')`
+- [ ] 7.3 For internal URLs, call `router.push(url)` or use `<a href>`
+- [ ] 7.4 Add `rel="noopener noreferrer"` to fallback `<a>` tags
+- [ ] 7.5 Do NOT navigate same-tab on external URLs
+
+## 8. Icon rendering
+
+- [ ] 8.1 Implement icon resolution helper (reuse from link-button-widget if possible)
+- [ ] 8.2 For URLs starting with `/` or `http`, render `<img>` tag
+- [ ] 8.3 For bare names, render via `IconRenderer` component (MDI built-ins)
+- [ ] 8.4 For empty/null, render no icon
+- [ ] 8.5 Set icon size to 16-24 px (CSS `width: 20px; height: 20px;` as default)
+- [ ] 8.6 Position icon to the left of label in all layouts
+- [ ] 8.7 When `showIcons: false`, hide all icons but don't remove them from DOM (preserve layout)
+
+## 9. Edit form
+
+- [ ] 9.1 Create `src/components/Widgets/Forms/MenuForm.vue`
+- [ ] 9.2 Implement config section:
+  - [ ] 9.2a Dropdown for `style` with options: dropdown, megamenu, tree
+  - [ ] 9.2b Dropdown for `orientation` with options: horizontal, vertical (disable for tree)
+  - [ ] 9.2c Dropdown for `activeItemHighlight` with options: background, underline, left-bar, none
+  - [ ] 9.2d Toggle for `showIcons` (default true)
+  - [ ] 9.2e Toggle for `expandedByDefault` (only visible for tree style)
+- [ ] 9.3 Implement tree editor for `items` array:
+  - [ ] 9.3a Render each item as an editable row with: label input, url input, icon picker, buttons
+  - [ ] 9.3b "Add children" button for items at depth < 2
+  - [ ] 9.3c "Remove item" button for each item
+  - [ ] 9.3d Drag-and-drop reordering within the same parent level
+  - [ ] 9.3e Depth indicator next to each item (e.g., "Level 2", "Level 3 - max reached")
+- [ ] 9.4 Icon picker per item:
+  - [ ] 9.4a Reuse or adapt icon picker from link-button-widget (REQ-LBN-002)
+  - [ ] 9.4b Allow selection of built-in MDI icons OR upload custom URL
+- [ ] 9.5 Validate on form submit: reject if depth validation fails (call `MenuService::validateMenuItems`)
+- [ ] 9.6 Pre-fill all fields from `editingWidget.content` when editing existing widget
+- [ ] 9.7 Handle creation of new items: default shape `{label: '', url: '', icon: '', children: []}`
+
+## 10. Widget registration
+
+- [ ] 10.1 Add `menu` entry to `src/constants/widgetRegistry.js`
+- [ ] 10.2 Set default content shape: `{items: [], style: 'dropdown', orientation: 'horizontal', showIcons: true, expandedByDefault: false, activeItemHighlight: 'underline'}`
+- [ ] 10.3 Map to renderer component `MenuWidget.vue`
+- [ ] 10.4 Map to form component `MenuForm.vue`
+
+## 11. Empty state
+
+- [ ] 11.1 In `MenuWidget.vue` renderer, detect empty `items` array
+- [ ] 11.2 Display message: "No menu items yet — click the gear icon to add some."
+- [ ] 11.3 Display a gear/settings icon within the message
+- [ ] 11.4 If user is editor/admin, make gear icon clickable to trigger edit mode
+- [ ] 11.5 Hide message when `items.length > 0`
+
+## 12. Styling
+
+- [ ] 12.1 Use CSS variables for colours: `--color-primary`, `--color-primary-text`, `--color-main-background`
+- [ ] 12.2 Dropdown: add subtle background and border to popover/flyout
+- [ ] 12.3 Megamenu: add subtle background and border to full-width panel
+- [ ] 12.4 Tree: indent children with consistent spacing
+- [ ] 12.5 Apply active item highlight styles per `activeItemHighlight` field
+- [ ] 12.6 Add hover effects: slight background change or text emphasis on non-active items
+- [ ] 12.7 Ensure focus indicators visible for keyboard navigation (e.g., outline on focused items)
+
+## 13. Tests
+
+- [ ] 13.1 PHPUnit: depth validation passes for 3-level nesting
+- [ ] 13.2 PHPUnit: depth validation rejects 4-level nesting with correct error message
+- [ ] 13.3 PHPUnit: invalid `style`, `orientation`, `activeItemHighlight` values rejected
+- [ ] 13.4 Vitest: active item detection matches internal routes (exact + prefix)
+- [ ] 13.5 Vitest: active item detection skips external URLs
+- [ ] 13.6 Vitest: ancestors of active items marked as "in current path"
+- [ ] 13.7 Vitest: active item highlight styles applied correctly
+- [ ] 13.8 Vitest: dropdown opens and closes on click/Esc
+- [ ] 13.9 Vitest: megamenu panel switches on top-level click
+- [ ] 13.10 Vitest: tree expands/collapses on caret click and arrow keys
+- [ ] 13.11 Vitest: expandedByDefault expands all items on initial render
+- [ ] 13.12 Vitest: Tab moves focus; closes dropdowns
+- [ ] 13.13 Vitest: external URLs open in new tab; internal URLs use router.push
+- [ ] 13.14 Vitest: icons render (MDI, custom URL, no icon cases)
+- [ ] 13.15 Vitest: empty state displays and hides appropriately
+- [ ] 13.16 Vitest: form validation rejects depth > 3
+- [ ] 13.17 Vitest: form pre-fills existing widget content
+- [ ] 13.18 Playwright: dropdown style end-to-end (open, click item, navigate)
+- [ ] 13.19 Playwright: megamenu style end-to-end (switch panels, click item)
+- [ ] 13.20 Playwright: tree style end-to-end (expand, collapse, navigate)
+- [ ] 13.21 Playwright: keyboard navigation (Tab, arrow keys, Esc)
+
+## 14. Quality
+
+- [ ] 14.1 `composer check:strict` passes (PHPCS, PHPMD, Psalm, PHPStan)
+- [ ] 14.2 ESLint clean
+- [ ] 14.3 OpenAPI spec updated (no new routes; static rendering only)
+- [ ] 14.4 Translation entries added in `l10n/en.js` and `l10n/nl.js`:
+  - [ ] `Menu`, `Menu Widget`, `No menu items yet — click the gear icon to add some.`
+  - [ ] `Menu Style`, `Dropdown`, `Megamenu`, `Tree`
+  - [ ] `Orientation`, `Horizontal`, `Vertical`
+  - [ ] `Active Item Highlight`, `Underline`, `Background`, `Left Bar`, `None`
+  - [ ] `Show Icons`, `Expanded by Default`
+  - [ ] `Add Item`, `Remove Item`, `Add Children`, `Label`, `URL`, `Icon`
+  - [ ] `Items`, `Level 1`, `Level 2`, `Level 3 - max reached`

--- a/openspec/changes/navigation-editor-org/design.md
+++ b/openspec/changes/navigation-editor-org/design.md
@@ -1,0 +1,227 @@
+# Design — Org-wide navigation editor
+
+## Context
+
+The `navigation-editor-org` spec (REQ-ONAV-001 through REQ-ONAV-012) was drafted assuming that
+the org-wide navigation tree would be stored as a single JSON blob in a Nextcloud app config key
+(`mydash.org_navigation_tree`, max 64 KB). This design document resolves that open question by
+examining how the reference intranet product actually stores and serves its navigation tree.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Decide the storage backend for the org-wide navigation tree
+- Align the API shape (wholesale PUT vs per-node CRUD) with the chosen backend
+- Clarify per-language navigation, group-visibility encoding, depth enforcement, and active-item detection
+
+**Non-Goals:**
+- Defining the page-content storage (pages live in Nextcloud GroupFolders — unchanged)
+- Per-user personalisation of the org-nav (out of scope for this capability)
+- Rewriting the spec in this document; flag only which REQ-ONAV-NNN items need amendment
+
+---
+
+## Decisions
+
+### D1: Storage — JSON blob in app config vs file on disk vs DB table
+
+**Decision:** Store the org-nav tree as a **JSON file on the Nextcloud filesystem** (`navigation.json`)
+inside a dedicated GroupFolder path, one file per language. Do **not** use a monolithic app-config key.
+
+**Source evidence:**
+- `intravox-source/lib/Service/NavigationService.php:44–91` — `getNavigation()` opens
+  `IntraVox/{lang}/navigation.json` from the user's mounted GroupFolder view.
+- `intravox-source/lib/Service/NavigationService.php:122–143` — `saveNavigation()` writes or
+  creates `navigation.json` in the language folder via `file->putContent()`.
+- `intravox-source/lib/Service/SystemFileService.php:29` — fallback reads the same JSON file at
+  up to 5 MB; `ALLOWED_SHARED_FILES = ['navigation.json', 'footer.json']`.
+- `intravox-source/lib/Controller/NavigationController.php:51–103` — single `GET /api/navigation`
+  reads the file; no DB or app-config call anywhere in the call chain.
+- `intravox-source/lib/Migration/` — no migration creates a `navigation` table. The two DB tables
+  that do exist (`intravox_lms_tokens` from Version001200, `intravox_page_index` from Version001300)
+  serve OAuth tokens and a page-metadata search index, respectively.
+
+**Implication for MyDash:** The spec's `mydash.org_navigation_tree` Nextcloud app-config key and
+64 KB cap are **wrong**. A file-based approach inside a dedicated Nextcloud GroupFolder (or an
+equivalent user-accessible storage location) scales to megabytes and separates concerns cleanly.
+For MyDash's simpler use-case (admin-only tree, no per-user GroupFolder ACL complexity), storing
+`navigation.json` in a well-known Nextcloud app-data folder (e.g. `appdata_<instanceid>/mydash/`)
+is equivalent in principle and avoids GroupFolder dependency. The write API must still be
+wholesale-replace per file write, but the file itself is not bounded by the 64 KB app-config limit.
+
+---
+
+### D2: Per-language navigation
+
+**Decision:** Separate `navigation.json` file per language under a language subfolder
+(`IntraVox/{lang}/navigation.json`). Languages supported: `nl`, `en`, `de`, `fr`.
+
+**Source evidence:**
+- `intravox-source/lib/Service/NavigationService.php:20` — `SUPPORTED_LANGUAGES = ['nl', 'en', 'de', 'fr']`
+- `intravox-source/lib/Service/NavigationService.php:220–233` — `getLanguageFolder()` navigates
+  to `IntraVox/{lang}/`; creates the folder if absent.
+- `intravox-source/lib/Command/CopyNavigationCommand.php:15–138` — `intravox:copy-navigation`
+  copies one language's JSON file to another. Arguments are `source` and `target` language codes
+  (or `all`). This proves trees are independent per-language files, not a single tree with
+  language tags embedded in node objects.
+
+**Implication for MyDash:** The spec makes no mention of per-language trees. REQ-ONAV-001 (node
+schema) and REQ-ONAV-003 (PUT API) define a single tree with no language dimension. If MyDash needs
+multi-language org-nav in the future, the storage format must add a language segment. For the
+current scope (NL + EN), the recommended approach is to store two files:
+`appdata/mydash/org-navigation-{lang}.json`. A copy/sync CLI command modelled on
+`CopyNavigationCommand` should be considered as a follow-up.
+
+---
+
+### D3: Group-visibility encoding
+
+**Decision:** Group visibility is **not** encoded in the navigation JSON in the reference
+implementation. Filtering is done by file-system ACL (GroupFolder read permissions), not by
+per-node group arrays.
+
+**Source evidence:**
+- `intravox-source/lib/Service/PermissionService.php:535–582` — `filterNavigation()` checks
+  whether the user can read the page the nav item points to (`canRead($pagePath)`), using
+  Nextcloud's native filesystem ACL. There is no `groupVisibility` field in the node schema.
+- `intravox-source/lib/Service/NavigationService.php:180–196` — validated node schema has fields:
+  `id`, `title`, `uniqueId`, `url`, `target`, `children`. No `groupVisibility` field.
+- The `intravox_page_index` table (`parent_id`, `unique_id`, `language`, `path`, `status`) also
+  has no group-visibility column.
+
+**Implication for MyDash:** The spec's `groupVisibility: ["g1","g2"]` per-node array field is a
+**MyDash invention** with no reference-implementation counterpart. This is a valid design choice
+for an admin-curated tree that has no corresponding filesystem ACL to piggyback on. The per-node
+array approach (null = all, array = restrict) is simpler than a join table for a tree stored in a
+single JSON file. The spec's approach should be **retained** but the implementation must add
+explicit group-membership checking logic that the reference source delegates to the filesystem.
+
+No join table is needed; the array-per-node approach is correct for file-based storage.
+
+---
+
+### D4: Write API shape
+
+**Decision:** Wholesale replacement (`POST /api/navigation` with the full tree) — identical in
+effect to a PUT-replace. The reference source does not expose per-node CRUD endpoints.
+
+**Source evidence:**
+- `intravox-source/appinfo/routes.php:57–58`:
+  ```
+  ['name' => 'navigation#get',  'url' => '/api/navigation', 'verb' => 'GET'],
+  ['name' => 'navigation#save', 'url' => '/api/navigation', 'verb' => 'POST'],
+  ```
+- `intravox-source/lib/Controller/NavigationController.php:109–138` — `save()` accepts the
+  entire navigation object and calls `saveNavigation()` which overwrites `navigation.json`.
+- No PATCH, no per-node PUT, no DELETE by id.
+
+**Implication for MyDash:** The spec's `PUT /api/admin/org-navigation` wholesale-replace design
+is **confirmed correct**. The 64 KB limit in REQ-ONAV-001/003 is wrong (see D1); remove it. File
+size is bounded only by practical tree size (hundreds of nodes are well under 1 MB).
+
+---
+
+### D5: Depth limit
+
+**Decision:** Enforced in **both** backend service (silent truncation) and frontend editor (visual
+block).
+
+**Source evidence:**
+- `intravox-source/lib/Service/NavigationService.php:166–197` — `validateNavigationItems()` takes
+  a `$level` argument; silently returns `[]` when `$level > 3`; recursion stops at `$level < 3`
+  for children. No HTTP 400 — excess depth is silently discarded.
+- `intravox-source/src/components/NavigationItem.vue:80` — `v-if="level < 3"` hides the
+  "Add sub-item" button at level 3 in the editor.
+
+**Implication for MyDash:** The spec's REQ-ONAV-003 returns HTTP 400 on depth violation — that is
+a **stricter and safer** approach than silent truncation. Retain the 400 response. The frontend
+depth guard (`v-if="level < 3"`) matches REQ-ONAV-007 exactly.
+
+---
+
+### D6: Active-item detection
+
+**Decision:** Entirely **client-side** in the frontend Vue component. The backend returns the full
+(filtered) tree; the active node is computed in JavaScript by comparing `window.location` to each
+node's URL or `uniqueId` hash.
+
+**Source evidence:**
+- `intravox-source/lib/Controller/NavigationController.php` — response contains `navigation`
+  (tree), `canEdit`, `language`, `permissions`. No `activeNodeId` or server-side resolved active
+  flag.
+- `intravox-source/src/components/Navigation.vue:330–364` — `getItemKey()` and `getItemUrl()`
+  derive the key from `uniqueId` or a slug; click handlers call `$emit('navigate', item)`.
+  Active item tracking (`activeDropdown`, `activeMegaMenu`) is local component state for
+  hover/focus, not a URL-match-based active class.
+- No backend route that returns "the active node for the current URL."
+
+**Implication for MyDash:** The spec's REQ-ONAV-009 (client-side URL prefix match for `active`
+CSS class) is **confirmed correct**. Nothing needs to change.
+
+---
+
+### D7: Mobile vs desktop rendering
+
+**Decision:** A single component handles both; mobile hamburger + expand/collapse is CSS-class
+and `v-if` driven, not a separate component or route.
+
+**Source evidence:**
+- `intravox-source/src/components/Navigation.vue:11–82` — `<!-- Mobile hamburger menu -->` block
+  with `mobile-nav`, `mobile-nav-level-2`, `mobile-nav-level-3`, `mobile-nav-level-4` CSS classes.
+  The desktop dropdown/megamenu is a sibling block in the same template.
+- `intravox-source/src/components/Navigation.vue:489–530` — CSS defines `.mobile-nav` and indent
+  classes. No responsive breakpoint JS; toggling is via Vue `data` state (`mobileExpandedItems`).
+
+**Implication for MyDash:** REQ-ONAV-010's 800 px breakpoint + hamburger/drawer is correct in
+principle. The reference uses CSS classes rather than a JS `window.resize` listener; MyDash can
+use either. No spec change needed.
+
+---
+
+## Spec changes implied
+
+The following REQ-ONAV-NNN items contain assumptions that contradict the file-based storage model
+or reference-source evidence and should be rewritten when the spec moves to `review`:
+
+1. **REQ-ONAV-001** — Remove `mydash.org_navigation_tree` app-config key and 64 KB cap. Replace
+   with file-based storage path (e.g. `appdata/mydash/org-navigation-{lang}.json`). Update node
+   schema to add `groupVisibility` explicitly (it is a MyDash addition, not inherited).
+
+2. **REQ-ONAV-003** — Remove mention of persisting to `mydash.org_navigation_tree`. Reference the
+   file path from REQ-ONAV-001. Keep HTTP 400 on depth violation (stricter than reference, but
+   intentionally so). Remove the 64 KB mention.
+
+3. **REQ-ONAV-001 / REQ-ONAV-003** — Add a per-language dimension: the API should accept an
+   optional `?lang=` query parameter (default: organisation default language). Alternatively,
+   define a separate endpoint per language. If single-language-only is acceptable for v1, document
+   the constraint explicitly rather than silently ignoring it.
+
+4. **REQ-ONAV-004** — `mydash.org_navigation_position` as an app-config key is fine (it is a
+   scalar, not a tree). No change needed for this requirement.
+
+5. **REQ-ONAV-002** — Backend group-filtering logic must be added explicitly; it does not come
+   from filesystem ACL in MyDash's architecture (no GroupFolder ACL to piggyback on). The spec
+   already describes this correctly. Confirm the `IGroupManager` dependency is included in the
+   service.
+
+---
+
+## Open follow-ups
+
+- **Multi-language v1 scope:** Decide before implementation whether MyDash v1 ships one tree
+  (default language) or two (NL + EN). If two: add `?lang=` to GET/PUT and store two files.
+- **File size practical limit:** With no 64 KB cap, define a practical upper bound in validation
+  (e.g. 512 KB or 1000 nodes) to prevent runaway JSON accumulation.
+- **CLI copy command:** Consider a `mydash:copy-org-navigation <source> <target>` OCC command
+  modelled on `CopyNavigationCommand` for admin workflows.
+- **`groupVisibility` cascade rule edge case:** Spec says hidden parents cascade to children
+  (REQ-ONAV-002). Confirm whether a child with explicit `groupVisibility: null` overrides a
+  hidden parent or stays hidden. Reference implementation hides children unconditionally if the
+  parent page is inaccessible.
+- **`uniqueId` vs UUID:** Reference source uses arbitrary `id: uniqid('nav_')` strings (not UUID
+  v4). REQ-ONAV-001 requires UUID format. Clarify whether UUIDs are generated client-side (editor)
+  or server-side (on POST).
+- **SystemFileService fallback pattern:** Reference uses a system-context file reader for users
+  with restricted GroupFolder ACL. MyDash stores nav in `appdata` (admin-written), so all
+  authenticated users read the same file — no ACL fallback needed. Confirm and document this
+  simplification.

--- a/openspec/changes/navigation-editor-org/proposal.md
+++ b/openspec/changes/navigation-editor-org/proposal.md
@@ -1,0 +1,44 @@
+# Organization-wide Navigation Editor
+
+An admin-curated org-wide navigation tree that is distinct from each user's personal sidebar list. Where the existing dashboard-switcher-sidebar shows the dashboards a user owns or can access, this capability adds a second navigation surface — an admin-controlled tree of links and sections shared across the whole organisation. Useful for company resources, policy hubs, and tools panels.
+
+## Affected code units
+
+- `src/stores/orgNavigation.js` — new Pinia store managing org-nav tree state and read/write operations
+- `src/components/OrgNavigationPanel.vue` — new SFC rendering the filterable org-nav tree as a collapsible rail or drawer
+- `src/views/AdminOrgNavigationEditor.vue` — new admin editor with drag-and-drop tree builder, group visibility multi-select, icon picker integration
+- `src/App.vue` — mount `OrgNavigationPanel` as left/right/top rail or hidden (conditional on position setting)
+- `lib/AdminSettingsService.php` — extend to store/retrieve `mydash.org_navigation_tree` and `mydash.org_navigation_position` global settings
+- `lib/OrgNavigationService.php` — new service: validate tree depth (max 3), URL sanitise, filter tree by user's group memberships, resolve icon URLs
+- `Controller/AdminOrgNavigationController.php` — new controller: `GET /api/admin/org-navigation` (read+filter), `PUT /api/admin/org-navigation` (admin-only, validate, persist)
+
+## Why a capability
+
+The dashboard-switcher-sidebar serves a fundamentally different purpose: it lists personalised content (dashboards a user owns or can access). The org-nav tree is a global administrative interface — not personalised, not user-searchable, purely admin-curated. This requires separate storage, separate filtering logic, separate UI components, and a distinct read-permission model (any logged-in user may read filtered tree; only admin may write). A new capability cleanly separates concerns.
+
+## Approach
+
+- **Storage** — new global setting `mydash.org_navigation_tree` (JSON, max 64 KB). Each node is a UUID-identified object with `label`, `icon`, `url` (optional for section nodes), `openInNewTab`, `groupVisibility` (null = all users; array = restrict to groups), and `children`.
+- **Filtering** — `GET /api/admin/org-navigation` returns the full tree but filters out nodes the user cannot see (per group memberships). Cascading: hidden parents hide children.
+- **Validation** — `PUT /api/admin/org-navigation` enforces max depth 3, UUID id values, no duplicate ids, URL sanitisation (reject `javascript:`, `data:`), required fields per node.
+- **Admin UI** — drag-and-drop tree editor in admin section with per-node group-visibility multi-select, icon picker (reusing existing icon-resolution logic), depth indicator.
+- **Rendering** — Vue 3 SFC `OrgNavigationPanel.vue` mounted by `App.vue`. Responsive: rail at viewport ≥800px, hamburger+drawer at <800px. Position is configurable via `mydash.org_navigation_position` (left, right, top, hidden; default hidden). Active item detection based on URL match.
+- **Empty tree** — if the tree is empty OR the user has no visible nodes after filtering, the rail is not rendered even if position is set.
+
+## Capabilities
+
+**New Capabilities:**
+
+- `navigation-editor-org` (admin-curated org-wide navigation tree)
+
+**Modified Capabilities:**
+
+- `admin-settings` — gain new global settings keys: `mydash.org_navigation_tree`, `mydash.org_navigation_position`
+
+## Notes
+
+- No conflict with personal navigation (dashboard-switcher-sidebar) — two separate surfaces.
+- Group visibility uses Nextcloud's native group membership; hidden nodes cascade to children.
+- Mobile collapse to drawer is automatic via responsive CSS; no separate mobile branch in tree structure.
+- Icon resolution reuses existing link-button-widget logic (URL images vs. MDI names).
+- Position setting applies globally; per-user position preferences are out of scope for this capability.

--- a/openspec/changes/navigation-editor-org/proposal.md
+++ b/openspec/changes/navigation-editor-org/proposal.md
@@ -8,8 +8,8 @@ An admin-curated org-wide navigation tree that is distinct from each user's pers
 - `src/components/OrgNavigationPanel.vue` — new SFC rendering the filterable org-nav tree as a collapsible rail or drawer
 - `src/views/AdminOrgNavigationEditor.vue` — new admin editor with drag-and-drop tree builder, group visibility multi-select, icon picker integration
 - `src/App.vue` — mount `OrgNavigationPanel` as left/right/top rail or hidden (conditional on position setting)
-- `lib/AdminSettingsService.php` — extend to store/retrieve `mydash.org_navigation_tree` and `mydash.org_navigation_position` global settings
-- `lib/OrgNavigationService.php` — new service: validate tree depth (max 3), URL sanitise, filter tree by user's group memberships, resolve icon URLs
+- `lib/AdminSettingsService.php` — extend to store/retrieve `mydash.org_navigation_position` global setting (scalar; unchanged)
+- `lib/OrgNavigationFileService.php` — new service: read/write `appdata/mydash/org-navigation-{lang}.json` (up to 5 MB), validate tree depth (max 3), URL sanitise, filter tree by user's group memberships via `IGroupManager`, resolve icon URLs
 - `Controller/AdminOrgNavigationController.php` — new controller: `GET /api/admin/org-navigation` (read+filter), `PUT /api/admin/org-navigation` (admin-only, validate, persist)
 
 ## Why a capability
@@ -18,9 +18,9 @@ The dashboard-switcher-sidebar serves a fundamentally different purpose: it list
 
 ## Approach
 
-- **Storage** — new global setting `mydash.org_navigation_tree` (JSON, max 64 KB). Each node is a UUID-identified object with `label`, `icon`, `url` (optional for section nodes), `openInNewTab`, `groupVisibility` (null = all users; array = restrict to groups), and `children`.
-- **Filtering** — `GET /api/admin/org-navigation` returns the full tree but filters out nodes the user cannot see (per group memberships). Cascading: hidden parents hide children.
-- **Validation** — `PUT /api/admin/org-navigation` enforces max depth 3, UUID id values, no duplicate ids, URL sanitisation (reject `javascript:`, `data:`), required fields per node.
+- **Storage** — per-language JSON files at `appdata/mydash/org-navigation-{lang}.json` (up to 5 MB each; not stored in app-config). v1 supports `nl` and `en`. The tree is wholesale-replaced per language via `PUT /api/admin/org-navigation?lang={lang}`. Each node is a UUID-identified object with `label`, `icon`, `url` (optional for section nodes), `openInNewTab`, `groupVisibility` (null = all users; array = restrict to groups — a MyDash-specific field, not inherited from the reference implementation), and `children`.
+- **Filtering** — `GET /api/admin/org-navigation?lang={lang}` returns the full tree for that language but filters out nodes the user cannot see (per group memberships via `IGroupManager`). Cascading: hidden parents hide children. No filesystem ACL is used; group-membership checks are explicit.
+- **Validation** — `PUT /api/admin/org-navigation` enforces max depth 3 (HTTP 400 on violation — stricter than reference), UUID id values, no duplicate ids, URL sanitisation (reject `javascript:`, `data:`), required fields per node.
 - **Admin UI** — drag-and-drop tree editor in admin section with per-node group-visibility multi-select, icon picker (reusing existing icon-resolution logic), depth indicator.
 - **Rendering** — Vue 3 SFC `OrgNavigationPanel.vue` mounted by `App.vue`. Responsive: rail at viewport ≥800px, hamburger+drawer at <800px. Position is configurable via `mydash.org_navigation_position` (left, right, top, hidden; default hidden). Active item detection based on URL match.
 - **Empty tree** — if the tree is empty OR the user has no visible nodes after filtering, the rail is not rendered even if position is set.
@@ -33,7 +33,7 @@ The dashboard-switcher-sidebar serves a fundamentally different purpose: it list
 
 **Modified Capabilities:**
 
-- `admin-settings` — gain new global settings keys: `mydash.org_navigation_tree`, `mydash.org_navigation_position`
+- `admin-settings` — gain new global settings key: `mydash.org_navigation_position` (scalar; the tree itself is stored as filesystem files, not in app-config)
 
 ## Notes
 

--- a/openspec/changes/navigation-editor-org/specs/navigation-editor-org/spec.md
+++ b/openspec/changes/navigation-editor-org/specs/navigation-editor-org/spec.md
@@ -1,0 +1,412 @@
+---
+status: draft
+---
+
+# Organization-wide Navigation Editor
+
+## ADDED Requirements
+
+### Requirement: REQ-ONAV-001 Org navigation tree storage
+
+The system MUST persist an organisation-wide navigation tree in a new global Nextcloud app setting `mydash.org_navigation_tree` (JSON string, maximum 64 KB). The tree is an ordered array of node objects, each with:
+
+```json
+{
+  "id": "string (UUID format, required, must be unique)",
+  "label": "string (required, non-empty)",
+  "icon": "string (optional, icon name or URL)",
+  "url": "string (optional, null for section nodes)",
+  "openInNewTab": "boolean (optional, default: false)",
+  "groupVisibility": "array of string (optional, null = visible to all users, populated array = restrict to listed group ids)",
+  "children": "array of same shape (optional, max 3 levels total including root)"
+}
+```
+
+The root level of the tree is an array; each child node follows the same schema recursively. The tree depth (including root) MUST NOT exceed 3 levels.
+
+#### Scenario: Tree persists to global setting
+- GIVEN an admin creates and saves an org-nav tree with 2 top-level sections and 3 subsections
+- WHEN the setting `mydash.org_navigation_tree` is queried
+- THEN it MUST contain valid JSON with the persisted tree structure
+
+#### Scenario: Node id is uuid
+- GIVEN an admin creates a node in the tree
+- WHEN the node is saved
+- THEN the node's `id` field MUST be a valid UUID (v4 or v5)
+
+#### Scenario: Tree respects max depth 3
+- GIVEN a tree with root items containing children containing grandchildren
+- WHEN the tree is retrieved
+- THEN the depth (root → children → grandchildren) MUST be exactly 3 levels
+
+#### Scenario: Label is required per node
+- GIVEN a node is created without a label
+- WHEN the save is attempted
+- THEN the system MUST return HTTP 400 with error message containing `'label'`
+
+### Requirement: REQ-ONAV-002 Admin read API with group filtering
+
+The system MUST expose a `GET /api/admin/org-navigation` endpoint accessible to any logged-in user. The response MUST return the complete tree structure, but filtered to only include nodes the requesting user is permitted to see based on group memberships.
+
+A node is visible if and only if:
+- `groupVisibility` is `null` (visible to all), OR
+- The user belongs to at least one group listed in `groupVisibility`
+
+If a parent node is hidden, all its children are also hidden (cascading). Nodes with no visible children and no direct URL are rendered as empty sections or omitted (backend decision per rendering requirement REQ-ONAV-008).
+
+#### Scenario: All-users tree is visible to every user
+- GIVEN a tree with `groupVisibility = null` on all nodes
+- WHEN user A (member of group G1) and user B (member of group G2) both request the tree
+- THEN both receive the full unfiltered tree
+
+#### Scenario: Admin-only subtree filtered for non-admin
+- GIVEN a section with `groupVisibility: ['admin']` and 2 child links
+- AND user X is not a member of the 'admin' group
+- WHEN user X requests the tree
+- THEN the section and its children MUST NOT appear in the response
+
+#### Scenario: User in one of multiple groups sees node
+- GIVEN a section with `groupVisibility: ['marketing', 'sales']`
+- AND user Y is a member of 'sales' (but not 'marketing')
+- WHEN user Y requests the tree
+- THEN the section MUST be visible
+
+#### Scenario: Hidden parent hides children
+- GIVEN a section with `groupVisibility: ['restricted']` containing 3 child links
+- AND user Z is not a member of 'restricted'
+- WHEN user Z requests the tree
+- THEN neither the section nor its children MUST appear
+
+### Requirement: REQ-ONAV-003 Admin write API with validation
+
+The system MUST expose a `PUT /api/admin/org-navigation` endpoint accessible only to users with the admin role (e.g., `OC_PERMISSION_ADMIN` or app-level admin flag). The endpoint accepts a complete replacement tree (no PATCH) and validates before persisting.
+
+Validation rules:
+- The payload MUST be an array of node objects
+- Each node MUST have a non-empty `label` and a valid UUID `id`
+- No two nodes (at any depth) MUST have the same `id`
+- Tree depth (from root to deepest leaf) MUST NOT exceed 3 levels; return HTTP 400 `'Tree depth cannot exceed 3 levels'` if violated
+- The `url` field (if present) MUST NOT contain `javascript:` or `data:` schemes; return HTTP 400 `'URL scheme is not allowed'` if violated
+- The `groupVisibility` field (if present) MUST be either null or a non-empty array of string group ids
+- Return HTTP 403 if the requesting user is not an admin
+
+On success, persist the tree to `mydash.org_navigation_tree` and return HTTP 200 with the persisted tree (unchanged, not re-filtered).
+
+#### Scenario: Admin saves valid tree
+- GIVEN an admin provides a valid tree with 2 sections, each with 2 child links
+- WHEN `PUT /api/admin/org-navigation` is called
+- THEN the response MUST be HTTP 200
+- AND the tree MUST be persisted
+
+#### Scenario: Depth exceeded returns 400
+- GIVEN a tree with 4 levels (root → child → grandchild → great-grandchild)
+- WHEN `PUT /api/admin/org-navigation` is called
+- THEN the response MUST be HTTP 400 with message `'Tree depth cannot exceed 3 levels'`
+- AND the tree MUST NOT be persisted
+
+#### Scenario: Duplicate node ids return 400
+- GIVEN a tree where two nodes (at different depths) have the same UUID
+- WHEN the PUT is attempted
+- THEN the response MUST be HTTP 400 with message containing `'duplicate'` and `'id'`
+
+#### Scenario: Non-admin cannot write
+- GIVEN a user with role viewer (not admin)
+- WHEN the user calls `PUT /api/admin/org-navigation` with a valid tree
+- THEN the response MUST be HTTP 403
+
+#### Scenario: JavaScript URL is rejected
+- GIVEN a node with `url: 'javascript:alert(1)'`
+- WHEN the PUT is attempted
+- THEN the response MUST be HTTP 400 with message `'URL scheme is not allowed'`
+
+### Requirement: REQ-ONAV-004 Global position setting
+
+The system MUST support a global Nextcloud app setting `mydash.org_navigation_position` (string, enum: `'left'|'right'|'top'|'hidden'`, default: `'hidden'`). This setting controls where the org-nav rail/drawer is rendered in the UI (if at all).
+
+The setting MUST be configurable by admins via the admin editor (a dropdown or tab set on the navigation editor page). The position is global, not per-user; all users see the same position.
+
+When `position = 'hidden'`, the org-nav rail is not rendered even if the tree is non-empty (effectively opting out).
+
+#### Scenario: Position defaults to hidden
+- GIVEN a new MyDash installation
+- WHEN the app queries `mydash.org_navigation_position`
+- THEN it MUST return `'hidden'`
+
+#### Scenario: Admin changes position to left
+- GIVEN an admin sets `mydash.org_navigation_position = 'left'`
+- WHEN all users refresh the app
+- THEN the org-nav rail MUST appear on the left side
+
+#### Scenario: Position hidden suppresses rail
+- GIVEN `mydash.org_navigation_position = 'hidden'`
+- AND the tree is non-empty
+- WHEN the app renders
+- THEN no org-nav rail MUST be visible
+
+### Requirement: REQ-ONAV-005 Vue panel rendering
+
+The system MUST provide a Vue 3 SFC `OrgNavigationPanel.vue` that renders the filtered org-nav tree as a navigable panel. The panel MUST:
+
+1. Fetch the tree from `GET /api/admin/org-navigation` on mount
+2. Render each node as a list item with:
+   - Icon (if present, 24 px square, resolved per REQ-ONAV-006)
+   - Label (truncate or wrap if necessary)
+   - URL link (if present, `href` attribute; click opens the URL per `openInNewTab`)
+   - Children (expandable/collapsible section, indented, recursive)
+3. Highlight the current active node based on URL match: if the current page URL matches or starts with the node's `url`, the node receives an `active` CSS class
+4. Support expand/collapse per section (state tracked in component)
+5. Render as a tree with visual nesting (indentation and connecting lines optional but recommended)
+
+Desktop rendering: panel is a vertical rail (left, right, or top depending on REQ-ONAV-004 position). Mobile rendering: see REQ-ONAV-010.
+
+#### Scenario: Tree renders with icons and labels
+- GIVEN the org-nav tree contains a section "Company Resources" with icon "folder" and a child link "Handbook" with icon "file-document"
+- WHEN `OrgNavigationPanel.vue` mounts
+- THEN the section MUST show as an expandable item with the folder icon and label
+- AND on expand, the child link MUST appear indented with the document icon and label
+
+#### Scenario: Active item is highlighted
+- GIVEN the tree contains a node with `url: '/apps/mydash/dashboards/sales'`
+- AND the user is currently on the page `/apps/mydash/dashboards/sales/overview`
+- WHEN the panel renders
+- THEN the node MUST have the `active` CSS class (or visual indication of current location)
+
+#### Scenario: Child link without url is not clickable
+- GIVEN a section node with `url = null` (e.g., a section header)
+- WHEN the user hovers or interacts with it
+- THEN no link behavior MUST be triggered
+- AND the node MUST render as static text or an expandable container
+
+#### Scenario: openInNewTab respected
+- GIVEN a node with `url: 'https://external.com'` and `openInNewTab: true`
+- WHEN the user clicks the node
+- THEN the URL MUST open in a new browser tab (HTML `target="_blank"` or `window.open()`)
+
+### Requirement: REQ-ONAV-006 Icon resolution
+
+Each node's `icon` field MUST follow the same dual-mode convention as the link-button-widget (REQ-LBN-002):
+
+- A URL (starts with `/` or `http`) MUST render as an `<img>` element with `src=icon`
+- A bare name (e.g., `'folder'`, `'file-document'`) MUST render via the shared `IconRenderer` component (MDI icon set)
+- An empty or null value MUST render no icon
+
+Icon size MUST be consistently 24 px square across all nav items. The icon MUST appear to the left of the label in the horizontal direction.
+
+#### Scenario: Icon from URL renders as img
+- GIVEN a node with `icon: '/apps/mydash/icons/custom.png'` and `label: 'Portal'`
+- WHEN the panel renders
+- THEN an `<img src="/apps/mydash/icons/custom.png">` element MUST appear left of the label
+
+#### Scenario: Icon name renders via IconRenderer
+- GIVEN a node with `icon: 'briefcase'` (an MDI name) and `label: 'Business'`
+- WHEN the panel renders
+- THEN the MDI briefcase icon MUST appear left of the label
+
+#### Scenario: Missing icon renders no icon
+- GIVEN a node with `icon: null` (or omitted) and `label: 'Help'`
+- WHEN the panel renders
+- THEN no icon MUST be visible
+- AND only the label MUST be shown
+
+### Requirement: REQ-ONAV-007 Drag-and-drop admin editor
+
+The system MUST provide an admin editor UI (accessible at a route like `/apps/mydash/admin/navigation`) with the following features:
+
+1. A drag-and-drop tree builder displaying the current org-nav tree (or empty state if none exists)
+2. Per-node controls:
+   - Edit button (inline or modal): edit `label`, `url`, `icon`, `openInNewTab`
+   - Drag handle (standard drag-to-reorder within parent or across levels, respecting depth limit)
+   - Delete button
+   - Group visibility multi-select (list all Nextcloud groups; "Visible to everyone" = null; else array of selected group ids)
+   - Icon picker (reuse existing link-button-widget icon picker logic, or integrate with link editor modal)
+3. Add node buttons:
+   - "Add section" (creates a node with `url = null`, `label = "New Section"`, `children = []`)
+   - "Add link" (creates a node with required `url`, optional `label`, optional `icon`)
+4. Visual depth indicator: warn if user drags a node to exceed depth 3
+5. Save button: calls `PUT /api/admin/org-navigation` with the edited tree; on success, display confirmation; on error (e.g., depth exceeded, duplicate id), show error banner and prevent save
+
+#### Scenario: Drag to reorder at same level
+- GIVEN the editor shows 3 top-level sections A, B, C
+- WHEN the user drags section B above section A
+- THEN the tree order MUST become [B, A, C]
+
+#### Scenario: Drag to nest under parent
+- GIVEN 3 top-level sections with section A containing 2 children
+- WHEN the user drags section B into section A (as a grandchild)
+- AND the result would be 2 levels deep
+- THEN the drag MUST succeed
+
+#### Scenario: Depth limit warn on drag
+- GIVEN a tree already at max depth 3
+- WHEN the user attempts to drag a node to nest it further
+- THEN a visual warning or disable MUST prevent the drag
+- OR a tooltip MUST indicate `'Tree depth cannot exceed 3 levels'`
+
+#### Scenario: Group visibility multi-select
+- GIVEN the editor is open on a node with `groupVisibility: ['marketing', 'sales']`
+- WHEN the user opens the group visibility selector
+- THEN checkboxes or pills MUST show for all NC groups, with 'marketing' and 'sales' pre-checked
+- AND a "Visible to everyone" toggle MUST be available to clear the array
+
+#### Scenario: Save valid tree persists
+- GIVEN the user edits the tree (add 2 sections, reorder, set group visibility)
+- WHEN the user clicks Save
+- AND no validation errors occur
+- THEN the tree MUST be persisted to the backend
+- AND a success message MUST appear
+
+#### Scenario: Save with error prevents persist
+- GIVEN the edited tree violates depth limit or contains duplicate ids
+- WHEN the user clicks Save
+- THEN validation errors MUST appear on the editor
+- AND the tree MUST NOT be persisted
+
+### Requirement: REQ-ONAV-008 Empty tree and no-visible-nodes handling
+
+If the org-nav tree is empty (no nodes), OR if the user has no visible nodes after group-visibility filtering (REQ-ONAV-002), the `OrgNavigationPanel.vue` MUST NOT render any visible content. The rail/drawer MUST not be displayed even if `mydash.org_navigation_position` is set to `'left'`, `'right'`, or `'top'`.
+
+This prevents visual clutter when the tree is disabled or not yet configured.
+
+#### Scenario: Empty tree renders nothing
+- GIVEN `mydash.org_navigation_tree` is an empty array `[]`
+- AND `mydash.org_navigation_position = 'left'`
+- WHEN the app renders
+- THEN no org-nav rail MUST be visible
+
+#### Scenario: Filtered to zero nodes renders nothing
+- GIVEN the tree has 1 section with `groupVisibility: ['admin']`
+- AND the user is not an admin
+- WHEN the user views the app
+- THEN no org-nav rail MUST be visible (all nodes filtered out)
+
+#### Scenario: Partial filtering still renders visible nodes
+- GIVEN the tree has 2 sections: one visible to all, one restricted to admins
+- AND the user is not an admin
+- WHEN the user views the app
+- THEN the first section MUST be visible in the rail
+- AND the restricted section MUST NOT be visible
+
+### Requirement: REQ-ONAV-009 Active item detection
+
+The `OrgNavigationPanel.vue` MUST detect and highlight the currently active node based on the current page URL. A node is considered active if:
+
+- The node has a non-null `url` field, AND
+- The current page URL exactly matches the node's `url`, OR
+- The current page URL starts with the node's `url` as a prefix (e.g., current is `/apps/mydash/dashboards/sales/overview`, node's `url` is `/apps/mydash/dashboards/sales`)
+
+The active node MUST receive an `active` CSS class (or similar visual indicator, e.g., background highlight, bold label, accent border). Parent nodes of an active child MUST be visually indicated as expanded (if collapsed) and may receive a "contains active descendant" style.
+
+#### Scenario: Exact URL match
+- GIVEN a node with `url: '/apps/mydash/policies'`
+- AND the current page is exactly `/apps/mydash/policies`
+- WHEN the panel renders
+- THEN the node MUST have the `active` class
+
+#### Scenario: Prefix match
+- GIVEN a node with `url: '/apps/mydash/dashboards'`
+- AND the current page is `/apps/mydash/dashboards/sales/details`
+- WHEN the panel renders
+- THEN the node MUST have the `active` class
+
+#### Scenario: Parent auto-expands if child is active
+- GIVEN a section "Dashboards" with a child "Sales Dashboard"
+- AND the child has `url: '/apps/mydash/dashboards/sales'`
+- AND the user is on `/apps/mydash/dashboards/sales`
+- WHEN the panel renders
+- THEN the parent section MUST be expanded (if it was collapsed)
+- AND the child MUST have the `active` class
+
+### Requirement: REQ-ONAV-010 Mobile responsive layout
+
+At viewport widths less than 800 px, the org-nav rail MUST collapse to a hamburger button (icon + "Navigation" label or icon only). Clicking the hamburger MUST open the org-nav tree as a slide-in drawer (left-to-right or bottom-up, consistent with the position setting) that overlays the main content. The drawer MUST include:
+
+- A close button (X or back arrow)
+- The full tree rendered as per REQ-ONAV-005
+
+At 800 px and above, the drawer MUST close and the full rail/sidebar MUST be visible per the position setting (REQ-ONAV-004).
+
+Internally, the tree structure and content MUST remain the same; only the container and toggle mechanism change.
+
+#### Scenario: Mobile hamburger visible
+- GIVEN the viewport width is 600 px
+- AND the org-nav tree is non-empty
+- WHEN the app renders
+- THEN a hamburger button MUST appear (no full rail visible)
+
+#### Scenario: Click hamburger opens drawer
+- GIVEN the hamburger button is visible
+- WHEN the user clicks the hamburger
+- THEN a drawer/modal MUST slide in from the side, showing the full tree
+
+#### Scenario: Close drawer on selection
+- GIVEN the drawer is open and showing the tree
+- WHEN the user clicks a node with a URL
+- THEN the URL MUST be navigated to
+- AND the drawer MUST auto-close
+
+#### Scenario: Desktop rail visible at 800px
+- GIVEN the viewport width is 800 px or greater
+- AND the org-nav tree is non-empty
+- AND `mydash.org_navigation_position = 'left'`
+- WHEN the app renders
+- THEN the full rail MUST appear on the left side
+- AND no hamburger button MUST be visible
+
+### Requirement: REQ-ONAV-011 URL sanitisation and validation
+
+When admin saves an org-nav tree via `PUT /api/admin/org-navigation`, each node's `url` field (if present) MUST be validated to reject potentially dangerous schemes:
+
+- Reject URLs starting with `javascript:` (case-insensitive)
+- Reject URLs starting with `data:` (case-insensitive)
+- Reject URLs starting with `vbscript:` (case-insensitive)
+- Allow all other schemes: `http`, `https`, relative paths (e.g., `/apps/mydash/...`), and fragment-only URLs (e.g., `#section`)
+
+Return HTTP 400 with a message like `'URL contains a disallowed scheme'` if validation fails. This protects against XSS and other injection attacks via the admin editor.
+
+#### Scenario: JavaScript URL rejected
+- GIVEN a node with `url: 'JavaScript:alert("xss")'`
+- WHEN the admin saves
+- THEN HTTP 400 MUST be returned with error message
+
+#### Scenario: Data URL rejected
+- GIVEN a node with `url: 'data:text/html,<script>alert(1)</script>'`
+- WHEN the admin saves
+- THEN HTTP 400 MUST be returned
+
+#### Scenario: HTTPS URL allowed
+- GIVEN a node with `url: 'https://example.com/secure'`
+- WHEN the admin saves
+- THEN the URL MUST be accepted and persisted
+
+#### Scenario: Relative path allowed
+- GIVEN a node with `url: '/apps/mydash/dashboards/sales'`
+- WHEN the admin saves
+- THEN the URL MUST be accepted
+
+### Requirement: REQ-ONAV-012 Internationalization
+
+All user-facing strings in the org-nav tree editor and panel MUST support i18n (Dutch and English at minimum, per company standard). Strings to translate include:
+
+- Admin page title: "Organization Navigation"
+- Section labels: "Add section", "Add link", "Edit", "Delete", "Visible to everyone", "Group visibility"
+- Error messages: "Tree depth cannot exceed 3 levels", "URL contains a disallowed scheme", "Label is required", etc.
+- Mobile: "Navigation" (hamburger label)
+- Empty states: "No navigation configured" or similar
+
+Translations MUST be stored in the standard location (e.g., `l10n/en.json`, `l10n/nl.json`) and loaded via Nextcloud's i18n integration. The `OrgNavigationPanel.vue` and admin editor Vue components MUST use the `$t()` function for all user-visible text.
+
+#### Scenario: Dutch translation available
+- GIVEN the user's language is set to Dutch
+- WHEN the navigation editor loads
+- THEN all labels, buttons, and messages MUST be in Dutch
+
+#### Scenario: English translation fallback
+- GIVEN a string has no Dutch translation
+- WHEN the user's language is Dutch
+- THEN the English translation MUST be displayed (or the key itself if no English exists)
+
+---
+
+## Summary
+
+The `navigation-editor-org` capability provides a robust, admin-curated, group-aware org-nav tree distinct from personal dashboard lists. It combines centralised storage, flexible group visibility, drag-and-drop editing, responsive mobile support, and security safeguards to deliver a professional navigation surface for organisations.

--- a/openspec/changes/navigation-editor-org/specs/navigation-editor-org/spec.md
+++ b/openspec/changes/navigation-editor-org/specs/navigation-editor-org/spec.md
@@ -8,7 +8,11 @@ status: draft
 
 ### Requirement: REQ-ONAV-001 Org navigation tree storage
 
-The system MUST persist an organisation-wide navigation tree in a new global Nextcloud app setting `mydash.org_navigation_tree` (JSON string, maximum 64 KB). The tree is an ordered array of node objects, each with:
+The system MUST persist an organisation-wide navigation tree as a **JSON file on the Nextcloud filesystem** at a well-known path within the application's data directory. One file is stored per language: `appdata/mydash/org-navigation-{lang}.json` (e.g., `org-navigation-nl.json`, `org-navigation-en.json`). The implementation MUST NOT use a Nextcloud app-config key for the tree payload. The maximum accepted file size is **5 MB** (enforced on read and write).
+
+> **v1 language scope:** MyDash v1 ships with support for `nl` (Dutch) and `en` (English). Both language files are maintained independently; changing one does not affect the other. The API accepts an optional `?lang=` query parameter (default: `nl`). A CLI copy command (`mydash:copy-org-navigation <source> <target>`) is a planned follow-up, not part of v1.
+
+The tree is an ordered array of node objects, each with:
 
 ```json
 {
@@ -22,11 +26,13 @@ The system MUST persist an organisation-wide navigation tree in a new global Nex
 }
 ```
 
-The root level of the tree is an array; each child node follows the same schema recursively. The tree depth (including root) MUST NOT exceed 3 levels.
+> **NOTE — MyDash addition:** The `groupVisibility` field is a MyDash-specific design choice. The reference intranet product does not store group visibility in the navigation JSON; it relies on filesystem ACL (GroupFolder read permissions) to filter nodes. Because MyDash stores the tree in application data (not in per-user GroupFolders), no ACL is available to piggyback on. The per-node array approach (`null` = all users, populated array = restrict to listed group IDs) is the deliberate MyDash substitute. The filtering logic is implemented explicitly in `OrgNavigationService.php` using Nextcloud's `IGroupManager`.
 
-#### Scenario: Tree persists to global setting
+The root level of the tree is an array; each child node follows the same schema recursively. The tree depth (including root) MUST NOT exceed 3 levels. This is a stricter limit than some reference implementations (which are unlimited) and is a deliberate MyDash choice to keep the admin UI manageable.
+
+#### Scenario: Tree persists to file
 - GIVEN an admin creates and saves an org-nav tree with 2 top-level sections and 3 subsections
-- WHEN the setting `mydash.org_navigation_tree` is queried
+- WHEN the file `appdata/mydash/org-navigation-nl.json` is read
 - THEN it MUST contain valid JSON with the persisted tree structure
 
 #### Scenario: Node id is uuid
@@ -46,7 +52,7 @@ The root level of the tree is an array; each child node follows the same schema 
 
 ### Requirement: REQ-ONAV-002 Admin read API with group filtering
 
-The system MUST expose a `GET /api/admin/org-navigation` endpoint accessible to any logged-in user. The response MUST return the complete tree structure, but filtered to only include nodes the requesting user is permitted to see based on group memberships.
+The system MUST expose a `GET /api/admin/org-navigation` endpoint accessible to any logged-in user. The endpoint MUST accept an optional `?lang=` query parameter (values: `nl`, `en`; default: `nl`) that selects which language file is read. The response MUST return the complete tree structure for that language, filtered to only include nodes the requesting user is permitted to see based on group memberships.
 
 A node is visible if and only if:
 - `groupVisibility` is `null` (visible to all), OR
@@ -79,7 +85,7 @@ If a parent node is hidden, all its children are also hidden (cascading). Nodes 
 
 ### Requirement: REQ-ONAV-003 Admin write API with validation
 
-The system MUST expose a `PUT /api/admin/org-navigation` endpoint accessible only to users with the admin role (e.g., `OC_PERMISSION_ADMIN` or app-level admin flag). The endpoint accepts a complete replacement tree (no PATCH) and validates before persisting.
+The system MUST expose a `PUT /api/admin/org-navigation` endpoint accessible only to users with the admin role (e.g., `OC_PERMISSION_ADMIN` or app-level admin flag). The endpoint accepts an optional `?lang=` query parameter (values: `nl`, `en`; default: `nl`) that selects which language file to overwrite. The endpoint accepts a complete replacement tree for that language file (no PATCH) and validates before persisting.
 
 Validation rules:
 - The payload MUST be an array of node objects
@@ -90,13 +96,13 @@ Validation rules:
 - The `groupVisibility` field (if present) MUST be either null or a non-empty array of string group ids
 - Return HTTP 403 if the requesting user is not an admin
 
-On success, persist the tree to `mydash.org_navigation_tree` and return HTTP 200 with the persisted tree (unchanged, not re-filtered).
+On success, write the validated tree to `appdata/mydash/org-navigation-{lang}.json` (wholesale file replacement) and return HTTP 200 with the persisted tree (unchanged, not re-filtered). The 3-level depth limit returns HTTP 400 rather than silently truncating — this is intentionally stricter than reference implementations that silently discard excess depth.
 
 #### Scenario: Admin saves valid tree
 - GIVEN an admin provides a valid tree with 2 sections, each with 2 child links
 - WHEN `PUT /api/admin/org-navigation` is called
 - THEN the response MUST be HTTP 200
-- AND the tree MUST be persisted
+- AND the tree MUST be persisted to `appdata/mydash/org-navigation-nl.json` (default language)
 
 #### Scenario: Depth exceeded returns 400
 - GIVEN a tree with 4 levels (root → child → grandchild → great-grandchild)
@@ -252,7 +258,7 @@ The system MUST provide an admin editor UI (accessible at a route like `/apps/my
 - GIVEN the user edits the tree (add 2 sections, reorder, set group visibility)
 - WHEN the user clicks Save
 - AND no validation errors occur
-- THEN the tree MUST be persisted to the backend
+- THEN `PUT /api/admin/org-navigation` MUST be called and the tree written to `appdata/mydash/org-navigation-{lang}.json`
 - AND a success message MUST appear
 
 #### Scenario: Save with error prevents persist
@@ -268,7 +274,7 @@ If the org-nav tree is empty (no nodes), OR if the user has no visible nodes aft
 This prevents visual clutter when the tree is disabled or not yet configured.
 
 #### Scenario: Empty tree renders nothing
-- GIVEN `mydash.org_navigation_tree` is an empty array `[]`
+- GIVEN `appdata/mydash/org-navigation-nl.json` contains an empty array `[]`
 - AND `mydash.org_navigation_position = 'left'`
 - WHEN the app renders
 - THEN no org-nav rail MUST be visible

--- a/openspec/changes/navigation-editor-org/tasks.md
+++ b/openspec/changes/navigation-editor-org/tasks.md
@@ -1,0 +1,221 @@
+# Tasks — navigation-editor-org
+
+## 1. Backend domain model
+
+- [ ] 1.1 Add global IAppConfig setting `mydash.org_navigation_tree` (JSON string, type `mixed`)
+- [ ] 1.2 Add global IAppConfig setting `mydash.org_navigation_position` (JSON string, default `'hidden'`)
+- [ ] 1.3 Create `OrgNavigationService` class with methods:
+  - `getTree(): array` — return parsed tree from setting (or empty array if not set)
+  - `setTree(array $tree): void` — validate and persist tree to setting
+  - `filterTreeByUserGroups(array $tree, string $userId): array` — recursively filter nodes by user's group memberships
+  - `validateTree(array $tree): void` — validate depth, ids, urls, return error on invalid
+  - `sanitiseUrl(string $url): string` — reject javascript:, data:, vbscript: schemes
+
+## 2. Backend API controller
+
+- [ ] 2.1 Create `AdminOrgNavigationController` class
+- [ ] 2.2 Implement `getOrgNavigation()` → `GET /api/admin/org-navigation`: fetch tree, filter by user's groups, return JSON; accessible to all logged-in users
+- [ ] 2.3 Implement `updateOrgNavigation()` → `PUT /api/admin/org-navigation`: admin-only, validate tree, persist, return HTTP 200 on success or HTTP 400/403 on error
+- [ ] 2.4 Register routes in `app.php` or `routes.php`:
+  - `GET /api/admin/org-navigation` → `AdminOrgNavigationController::getOrgNavigation`
+  - `PUT /api/admin/org-navigation` → `AdminOrgNavigationController::updateOrgNavigation`
+- [ ] 2.5 Add admin permission check: return HTTP 403 if user is not admin on `PUT`
+
+## 3. Backend validation
+
+- [ ] 3.1 In `OrgNavigationService::validateTree()`, check tree depth (max 3 levels); return structured error if exceeded
+- [ ] 3.2 Check all node ids are valid UUIDs; return error if invalid
+- [ ] 3.3 Check for duplicate node ids across all levels; return error if found
+- [ ] 3.4 Check each node has required `label` (non-empty string) and `id` (UUID); return error if missing
+- [ ] 3.5 Check node `url` (if present) passes `sanitiseUrl()` validation; reject javascript:, data:, vbscript:
+- [ ] 3.6 Check `groupVisibility` (if present) is either null or non-empty array of strings
+- [ ] 3.7 Return HTTP 400 with detailed error message on any validation failure
+- [ ] 3.8 Add PHPUnit test: valid tree passes validation
+- [ ] 3.9 Add PHPUnit test: depth exceeded returns error
+- [ ] 3.10 Add PHPUnit test: duplicate ids return error
+- [ ] 3.11 Add PHPUnit test: javascript: url rejected
+- [ ] 3.12 Add PHPUnit test: data: url rejected
+
+## 4. Backend group filtering
+
+- [ ] 4.1 In `OrgNavigationService::filterTreeByUserGroups()`, recursively traverse tree
+- [ ] 4.2 For each node, check `groupVisibility`:
+  - If null → node is visible
+  - If array → check if user belongs to any group in array; if yes, visible; if no, hidden
+- [ ] 4.3 If parent is hidden, children are also hidden (cascading)
+- [ ] 4.4 Return filtered tree (non-visible nodes and their children removed)
+- [ ] 4.5 Add PHPUnit test: tree with all-null visibility is fully visible
+- [ ] 4.6 Add PHPUnit test: user in matching group sees restricted node
+- [ ] 4.7 Add PHPUnit test: user not in any matching group does not see restricted node
+- [ ] 4.8 Add PHPUnit test: hidden parent hides children
+
+## 5. Frontend store
+
+- [ ] 5.1 Create `src/stores/orgNavigation.js` (Pinia store) with state:
+  - `tree`: array (current filtered tree)
+  - `loading`: boolean
+  - `error`: string or null
+- [ ] 5.2 Implement actions:
+  - `fetchTree()` — call `GET /api/admin/org-navigation`, store filtered tree in state
+  - `updateTree(newTree)` — call `PUT /api/admin/org-navigation`, validate response, update state
+- [ ] 5.3 Implement getters:
+  - `visibleTree` — return current filtered tree
+  - `isEmpty` — return true if tree is empty after filtering
+  - `isLoading` — return loading state
+- [ ] 5.4 On store initialisation, call `fetchTree()` to load tree on app startup
+- [ ] 5.5 Add error handling: if `GET` fails, log error, set `error` state
+
+## 6. Frontend navigation panel component
+
+- [ ] 6.1 Create `src/components/OrgNavigationPanel.vue` (Vue 3 SFC)
+- [ ] 6.2 On mount, subscribe to `orgNavigation` store and render filtered tree
+- [ ] 6.3 Render each node as a list item with:
+  - Icon (24 px, resolved per REQ-ONAV-006: URL → `<img>`, name → `IconRenderer`, null → no icon)
+  - Label (text)
+  - Children (expandable/collapsible, recursive)
+  - Link (if `url` is present)
+- [ ] 6.4 Implement expand/collapse state per section (tracked in component state or URL)
+- [ ] 6.5 Implement active item detection: highlight node if current page URL matches or starts with node's `url`
+- [ ] 6.6 Auto-expand parent if a child is active
+- [ ] 6.7 On node click, navigate to `url` if present; respect `openInNewTab` (target="_blank")
+- [ ] 6.8 Render tree with visual nesting: indentation and optional connecting lines
+- [ ] 6.9 Add error state: if store has error, display error banner
+- [ ] 6.10 Add i18n: use `$t()` for any user-visible labels
+- [ ] 6.11 Add unit test: panel renders with sample tree data
+- [ ] 6.12 Add unit test: clicking node navigates to url
+- [ ] 6.13 Add unit test: active node receives active class
+
+## 7. Frontend responsive layout & App.vue integration
+
+- [ ] 7.1 In `OrgNavigationPanel.vue`, add responsive logic:
+  - At viewport < 800px: render hamburger button (icon + "Navigation" label or icon only)
+  - At viewport ≥ 800px: render full rail per position setting
+- [ ] 7.2 Hamburger click opens drawer/slide-in overlay showing full tree
+- [ ] 7.3 Drawer close button (X or back arrow) closes drawer
+- [ ] 7.4 Clicking a tree node in drawer auto-closes drawer and navigates
+- [ ] 7.5 In `src/App.vue`, mount `OrgNavigationPanel` as conditional rail:
+  - Fetch `mydash.org_navigation_position` from store (or query backend)
+  - If position = 'hidden', render nothing
+  - If position = 'left', render panel in left column (flex order or CSS grid placement)
+  - If position = 'right', render panel in right column
+  - If position = 'top', render panel above main content (full width or constrained)
+- [ ] 7.6 Do not render panel if tree is empty after filtering (REQ-ONAV-008)
+- [ ] 7.7 Add CSS: hamburger button styling, drawer overlay, rail flex layout
+- [ ] 7.8 Add unit test: hamburger visible on small viewport
+- [ ] 7.9 Add unit test: rail visible on large viewport
+- [ ] 7.10 Add unit test: drawer opens/closes correctly
+
+## 8. Frontend admin editor component
+
+- [ ] 8.1 Create `src/views/AdminOrgNavigationEditor.vue` (Vue 3 SFC, admin page)
+- [ ] 8.2 On mount, fetch current tree from store via `orgNavigation.visibleTree` (or raw tree if admin has no filters)
+- [ ] 8.3 Implement drag-and-drop tree builder:
+  - Each node displays as a draggable row/card
+  - Drag handle (icon or chevron area) allows reorder within parent or reparent to another parent
+  - Respect depth limit: warn or disable drag if would exceed depth 3
+- [ ] 8.4 Per-node controls:
+  - "Edit" button → opens modal with `label`, `url`, `icon`, `openInNewTab` fields (reuse or create single-node edit form)
+  - "Delete" button → remove node from tree (confirm before delete)
+  - "Group visibility" button/link → opens multi-select with all NC groups, current selection checked, "Visible to everyone" toggle
+  - "Add child" button (for sections) → add new child node
+- [ ] 8.5 Top-level "Add section" and "Add link" buttons to add root nodes
+- [ ] 8.6 Icon picker integration: in node edit modal, reuse existing link-button-widget icon picker (or create shared component)
+- [ ] 8.7 Visual depth indicator: show current depth of tree, warn if approaching limit 3
+- [ ] 8.8 Save button: call `orgNavigation.updateTree(tree)`, handle errors (show banner with error message, prevent save)
+- [ ] 8.9 On save success, show confirmation toast/banner
+- [ ] 8.10 Add i18n: all labels, buttons, error messages use `$t()`
+- [ ] 8.11 Add unit test: drag reorder at same level
+- [ ] 8.12 Add unit test: edit node modal opens and saves changes
+- [ ] 8.13 Add unit test: delete node removes from tree
+- [ ] 8.14 Add unit test: add child creates new node under parent
+- [ ] 8.15 Add integration test: user edits tree with multiple changes, saves, tree persists
+
+## 9. Backend position setting
+
+- [ ] 9.1 In admin editor, add a "Position" dropdown/tab set with options: Left, Right, Top, Hidden
+- [ ] 9.2 On change, call a new endpoint or store method to update `mydash.org_navigation_position`
+- [ ] 9.3 Endpoint: `PUT /api/admin/org-navigation/position` (admin-only) — accept JSON `{ "position": "left"|"right"|"top"|"hidden" }`, validate, persist
+- [ ] 9.4 Add PHPUnit test: admin can change position
+- [ ] 9.5 Add PHPUnit test: position defaults to 'hidden'
+
+## 10. Frontend position integration
+
+- [ ] 10.1 In `src/App.vue`, fetch `mydash.org_navigation_position` from backend on app init or from store
+- [ ] 10.2 Pass position as prop to `OrgNavigationPanel` or use it in conditional layout logic
+- [ ] 10.3 Re-render panel position when setting changes (e.g., after admin saves new position)
+- [ ] 10.4 Test: changing position in admin editor updates panel position in real-time (with page refresh or reactive store)
+
+## 11. Icon resolution
+
+- [ ] 11.1 In `OrgNavigationService`, add icon resolution logic (or use existing shared logic if available):
+  - URL (starts with `/` or `http`) → return as-is for `<img src>`
+  - Bare name → return as-is for `IconRenderer` component
+  - Null/empty → return null
+- [ ] 11.2 In `OrgNavigationPanel.vue`, render icon:
+  - If `icon.startsWith('/')` or `icon.startsWith('http')` → `<img :src="icon" class="icon" style="width: 24px; height: 24px">`
+  - Else → `<IconRenderer :name="icon" :size="24">`
+  - Else (null) → nothing
+
+## 12. Nextcloud group integration
+
+- [ ] 12.1 Query Nextcloud's group service (`\OCP\IGroupManager`) to get list of all groups
+- [ ] 12.2 In admin editor, populate "Group visibility" multi-select with full list of groups
+- [ ] 12.3 When saving tree, retrieve user's groups (`\OCP\IGroupManager::getUserGroupIds()`) to validate group-visibility filters
+
+## 13. Internationalization
+
+- [ ] 13.1 Create or update translation files:
+  - `l10n/en.json` — English translations
+  - `l10n/nl.json` — Dutch translations
+- [ ] 13.2 Add i18n keys for:
+  - Admin page title: `onav_admin_title` → "Organization Navigation"
+  - Buttons: `onav_add_section`, `onav_add_link`, `onav_edit`, `onav_delete`, `onav_save`, etc.
+  - Labels: `onav_position`, `onav_group_visibility`, `onav_visible_to_all`, etc.
+  - Mobile: `onav_mobile_menu` → "Navigation"
+  - Error messages: `onav_error_depth_exceeded`, `onav_error_url_scheme`, `onav_error_label_required`, etc.
+- [ ] 13.3 Use `$t()` in all Vue components and PHP error messages (via Nextcloud's i18n API)
+- [ ] 13.4 Add unit test: Dutch translation loads correctly
+
+## 14. Security and validation edge cases
+
+- [ ] 14.1 Test case: admin tries to save tree with > 64 KB JSON (setting storage limit)
+- [ ] 14.2 Test case: tree with very deep nesting (level 100+) is rejected
+- [ ] 14.3 Test case: tree with thousands of nodes is accepted and filtered correctly
+- [ ] 14.4 Test case: url with query string and fragment (`/path?foo=bar#section`) is accepted
+- [ ] 14.5 Test case: url with encoded characters (`/path%20with%20spaces`) is accepted
+- [ ] 14.6 Test case: empty label on node is rejected
+- [ ] 14.7 Test case: duplicate uuids are detected across multiple levels
+- [ ] 14.8 Test case: groupVisibility with non-existent group ids is accepted (graceful: those groups simply match no users)
+
+## 15. E2E Playwright tests
+
+- [ ] 15.1 Admin creates a navigation tree with 2 sections and 3 child links, saves successfully
+- [ ] 15.2 Admin changes position to 'left', verifies panel appears on left in main app
+- [ ] 15.3 Admin sets group visibility on a section to 'marketing' only
+- [ ] 15.4 Non-marketing user logs in, verifies that section is not visible in panel
+- [ ] 15.5 Marketing user logs in, verifies that section is visible in panel
+- [ ] 15.6 User clicks a link in the panel, verifies navigation to the correct URL
+- [ ] 15.7 Mobile viewport: hamburger button is visible, clicking opens drawer, selecting a link closes drawer
+- [ ] 15.8 Admin drags a node to reorder, saves, verifies order persists after reload
+- [ ] 15.9 Active item detection: user navigates to `/apps/mydash/dashboards/sales`, verifies the matching node is highlighted
+- [ ] 15.10 Admin deletes a node, saves, verifies it no longer appears
+
+## 16. Quality gates
+
+- [ ] 16.1 `composer check:strict` passes (PHPCS, PHPMD, Psalm, PHPStan)
+- [ ] 16.2 ESLint + Stylelint clean on all Vue/JS files
+- [ ] 16.3 Test coverage for new code ≥ 75% (PHPUnit + Playwright combined)
+- [ ] 16.4 SPDX-License-Identifier header added to all new PHP files (inside docblock)
+- [ ] 16.5 No console warnings or errors in browser on main app
+- [ ] 16.6 i18n keys for all user-facing strings (Dutch + English)
+- [ ] 16.7 Accessibility: panel is navigable via keyboard (Tab, Enter, Arrow keys)
+- [ ] 16.8 Accessibility: panel has proper ARIA labels and roles (navigation, menuitem, etc.)
+- [ ] 16.9 Run all hydra-gates locally before opening PR
+
+## 17. Documentation
+
+- [ ] 17.1 Update or create admin documentation explaining how to configure org navigation
+- [ ] 17.2 Add a note in the changelog: "Added organization-wide navigation editor for admin-curated tree of links and sections with group visibility support"
+- [ ] 17.3 Document the API endpoints: `GET /api/admin/org-navigation`, `PUT /api/admin/org-navigation`
+- [ ] 17.4 Document the global settings: `mydash.org_navigation_tree`, `mydash.org_navigation_position`
+- [ ] 17.5 Add screenshot or animation to docs showing the admin editor UI and the rendered panel

--- a/openspec/changes/nc-unified-search-integration/design.md
+++ b/openspec/changes/nc-unified-search-integration/design.md
@@ -1,0 +1,97 @@
+# Design — NC Unified Search Integration
+
+## Context
+
+Nextcloud ships a platform-wide search surface (Ctrl+K) backed by the `OCP\Search\IProvider`
+contract. Any app registering a provider gains automatic presence in the search dropdown — no
+custom UI or route is needed. MyDash currently has no registered provider, so dashboards and
+widget content are invisible to operators and end-users searching from the global bar.
+
+The integration must stay simple: the unified search fires on keypress, so the response budget
+is tight. A pre-built search index would require a separate indexing job, schema migrations, and
+cache invalidation logic that is disproportionate for this scope. Live querying at search-time
+with a narrow `LIKE %term%` scan is sufficient because the total number of dashboards per user
+is small.
+
+Permission correctness is non-negotiable. The NC search API passes results straight to the
+frontend, so any dashboard the requester cannot view must be excluded server-side before the
+response is assembled. The existing `canViewDashboard($userId, $dashboard)` helper on the
+`DashboardService` is the single gate for this check.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Register a `mydash` search provider visible in the NC Ctrl+K dropdown.
+- Surface dashboard titles, descriptions, and widget body text as search results.
+- Enforce per-result permission filtering before returning results.
+- Return a direct link that opens the matching dashboard.
+
+**Non-Goals:**
+- Pre-built or persisted search index.
+- Searching widget configuration / settings fields.
+- Full-text-search infrastructure (e.g. Elasticsearch integration).
+- Cross-user or admin-wide search (results are always scoped to the requesting user).
+
+## Decisions
+
+### D1: Indexed surface
+**Decision:** Index dashboard title + description + widget body text only. Widget config keys,
+setting values, and internal metadata are excluded.
+**Alternatives considered:** Index everything stored in the widget JSON blob.
+**Rationale:** Config fields are operator-facing strings (column names, filter expressions) that
+produce meaningless results for end-users. Keeping the surface narrow also bounds query cost.
+
+### D2: Search backend
+**Decision:** Execute a live `LIKE %term%` query at search-time via the existing
+`DashboardMapper` and `WidgetMapper`. No index table is created.
+**Alternatives considered:** Nightly job building a `mydash_search_index` table with pre-tokenised
+snippets.
+**Rationale:** The `IProvider` contract does not require an index. User dashboard counts are low
+(typically < 100), so a live query is fast enough. An index adds migration surface and cache
+invalidation complexity with no measurable benefit at this scale.
+
+### D3: Permission filtering
+**Decision:** Call `DashboardService::canViewDashboard($userId, $dashboard)` for every candidate
+result before adding it to the response. Results that fail the check are silently dropped.
+**Alternatives considered:** Pre-filter by a join on the shares table inside the SQL query.
+**Rationale:** Centralising the permission check in the service layer ensures the search path
+uses the same logic as the page controller — no risk of the two diverging.
+
+### D4: Result ranking
+**Decision:** Title matches are returned before description matches, which are returned before
+widget body matches. Within each tier, results are ordered by `updatedAt DESC`.
+**Alternatives considered:** Relevance scoring with term frequency; single flat list ordered by
+`updatedAt`.
+**Rationale:** A simple tier sort is deterministic and requires no scoring infrastructure. It
+matches user intuition (a title match is more relevant than a body match).
+
+### D5: Provider ID and group label
+**Decision:** Register the provider with id `mydash`. The NC search UI derives the dropdown
+group label from the provider id — this will render as "MyDash".
+**Alternatives considered:** `my_dash`, `intravox`, or a localised string id.
+**Rationale:** `mydash` matches the app id used everywhere else in info.xml and routes, keeping
+the namespace consistent and avoiding a separate label mapping.
+
+### D6: Result link target
+**Decision:** Each result's URL is built via
+`linkToRoute('mydash.PageController.view', ['dashboardUuid' => $dashboard->getUuid()])`.
+**Alternatives considered:** A dedicated `/search-result/{uuid}` redirect route.
+**Rationale:** The page controller route already handles deep-linking to a specific dashboard.
+Adding a redirect layer would be dead weight.
+
+## Risks / Trade-offs
+
+- `LIKE %term%` queries on large body-text columns can be slow; a database index on the widget
+  body column should be added in the same migration.
+- The provider runs in the NC search request context (user-authenticated); CLI or cron contexts
+  must not trigger it.
+- Widget body text may contain raw HTML from rich-text widgets; strip tags before indexing to
+  avoid leaking markup fragments into search snippets.
+
+## Open follow-ups
+
+- Evaluate whether a dedicated `mydash_search_index` table is warranted once widget counts
+  grow beyond ~1 000 per installation.
+- Add snippet highlighting (bold the matched term) if NC's `SearchResult` API exposes that
+  field in a future platform version.
+- Consider exposing a `mydash:search:reindex` CLI command if an index is adopted later.

--- a/openspec/changes/nc-unified-search-integration/proposal.md
+++ b/openspec/changes/nc-unified-search-integration/proposal.md
@@ -1,0 +1,57 @@
+# Nextcloud unified search integration
+
+## Why
+
+Nextcloud's Ctrl+K / Cmd+K unified search is the primary discovery mechanism for users navigating between apps and finding content. MyDash dashboards and widget content currently have no integration with this search, meaning users must navigate explicitly to the MyDash app and browse manually. This change exposes dashboards and widget content to Nextcloud's search provider system, allowing users to find and jump directly to dashboards by name, description, or widget text from the global search bar.
+
+## What Changes
+
+- Register a new `MyDashSearchProvider` class implementing `OCP\Search\IProvider` in the MyDash app.
+- The provider exposes search results for:
+  - Dashboards the user can VIEW whose name or description matches the query.
+  - Text-display-widget placements on viewable dashboards whose HTML/markdown content matches the query (with deep-link to the specific widget).
+  - Dashboard metadata field values matching the query (when the `dashboard-metadata-fields` capability is enabled; silent degradation if not).
+- Each result entry includes a dashboard or widget icon, title, subline (e.g., creation metadata), and a deep-link resource URL for immediate navigation.
+- Search results are paginated with cursor support so "Load more" in Nextcloud's search UI works seamlessly.
+- The provider caps result types to maintain search-popup responsiveness and respects permission boundaries via the existing `permissions` capability.
+
+## Capabilities
+
+### New Capabilities
+
+`nc-unified-search-integration` — provider registration + search contract + match logic + permission filtering + pagination + localization.
+
+### Modified Capabilities
+
+`dashboards` — now discoverable via Nextcloud unified search; no REQ changes, but the feature depends on existing dashboards and permissions REQs.
+
+## Impact
+
+**Affected code:**
+
+- `lib/Service/SearchProvider/MyDashSearchProvider.php` — new class implementing `OCP\Search\IProvider` with `search(IUser, ISearchQuery): SearchResult` method.
+- `appinfo/info.xml` — register the search provider via `<types>` declaration.
+- `lib/Service/SearchProvider/DashboardSearchIndexer.php` — optional helper to index searchable dashboard fields and widget content (deferred to follow-up optimization; basic LIKE queries acceptable at 10K-dashboard scale).
+- `src/views/DashboardDetail.vue` — optional: enhance the dashboard detail route to support `#widget-{placementId}` hash fragment for deep-linking from search results (or use GET param `?widgetId=X` as fallback).
+
+**Affected APIs:**
+
+- 1 new search provider registered; no changes to existing dashboard/widget API routes.
+- Nextcloud's built-in `GET /ocs/v2.php/search/providers/{providerId}/search?term={query}` route automatically calls the provider's `search()` method.
+
+**Dependencies:**
+
+- `OCP\Search\IProvider`, `OCP\Search\SearchResult`, `OCP\Search\SearchResultEntry` (Nextcloud 21+, available in all supported Nextcloud versions).
+- `OCP\IL10N` for localized provider name and result sublines.
+- No new composer or npm dependencies.
+
+**Migration:**
+
+- Zero-impact: the provider is registered at app bootstrap and queries are read-only.
+- No schema migration required.
+
+## Risks
+
+- **Performance**: Naive LIKE queries on large dashboard datasets (10K+) may exceed the 500ms timeout. Indexed columns and query limits mitigate this; a full-text index is a future concern (ADR-level if adopted).
+- **Permission boundary**: must never leak dashboards the user cannot VIEW — the implementation delegates to the existing `permissions` capability for the boundary check.
+- **Localization coverage**: provider name and result sublines must be translated; missing translations fall back to English strings.

--- a/openspec/changes/nc-unified-search-integration/specs/nc-unified-search-integration/spec.md
+++ b/openspec/changes/nc-unified-search-integration/specs/nc-unified-search-integration/spec.md
@@ -1,0 +1,433 @@
+---
+status: draft
+---
+
+# Nextcloud Unified Search Integration Specification
+
+## Purpose
+
+Nextcloud's unified search (Ctrl+K / Cmd+K) provides a global discovery mechanism for content across all installed apps. MyDash dashboards, widgets, and metadata are currently invisible to this search. This specification formalises the integration of MyDash content into Nextcloud's search provider system, allowing users to discover and navigate to dashboards by name, description, widget content, or metadata field values from the global search bar.
+
+## ADDED Requirements
+
+### Requirement: REQ-SRCH-001 Search Provider Registration
+
+The MyDash app MUST register a search provider implementing Nextcloud's `OCP\Search\IProvider` interface so that pressing Ctrl+K / Cmd+K in Nextcloud automatically includes MyDash dashboards in the unified search results.
+
+#### Scenario: Provider is registered and discoverable
+- GIVEN Nextcloud is running with MyDash app installed and enabled
+- WHEN a user presses Ctrl+K to open the unified search bar
+- THEN the MyDash search provider MUST be loaded via the app's bootstrap process
+- AND the provider's `getId()` MUST return `'mydash'`
+- AND the provider's `getName()` MUST return the translated string `'Dashboards'` in the user's Nextcloud language
+- AND the provider's `getOrder()` MUST return `50` to position it mid-range (admin-search providers typically have lower order values)
+
+#### Scenario: Provider implements the IProvider contract
+- GIVEN the MyDash app is installed
+- WHEN Nextcloud's search dispatcher calls the provider interface
+- THEN the provider class MUST implement all required methods: `getId()`, `getName()`, `getOrder()`, `search(IUser, ISearchQuery): SearchResult`
+- AND the methods MUST have correct type hints matching `OCP\Search\IProvider`
+
+#### Scenario: Provider initialization via app bootstrap
+- GIVEN MyDash app info.xml declares `<types><type>search</type></types>`
+- WHEN the MyDash app boots
+- THEN the container MUST register an instance of `MyDashSearchProvider` with the Nextcloud search registry
+- AND the provider instance MUST be reachable at `/apps/mydash/lib/Service/SearchProvider/MyDashSearchProvider.php`
+
+#### Scenario: Localized provider name
+- GIVEN a Nextcloud instance with language set to Dutch (nl)
+- WHEN the search provider's `getName()` is called
+- THEN the returned string MUST be translated to Dutch via `IL10N::t('Dashboards')`
+- AND the user's search bar MUST display "Dashboards" (Dutch: potentially "Dashboards" or localized equivalent) as the provider label
+
+#### Scenario: Provider name appears in search UI
+- GIVEN a user opens the unified search bar (Ctrl+K)
+- WHEN MyDash results are shown
+- THEN the search UI MUST display the provider name from `getName()` as a section header
+- NOTE: Nextcloud's search UI typically groups results by provider name.
+
+### Requirement: REQ-SRCH-002 Dashboard Name and Description Matching
+
+The search provider MUST find dashboards whose name or description matches the search query using case-insensitive substring matching.
+
+#### Scenario: Dashboard name match
+- GIVEN user "alice" has a dashboard named "Marketing Campaign 2026"
+- WHEN she searches for "market" via the unified search bar
+- THEN the "Marketing Campaign 2026" dashboard MUST appear in the search results
+- AND the result title MUST be "Marketing Campaign 2026"
+- AND the search MUST be case-insensitive (searching "MARKET" or "Market" also returns the result)
+
+#### Scenario: Dashboard description match
+- GIVEN user "bob" has a dashboard with name "Q1 Metrics" and description "Company quarterly performance overview"
+- WHEN he searches for "quarterly" via the unified search bar
+- THEN the "Q1 Metrics" dashboard MUST appear in the search results
+- AND the result title MUST be "Q1 Metrics" (name, not description)
+- AND the subline MUST include metadata like creation info or widget count
+
+#### Scenario: Partial substring match
+- GIVEN user "alice" has a dashboard named "Sales Pipeline Analysis"
+- WHEN she searches for "pipe"
+- THEN the "Sales Pipeline Analysis" dashboard MUST appear
+- AND the search MUST use substring matching, not whole-word matching (so "pipe" matches "Pipeline")
+
+#### Scenario: Exact match and partial matches coexist
+- GIVEN user "alice" has three dashboards: "Marketing", "Market Research", "Marketing Campaigns"
+- WHEN she searches for "market"
+- THEN all three dashboards MUST appear in the results
+- AND Nextcloud's search UI MAY rank exact matches higher (rank order is not mandated by this spec)
+
+#### Scenario: No match returns empty result
+- GIVEN user "alice" has dashboards "Sales", "Marketing", "HR"
+- WHEN she searches for "engineering"
+- THEN no dashboard results MUST be returned
+- AND the search provider MUST return `SearchResult::complete()` with an empty array (no error thrown)
+
+### Requirement: REQ-SRCH-003 Widget Content Matching
+
+The search provider MUST find text-display-widget placements on dashboards whose HTML or markdown content matches the search query, with a deep-link to the specific widget on the dashboard.
+
+#### Scenario: Text widget content match
+- GIVEN user "alice" has a dashboard "Analytics" with a text-display widget containing the markdown `## Budget Proposal for Q2`
+- WHEN she searches for "budget"
+- THEN a search result MUST appear with title "Analytics" and subline indicating a widget match (e.g., "Widget content on Analytics")
+- AND the result `resourceUrl` MUST be `/apps/mydash/dashboard/{dashboardUuid}#widget-{placementId}` to deep-link to the specific widget
+
+#### Scenario: Multiple text widgets on same dashboard
+- GIVEN user "bob" has a dashboard "Notes" with three text widgets:
+  - Widget A: "Meeting notes from Monday"
+  - Widget B: "Project timeline: starts in January"
+  - Widget C: "Sales targets for 2026"
+- WHEN he searches for "january"
+- THEN the result for Widget B MUST appear with a deep-link to Widget B's `{placementId}`
+- AND searching for "sales" MUST return the result for Widget C
+- AND both results share the same dashboard UUID but different widget placement IDs
+
+#### Scenario: Text widget with HTML rendering
+- GIVEN user "alice" uploads HTML content to a text-display widget: `<h1>Quarterly Report</h1><p>Revenue up 15%</p>`
+- WHEN she searches for "revenue" or "quarterly"
+- THEN the widget MUST be found via substring match on the rendered/stripped HTML content
+- AND the search MUST handle HTML tags gracefully (not require exact tag matching)
+
+#### Scenario: Case-insensitive widget content search
+- GIVEN user "bob" has a text widget with content "IMPORTANT: Project Deadline Tomorrow"
+- WHEN he searches for "important" (lowercase)
+- THEN the widget MUST be found via case-insensitive match
+- AND searching for "DEADLINE" (uppercase) MUST also return the result
+
+#### Scenario: Widget placement without matching content
+- GIVEN user "alice" has a dashboard with a text widget containing only "Lorem Ipsum"
+- WHEN she searches for "budget"
+- THEN this widget MUST NOT appear in the search results
+- AND other non-matching widgets on the same dashboard MUST also not appear
+
+#### Scenario: Non-text widgets are skipped
+- GIVEN user "bob" has a dashboard with a weather widget, a calendar widget, and a text widget
+- WHEN he searches for "forecast"
+- THEN only the text widget is searchable (weather and calendar widgets are not indexed for content search)
+- AND non-text widget types MUST be skipped silently (no error)
+
+### Requirement: REQ-SRCH-004 Dashboard Metadata Field Matching (Optional Degradation)
+
+When the `dashboard-metadata-fields` capability is enabled, the search provider MUST find dashboards whose metadata field values match the search query. The provider MUST degrade silently if the capability is not available.
+
+#### Scenario: Metadata field value match (when capability enabled)
+- GIVEN the `dashboard-metadata-fields` capability is enabled
+- AND user "alice" has a dashboard with a custom metadata field "Year: 2026" and another field "Department: Sales"
+- WHEN she searches for "2026"
+- THEN a result MUST appear with title "Alice's Dashboard" and subline "Metadata: Year = 2026"
+- AND the resourceUrl MUST be `/apps/mydash/dashboard/{dashboardUuid}`
+
+#### Scenario: Metadata search falls back gracefully
+- GIVEN the `dashboard-metadata-fields` capability is NOT available in the MyDash app
+- WHEN user "bob" performs a search
+- THEN the search provider MUST still return dashboard-name, description, and widget-content results
+- AND no error MUST be thrown about missing metadata fields
+- AND the provider MUST not attempt to fetch metadata (graceful degradation)
+
+#### Scenario: Metadata field names are not searchable, only values
+- GIVEN user "alice" has a metadata field named "ProjectStatus" with value "In Progress"
+- WHEN she searches for "ProjectStatus"
+- THEN the result MUST NOT appear (field name is not searchable)
+- WHEN she searches for "In Progress"
+- THEN the result MUST appear (field value is searchable)
+
+#### Scenario: Case-insensitive metadata value search
+- GIVEN user "bob" has a metadata field with value "URGENT"
+- WHEN he searches for "urgent" (lowercase)
+- THEN the result MUST appear via case-insensitive match
+
+### Requirement: REQ-SRCH-005 Permission Filtering
+
+The search provider MUST never return search results for dashboards that the user does NOT have VIEW permission on. Permission boundaries are enforced via the existing `permissions` capability.
+
+#### Scenario: User sees only dashboards with VIEW permission
+- GIVEN user "alice" owns dashboard "My Dashboard" and user "bob" owns dashboard "Bob's Private Dashboard" (not shared with alice)
+- WHEN alice searches
+- THEN "My Dashboard" MUST appear in results
+- AND "Bob's Private Dashboard" MUST NOT appear
+- AND the provider MUST call `DashboardPermissionService::canView()` for each candidate dashboard
+
+#### Scenario: Permission check happens before result inclusion
+- GIVEN user "alice" searches for a term that matches a dashboard she cannot view
+- WHEN the search provider evaluates the match
+- THEN the permission check MUST happen before the result is added to the SearchResult
+- AND the match score or relevance is irrelevant if permission is denied (no leakage)
+
+#### Scenario: Group-shared dashboard visible only to group members
+- GIVEN the `multi-scope-dashboards` capability is enabled
+- AND a group-shared dashboard "Team Analytics" exists with `groupId = 'sales'`
+- AND user "alice" is in the 'sales' group, user "bob" is not
+- WHEN alice searches for "analytics"
+- THEN "Team Analytics" MUST appear
+- WHEN bob searches for "analytics"
+- THEN "Team Analytics" MUST NOT appear
+- NOTE: Permission checking delegates to the existing `permissions` capability's group-membership logic
+
+#### Scenario: Permission service unavailable (fall back to safe default)
+- GIVEN the `permissions` capability or permission service fails to load
+- WHEN a search is performed
+- THEN the search provider MUST fail safely (return empty results or re-throw error in debug mode)
+- AND the provider MUST NOT return any results if permission cannot be verified
+
+### Requirement: REQ-SRCH-006 Result Entry Structure and Icons
+
+Each SearchResultEntry returned by the provider MUST include a title, subline, thumbnail icon, and resource URL that identifies the dashboard or widget uniquely.
+
+#### Scenario: Dashboard search result entry
+- GIVEN user "alice" has a dashboard "Sales Dashboard" created by her with 5 widgets
+- WHEN a search result is returned for this dashboard
+- THEN the SearchResultEntry MUST include:
+  - `title`: "Sales Dashboard" (dashboard name)
+  - `subline`: "Created by Alice • 5 widgets" (formatted via IL10N)
+  - `thumbnailUrl`: a URL to the MyDash dashboard icon (e.g., `/apps/mydash/img/dashboard-icon.svg` or Nextcloud's built-in icon)
+  - `resourceUrl`: `/apps/mydash/dashboard/{uuid}` (absolute or relative, deep-link to the dashboard)
+
+#### Scenario: Widget content search result entry
+- GIVEN user "bob" has a dashboard "Analytics" with a text widget on widget placement 42
+- WHEN a search result is returned for the widget
+- THEN the SearchResultEntry MUST include:
+  - `title`: "Analytics" (parent dashboard name)
+  - `subline`: "Widget content on Analytics" (formatted via IL10N)
+  - `thumbnailUrl`: a URL to a widget-type icon (e.g., `/apps/mydash/img/widget-icon.svg` or the text-widget icon)
+  - `resourceUrl`: `/apps/mydash/dashboard/{dashboardUuid}#widget-{placementId}` (hash fragment targets the specific widget)
+
+#### Scenario: Metadata field search result entry
+- GIVEN the `dashboard-metadata-fields` capability is enabled
+- AND a search result for a metadata field match is returned
+- THEN the SearchResultEntry MUST include:
+  - `title`: dashboard name
+  - `subline`: "Metadata: {fieldName} = {fieldValue}" (formatted via IL10N)
+  - `thumbnailUrl`: a metadata icon or fallback to dashboard icon
+  - `resourceUrl`: `/apps/mydash/dashboard/{uuid}` (no hash fragment, user lands on main dashboard view)
+
+#### Scenario: Icon URL is valid and reachable
+- GIVEN a search result is returned with a `thumbnailUrl`
+- WHEN the Nextcloud frontend fetches the icon
+- THEN the URL MUST be accessible (HTTP 200) and return a valid SVG or image file
+- AND the icon MUST be sized appropriately for display in the search UI (typically 32×32 or 64×64px)
+
+### Requirement: REQ-SRCH-007 Result Capping and Pagination
+
+The search provider MUST cap result counts per result type to keep the search-popup responsive. Pagination MUST support cursor-based navigation so "Load more" in Nextcloud's search UI works seamlessly.
+
+#### Scenario: Dashboard results capped to 10
+- GIVEN user "alice" has 25 dashboards matching the search term "dashboard"
+- WHEN she searches
+- THEN the initial results MUST include at most 10 dashboard entries
+- AND the SearchResult MUST include a cursor or pagination indicator so the frontend can load the next 10
+
+#### Scenario: Widget results capped to 10
+- GIVEN user "bob" has 50 text widgets with matching content across multiple dashboards
+- WHEN he searches
+- THEN the initial results MUST include at most 10 widget entries
+- AND each result MUST deep-link to the correct widget placement ID
+
+#### Scenario: Metadata results capped to 10
+- GIVEN the `dashboard-metadata-fields` capability is enabled
+- AND 15 metadata field values match the search term
+- WHEN the search is performed
+- THEN at most 10 metadata results MUST be returned
+- AND a cursor MUST be provided for pagination
+
+#### Scenario: Query limit parameter is respected
+- GIVEN a search query includes a limit parameter `?limit=20`
+- WHEN the search is performed
+- THEN the provider MUST respect the limit up to its internal maximum (or override with 10 if 20 > max)
+- AND Nextcloud's `ISearchQuery::getLimit()` method MUST be called to determine the requested limit
+
+#### Scenario: Cursor-based pagination
+- GIVEN user "alice" has 25 matching dashboards and requests the first page
+- WHEN the search completes with 10 results
+- THEN the SearchResult MUST include a cursor (typically the ID of the last-seen result)
+- WHEN alice clicks "Load more" and the same search is re-run with the cursor parameter
+- THEN the next 10 results MUST be returned, skipping the first 10
+- AND the cursor parameter is obtained from `ISearchQuery::getCursor()`
+
+#### Scenario: Combined result types and capping
+- GIVEN a search matches 5 dashboards, 8 widgets, and 6 metadata fields
+- WHEN results are returned
+- THEN the total MUST not exceed approximately 30 items (10 per type, rough guideline; exact cap is left to implementation)
+- AND each result type SHOULD be represented fairly to give users visibility into all result categories
+
+### Requirement: REQ-SRCH-008 Localization of Provider and Results
+
+All user-facing strings in the search provider MUST be translated via Nextcloud's `IL10N` translation factory so they appear in the user's language.
+
+#### Scenario: Provider name is translated
+- GIVEN Nextcloud language is set to Dutch (nl)
+- WHEN a user opens the unified search
+- THEN the provider label MUST be displayed in Dutch (e.g., as translated by `IL10N::t('Dashboards')`)
+- AND the translation string MUST be registered in the app's translation files
+
+#### Scenario: Subline strings are translated
+- GIVEN user "bob" (NC language: Dutch) has a dashboard "Analytics" with 5 widgets
+- WHEN he views the search result
+- THEN the subline MUST read "Created by Bob • 5 widgets" translated to Dutch
+- AND the translation string `'Created by %s • %d widgets'` MUST exist in Dutch translation files
+
+#### Scenario: Widget subline is translated
+- GIVEN a search result for a widget on dashboard "Marketing"
+- WHEN displayed to a user with NC language set to French
+- THEN the subline MUST read "Widget content on Marketing" translated to French
+- AND the translation string `'Widget content on %s'` MUST exist in French translation files (or fallback to English)
+
+#### Scenario: Metadata subline is translated (when capability enabled)
+- GIVEN the `dashboard-metadata-fields` capability is enabled
+- AND a search result for a metadata field match is shown
+- THEN the subline MUST read "Metadata: Year = 2026" translated to the user's language
+- AND the translation string `'Metadata: %s = %s'` MUST exist in the app's translation files
+
+#### Scenario: Missing translation falls back to English
+- GIVEN Nextcloud language is set to a language not yet translated (e.g., "xx-test")
+- WHEN a search is performed
+- THEN the provider MUST fall back to English strings via `IL10N` (Nextcloud's standard behavior)
+- AND no error MUST be thrown
+
+### Requirement: REQ-SRCH-009 Empty Result Handling
+
+When a search query matches no dashboards, widgets, or metadata fields, the provider MUST return an empty SearchResult instead of an error or 404 response.
+
+#### Scenario: No matches returns empty array
+- GIVEN user "alice" has dashboards "Sales", "Marketing", "HR"
+- WHEN she searches for "nonexistent-term-xyz"
+- THEN the search provider MUST return `SearchResult::complete($this->getName(), [])`
+- AND the response HTTP status MUST be 200 (not 404 or 500)
+- AND the user's search bar MUST show "No results for 'nonexistent-term-xyz'" or equivalent
+
+#### Scenario: Empty search term
+- GIVEN a user submits a search with an empty or whitespace-only query string
+- WHEN the provider processes the query
+- THEN the provider MAY return an empty array (implementation-specific)
+- OR the provider MAY return a helpful message like "Enter a search term"
+- AND no error MUST occur
+
+#### Scenario: Very short query term (single character)
+- GIVEN user "bob" searches for "a" (single character)
+- WHEN the search is performed
+- THEN the provider MUST attempt to match (e.g., dashboard "Admin Dashboard" matches)
+- AND if no matches exist, return an empty result gracefully
+- NOTE: Single-character searches are allowed by Nextcloud; performance impacts are implementation-specific
+
+### Requirement: REQ-SRCH-010 Search Performance
+
+The search provider MUST complete all queries in under 500ms for dashboard libraries up to 10,000 dashboards. Indexed database columns and result capping are the primary mechanisms to achieve this.
+
+#### Scenario: Query completes in <500ms for 1000 dashboards
+- GIVEN a MyDash instance with 1,000 dashboards
+- WHEN user "alice" performs a search query
+- THEN the provider's `search()` method MUST return within 500ms
+- AND the response MUST be complete (all matching results returned or capped per REQ-SRCH-007)
+
+#### Scenario: Query completes in <500ms for 10000 dashboards
+- GIVEN a MyDash instance with 10,000 dashboards
+- WHEN user "bob" performs a search query matching 100+ dashboards
+- THEN the provider's `search()` method MUST return within 500ms
+- AND results MUST be capped to 10 per type to keep response time acceptable
+- AND the database query MUST use indexed columns (`name`, `description`) with LIKE operators
+
+#### Scenario: Indexed columns are present
+- GIVEN the MyDash app is installed and a schema migration has run
+- WHEN the database is queried
+- THEN the `oc_mydash_dashboards.name` column MUST have an index
+- AND the `oc_mydash_dashboards.description` column MUST have an index
+- AND LIKE queries on these columns MUST benefit from the index for fast substring search
+- NOTE: Full-text indices are a future optimization (out of scope for this change)
+
+#### Scenario: Widget content search is efficient
+- GIVEN user "alice" has 10,000 dashboards with a total of 50,000 text-widget placements
+- WHEN she searches for a term
+- THEN the search MUST NOT scan all 50,000 widgets individually
+- AND the provider MUST return within 500ms by using a JOIN with the indexed dashboards table or similar optimization
+
+#### Scenario: Permission checks do not degrade performance
+- GIVEN user "bob" performs a search
+- WHEN the provider calls `DashboardPermissionService::canView()` for each result candidate
+- THEN the permission checks MUST be efficient (e.g., use a single batch query or in-memory set of readable dashboard IDs)
+- AND the total search time (including permission filtering) MUST remain <500ms
+
+### Requirement: REQ-SRCH-011 Nextcloud Search UI Integration
+
+The search provider MUST integrate seamlessly with Nextcloud's built-in search UI so that users can navigate directly to dashboards by clicking search results or pressing Enter.
+
+#### Scenario: Search result is clickable
+- GIVEN user "alice" opens the unified search (Ctrl+K) and types "marketing"
+- WHEN the "Marketing Dashboard" result appears
+- WHEN she clicks on the result title or thumbnail
+- THEN the browser MUST navigate to `/apps/mydash/dashboard/{uuid}`
+- AND the MyDash app MUST render the dashboard view
+
+#### Scenario: Search result resourceUrl is deep-linked
+- GIVEN a search result for a widget on dashboard "Analytics"
+- WHEN user "bob" clicks the result
+- THEN the browser MUST navigate to `/apps/mydash/dashboard/{dashboardUuid}#widget-{placementId}`
+- AND the MyDash frontend MUST scroll or highlight the widget with placement ID `{placementId}`
+
+#### Scenario: Search result thumbnail is displayed
+- GIVEN a search result is rendered in Nextcloud's search popup
+- WHEN the result entry includes a `thumbnailUrl`
+- THEN Nextcloud's UI MUST fetch and display the thumbnail image
+- AND the image MUST be sized appropriately (typically 32×32px or 64×64px)
+
+#### Scenario: Search result appears in the correct section
+- GIVEN the search results include dashboards, files, and contacts
+- WHEN the results are displayed
+- THEN the MyDash results MUST appear under a "Dashboards" section header (from `getName()`)
+- AND they MUST NOT be mixed with other app results
+
+### Requirement: REQ-SRCH-012 Provider Order in Nextcloud Search
+
+The MyDash search provider MUST be positioned at order `50` so that it appears after high-priority admin-search providers but before lower-priority result types in Nextcloud's search UI.
+
+#### Scenario: Provider order is respected
+- GIVEN Nextcloud has multiple search providers installed (e.g., admin-search at order 10, MyDash at order 50, contacts at order 100)
+- WHEN the unified search is opened
+- THEN the results MUST be grouped and displayed in order: admin-search results first, then MyDash results, then contacts
+- AND the order is determined by `getOrder()` returning `50`
+
+#### Scenario: Order does not affect search completeness
+- GIVEN user "alice" searches for a term
+- WHEN the search is performed
+- THEN all matching MyDash results MUST be found regardless of order
+- AND the order only affects the visual grouping and ranking in the search UI
+
+---
+
+## ADDED Dependencies
+
+- `OCP\Search\IProvider` (Nextcloud 21+)
+- `OCP\Search\SearchResult` (Nextcloud 21+)
+- `OCP\Search\SearchResultEntry` (Nextcloud 21+)
+- `OCP\Search\ISearchQuery` (Nextcloud 21+)
+- `OCP\IUser` (Nextcloud Core)
+- `OCP\IL10N` (Nextcloud Core)
+- Existing: `DashboardMapper`, `DashboardPermissionService`
+
+## ADDED Indexes
+
+- `oc_mydash_dashboards.name` (existing; confirm via schema)
+- `oc_mydash_dashboards.description` (may need to be added if missing)
+
+## ADDED Configuration / Feature Flags
+
+- None; the search provider is always available when MyDash is enabled.
+- If `dashboard-metadata-fields` capability is available, metadata search is enabled; otherwise, graceful degradation.

--- a/openspec/changes/nc-unified-search-integration/tasks.md
+++ b/openspec/changes/nc-unified-search-integration/tasks.md
@@ -1,0 +1,101 @@
+# Tasks — nc-unified-search-integration
+
+## 1. Service layer — Search provider
+
+- [ ] 1.1 Create `lib/Service/SearchProvider/MyDashSearchProvider.php` implementing `OCP\Search\IProvider`
+- [ ] 1.2 Inject dependencies: `DashboardMapper`, `DashboardPermissionService`, `IL10N` (from `@Inject` annotations or constructor)
+- [ ] 1.3 Implement `getId()` returning `'mydash'`
+- [ ] 1.4 Implement `getName()` returning `$this->l10n->t('Dashboards')` (localized via IL10N)
+- [ ] 1.5 Implement `getOrder()` returning `50` (mid-range priority so admin-search providers come first)
+- [ ] 1.6 Implement `search(IUser $user, ISearchQuery $query): SearchResult` method stub
+- [ ] 1.7 Add inline comment on the class linking to REQ-SRCH-001, REQ-SRCH-002, REQ-SRCH-003 from the spec
+
+## 2. Search method — Dashboard name/description match
+
+- [ ] 2.1 In `search()`, fetch all dashboards the user can VIEW via `DashboardMapper::findByUserId($user->getUID())` filtered through `DashboardPermissionService::canView()`
+- [ ] 2.2 Implement case-insensitive substring match on dashboard name: `stripos(dashboard.name, query) !== false`
+- [ ] 2.3 Implement case-insensitive substring match on dashboard description: `stripos(dashboard.description, query) !== false`
+- [ ] 2.4 Build SearchResultEntry for each matching dashboard with: `title` = dashboard name, `subline` = `sprintf($this->l10n->t('Created by %s • %d widgets'), creatorName, widgetCount)`, `resourceUrl` = `/apps/mydash/dashboard/{uuid}`, `thumbnailUrl` = built-in MyDash icon URL
+- [ ] 2.5 Cap results to 10 entries (override with `$query->getLimit()` if larger)
+- [ ] 2.6 Return `SearchResult::complete($this->getName(), $entries)`
+
+## 3. Search method — Widget content match
+
+- [ ] 3.1 For each dashboard the user can VIEW, fetch all text-display-widget placements via `WidgetPlacementMapper::findByDashboardId()`
+- [ ] 3.2 For each placement of type `text_display` (or similar), check if the rendered `content` (HTML/markdown) contains a case-insensitive substring match
+- [ ] 3.3 Build SearchResultEntry for each matching placement with: `title` = dashboard name, `subline` = `sprintf($this->l10n->t('Widget content on %s'), dashboardName)`, `resourceUrl` = `/apps/mydash/dashboard/{dashboardUuid}#widget-{placementId}`, `thumbnailUrl` = widget-type icon (or fallback to MyDash icon)
+- [ ] 3.4 Cap widget-content results to 10 entries
+- [ ] 3.5 Return combined `SearchResult` with both dashboard + widget entries
+
+## 4. Search method — Metadata field match (optional, degrade silently)
+
+- [ ] 4.1 If the `dashboard-metadata-fields` capability is available (check via `$this->container->has('mydash.metadata.fields')`), fetch metadata field definitions
+- [ ] 4.2 For each dashboard the user can VIEW, fetch metadata field values via the metadata service
+- [ ] 4.3 Match metadata field values case-insensitively against the query string
+- [ ] 4.4 Build SearchResultEntry for each matching field value with: `title` = dashboard name, `subline` = `sprintf($this->l10n->t('Metadata: %s = %s'), fieldName, fieldValue)`, `resourceUrl` = `/apps/mydash/dashboard/{dashboardUuid}`, `thumbnailUrl` = metadata icon or fallback
+- [ ] 4.5 If `dashboard-metadata-fields` is not available, skip this step silently (no error returned)
+- [ ] 4.6 Cap metadata-value results to 10 entries
+
+## 5. Permission filtering
+
+- [ ] 5.1 Before returning any dashboard or widget entry, call `DashboardPermissionService::canView($dashboard, $user)` to confirm the user has VIEW permission
+- [ ] 5.2 Never return entries for dashboards with permission result = false
+- [ ] 5.3 Inline comment linking to REQ-SRCH-005 (Permission filter) and the `permissions` capability
+
+## 6. Pagination / cursor support
+
+- [ ] 6.1 Implement cursor-based pagination by storing the last-seen dashboard/widget ID in the cursor
+- [ ] 6.2 Accept `$query->getCursor()` and use it to resume the search from the previous position
+- [ ] 6.3 Pass a new cursor to `SearchResult::complete()` so the frontend's "Load more" button can continue the search
+- [ ] 6.4 Confirm Nextcloud's search UI calls `search()` multiple times with advancing cursors until cursor is null
+
+## 7. Performance & indexing
+
+- [ ] 7.1 Confirm that `oc_mydash_dashboards.name` and `oc_mydash_dashboards.description` have database indexes (or add them in a schema migration)
+- [ ] 7.2 Use `LIKE '%{query}%'` with indexed columns; queries MUST complete in <500ms for 10K dashboards (test locally with load data)
+- [ ] 7.3 If performance is suboptimal, consider a follow-up full-text index (out of scope for this change)
+
+## 8. Localization
+
+- [ ] 8.1 Ensure all translatable strings use `$this->l10n->t(...)` or `$this->l10n->n(...)`:
+  - Provider name: "Dashboards"
+  - Subline format: "Created by %s • %d widgets"
+  - Subline format: "Widget content on %s"
+  - Subline format: "Metadata: %s = %s" (if metadata fields capability is enabled)
+- [ ] 8.2 Add corresponding translation strings to `translationFiles` in `appinfo/info.xml`
+- [ ] 8.3 Run `composer run extracttranslations` or equivalent to populate `l10n/en.json`, `l10n/nl.json`
+
+## 9. App registration
+
+- [ ] 9.1 Update `appinfo/info.xml` to declare the search provider in a `<types>` section:
+  ```xml
+  <types>
+    <type>search</type>
+  </types>
+  ```
+- [ ] 9.2 Register `MyDashSearchProvider` in the app's container bootstrap (typically in `lib/AppInfo/Application.php` using `$container->registerService()` or similar)
+
+## 10. Testing — Behat / E2E
+
+- [ ] 10.1 Create `tests/Integration/Search/SearchProviderTest.php` PHPUnit test
+- [ ] 10.2 Test: dashboard named "Marketing" appears in `GET /ocs/v2.php/search/providers/mydash/search?term=mark` with the correct deep-link
+- [ ] 10.3 Test: widget with content "budget proposal" on a dashboard appears when searching for "budget"
+- [ ] 10.4 Test: metadata field value "Q1 2026" appears in search results for "2026" (if metadata capability is enabled)
+- [ ] 10.5 Test: search does NOT return dashboards the user cannot VIEW
+- [ ] 10.6 Test: empty query result returns `SearchResult::complete()` with empty array (no 404)
+- [ ] 10.7 Test: cursor pagination returns the next batch of results correctly
+- [ ] 10.8 Create Behat feature test covering: user navigates via Ctrl+K, types "dashboard name", presses Enter, lands on the correct dashboard view
+
+## 11. Frontend — Deep-link support
+
+- [ ] 11.1 In `src/views/DashboardDetail.vue`, add support for the `#widget-{placementId}` URL hash fragment
+- [ ] 11.2 On component mount, extract the widget ID from the hash and programmatically scroll/highlight that widget placement
+- [ ] 11.3 Fallback: if hash is not present, render the dashboard normally (no regression for non-search-based navigation)
+- [ ] 11.4 Inline comment linking to REQ-SRCH-004 (Widget deep-link)
+
+## 12. Quality & code review
+
+- [ ] 12.1 Run `composer check:strict` (PHPCS, PHPMD, PHPStan) to ensure code quality
+- [ ] 12.2 Fix any pre-existing quality issues in the search provider class
+- [ ] 12.3 Verify no unused imports or dead code
+- [ ] 12.4 Add inline docblock comments to the search method explaining the permission boundary and cursor semantics

--- a/openspec/changes/news-widget/design.md
+++ b/openspec/changes/news-widget/design.md
@@ -1,0 +1,93 @@
+# Design — News Widget
+
+## Context
+
+The news widget aggregates RSS and Atom feed items from one or more configured sources and renders them directly on a MyDash dashboard. Feed data is never fetched at render time: the sibling change `background-job-feed-refresh` owns the scheduled fetch-and-cache cycle, writing items into a server-side cache table. The news widget reads exclusively from that cache, so dashboard page loads are fast even when upstream feed servers are slow or unreachable.
+
+Per-placement configuration (stored in `widgetContent` JSON) controls which feed URLs are included, the layout mode, an optional item cap, and an optional metadata filter. When a `metadataFilter` is configured, the widget only surfaces items tagged with a matching value, enabling context-sensitive feeds — for example, a department dashboard that surfaces only items tagged for that department.
+
+HTML sanitisation is applied server-side before items reach the client: only a small set of inline elements is permitted, and all links receive `rel="noopener noreferrer"`. This design keeps the frontend component simple and prevents re-sanitisation inconsistencies across layout modes.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Render merged, deduplicated feed items from the server-side cache with no on-render upstream fetch.
+- Support list, grid, and carousel layout modes driven by a single CSS layout enum — no per-layout backend variation.
+- Apply server-side metadata filtering when a `metadataFilter` is configured for a placement.
+- Enforce an admin-controlled feed host allow-list and a per-render item cap.
+- Degrade gracefully: a single failing feed source must not suppress items from healthy sources.
+
+**Non-Goals:**
+- The widget does not own feed fetching or scheduling — that is `background-job-feed-refresh`'s responsibility.
+- Full-text search across feed items is out of scope for this change.
+- Offline / push notification for new items is not provided.
+
+## Decisions
+
+### D1: No on-render fetch — cache-only reads
+
+**Decision:** The widget backend reads exclusively from the feed-cache table written by `background-job-feed-refresh`. If the cache is empty for a placement's feed URLs the response returns an empty item list and the frontend displays an "Updating…" placeholder.
+
+**Alternatives considered:** Perform a live fetch when cache is cold, falling back to cache. Maintains freshness but adds latency and introduces upstream failures at page-load time.
+
+**Rationale:** Predictable, fast page loads are more important than absolute freshness for a feed widget. The background job ensures cache is populated within its configured interval; a one-time "Updating…" state on first install is acceptable.
+
+### D2: Server-side metadata filter
+
+**Decision:** When a placement specifies `metadataFilter: {fieldKey, value}`, the backend joins cached items against per-item metadata stored alongside the cache entry and applies a `fieldKey = value` equality filter before returning results.
+
+**Alternatives considered:** Client-side filtering after receiving all items. Simpler backend but leaks items the filter should suppress, and is impractical at large item counts.
+
+**Rationale:** Server-side filtering avoids sending unwanted data to the client and keeps the Vue component stateless with respect to filtering logic. The metadata is already stored in the cache table by `background-job-feed-refresh`.
+
+### D3: Three-mode layout enum (list / grid / carousel)
+
+**Decision:** The `layoutMode` placement config field accepts exactly `list | grid | carousel`. All three are implemented as CSS display modes (`flex-column`, `grid`, `flex-row overflow-x-scroll`) on a shared item template. The backend API is layout-agnostic.
+
+**Alternatives considered:** Separate Vue components per layout. More isolated but triples the component surface and duplicates item-rendering logic.
+
+**Rationale:** A single item template with a CSS wrapper class switch is maintainable, keeps the API response identical across modes, and lets future layout additions avoid backend changes.
+
+### D4: Max items per render — admin cap with hard ceiling
+
+**Decision:** Admin setting `mydash.news_widget_max_items_per_render` controls the default maximum returned per API call (default 50). A hard ceiling of 200 is enforced server-side regardless of the admin setting or the `limit` query parameter to prevent out-of-memory conditions on large merged feeds.
+
+**Alternatives considered:** No server-side cap — rely on the client's requested `limit`. Allows integrators to accidentally configure unbounded fetches; feeds can contain thousands of entries.
+
+**Rationale:** The hard ceiling is a safety rail. The admin-configurable default is a sensible per-deployment tuning knob. Both are enforced in `NewsWidgetService` before the response is built.
+
+### D5: Thumbnail fallback chain
+
+**Decision:** For each item, thumbnail resolution follows: `<enclosure url>` → `og:image` meta extracted at cache time → first `<img>` src in body content → null (no image rendered). The fallback chain is resolved by `background-job-feed-refresh` at cache-write time and stored as `thumbnailUrl` alongside the cache entry; the widget reads the pre-resolved value.
+
+**Alternatives considered:** Resolve thumbnails at render time in the frontend. Adds client-side image probing requests and inconsistent resolution across browsers.
+
+**Rationale:** Resolving the chain once at cache time and storing the result avoids per-render external requests and keeps the widget component simple.
+
+### D6: Feed host allow-list
+
+**Decision:** Admin setting `mydash.news_widget_allowed_feed_hosts` (JSON array of hostnames) controls which feed origins are permitted. An empty array means all hosts are allowed. URLs whose hostnames are not on a non-empty list are silently skipped at config-save time, not at fetch time.
+
+**Alternatives considered:** Block at fetch time in the background job. Cleaner failure surface but the widget config UI would not surface the restriction to the configuring user.
+
+**Rationale:** Skipping at config-save time surfaces the restriction immediately in the config UI (the saved feed list omits blocked hosts), giving editors immediate feedback and preventing background-job attempts against disallowed origins.
+
+### D7: Failure-tolerance badge
+
+**Decision:** When one or more feed sources fail to populate the cache (tracked via a `fetchStatus` map in the cache table), the widget renders available items and shows a small corner badge with a count of unavailable sources. Clicking the badge expands a tooltip listing affected feed URLs.
+
+**Alternatives considered:** Show a top-level error banner that blocks rendering. Disruptive — a single broken feed should not degrade the whole widget.
+
+**Rationale:** Partial failure is the expected steady state for external feeds. Surfacing it as a non-blocking badge keeps the widget useful while informing the dashboard admin that remediation may be needed.
+
+## Risks / Trade-offs
+
+- **Cache staleness** → Acceptable given the background job interval; "Updating…" placeholder communicates state on cold start.
+- **HTML sanitisation bypass via future allowed-tag additions** → Allowlist must remain minimal; any expansion requires a security review.
+- **Metadata filter field mismatch** → If `fieldKey` references a non-existent field the filter returns zero items silently; empty-state copy should hint at checking filter config.
+
+## Open follow-ups
+
+- Evaluate whether the "Updating…" placeholder should trigger a single synchronous fetch on cold-start rather than staying blank until the background job runs.
+- Consider exposing per-source fetch status via a dedicated admin view rather than per-widget corner badges.
+- Specify the deduplication algorithm for items shared across sources — tie-break rule for identical GUID/link collisions is undefined.

--- a/openspec/changes/news-widget/proposal.md
+++ b/openspec/changes/news-widget/proposal.md
@@ -1,0 +1,61 @@
+# News Widget
+
+## Why
+
+MyDash users often need to stay informed about industry news, product updates, and organizational announcements. Currently, there is no built-in way to aggregate RSS or Atom feeds directly on the dashboard. Users must either leave the dashboard and open feed readers separately, or manually check multiple sources. A news widget bridges this gap by rendering merged and deduplicated feed items from configurable sources, with optional filtering by dashboard metadata to surface only relevant content on dashboard contexts (e.g., marketing news only on a "marketing" dashboard).
+
+## What Changes
+
+- Register a new dashboard widget with id `mydash_news` via `OCP\Dashboard\IManager` that appears in the widget picker.
+- Add per-placement configuration stored in `widgetContent JSON` to specify RSS/Atom feed URLs, layout mode, item limit, optional metadata filtering, and presentation preferences (thumbnails, summaries, date format).
+- Implement backend `GET /api/widgets/news/{placementId}/items?limit=N` to return merged, deduplicated feed items with source attribution, sorted by publication date.
+- Integrate with the sibling change `background-job-feed-refresh` (required dependency): this widget reads from a feed-cache table populated by that background job. On cold-start (cache empty), perform a single on-demand fetch; regular updates are delegated to the background job.
+- Cache external feed fetches for 60 minutes using Nextcloud's `ICache`, tunable via admin setting `mydash.news_widget_feed_cache_ttl_seconds`.
+- Enforce an allow-list of feed hosts via admin setting `mydash.news_widget_allowed_feed_hosts` (JSON array of hostnames; empty = all allowed; populated = restricted to those hosts). URLs not matching the allow-list are silently skipped.
+- Implement HTML sanitisation for item summaries (allow `<p>`, `<a>`, `<strong>`, `<em>`, `<br>`, `<ul>`, `<ol>`, `<li>`; strip everything else; force `rel="noopener noreferrer"` on links).
+- Support optional metadata filtering: if a widget specifies a `metadataFilter` with fieldKey and value, the widget only fetches items if the dashboard's metadata field (referenced by fieldKey) matches the value. This allows e.g. a "marketing" dashboard to show only marketing-tagged feed items.
+- Provide Vue 3 SFC `NewsWidget.vue` with three layout modes: list (single column), grid (cards), and carousel (horizontal scroll).
+- Display empty state ("No news yet — try adding feeds in the widget settings") and failure tolerance (single feed source fetch failure does not break the widget; successful sources render, failed ones are noted in a corner badge).
+- Click on item → open in new tab (`target="_blank" rel="noopener"`).
+
+## Capabilities
+
+### New Capabilities
+
+- `news-widget` — A new MyDash dashboard widget capability providing merged, deduplicated RSS/Atom feed streams with configurable sources, filtering, and layouts.
+
+## Impact
+
+**Affected code:**
+
+- `lib/Service/NewsWidgetService.php` — core logic for fetching, parsing, merging, deduplicating, sanitising, and filtering feed items.
+- `lib/Controller/WidgetController.php` — new endpoint `GET /api/widgets/news/{placementId}/items`.
+- `src/components/widgets/NewsWidget.vue` — three-mode render component (list, grid, carousel).
+- `src/components/widgets/newspicker/NewsWidgetConfig.vue` — placement config UI for feed URLs, layout, filtering preferences.
+- `appinfo/routes.php` — register the new news widget items endpoint.
+- `lib/Migration/VersionXXXXDate2026...AddNewsWidgetSettings.php` — schema migration adding app config settings (`mydash.news_widget_*` keys).
+- `src/stores/widgets.js` — add widget-specific runtime state for cached item data and fetch status per placement.
+
+**Affected APIs:**
+
+- 1 new route: `GET /api/widgets/news/{placementId}/items`
+- 0 changes to existing routes.
+
+**Dependencies:**
+
+- `lib/Service/FeedCacheService.php` — (from sibling change `background-job-feed-refresh`) provides feed cache table and refresh job orchestration.
+- `OCP\ICache` — cache feed fetches for 60 minutes per placement.
+- `OCP\IAppConfig` — admin settings for feed cache TTL and allow-list.
+- `OCP\Dashboard\IManager` — widget registration.
+- No new composer or npm dependencies. (HTML sanitisation via Nextcloud's existing utilities.)
+
+**Migration:**
+
+- Zero-impact: app config keys are created on demand via IAppConfig getter. No schema changes required beyond optional logging setup.
+- No data backfill required. Existing placements without news widget config simply don't render the widget.
+- Dependency on `background-job-feed-refresh` change: that change MUST be implemented first or in parallel; this widget's initial data load is synchronous (first fetch on-demand) and delegates polling to the background job.
+
+**Interdependencies:**
+
+- This change depends on `background-job-feed-refresh` being available to provide the feed-cache table and periodic refresh infrastructure.
+- The sibling change `dashboard-metadata-fields` (if present) enables metadata-based filtering: a news widget can specify a filter keyed to a dashboard's metadata field.

--- a/openspec/changes/news-widget/specs/news-widget/spec.md
+++ b/openspec/changes/news-widget/specs/news-widget/spec.md
@@ -1,0 +1,439 @@
+---
+status: draft
+---
+
+# News Widget Specification
+
+## ADDED Requirements
+
+### Requirement: REQ-NEWS-001 Widget Registration
+
+The system MUST register a new dashboard widget with id `mydash_news` via `OCP\Dashboard\IManager` that appears in the widget picker alongside other discovered Nextcloud dashboard widgets.
+
+#### Scenario: Widget registration on bootstrap
+- GIVEN MyDash is installed and enabled
+- WHEN the application bootstraps (AppInfo/Bootstrap.php or equivalent lifecycle hook)
+- THEN the system MUST call `IManager::registerWidget()` with widget metadata
+- AND the widget MUST have id `mydash_news`, translatable title (e.g., `app.mydash.news_widget_title`), and a feed/newspaper icon URL
+- AND the widget MUST support Nextcloud Dashboard Widget API v2 (`IAPIWidgetV2`) for item loading
+
+#### Scenario: Widget picker includes news widget
+- GIVEN a user opens the widget picker dialog
+- WHEN the picker loads available Nextcloud widgets
+- THEN the `mydash_news` widget MUST appear in the list of discovered widgets
+- AND it MUST be selectable for placement on any dashboard
+
+#### Scenario: Multiple news widget instances
+- GIVEN a user has added the news widget to their dashboard once
+- WHEN they open the widget picker again
+- THEN they MUST be able to add the news widget a second time (duplicates allowed)
+- AND each placement MUST have independent configuration and cache
+
+#### Scenario: Widget metadata is discoverable
+- GIVEN the widget is registered
+- WHEN the frontend fetches `GET /api/widgets`
+- THEN the response MUST include an object with id `mydash_news` and basic metadata (title, icon_url)
+
+### Requirement: REQ-NEWS-002 Per-Placement Configuration
+
+Widget placements MUST store configuration in the `widgetContent` JSON field to specify feed sources, layout, and filtering preferences.
+
+#### Scenario: Configure feed URLs
+- GIVEN a user is editing a news widget placement
+- WHEN they specify feed URLs `["https://example.com/feed", "https://other.org/rss"]`
+- AND save via PUT /api/widgets/{placementId} with `{"widgetContent": {"feedUrls": [...]}}`
+- THEN the placement MUST store the URLs in its widgetContent JSON
+- AND the stored URLs MUST be validated to be HTTP or HTTPS (reject ftp://, file://, etc.)
+
+#### Scenario: Configure layout mode
+- GIVEN a placement is created
+- WHEN the config specifies `layout: "grid"`
+- THEN the widget MUST render in grid (card) layout instead of the default list layout
+- AND valid layout values MUST be: `list`, `grid`, `carousel`
+
+#### Scenario: Configure item limit
+- GIVEN a placement specifies `itemLimit: 15`
+- WHEN items are fetched
+- THEN the backend MUST limit the result to 15 items (default 10, max 50)
+- AND the API parameter ?limit=N MUST override the placement config (request-time override)
+
+#### Scenario: Configure thumbnail and summary display
+- GIVEN a placement specifies `{"showThumbnails": false, "showSummary": true, "summaryMaxChars": 150}`
+- WHEN the widget renders
+- THEN thumbnails MUST NOT be displayed
+- AND summaries MUST be displayed, truncated to 150 characters
+- AND defaults MUST be: showThumbnails=true, showSummary=true, summaryMaxChars=200
+
+#### Scenario: Configure date format
+- GIVEN a placement specifies `dateFormat: "relative"`
+- WHEN the widget renders
+- THEN item publication dates MUST display as "2 hours ago", "1 day ago", etc.
+- AND if `dateFormat: "absolute"`, dates MUST display as ISO 8601 or human-readable format (e.g., "May 1, 2026 14:30")
+
+#### Scenario: Optional metadata filtering configuration
+- GIVEN a placement specifies `metadataFilter: {"fieldKey": "department", "value": "marketing"}`
+- WHEN the widget processes items
+- THEN the widget MUST verify that the parent dashboard's metadata field `department` equals `marketing`
+- AND if the filter does not match, the widget MUST not fetch items (see REQ-NEWS-008)
+
+#### Scenario: Config defaults and fallback
+- GIVEN a placement has empty or minimal widgetContent
+- WHEN the service calls `extractNewsConfig(placement)`
+- THEN defaults MUST apply: feedUrls=[], layout=list, itemLimit=10, showThumbnails=true, showSummary=true, summaryMaxChars=200, dateFormat=relative, metadataFilter=null
+
+### Requirement: REQ-NEWS-003 Fetch and Merge Feed Items
+
+The backend MUST provide an endpoint to fetch, parse, and return merged feed items from all configured sources.
+
+#### Scenario: Fetch items for a news widget placement
+- GIVEN a placement (id=42) has config `{"feedUrls": ["https://example.com/rss", "https://other.org/feed"]}`
+- WHEN the frontend sends GET /api/widgets/news/42/items?limit=10
+- THEN the system MUST call `NewsWidgetService::getItemsForPlacement(42, 10)`
+- AND return HTTP 200 with a JSON array of items: `[{guid, title, summary, link, pubDate, sourceUrl, sourceTitle, thumbnailUrl}]`
+
+#### Scenario: Items sorted by publication date (newest first)
+- GIVEN feed sources contain items with pubDates [2026-05-01T14:00, 2026-04-30T10:00, 2026-05-01T16:00]
+- WHEN items are merged and returned
+- THEN the response order MUST be: [2026-05-01T16:00, 2026-05-01T14:00, 2026-04-30T10:00]
+- AND sorting MUST be descending (newest first)
+
+#### Scenario: Deduplicate items across feeds
+- GIVEN feed A has item guid="article-123" and feed B also has guid="article-123"
+- WHEN items are merged
+- THEN only one copy of the item MUST be included
+- AND the first occurrence MUST be retained
+- AND if the sources differ, the sourceTitle MUST indicate both (or the first found)
+
+#### Scenario: Item deduplication by guid
+- GIVEN multiple feeds include the same article (identified by matching guid)
+- WHEN items are deduplicated
+- THEN the guid field MUST be the primary deduplication key
+- AND items without a guid MUST generate a synthetic guid from hash(title + pubDate + sourceUrl)
+
+#### Scenario: Response includes source attribution
+- GIVEN an item from feed "https://example.com/rss"
+- WHEN returned in the API response
+- THEN the item object MUST include:
+  - `sourceUrl`: the feed URL
+  - `sourceTitle`: the feed's title (extracted from feed metadata or URL)
+
+#### Scenario: Limit parameter validation
+- GIVEN the frontend sends GET /api/widgets/news/42/items?limit=100
+- WHEN the backend processes the request
+- THEN the system MUST reject limit > 50 and return HTTP 400
+- AND limit < 1 MUST also return HTTP 400
+- AND limit parameter MUST be optional (default 10)
+
+#### Scenario: Missing or empty feed list
+- GIVEN a placement has no feedUrls configured
+- WHEN the frontend requests items
+- THEN the system MUST return HTTP 200 with an empty array `[]`
+- AND the widget MUST display the empty state
+
+### Requirement: REQ-NEWS-004 Feed Cache Integration
+
+The widget MUST read from a feed-cache table (populated by the `background-job-feed-refresh` change) and only perform on-demand fetches on cold-start.
+
+#### Scenario: Cache hit — serve from background job refresh
+- GIVEN a feed "https://example.com/rss" was fetched 5 minutes ago
+- AND the cache entry is fresh (TTL 60 minutes not expired)
+- WHEN the widget requests items
+- THEN the system MUST retrieve items from the feed-cache table (populated by the background job)
+- AND NO HTTP request to https://example.com/rss MUST occur
+- AND response time MUST be sub-100ms (in-database lookup)
+
+#### Scenario: Cache miss — on-demand fetch (cold-start)
+- GIVEN a feed cache has no entry for "https://example.com/rss"
+- WHEN the widget requests items for the first time
+- THEN the system MUST perform a synchronous HTTP fetch to https://example.com/rss
+- AND the raw feed content MUST be stored in Nextcloud's ICache with TTL 60 minutes
+- AND subsequent requests within TTL MUST use the cache (delegating refresh to background job)
+
+#### Scenario: Cache TTL configuration
+- GIVEN an admin sets `mydash.news_widget_feed_cache_ttl_seconds` to 1800 (30 minutes)
+- WHEN a feed is cached
+- THEN the cache entry MUST expire after 1800 seconds
+- AND cache TTL MUST be readable from `IAppConfig::getValueInt('mydash', 'news_widget_feed_cache_ttl_seconds', 3600)`
+- AND default TTL MUST be 3600 seconds (60 minutes)
+
+#### Scenario: Dependency on background-job-feed-refresh
+- GIVEN the `background-job-feed-refresh` change has NOT been implemented
+- WHEN the widget attempts to fetch items
+- THEN the widget MUST fall back to synchronous on-demand fetch (graceful degradation)
+- AND a WARN-level log MUST note that background job is unavailable
+- AND the widget MUST still function (not crash)
+
+### Requirement: REQ-NEWS-005 HTML Sanitisation of Summaries
+
+Feed item summaries MUST be sanitised to remove dangerous HTML while preserving safe formatting.
+
+#### Scenario: Allow whitelisted tags
+- GIVEN a feed item summary contains HTML: `<p>Read our <strong>latest</strong> post <a href="https://example.com">here</a></p>`
+- WHEN the summary is sanitised
+- THEN the output MUST retain: `<p>`, `<strong>`, and `<a>` tags
+- AND the rendered summary MUST preserve the formatting
+
+#### Scenario: Strip dangerous tags
+- GIVEN a feed item summary contains `<script>alert('xss')</script>` or `<iframe>`, `<svg>`, or `<img onerror="...">`
+- WHEN sanitised
+- THEN these tags MUST be completely removed
+- AND only their safe content (if any) MUST remain (no tag wrapper)
+
+#### Scenario: Enforce rel attributes on links
+- GIVEN a sanitised summary contains an `<a>` tag: `<a href="https://external.com">Link</a>`
+- WHEN rendered in the widget
+- THEN the system MUST ensure the tag becomes `<a href="https://external.com" rel="noopener noreferrer">Link</a>`
+- AND this MUST apply to all `<a>` tags in summaries (enforce during sanitisation or template rendering)
+
+#### Scenario: Allowed tag whitelist
+- GIVEN a feed summary with mixed formatting
+- WHEN sanitised
+- THEN the following tags MUST be allowed: `<p>`, `<a>`, `<strong>`, `<em>`, `<br>`, `<ul>`, `<ol>`, `<li>`
+- AND all other tags (including custom data attributes) MUST be stripped
+- AND tag attributes MUST be restricted (e.g., `href` allowed on `<a>`, but `onclick` stripped)
+
+#### Scenario: XSS prevention in summary content
+- GIVEN a feed item summary contains encoded or obfuscated malicious content: `<p>Click here: <a href="javascript:void(0)">x</a></p>`
+- WHEN sanitised
+- THEN the `href="javascript:..."` MUST be stripped/replaced with a safe default (e.g., `href="#"`)
+- AND the link text MUST be preserved
+
+### Requirement: REQ-NEWS-006 Feed Host Allow-List
+
+An admin setting MUST restrict feed sources to an explicit allow-list of hostnames.
+
+#### Scenario: Allow-list is empty or null (all hosts allowed)
+- GIVEN the admin setting `mydash.news_widget_allowed_feed_hosts` is `null` or `[]`
+- WHEN a widget specifies feedUrl "https://any-domain.com/feed"
+- THEN the system MUST accept and fetch from the URL
+- AND no whitelist check failure MUST occur
+
+#### Scenario: Allow-list restricts to specified hosts
+- GIVEN the admin sets `mydash.news_widget_allowed_feed_hosts` to `["bbc.com", "example.org"]`
+- WHEN a widget specifies feedUrl "https://bbc.com/rss"
+- THEN the system MUST allow the fetch
+- AND when feedUrl "https://other-domain.com/feed" is specified
+- THEN the fetch MUST be silently skipped (not allowed)
+
+#### Scenario: Disallowed feed is skipped without error
+- GIVEN feedUrl "https://blocked-domain.com/feed" fails the allow-list check
+- WHEN the widget attempts to fetch items
+- THEN the URL MUST be silently skipped (not causing the entire widget to fail)
+- AND a WARN-level log MUST note that the URL was disallowed
+- AND the widget MUST continue fetching other allowed feeds
+- AND a failure badge MUST note "1 feed skipped (disallowed)" or similar
+
+#### Scenario: Hostname comparison is case-insensitive
+- GIVEN the allow-list contains "Example.Org"
+- WHEN feedUrl "https://example.org/feed" is checked
+- THEN the match MUST succeed (case-insensitive comparison)
+
+#### Scenario: Subdomain matching
+- GIVEN the allow-list contains "example.org"
+- WHEN feedUrl "https://news.example.org/feed" is checked
+- THEN the match MUST fail (exact hostname required, no wildcard subdomain expansion)
+- AND the feed MUST be skipped
+
+### Requirement: REQ-NEWS-007 Metadata-Based Filtering
+
+The system MUST support optional metadata-based filtering: if a widget specifies a metadata filter, the widget SHALL only process items if the parent dashboard's metadata field matches the filter value.
+
+#### Scenario: Widget with no metadata filter (bypass check)
+- GIVEN a placement specifies no `metadataFilter` (null or absent from config)
+- WHEN the widget requests items
+- THEN the check MUST pass and the widget MUST fetch items normally
+- AND no metadata lookup MUST occur
+
+#### Scenario: Widget with metadata filter — match succeeds
+- GIVEN a dashboard has metadata field `department: "marketing"`
+- AND a placement specifies `metadataFilter: {"fieldKey": "department", "value": "marketing"}`
+- WHEN the widget requests items
+- THEN the check MUST pass
+- AND items MUST be fetched and returned normally
+
+#### Scenario: Widget with metadata filter — no match
+- GIVEN a dashboard has metadata field `department: "engineering"`
+- AND a placement specifies `metadataFilter: {"fieldKey": "department", "value": "marketing"}`
+- WHEN the widget requests items
+- THEN the check MUST fail
+- AND the API MUST return HTTP 200 with an empty items array `[]`
+- AND no feed fetches MUST occur (optimization)
+
+#### Scenario: Metadata field missing or null
+- GIVEN a dashboard has no metadata field "department" (field not set on dashboard)
+- AND a placement specifies `metadataFilter: {"fieldKey": "department", "value": "marketing"}`
+- WHEN the widget requests items
+- THEN the check MUST treat missing field as null
+- AND the comparison null !== "marketing" MUST fail
+- AND return empty items array
+
+#### Scenario: Metadata filter dependency on dashboard-metadata-fields spec
+- GIVEN the sibling spec `dashboard-metadata-fields` is NOT yet implemented
+- WHEN a widget specifies a metadata filter
+- THEN the system MUST gracefully handle missing metadata (treat as no fields defined)
+- AND return empty items array if a required metadata field is absent
+
+### Requirement: REQ-NEWS-008 Failure Tolerance
+
+A single feed source failure MUST NOT break the widget. Successful feeds MUST render while failed ones are noted.
+
+#### Scenario: Single feed fails, others succeed
+- GIVEN a placement has feedUrls: ["https://good.com/rss", "https://bad.com/rss", "https://good2.com/rss"]
+- WHEN https://bad.com/rss returns HTTP 500 or times out
+- THEN the widget MUST fetch from good.com and good2.com successfully
+- AND items from both successful feeds MUST render
+- AND a failure badge (top-right corner) MUST show "1 feed failed" with hover tooltip listing "bad.com"
+
+#### Scenario: HTTP error handling
+- GIVEN a feed URL returns HTTP 404, 403, or 5xx
+- WHEN the widget fetches
+- THEN the system MUST log a WARN-level message and skip the URL
+- AND the response MUST include metadata: `{"feedsFailed": 1, "failedUrls": ["https://..."]}` in the header or footer (or returned separately)
+- AND the failure badge MUST be displayed
+
+#### Scenario: Timeout handling
+- GIVEN an HTTP fetch to a feed URL takes longer than 10 seconds
+- WHEN the system is fetching
+- THEN the fetch MUST timeout and be skipped
+- AND a WARN-level log MUST note the timeout
+- AND the failure badge MUST count this as a failed feed
+
+#### Scenario: Malformed feed XML
+- GIVEN a feed returns valid HTTP 200 but invalid/malformed RSS/Atom XML
+- WHEN the system attempts to parse
+- THEN parsing MUST fail gracefully
+- AND a WARN-level log MUST note the parse error
+- AND this feed MUST be skipped
+- AND the failure badge MUST count it as failed
+
+#### Scenario: All feeds fail
+- GIVEN all feedUrls fail (404, timeout, or parse error)
+- WHEN the widget requests items
+- THEN the response MUST be HTTP 200 with empty array `[]`
+- AND the widget MUST display empty state plus failure badge showing "All N feeds failed"
+
+### Requirement: REQ-NEWS-009 Three Layout Modes
+
+The widget MUST support three distinct render layouts: list, grid, and carousel.
+
+#### Scenario: List layout (default)
+- GIVEN a placement specifies `layout: "list"` or uses the default
+- WHEN the widget renders
+- THEN items MUST be displayed in a single-column vertical list
+- AND each item MUST show (if enabled in config):
+  - Thumbnail (left or top, if showThumbnails=true)
+  - Title (bold or heading)
+  - Summary (preview text, if showSummary=true)
+  - Link (as clickable text or button)
+  - Date (formatted per config)
+  - Source attribution (small text, e.g., "from BBC News")
+
+#### Scenario: Grid layout
+- GIVEN a placement specifies `layout: "grid"`
+- WHEN the widget renders
+- THEN items MUST be displayed as cards in a multi-column grid (2-4 columns depending on widget size)
+- AND each card MUST show:
+  - Thumbnail at the top (if enabled)
+  - Title
+  - Summary (truncated, if enabled)
+  - Link
+  - Date
+  - Source
+- AND card styling MUST use border and shadow for visual separation
+
+#### Scenario: Carousel layout
+- GIVEN a placement specifies `layout: "carousel"`
+- WHEN the widget renders
+- THEN items MUST be displayed in a horizontal carousel (single item visible)
+- AND navigation arrows (left/right) MUST allow browsing through items
+- AND each item card MUST show all information (thumbnail, title, summary, link, date, source)
+- AND carousel auto-advance is OPTIONAL (implementation choice; manual nav is sufficient)
+
+#### Scenario: Layout switching
+- GIVEN a user edits the widget placement and changes layout from "list" to "grid"
+- WHEN they save
+- THEN the widget MUST immediately re-render in grid layout
+- AND no data re-fetch MUST be needed (layout is UI-only)
+
+#### Scenario: Responsive layout
+- GIVEN a widget is rendered on mobile (narrow viewport)
+- WHEN the layout is grid or carousel
+- THEN the grid MUST collapse to 1 column on small screens (no explicit requirement; best-practice behavior)
+
+### Requirement: REQ-NEWS-010 Empty State and User Messaging
+
+The widget MUST display a helpful empty state and clear error/failure information.
+
+#### Scenario: Empty state when no feeds configured
+- GIVEN a placement has feedUrls: []
+- WHEN the widget renders
+- THEN the widget content area MUST display:
+  - A message: "No news yet — try adding feeds in the widget settings"
+  - An icon (e.g., RSS or newspaper)
+  - A call-to-action button or link to open the placement config (implementation choice)
+
+#### Scenario: Empty state when no items found
+- GIVEN feedUrls are configured and feeds were fetched, but no items exist (or all are filtered)
+- WHEN the widget renders
+- THEN the widget MUST display the same empty state message
+- AND the failure badge MUST NOT appear (0 feeds failed)
+
+#### Scenario: Failure badge — single failure
+- GIVEN a placement has 3 feeds, and 1 failed
+- WHEN the widget renders
+- THEN a small badge (top-right) MUST show "1 feed failed"
+- AND hovering over the badge MUST show a tooltip with "Failed: bad.com" (URL of the failed feed)
+
+#### Scenario: Failure badge — multiple failures
+- GIVEN 3 feeds fail out of 5
+- WHEN the widget renders
+- THEN the badge MUST show "3 feeds failed"
+- AND the tooltip MUST list all failed URLs (or "3 feeds failed; see details in widget settings")
+
+#### Scenario: Loading state
+- GIVEN the widget is fetching items from feeds
+- WHEN the fetch is in progress
+- THEN a loading spinner or skeleton placeholders MUST be visible
+- AND the widget MUST not block user interaction (async fetch)
+
+#### Scenario: Fetch error message
+- GIVEN an unexpected error occurs during fetch (e.g., database connection lost)
+- WHEN the widget attempts to render
+- THEN a user-friendly error message MUST be displayed: "Unable to load news. Please try again later."
+- AND technical details MUST NOT be exposed to the user
+- AND a WARN or ERROR-level log MUST contain full error context
+
+### Requirement: REQ-NEWS-011 Link Handling and Click-Through
+
+Clicking on a feed item MUST open the link in a new tab with security protections.
+
+#### Scenario: Click on item title or link
+- GIVEN a feed item has `link: "https://example.com/article"`
+- WHEN the user clicks on the item title, summary text, or a dedicated "Read more" link
+- THEN the system MUST open the link in a new tab: `window.open(url, '_blank')`
+- AND the link MUST have `target="_blank" rel="noopener noreferrer"` in the HTML
+
+#### Scenario: Link security — noopener
+- GIVEN an item link is rendered
+- WHEN the link is opened in a new tab
+- THEN the new page MUST NOT have access to the `window.opener` object (XSS protection)
+- AND this MUST be enforced by the `rel="noopener"` attribute
+
+#### Scenario: Link security — noreferrer
+- GIVEN an item link is opened in a new tab
+- WHEN the user navigates to the target URL
+- THEN the referrer header MUST NOT be sent to the destination site (privacy protection)
+- AND this MUST be enforced by the `rel="noreferrer"` attribute
+
+#### Scenario: Missing link in feed item
+- GIVEN a feed item has no link (null or empty string)
+- WHEN the widget renders
+- THEN the item MUST still display (title, summary, thumbnail)
+- AND the click action MUST be disabled or the link area MUST be a non-interactive element
+- AND no error MUST be logged
+
+#### Scenario: Malformed or unsafe link
+- GIVEN a feed item link is "javascript:alert('xss')" or "data:text/html,..."
+- WHEN sanitised
+- THEN the link MUST be replaced with "#" or removed entirely
+- AND the click MUST not execute arbitrary JavaScript

--- a/openspec/changes/news-widget/tasks.md
+++ b/openspec/changes/news-widget/tasks.md
@@ -1,0 +1,207 @@
+# Tasks — news-widget
+
+## 1. Widget registration and service layer
+
+- [ ] 1.1 Create `lib/Service/NewsWidgetService.php` with core methods:
+  - `getWidgetInfo(): array` — returns widget metadata (id, title, icon_url, v2 API support)
+  - `getItemsForPlacement(int $placementId, int $limit = 10): array` — orchestrates feed fetching and filtering
+  - `fetchAndMergeFeeds(array $feedUrls, int $limit = 10): array` — fetch from cache or on-demand, merge, deduplicate
+  - `parseRssFeed(string $feedContent, string $sourceUrl, string $sourceTitle): array` — parse RSS/Atom, extract items (guid, title, summary, link, pubDate, thumbnailUrl)
+  - `deduplicateItems(array $items): array` — deduplicate by guid, keep first occurrence
+  - `sortItemsByDate(array $items): array` — sort by pubDate descending
+  - `sanitiseSummaryHtml(string $html): string` — allow safe tags, strip dangerous content, force rel attributes
+  - `checkAllowList(string $url): bool` — checks hostname against allow-list setting
+  - `checkMetadataFilter(int $dashboardId, array $metadataFilter): bool` — verify dashboard metadata matches filter criteria
+- [ ] 1.2 Register the widget in a boot/lifecycle hook or service provider:
+  - Hook into Nextcloud's dashboard widget registration (e.g., in `AppInfo/Bootstrap.php` or a listener on `IManager`)
+  - Call `IManager::registerWidget()` with a widget provider or inline metadata
+  - Widget id: `mydash_news`, title: translatable `app.mydash.news_widget_title`, icon: feed/newspaper icon URL
+- [ ] 1.3 Create fixture-based PHPUnit tests for `NewsWidgetService`:
+  - `testFetchAndMergeFeedsSuccess` — mock feed URLs, verify merged array returned
+  - `testDeduplicateItemsByGuid` — duplicate items with same guid removed, first occurrence kept
+  - `testSortItemsByDateDescending` — verify pubDate sorting (newest first)
+  - `testSanitiseSummaryHtmlAllowList` — verify safe tags allowed, dangerous tags stripped
+  - `testAllowListMatching` — hostname match, mismatch, case-insensitivity
+  - `testCheckMetadataFilterMatches` — verify metadata field comparison logic
+
+## 2. Backend controller and routing
+
+- [ ] 2.1 Add endpoint method to `lib/Controller/WidgetController.php`:
+  - `public function newsItems(int $placementId, ?int $limit = 10): DataResponse`
+  - Validate placement ownership (return 403 if user cannot see dashboard)
+  - Validate limit (positive integer, max 50; default 10)
+  - Call `NewsWidgetService::getItemsForPlacement()`
+  - Return HTTP 200 with item array
+  - Decorate with `#[NoCSRFRequired]` and `#[NoAdminRequired]`
+- [ ] 2.2 Register route in `appinfo/routes.php`:
+  - `GET /api/widgets/news/{placementId}/items` → `WidgetController::newsItems()`
+  - Route requirements: placementId (digits), limit (optional query param, digits)
+- [ ] 2.3 Create PHPUnit test for controller:
+  - `testNewsItemsSuccess` — mock service, verify HTTP 200 + item payload
+  - `testNewsItemsMissingPlacement` — return 404 when placement doesn't exist
+  - `testNewsItemsAccessDenied` — return 403 when user cannot see dashboard
+  - `testNewsItemsInvalidLimit` — return 400 for limit < 1 or > 50
+
+## 3. Placement configuration and schema migration
+
+- [ ] 3.1 Create `lib/Migration/VersionXXXXDate2026...AddNewsWidgetSettings.php`:
+  - Add app config table entries for `mydash.news_widget_feed_cache_ttl_seconds` (default 3600)
+  - Add app config table entries for `mydash.news_widget_allowed_feed_hosts` (default `null` or `[]`)
+  - NOTE: No new `oc_mydash_*` table columns required; all config is stored in placement `widgetContent` JSON
+- [ ] 3.2 Add getter/setter methods in `WidgetPlacementService` or factory to safely parse `widgetContent` JSON:
+  - `extractNewsConfig(WidgetPlacement $placement): array` — returns parsed config with defaults (feedUrls, layout, itemLimit, showThumbnails, showSummary, summaryMaxChars, dateFormat, metadataFilter)
+  - Validate and sanitize config (feedUrls must be HTTP/HTTPS, itemLimit 1-50)
+- [ ] 3.3 Create PHPUnit test for placement config parsing:
+  - `testExtractNewsConfigWithDefaults` — verify default values are applied
+  - `testExtractNewsConfigValidation` — invalid URLs rejected, valid ones accepted
+
+## 4. Feed fetching, caching, and allow-list
+
+- [ ] 4.1 Implement in `NewsWidgetService::fetchAndMergeFeeds()`:
+  - For each URL in `feedUrls`:
+    - Check allow-list via `checkAllowList($url)`
+    - If disallowed, skip and log warning
+    - If allowed, try to fetch from cache key `mydash_news_feed_{placementId}_{urlHash}` (via FeedCacheService if available, else ICache directly)
+    - If cache hit, use cached raw feed content
+    - If cache miss, HTTP fetch with 10-second timeout (use `IClientService`)
+    - On HTTP 4xx/5xx, log warning, skip URL, record failure for UI badge
+    - On timeout, log warning, skip URL, record failure
+    - On success, cache raw feed for TTL (read from `IAppConfig::getValueInt()`)
+    - Parse cached/fetched feed via `NewsWidgetService::parseRssFeed()` 
+    - Merge and deduplicate across all sources
+    - Sort by pubDate descending
+    - Collect failure info (number of failed feeds) for response metadata
+- [ ] 4.2 Implement `NewsWidgetService::parseRssFeed()`:
+  - Accept raw XML/feed content and source metadata (URL, title)
+  - Use SimpleXML or lightweight feed parser to extract VEVENT/VENTRY data
+  - For each item, extract: guid (unique identifier), title, summary, link, pubDate (ISO 8601), thumbnailUrl (if present)
+  - Handle both RSS 2.0 and Atom 1.0 formats
+  - Return flat array of item objects
+  - Log malformed feeds at INFO level (don't crash widget)
+- [ ] 4.3 Implement `NewsWidgetService::checkAllowList()`:
+  - Read `mydash.news_widget_allowed_feed_hosts` from `IAppConfig::getValueString()`
+  - If empty or null, return true (all allowed)
+  - Otherwise, parse URL, extract hostname (case-insensitive)
+  - Check for exact match in allow-list (no wildcard subdomain expansion)
+  - Return boolean
+
+## 5. HTML sanitisation and metadata filtering
+
+- [ ] 5.1 Implement `NewsWidgetService::sanitiseSummaryHtml()`:
+  - Accept raw HTML string from feed item summary
+  - Use Nextcloud's `HtmlSanitizer` or equivalently safe library (e.g., `HTML Purifier` if available)
+  - Allow tags: `<p>`, `<a>`, `<strong>`, `<em>`, `<br>`, `<ul>`, `<ol>`, `<li>`
+  - Strip all other HTML tags
+  - Force `rel="noopener noreferrer"` on all `<a>` elements
+  - Return sanitised HTML
+  - Log dropped content at DEBUG level if substantial content is removed
+- [ ] 5.2 Implement `NewsWidgetService::checkMetadataFilter()`:
+  - Accept dashboard ID and metadata filter object `{fieldKey: string, value: string}`
+  - If metadataFilter is null, return true (no filter applied)
+  - Look up dashboard and retrieve its metadata fields (from sibling spec `dashboard-metadata-fields`)
+  - Check if the field identified by `fieldKey` has value matching `value` (case-sensitive string comparison)
+  - Return boolean: true if filter passes, false if filter fails
+  - Log filter rejection at DEBUG level for troubleshooting
+- [ ] 5.3 Create PHPUnit tests:
+  - `testSanitiseSummaryAllowsWhitelistedTags` — `<p>`, `<a>`, `<strong>`, etc. preserved
+  - `testSanitiseSummaryStripsScriptTags` — `<script>`, `<iframe>`, `<svg>` removed
+  - `testSanitiseSummaryForcesRelAttributes` — all `<a>` tags get `rel="noopener noreferrer"`
+  - `testMetadataFilterMatches` — dashboard metadata matches filter
+  - `testMetadataFilterRejects` — dashboard metadata does not match filter
+  - `testMetadataFilterNullBypass` — null filter returns true
+
+## 6. Vue component and UI rendering
+
+- [ ] 6.1 Create `src/components/widgets/NewsWidget.vue`:
+  - Three layout modes: `list`, `grid`, `carousel` (switchable via placement config)
+  - List: single-column item feed, title + thumbnail (if enabled) + summary preview (if enabled) + link + date
+  - Grid: multi-column card layout, thumbnail, title, summary truncated, link, date
+  - Carousel: horizontal scroll, card layout, single item visible with arrow navigation
+  - Empty state: "No news yet — try adding feeds in the widget settings"
+  - Failure badge (top-right corner): shows "N feeds failed" with hover tooltip listing failed URLs
+  - Click on item → `window.open(item.link, '_blank', 'rel=noopener')`
+  - Date formatting: `dateFormat: 'relative'` shows "2 hours ago", `'absolute'` shows "2026-05-01 14:30"
+  - Load items via `GET /api/widgets/news/{placementId}/items?limit={itemLimit}`
+  - Show loading spinner while fetching
+  - Handle fetch error with user-friendly message
+- [ ] 6.2 Create `src/components/widgets/newspicker/NewsWidgetConfig.vue`:
+  - Placement config form with fields:
+    - Feed URLs (array input with add/remove)
+    - Layout mode (radio or select: list, grid, carousel)
+    - Item limit (number input, 1-50)
+    - Metadata filter (optional):
+      - Checkbox "Filter by dashboard metadata"
+      - If enabled: fieldKey select (populated from dashboard's metadata field keys), value text input
+    - Show thumbnails (checkbox, default true)
+    - Show summary (checkbox, default true)
+    - Summary max chars (number input, default 200)
+    - Date format (radio: relative, absolute)
+  - Validation: feedUrls must be HTTP/HTTPS
+  - Save via `PUT /api/widgets/{placementId}` with updated `widgetContent`
+- [ ] 6.3 Create Storybook stories (optional but recommended):
+  - NewsWidget with list layout
+  - NewsWidget with grid layout
+  - NewsWidget with carousel layout
+  - NewsWidget empty state
+  - NewsWidget with failure badge
+  - NewsWidgetConfig form
+
+## 7. Integration tests and edge cases
+
+- [ ] 7.1 Create integration test `tests/Integration/WidgetNewsIntegrationTest.php`:
+  - `testNewsWidgetE2E` — create dashboard, add news widget placement, fetch items via API, verify merge and dedup
+  - `testMetadataFilterEnforcement` — widget with metadata filter only returns items when dashboard metadata matches
+  - `testFeedCacheTTL` — verify cache expiry and refetch
+  - `testAllowListEnforcement` — disallowed feed hosts are skipped
+  - `testFailureTolerance` — single feed failure does not break widget; other feeds still render
+- [ ] 7.2 Handle edge cases:
+  - Empty feed list → return empty items array + empty state
+  - All feeds fail → return empty items array + failure badge showing "All feeds failed"
+  - Feed with no items → skip, no error, continue with other feeds
+  - Feed item missing guid → generate synthetic guid from title + pubDate + sourceUrl
+  - Feed item missing pubDate → use current timestamp as fallback
+  - Circular or self-referential metadataFilter → log and skip (safety)
+- [ ] 7.3 Performance considerations:
+  - Fetch timeout: 10 seconds per URL (prevent hang)
+  - Cache hits should be sub-100ms
+  - Deduplication uses O(n) hash-based lookup, not O(n²)
+  - Sorting uses native array sort (stable)
+
+## 8. Admin settings UI
+
+- [ ] 8.1 Add admin settings form (in MyDash admin panel or central Nextcloud settings):
+  - `mydash.news_widget_feed_cache_ttl_seconds` — text input (number), default 3600, help text "Cache TTL in seconds (60-86400)"
+  - `mydash.news_widget_allowed_feed_hosts` — text area with JSON array format, help text "JSON array of allowed feed hostnames, e.g., `["bbc.com", "example.org"]`. Leave empty to allow all."
+  - Validate: cache TTL must be 60-86400; JSON must parse
+  - Save via existing Nextcloud admin settings API
+- [ ] 8.2 Add documentation in README or inline comments:
+  - Explain feed allow-list purpose (security, bandwidth control)
+  - Explain cache TTL and its relation to background job refresh frequency
+  - Note: widget relies on `background-job-feed-refresh` for periodic updates
+
+## 9. Documentation and examples
+
+- [ ] 9.1 Add example to `openspec/examples/news-widget-placement-config.json`:
+  ```json
+  {
+    "feedUrls": [
+      "https://news.bbc.co.uk/rss/feeds/world",
+      "https://feeds.example.org/marketing"
+    ],
+    "layout": "grid",
+    "itemLimit": 15,
+    "metadataFilter": {
+      "fieldKey": "department",
+      "value": "marketing"
+    },
+    "showThumbnails": true,
+    "showSummary": true,
+    "summaryMaxChars": 250,
+    "dateFormat": "relative"
+  }
+  ```
+- [ ] 9.2 Add developer notes to `openspec/changes/news-widget/IMPLEMENTATION_NOTES.md`:
+  - Feed format support (RSS 2.0, Atom 1.0, description of any known limitations)
+  - Caching strategy (per-feed, per-placement, key structure)
+  - Metadata filter dependency on dashboard-metadata-fields spec
+  - Background job integration points

--- a/openspec/changes/orphaned-data-cleanup/design.md
+++ b/openspec/changes/orphaned-data-cleanup/design.md
@@ -1,0 +1,97 @@
+# Design — Orphaned Data Cleanup
+
+## Context
+
+Over time, MyDash accumulates stale rows that are no longer referenced by any live entity:
+widget assets uploaded for a dashboard that was subsequently deleted, locks held by sessions
+that crashed before releasing them, and share tokens whose parent dashboards no longer exist.
+These rows waste storage, pollute admin diagnostics, and — in the case of dangling locks — can
+block legitimate write operations.
+
+The cleanup surface is not static. New capabilities (calendar widgets, embedded media, advanced
+sharing) will introduce their own orphan categories. A hardcoded list of cleanup steps would
+require a core change every time a new capability ships. The design therefore uses a registry
+pattern: each capability registers its own detector, and the cleanup command and admin UI
+iterate the registry without knowing the detector details.
+
+Safety is the overriding constraint. A cleanup that deletes data the admin did not intend to
+remove is worse than leaving orphans in place. The three-tier flow (scan → preview → confirm)
+and the checksum guard on the confirm step ensure that the admin reviews exactly the data that
+will be removed, and that a concurrent modification cannot cause a stale-state deletion.
+
+## Goals / Non-Goals
+
+**Goals:**
+- A `mydash:cleanup` CLI command that scans for and optionally removes orphaned data.
+- An admin UI panel that surfaces the scan results and allows one-click cleanup.
+- A DI-tag registry so capabilities can register detectors without modifying core.
+- Audit emission for every cleanup run.
+- Per-detector enable/disable toggles in admin settings.
+
+**Non-Goals:**
+- Automatic scheduled cleanup (operators must trigger it explicitly in v1).
+- Cleanup of data owned by other apps.
+- Recovery / undo of cleaned rows.
+
+## Decisions
+
+### D1: Registry pattern
+**Decision:** Detectors implement a `IOrphanDetector` interface and are registered via DI tag
+`mydash.orphan_detector`. The `OrphanCleanupService` collects all tagged implementations
+via constructor injection and runs them in sequence.
+**Alternatives considered:** A static list of detector class names in a config file; a database
+registry table.
+**Rationale:** DI tags are the idiomatic extension point in this framework. No database table
+or config file needs updating when a new capability ships its detector — only the DI wiring
+in the capability's own service definition.
+
+### D2: Three-tier safety flow
+**Decision:** The flow is scan → preview (show counts and a checksum) → cleanup (requires
+`?confirm=true` plus the checksum from the preview response).
+**Alternatives considered:** Single-step cleanup with a `?dryRun` flag; two-step (scan +
+immediate cleanup).
+**Rationale:** The checksum binds the confirm request to a specific scan result. If another
+process modifies the data between scan and confirm, the checksums diverge and the cleanup
+is rejected, preventing stale-state deletions.
+
+### D3: Per-detector enable/disable
+**Decision:** Each detector is toggled by `mydash.orphan_cleanup_<detector_id>_enabled`
+(default `true`). Disabled detectors are skipped and listed under `skipped` in the response.
+**Alternatives considered:** Single global toggle; no per-detector control.
+**Rationale:** Some installations legitimately retain certain orphan categories (e.g. assets
+kept for audit). Granular control avoids a global toggle blocking targeted cleanup.
+
+### D4: Audit emission
+**Decision:** Every run emits Activity event `mydash_orphan_cleanup_run` with
+`{detector, scannedCount, removedCount, dryRun}` — including scan-only runs.
+**Alternatives considered:** Log-only; emit only on destructive runs.
+**Rationale:** Admin actions that can remove data must produce a user-attributed, queryable
+audit trail.
+
+### D5: CLI default to scan-only
+**Decision:** `mydash:cleanup` scans by default; `--apply` triggers deletions;
+`--detector=<id>` isolates a single detector.
+**Alternatives considered:** Default to destructive, require explicit `--dry-run`.
+**Rationale:** An operator who forgets the flag gets a harmless report — not an unexpected
+deletion.
+
+### D6: Source reference
+**Decision:** The `OrphanedDataController` from `intravox-source/lib/Controller/` is the
+reference; the refactor swaps its hardcoded list for the DI-tag registry.
+**Alternatives considered:** Full rewrite ignoring source.
+**Rationale:** Reusing the HTTP scaffolding reduces risk; the registry swap is the only
+structural change.
+
+## Risks / Trade-offs
+
+- High-churn installations may see frequent checksum mismatches between scan and confirm,
+  requiring repeated scan cycles.
+- Slow detectors (large asset tables) should report per-detector duration to the operator.
+- A buggy detector that misclassifies live data as orphaned has only the preview step as a
+  safety net — the checksum does not validate detector logic.
+
+## Open follow-ups
+
+- Add `--since=<date>` to limit scans to recently orphaned rows.
+- Implement opt-in scheduled background job mode once behaviour is validated in the field.
+- Define a per-detector retention window (e.g. assets eligible only after 30 days orphaned).

--- a/openspec/changes/orphaned-data-cleanup/proposal.md
+++ b/openspec/changes/orphaned-data-cleanup/proposal.md
@@ -1,0 +1,80 @@
+# Orphaned Data Cleanup
+
+## Why
+
+MyDash accumulates orphaned data over time: widget assets from deleted dashboards, expired locks and share tokens, metadata-value rows whose field definitions no longer exist, role assignments for deleted users, and other referential integrity issues. Today, there is no standard way to scan for, report on, or safely remove such data, leading to accumulated technical debt and storage waste. A comprehensive scan + purge capability—with safety via dry-run mode, category selectivity, and audit logging—enables administrators to maintain database hygiene without manual SQL or risk of data loss.
+
+## What Changes
+
+- Add `php occ mydash:cleanup:scan` CLI command — report orphaned items by category (expired_locks, expired_share_tokens, orphaned_widget_assets, orphaned_metadata_values, orphaned_widget_placements, orphaned_feed_tokens, orphaned_role_assignments, dangling_dashboard_translations) as a table; return nonzero exit code if any orphans found (useful for CI).
+- Add `php occ mydash:cleanup:purge [--category=<name>] [--dry-run] [--yes]` CLI command — delete orphaned items; `--category` limits to one category (default all); `--dry-run` reports what WOULD be deleted; `--yes` skips confirmation prompt (interactive otherwise).
+- Add `GET /api/admin/cleanup/scan` endpoint (admin-only) — JSON of the scan output; cached with 5-minute TTL.
+- Add `POST /api/admin/cleanup/purge` endpoint (admin-only), body `{categories: [...], dryRun?: boolean}` — triggers purge, returns `{purgedByCategory: {...}, totalRows: N, durationMs: M}`.
+- Add daily background job `OrphanedDataCleanupJob` running at configured time, auto-purging a safe-to-auto-purge subset (default `['expired_locks','expired_share_tokens']`).
+- Add admin settings in Settings > Administration > MyDash: view last cleanup run, configure auto-purge categories and time of day.
+- Emit one NC activity event `mydash_cleanup_purge` per purge run with metadata: categories, totalRows, byUserId, durationMs.
+- Per-category extensibility via registry pattern — adding new categories requires one class addition, no central edits.
+
+## Capabilities
+
+### New Capabilities
+
+- `orphaned-data-cleanup`: provides REQ-CLN-001 through REQ-CLN-011 (scan CLI, purge CLI, scan API, purge API, per-category details, background job, safe auto-purge list, dry-run safety, audit logging, cache invalidation, registry extensibility).
+
+### Modified Capabilities
+
+- None. All other MyDash capabilities remain unchanged.
+
+## Impact
+
+**Affected code:**
+
+- `lib/Db/CleanupResult.php` — DTO for scan/purge results
+- `lib/Service/OrphanedDataCleanupService.php` — orchestrates scan and purge across all categories
+- `lib/Service/Cleanup/CategoryRegistryService.php` — registry holding all cleanup categories
+- `lib/Service/Cleanup/CleanupCategoryInterface.php` — interface for per-category scan/purge implementations
+- `lib/Service/Cleanup/ExpiredLocksCategory.php` — scan and purge expired locks
+- `lib/Service/Cleanup/ExpiredShareTokensCategory.php` — scan and purge expired share tokens
+- `lib/Service/Cleanup/OrphanedWidgetAssetsCategory.php` — scan and purge orphaned widget asset files
+- `lib/Service/Cleanup/OrphanedMetadataValuesCategory.php` — scan and purge dangling metadata values
+- `lib/Service/Cleanup/OrphanedWidgetPlacementsCategory.php` — scan and purge placements with no dashboard
+- `lib/Service/Cleanup/OrphanedFeedTokensCategory.php` — scan and purge tokens for deleted users
+- `lib/Service/Cleanup/OrphanedRoleAssignmentsCategory.php` — scan and purge role assignments for deleted users/groups
+- `lib/Service/Cleanup/DanglingDashboardTranslationsCategory.php` — scan and purge orphaned dashboard translations
+- `lib/Jobs/OrphanedDataCleanupJob.php` — scheduled background task
+- `lib/Controller/AdminCleanupController.php` — API endpoints
+- `lib/Command/CleanupScanCommand.php` — CLI scan command
+- `lib/Command/CleanupPurgeCommand.php` — CLI purge command
+- `appinfo/routes.php` — register cleanup API routes (admin-only)
+- `appinfo/backgroundjobs.php` — register cleanup job
+- `lib/Migration/VersionXXXXDate2026...php` — (if needed) any schema changes for cleanup metadata
+- `lib/Service/SettingsService.php` — (update) expose cleanup settings (auto-purge categories, last run timestamp)
+- `lib/Settings/AdminSettings.php` — (update) MyDash admin settings in Nextcloud Settings > Administration
+
+**Affected APIs:**
+
+- 2 new admin API routes (GET /api/admin/cleanup/scan, POST /api/admin/cleanup/purge)
+- No changes to existing dashboard, widget, or permission APIs
+
+**Dependencies:**
+
+- `OCP\ICache` — for caching scan results
+- `OCP\IConfig` — for reading/writing cleanup settings
+- `OCP\IUserManager` — for resolving user existence
+- `OCP\IGroupManager` — for resolving group existence
+- `OCP\Activity\IManager` — for emitting audit events
+- `OCP\ILogger` — for logging purge operations
+- No new composer dependencies
+
+**Migration:**
+
+- No schema changes required (all data already exists in standard tables).
+- On first run, creates admin settings with defaults.
+
+**Security:**
+
+- All endpoints and commands are admin-only; no unprivileged access.
+- Dry-run mode prevents accidental data loss.
+- Audit logging captures all purge operations for compliance.
+- Per-category selectivity allows conservative purging (safe categories first, risky categories manual-only).
+

--- a/openspec/changes/orphaned-data-cleanup/specs/orphaned-data-cleanup/spec.md
+++ b/openspec/changes/orphaned-data-cleanup/specs/orphaned-data-cleanup/spec.md
@@ -1,0 +1,409 @@
+---
+status: draft
+---
+
+# Orphaned Data Cleanup Specification
+
+## Purpose
+
+Provide administrators with a comprehensive, safe, and auditable mechanism to scan for and remove orphaned MyDash data: expired locks and tokens, widget assets from deleted dashboards, metadata-value rows with missing field definitions, placements with no dashboard, tokens for deleted users, role assignments for deleted users/groups, and translations for deleted dashboards. The capability MUST support dry-run (safe preview), per-category selectivity (scan vs. auto-purge), background automation (daily safe-categories job), and audit trails (activity events). A registry pattern enables adding new cleanup categories without editing central code.
+
+## Data Model
+
+Orphaned data exists in multiple tables and file locations. This spec defines what constitutes orphaned and the cleanup strategy for each:
+
+- **expired_locks**: rows in `oc_mydash_dashboard_locks` where `expiresAt < now()`
+- **expired_share_tokens**: rows in `oc_mydash_public_shares` where `expiresAt < now()` OR `revokedAt < (now() - 30 days)`
+- **orphaned_widget_assets**: files in `MyDash/Imports/*` and `MyDash/icons/*` (Nextcloud file storage) not referenced by any current dashboard or widget config
+- **orphaned_metadata_values**: rows in `oc_mydash_metadata_values` where `fieldId` does NOT exist in `oc_mydash_metadata_fields`
+- **orphaned_widget_placements**: rows in `oc_mydash_widget_placements` where `dashboardId` does NOT exist in `oc_mydash_dashboards`
+- **orphaned_feed_tokens**: rows in `oc_mydash_feed_tokens` where `userId` no longer exists in `oc_users`
+- **orphaned_role_assignments**: rows in `oc_mydash_role_assignments` where `userId` (or `groupId`) no longer exists in `oc_users` (or `oc_groups`)
+- **dangling_dashboard_translations**: rows in `oc_mydash_dashboard_translations` where `dashboardUuid` no longer exists in `oc_mydash_dashboards`
+
+Cleanup is grouped into three safety tiers:
+
+1. **Tier-A (Auto-safe)**: expired_locks, expired_share_tokens — always safe to auto-purge (no user-visible impact)
+2. **Tier-B (Manual-safe)**: orphaned_widget_assets, orphaned_metadata_values, orphaned_widget_placements, orphaned_feed_tokens, dangling_dashboard_translations — safe to purge manually but not auto (require data validation first)
+3. **Tier-C (Inspect-first)**: orphaned_role_assignments — purge only after inspection (role-based permissions at stake)
+
+Default auto-purge list: Tier-A (expired_locks, expired_share_tokens).
+
+## ADDED Requirements
+
+### Requirement: REQ-CLN-001 Scan CLI Command
+
+Administrators MUST be able to run a CLI command that reports all orphaned items by category WITHOUT deleting.
+
+#### Scenario: Scan finds orphaned items
+- GIVEN a MyDash installation with: 3 expired locks, 2 expired share tokens, 5 orphaned widget assets, 1 orphaned metadata value
+- WHEN an administrator runs `php occ mydash:cleanup:scan`
+- THEN the system MUST:
+  - Query all eight categories (expired_locks, expired_share_tokens, orphaned_widget_assets, orphaned_metadata_values, orphaned_widget_placements, orphaned_feed_tokens, orphaned_role_assignments, dangling_dashboard_translations)
+  - Display a table with one row per category, showing category name and count
+  - Return exit code 1 (nonzero) to signal that orphans exist
+- AND the output MUST include:
+  - `expired_locks: 3`
+  - `expired_share_tokens: 2`
+  - `orphaned_widget_assets: 5`
+  - `orphaned_metadata_values: 1`
+  - `orphaned_widget_placements: 0`
+  - etc.
+- AND no data MUST be deleted
+
+#### Scenario: Scan finds no orphans
+- GIVEN a clean MyDash installation with no orphaned data
+- WHEN an administrator runs `php occ mydash:cleanup:scan`
+- THEN the system MUST display a table with all categories showing count 0
+- AND return exit code 0 (success, no orphans)
+
+#### Scenario: Scan handles missing tables gracefully
+- GIVEN a MyDash installation where a feature (e.g., dashboard-rss-feeds) is not yet enabled
+- WHEN `php occ mydash:cleanup:scan` is run
+- THEN the system MUST skip categories tied to that feature (e.g., orphaned_feed_tokens)
+- AND display remaining categories; return 0 if no other orphans exist
+
+### Requirement: REQ-CLN-002 Purge CLI Command
+
+Administrators MUST be able to run a CLI command to DELETE orphaned items, with confirmation and per-category selectivity.
+
+#### Scenario: Purge all categories with confirmation
+- GIVEN a MyDash installation with 3 expired locks and 2 expired share tokens
+- WHEN an administrator runs `php occ mydash:cleanup:purge` (no --yes flag)
+- THEN the system MUST:
+  - Prompt interactively: "Delete orphaned data in categories: [expired_locks, expired_share_tokens, ...]? (yes/no)"
+  - Await user input
+- AND if the user enters "yes":
+  - Delete all orphaned items across all categories
+  - Display summary: "Purged 5 items across 2 categories in 123ms"
+  - Return exit code 0
+- AND if the user enters "no":
+  - Cancel without deleting
+  - Display "Purge cancelled"
+  - Return exit code 0 (user choice, not an error)
+
+#### Scenario: Purge with --yes flag (non-interactive)
+- GIVEN the same installation
+- WHEN an administrator runs `php occ mydash:cleanup:purge --yes`
+- THEN the system MUST:
+  - Delete all orphaned items immediately (no prompt)
+  - Display summary and return exit code 0
+
+#### Scenario: Purge specific category
+- GIVEN 3 expired locks and 2 expired share tokens
+- WHEN an administrator runs `php occ mydash:cleanup:purge --category=expired_locks --yes`
+- THEN the system MUST:
+  - Delete ONLY the 3 expired locks
+  - Display summary: "Purged 3 items from category 'expired_locks' in 45ms"
+  - Leave the 2 expired share tokens untouched
+
+#### Scenario: Purge non-existent category
+- GIVEN a valid cleanup setup
+- WHEN an administrator runs `php occ mydash:cleanup:purge --category=invalid_category --yes`
+- THEN the system MUST:
+  - Display error: "Unknown cleanup category: invalid_category"
+  - List valid categories
+  - Return exit code 1
+
+### Requirement: REQ-CLN-003 Dry-Run Safety Mode
+
+Both CLI commands MUST support a `--dry-run` flag that reports what WOULD be deleted without actually deleting.
+
+#### Scenario: Scan with dry-run (no-op)
+- GIVEN orphaned data exists
+- WHEN an administrator runs `php occ mydash:cleanup:scan --dry-run`
+- THEN the system MUST:
+  - Behave identically to scan without --dry-run (scan is always non-destructive)
+  - Display "(dry-run)" label in output if applicable
+  - Return appropriate exit code
+
+#### Scenario: Purge with dry-run
+- GIVEN 3 expired locks and 2 expired share tokens
+- WHEN an administrator runs `php occ mydash:cleanup:purge --dry-run --yes`
+- THEN the system MUST:
+  - Execute the same deletion queries but wrap in a transaction and ROLLBACK before commit
+  - Display: "DRY-RUN: Would purge 5 items across 2 categories in 78ms"
+  - Leave all data untouched
+  - Return exit code 0
+
+#### Scenario: Dry-run with category filter
+- GIVEN 3 expired locks and 2 expired share tokens
+- WHEN an administrator runs `php occ mydash:cleanup:purge --category=expired_locks --dry-run --yes`
+- THEN the system MUST:
+  - Report "DRY-RUN: Would purge 3 items from category 'expired_locks' in 42ms"
+  - Delete nothing
+
+### Requirement: REQ-CLN-004 Scan API Endpoint
+
+Administrators MUST be able to call an HTTP API endpoint to retrieve scan results as JSON, with caching.
+
+#### Scenario: GET /api/admin/cleanup/scan returns current orphan counts
+- GIVEN a MyDash installation with 3 expired locks
+- WHEN an administrator (user with admin role) sends `GET /api/admin/cleanup/scan`
+- THEN the system MUST:
+  - Return HTTP 200 with JSON body:
+    ```json
+    {
+      "expired_locks": 3,
+      "expired_share_tokens": 0,
+      "orphaned_widget_assets": 0,
+      "orphaned_metadata_values": 0,
+      "orphaned_widget_placements": 0,
+      "orphaned_feed_tokens": 0,
+      "orphaned_role_assignments": 0,
+      "dangling_dashboard_translations": 0,
+      "totalOrphans": 3,
+      "cached": false,
+      "cachedAt": null,
+      "scannedAt": "2026-05-01T12:34:56Z"
+    }
+    ```
+  - Perform a fresh scan (not cached)
+
+#### Scenario: Subsequent scan API call returns cached results
+- GIVEN the scan from the previous scenario completed 30 seconds ago
+- WHEN an administrator sends `GET /api/admin/cleanup/scan` again
+- THEN the system MUST:
+  - Return HTTP 200 with identical counts
+  - Include `"cached": true, "cachedAt": "2026-05-01T12:34:56Z"` (original scan time)
+  - Use cached result without re-querying database (cached 5 minutes by default)
+
+#### Scenario: Cache is invalidated after purge
+- GIVEN a cached scan with 3 expired locks
+- WHEN an administrator calls `POST /api/admin/cleanup/purge` and deletes those locks
+- THEN the next `GET /api/admin/cleanup/scan` MUST:
+  - Perform a fresh scan (cache cleared)
+  - Return 0 expired locks
+  - Include `"cached": false`
+
+#### Scenario: Non-admin user is denied access
+- GIVEN an unauthenticated or non-admin user
+- WHEN they send `GET /api/admin/cleanup/scan`
+- THEN the system MUST return HTTP 403 Forbidden
+
+### Requirement: REQ-CLN-005 Purge API Endpoint
+
+Administrators MUST be able to POST to an API endpoint to trigger purge with per-category selectivity and dry-run support.
+
+#### Scenario: Purge all categories via API
+- GIVEN 3 expired locks and 2 expired share tokens
+- WHEN an administrator sends `POST /api/admin/cleanup/purge` with body `{"categories": ["expired_locks", "expired_share_tokens"], "dryRun": false}`
+- THEN the system MUST:
+  - Delete all 5 items
+  - Return HTTP 200 with JSON:
+    ```json
+    {
+      "purgedByCategory": {
+        "expired_locks": 3,
+        "expired_share_tokens": 2
+      },
+      "totalRows": 5,
+      "durationMs": 123,
+      "dryRun": false
+    }
+    ```
+
+#### Scenario: Purge with dryRun=true
+- GIVEN the same data
+- WHEN an administrator sends `POST /api/admin/cleanup/purge` with body `{"categories": [...], "dryRun": true}`
+- THEN the system MUST:
+  - Return the same response structure BUT with `"dryRun": true`
+  - Leave all data untouched
+
+#### Scenario: Empty categories array purges all categories
+- GIVEN a request body `{"categories": [], "dryRun": false}`
+- WHEN the administrator sends `POST /api/admin/cleanup/purge`
+- THEN the system MUST:
+  - Treat empty array as "all categories"
+  - Purge everything
+  - Return totals for each category
+
+#### Scenario: Non-admin user is denied access
+- GIVEN a non-admin user
+- WHEN they send `POST /api/admin/cleanup/purge`
+- THEN the system MUST return HTTP 403 Forbidden
+
+### Requirement: REQ-CLN-006 Per-Category Breakdown
+
+The scan and purge results MUST include a per-category breakdown so administrators understand exactly what is being removed.
+
+#### Scenario: Scan output shows detailed breakdown
+- GIVEN orphaned data in multiple categories
+- WHEN an administrator calls `php occ mydash:cleanup:scan`
+- THEN the output table MUST display:
+  - Column 1: Category name (e.g., "expired_locks", "orphaned_widget_assets")
+  - Column 2: Count (e.g., 3, 0, 5)
+  - Alphabetical or logical order
+- AND the total row MUST show the sum of all categories
+
+#### Scenario: Purge API returns per-category counts
+- GIVEN a POST /api/admin/cleanup/purge request
+- WHEN the purge completes
+- THEN the response MUST include a `purgedByCategory` object mapping category name to count:
+  ```json
+  {
+    "purgedByCategory": {
+      "expired_locks": 3,
+      "expired_share_tokens": 2,
+      "orphaned_widget_assets": 0,
+      ...
+    },
+    "totalRows": 5
+  }
+  ```
+
+### Requirement: REQ-CLN-007 Background Job for Auto-Purge
+
+A scheduled daily job MUST run and automatically purge a safe-to-auto-purge subset of categories.
+
+#### Scenario: Daily cleanup job runs and purges Tier-A categories
+- GIVEN MyDash is configured with auto-purge categories = ["expired_locks", "expired_share_tokens"]
+- AND a background job is scheduled to run daily at 02:00 AM
+- WHEN the scheduled time arrives
+- THEN the system MUST:
+  - Instantiate `OrphanedDataCleanupJob`
+  - Call purge with only the configured categories
+  - Emit one activity event with metadata (see REQ-CLN-009)
+  - Log the result in the MyDash activity log
+
+#### Scenario: Admin changes auto-purge category list
+- GIVEN the admin navigates to Settings > Administration > MyDash > Cleanup
+- WHEN they uncheck "Auto-purge expired locks" and click Save
+- THEN the admin setting `mydash.cleanup_auto_purge_categories` MUST be updated
+- AND the next background job run MUST respect the new list
+
+#### Scenario: Auto-purge job is skipped if no categories enabled
+- GIVEN admin has unchecked all auto-purge categories
+- WHEN the daily job is scheduled to run
+- THEN the system MUST:
+  - Check the config
+  - Find an empty auto-purge list
+  - Skip the purge (log: "No categories enabled for auto-purge")
+  - Return successfully (exit code 0)
+
+### Requirement: REQ-CLN-008 Safe-to-Auto-Purge List
+
+The implementation MUST define which categories are safe enough to auto-purge without admin inspection.
+
+#### Scenario: Default auto-purge list is Tier-A only
+- GIVEN a fresh MyDash installation
+- WHEN the admin views Settings > Administration > MyDash > Cleanup
+- THEN the "Auto-purge categories" section MUST show:
+  - [x] expired_locks (checked by default)
+  - [x] expired_share_tokens (checked by default)
+  - [ ] orphaned_widget_assets (unchecked)
+  - [ ] orphaned_metadata_values (unchecked)
+  - [ ] orphaned_widget_placements (unchecked)
+  - [ ] orphaned_feed_tokens (unchecked)
+  - [ ] orphaned_role_assignments (unchecked)
+  - [ ] dangling_dashboard_translations (unchecked)
+
+#### Scenario: Admin opts into more aggressive auto-purge
+- GIVEN the admin has enabled auto-purge for "orphaned_widget_assets" as well
+- WHEN the daily job runs
+- THEN it MUST purge both Tier-A and the additional Tier-B categories
+
+#### Scenario: Scan results indicate which categories are auto-purged
+- GIVEN a scan result with the auto-purge config visible
+- WHEN the admin reviews the scan output (CLI or API)
+- THEN each category SHOULD display a hint or note: "(auto-purged daily)" if enabled in the auto-purge list
+
+### Requirement: REQ-CLN-009 Audit Logging
+
+Every purge operation (CLI, API, or background job) MUST emit exactly one activity event with structured metadata.
+
+#### Scenario: Purge CLI command emits activity event
+- GIVEN an administrator runs `php occ mydash:cleanup:purge --category=expired_locks --yes` and deletes 3 locks
+- WHEN the purge completes
+- THEN the system MUST emit one NC activity event with:
+  - Event type: `mydash_cleanup_purge`
+  - Subject: "Orphaned data cleanup"
+  - Message: "Purged 3 items from category 'expired_locks'"
+  - Metadata:
+    ```
+    {
+      "categories": ["expired_locks"],
+      "totalRows": 3,
+      "byCategory": {"expired_locks": 3},
+      "durationMs": 45,
+      "userId": "admin_user_id"
+    }
+    ```
+- AND the event MUST appear in the Nextcloud Activity log visible to admins
+
+#### Scenario: API purge emits activity event
+- GIVEN an administrator calls `POST /api/admin/cleanup/purge` with multiple categories
+- WHEN the purge deletes 5 items
+- THEN one activity event MUST be emitted with:
+  - Categories: the list sent in the request
+  - TotalRows: 5
+  - ByCategory: per-category counts
+  - Endpoint: "api" (distinguish from CLI)
+  - userId: the authenticated admin's ID
+
+#### Scenario: Dry-run purge does NOT emit activity event
+- GIVEN a purge with `dryRun=true` that would delete 5 items
+- WHEN the purge completes without touching data
+- THEN NO activity event MUST be emitted
+- AND the operation MUST log locally (if enabled) but not to the activity stream
+
+#### Scenario: Background job purge emits activity event
+- GIVEN the daily background job runs and auto-purges 10 items
+- WHEN the purge completes
+- THEN one activity event MUST be emitted with:
+  - Subject: "Orphaned data cleanup (background job)"
+  - UserId: "system" or similar
+  - Categories: the auto-purge list configured
+
+### Requirement: REQ-CLN-010 Cache Invalidation
+
+Scan results MUST be cached with a 5-minute TTL; cache MUST be invalidated on any successful (non-dry-run) purge.
+
+#### Scenario: Scan results are cached for 5 minutes
+- GIVEN a fresh scan at 12:00 PM returning 3 expired locks
+- WHEN another scan is requested at 12:01 PM (within TTL)
+- THEN the system MUST return cached results (same timestamp, `cached: true`)
+
+#### Scenario: Cache expires after 5 minutes
+- GIVEN a cached result from 12:00 PM
+- WHEN a new scan is requested at 12:06 PM (after 5 minutes)
+- THEN the system MUST discard the cache and perform a fresh scan
+- AND return `cached: false`
+
+#### Scenario: Purge invalidates cache
+- GIVEN a cached scan result
+- WHEN an administrator calls `POST /api/admin/cleanup/purge` and successfully deletes items
+- THEN the cache MUST be cleared immediately
+- AND the next scan MUST perform a fresh query
+
+#### Scenario: Dry-run purge does NOT invalidate cache
+- GIVEN a cached scan result
+- WHEN an administrator calls `POST /api/admin/cleanup/purge` with `dryRun=true`
+- THEN the cache MUST remain untouched
+- AND the next scan MUST return the same cached result
+
+### Requirement: REQ-CLN-011 Registry Pattern Extensibility
+
+Adding a new cleanup category in the future MUST require only creating one new class and registering it; no modifications to central orchestration code.
+
+#### Scenario: New category can be added without editing core classes
+- GIVEN that a new feature (e.g., "widget-favorites") introduces a new orphan type
+- WHEN a developer creates `lib/Service/Cleanup/OrphanedFavoritesCategory.php` implementing `CleanupCategoryInterface`
+- AND registers it in `CategoryRegistryService`
+- THEN the system MUST:
+  - Automatically include the new category in all scans (CLI, API)
+  - Automatically include it in all purges (unless category-filtered)
+  - Display it in the admin settings UI and auto-purge list
+  - NO changes to `OrphanedDataCleanupService`, command classes, or controller classes
+
+#### Scenario: Category interface contract
+- GIVEN the `CleanupCategoryInterface` with methods: `getName(): string`, `getDisplayName(): string`, `getSafeToPurgeAutomatically(): bool`, `scan(): int`, `purge(bool $dryRun = false): int`
+- WHEN a new category class implements this interface
+- THEN the registry MUST automatically discover and invoke it without modification to calling code
+
+#### Scenario: Backwards-compatible category additions
+- GIVEN an existing installation running cleanup regularly
+- WHEN a new category is added via a plugin or app update
+- THEN the existing CLI commands, API endpoints, and background job MUST work seamlessly with the new category
+- AND the admin UI MUST reflect the new category in the next page refresh
+

--- a/openspec/changes/orphaned-data-cleanup/tasks.md
+++ b/openspec/changes/orphaned-data-cleanup/tasks.md
@@ -1,0 +1,166 @@
+# Tasks — orphaned-data-cleanup
+
+## 1. Core domain model
+
+- [ ] 1.1 Create `lib/Db/CleanupResult.php` DTO with fields: `byCategory: array<string, int>`, `totalRows: int`, `durationMs: int`, `dryRun: bool`, `scannedAt: \DateTime` (for API and CLI reporting)
+- [ ] 1.2 Add getters/setters for each field with type hints
+
+## 2. Category registry infrastructure
+
+- [ ] 2.1 Create `lib/Service/Cleanup/CleanupCategoryInterface.php` interface with methods:
+  - [ ] `getName(): string` — unique category identifier (e.g., "expired_locks")
+  - [ ] `getDisplayName(): string` — human-readable label (e.g., "Expired Dashboard Locks")
+  - [ ] `getSafeToPurgeAutomatically(): bool` — whether this category can be auto-purged
+  - [ ] `scan(): int` — count orphaned items; return count
+  - [ ] `purge(bool $dryRun = false): int` — delete orphaned items (or simulate if dryRun); return count deleted
+- [ ] 2.2 Create `lib/Service/Cleanup/CategoryRegistryService.php` with:
+  - [ ] Constructor dependency injection of all category instances
+  - [ ] `getCategories(): array<CleanupCategoryInterface>` — return all registered categories
+  - [ ] `getCategoryByName(string $name): ?CleanupCategoryInterface` — lookup by name
+  - [ ] `getAutoSafeCategories(): array<string>` — return names of categories safe to auto-purge
+
+## 3. Category implementations (per-category scan/purge logic)
+
+- [ ] 3.1 Create `lib/Service/Cleanup/ExpiredLocksCategory.php` implementing `CleanupCategoryInterface`
+  - [ ] `scan()`: Query `oc_mydash_dashboard_locks` WHERE `expiresAt < NOW()`; return count
+  - [ ] `purge()`: DELETE from same; return count deleted
+  - [ ] `getSafeToPurgeAutomatically()`: return true
+
+- [ ] 3.2 Create `lib/Service/Cleanup/ExpiredShareTokensCategory.php`
+  - [ ] `scan()`: Query `oc_mydash_public_shares` WHERE `expiresAt < NOW() OR revokedAt < (NOW() - INTERVAL 30 DAY)`; return count
+  - [ ] `purge()`: DELETE from same; return count deleted
+  - [ ] `getSafeToPurgeAutomatically()`: return true
+
+- [ ] 3.3 Create `lib/Service/Cleanup/OrphanedWidgetAssetsCategory.php`
+  - [ ] `scan()`: Enumerate files in `MyDash/Imports/*` and `MyDash/icons/*` via `IAppData`; check if referenced in any dashboard/widget config JSON; count unreferenced; return count
+  - [ ] `purge()`: Delete unreferenced files; return count deleted
+  - [ ] `getSafeToPurgeAutomatically()`: return false (requires file system access validation)
+
+- [ ] 3.4 Create `lib/Service/Cleanup/OrphanedMetadataValuesCategory.php`
+  - [ ] `scan()`: Query `oc_mydash_metadata_values` LEFT JOIN `oc_mydash_metadata_fields` where field is NULL; return count
+  - [ ] `purge()`: DELETE orphaned values; return count deleted
+  - [ ] `getSafeToPurgeAutomatically()`: return false
+
+- [ ] 3.5 Create `lib/Service/Cleanup/OrphanedWidgetPlacementsCategory.php`
+  - [ ] `scan()`: Query `oc_mydash_widget_placements` LEFT JOIN `oc_mydash_dashboards` where dashboard is NULL; return count
+  - [ ] `purge()`: DELETE orphaned placements; return count deleted
+  - [ ] `getSafeToPurgeAutomatically()`: return false
+
+- [ ] 3.6 Create `lib/Service/Cleanup/OrphanedFeedTokensCategory.php` (conditional on dashboard-rss-feeds feature)
+  - [ ] `scan()`: Query `oc_mydash_feed_tokens` LEFT JOIN `oc_users` where user is NULL; return count
+  - [ ] `purge()`: DELETE orphaned tokens; return count deleted
+  - [ ] `getSafeToPurgeAutomatically()`: return true
+
+- [ ] 3.7 Create `lib/Service/Cleanup/OrphanedRoleAssignmentsCategory.php` (conditional on admin-roles feature)
+  - [ ] `scan()`: Query `oc_mydash_role_assignments` LEFT JOIN `oc_users` and `oc_groups` where both are NULL; return count
+  - [ ] `purge()`: DELETE orphaned assignments; return count deleted
+  - [ ] `getSafeToPurgeAutomatically()`: return false (Tier-C: inspect first)
+
+- [ ] 3.8 Create `lib/Service/Cleanup/DanglingDashboardTranslationsCategory.php` (conditional on dashboard-language-content feature)
+  - [ ] `scan()`: Query `oc_mydash_dashboard_translations` LEFT JOIN `oc_mydash_dashboards` where dashboard is NULL; return count
+  - [ ] `purge()`: DELETE dangling translations; return count deleted
+  - [ ] `getSafeToPurgeAutomatically()`: return false
+
+## 4. Orchestration service
+
+- [ ] 4.1 Create `lib/Service/OrphanedDataCleanupService.php` with dependencies: `CategoryRegistryService`, `ICache`, `ILogger`, `IActivity\IManager`
+- [ ] 4.2 Add `scan(array $categoryNames = []): CleanupResult` — if empty array, scan all categories; else scan only named categories; return result DTO
+- [ ] 4.3 Add `purge(array $categoryNames = [], bool $dryRun = false): CleanupResult` — if empty, purge all; else named only; if dryRun, wrap in transaction and ROLLBACK; emit activity event on success (non-dry-run only); invalidate cache; return result DTO
+- [ ] 4.4 Add `getCachedScanResult(): ?CleanupResult` — read from ICache with key 'mydash_cleanup_scan'; return null if expired
+- [ ] 4.5 Add `setCachedScanResult(CleanupResult $result): void` — write to cache with 5-minute TTL
+- [ ] 4.6 Add `invalidateCache(): void` — delete cache entry
+
+## 5. CLI commands
+
+- [ ] 5.1 Create `lib/Command/CleanupScanCommand.php` extending `Command`
+  - [ ] Constructor: inject `OrphanedDataCleanupService`
+  - [ ] `configure()`: set name, description
+  - [ ] `execute()`: call `service.scan()`, render table output with columns: Category | Count
+  - [ ] Display total row with sum of all counts
+  - [ ] Return exit code 0 if total == 0; exit code 1 if total > 0
+
+- [ ] 5.2 Create `lib/Command/CleanupPurgeCommand.php` extending `Command`
+  - [ ] Constructor: inject `OrphanedDataCleanupService`, `IInput`, `IOutput`
+  - [ ] Add options: `--category=<name>` (optional), `--dry-run`, `--yes`
+  - [ ] `execute()`: 
+    - [ ] If no `--yes` flag, prompt: "Delete orphaned data in categories: [list]? (yes/no)"
+    - [ ] If user says no, display "Purge cancelled" and exit code 0
+    - [ ] Call `service.purge(categoryNames, dryRun)` with options
+    - [ ] Render result: "Purged N items across M categories in X ms" (or "DRY-RUN: Would purge..." if dryRun)
+    - [ ] Return exit code 0 on success, 1 on error
+
+## 6. API controller
+
+- [ ] 6.1 Create `lib/Controller/AdminCleanupController.php` with dependencies: `OrphanedDataCleanupService`, `IRequest`
+- [ ] 6.2 Add `scan()` endpoint (admin-only middleware):
+  - [ ] GET /api/admin/cleanup/scan
+  - [ ] Call `service.scan()` (auto-uses cache if valid)
+  - [ ] Return JSON CleanupResult (or array with totalOrphans, cached, cachedAt, scannedAt fields)
+  - [ ] Return HTTP 200 on success, 403 if not admin
+- [ ] 6.3 Add `purge()` endpoint (admin-only):
+  - [ ] POST /api/admin/cleanup/purge
+  - [ ] Parse JSON body: `{categories?: string[], dryRun?: boolean}`
+  - [ ] Call `service.purge(categories, dryRun)`
+  - [ ] Return JSON with `purgedByCategory`, `totalRows`, `durationMs`, `dryRun` fields
+  - [ ] Return HTTP 200 on success, 403 if not admin, 400 if body invalid
+
+## 7. Routes registration
+
+- [ ] 7.1 Update `appinfo/routes.php` to register:
+  - [ ] GET /api/admin/cleanup/scan → `AdminCleanupController->scan()`
+  - [ ] POST /api/admin/cleanup/purge → `AdminCleanupController->purge()`
+  - [ ] Both routes admin-only (use `OCP\Middleware\OCSMiddleware` or equivalent authorization middleware)
+
+## 8. Background job
+
+- [ ] 8.1 Create `lib/Jobs/OrphanedDataCleanupJob.php` extends `TimedJob`
+  - [ ] Constructor: inject `OrphanedDataCleanupService`, `IConfig`, `ILogger`
+  - [ ] `run()`: 
+    - [ ] Read config `mydash.cleanup_auto_purge_categories` (JSON array, default `["expired_locks", "expired_share_tokens"]`)
+    - [ ] If empty, log "No categories enabled for auto-purge" and return
+    - [ ] Call `service.purge(categories, dryRun=false)`
+    - [ ] Log result to ILogger
+    - [ ] Activity event emitted by service (see REQ-CLN-009)
+  - [ ] Set frequency: daily at 02:00 AM (configurable via admin settings)
+
+- [ ] 8.2 Update `appinfo/backgroundjobs.php` to register the job
+
+## 9. Admin settings
+
+- [ ] 9.1 Create or update `lib/Settings/AdminSettings.php` (or similar) to expose cleanup settings:
+  - [ ] Last cleanup run timestamp (read-only)
+  - [ ] Auto-purge categories (checkboxes, one per category)
+  - [ ] Auto-purge time of day (time picker, default 02:00)
+  - [ ] Button: "Run Cleanup Now" (triggers purge with current auto-purge list)
+
+- [ ] 9.2 Update the admin settings admin/cleanup.php template to render the form
+
+## 10. Activity event emission
+
+- [ ] 10.1 In `OrphanedDataCleanupService.purge()`, after successful purge (not dry-run):
+  - [ ] Create activity event via `IActivityManager`:
+    - [ ] Type: `mydash_cleanup_purge`
+    - [ ] Subject: "Orphaned data cleanup"
+    - [ ] Message: "Purged N items from categories: [list]"
+    - [ ] Metadata: JSON with categories, totalRows, byCategory, durationMs, source (CLI/API/Job)
+    - [ ] UserId: current user (or "system" for background job)
+
+## 11. Migration (if needed)
+
+- [ ] 11.1 If cleanup needs to store metadata (e.g., last-run timestamp), create migration file `lib/Migration/VersionXXXXDate2026...php` (typically not needed if using IConfig)
+
+## 12. Testing
+
+- [ ] 12.1 Unit tests for each category class: scan and purge logic under various data states
+- [ ] 12.2 Unit tests for `CategoryRegistryService`: registration, lookup, auto-safe filtering
+- [ ] 12.3 Unit tests for `OrphanedDataCleanupService`: scan, purge, cache, activity emission
+- [ ] 12.4 Integration tests for CLI commands: prompt/confirmation, --yes flag, --category filter, --dry-run
+- [ ] 12.5 Integration tests for API endpoints: JSON parsing, per-category purge, dryRun mode, auth checks
+- [ ] 12.6 Unit tests for background job: config reading, category filtering, logging
+- [ ] 12.7 Verify PHPCS/PHPMD/PHPStan pass; run `composer check:strict`
+
+## 13. Documentation
+
+- [ ] 13.1 Add admin documentation: cleanup overview, CLI commands, API usage, auto-purge configuration
+- [ ] 13.2 Add developer documentation: extending cleanup with new categories, registry pattern, category interface
+

--- a/openspec/changes/people-widget/design.md
+++ b/openspec/changes/people-widget/design.md
@@ -1,0 +1,241 @@
+# Design — People widget
+
+## Context
+
+The people-widget spec (REQ-PPL-001 through REQ-PPL-012) was written before examining the
+existing implementation in the reference source app. This document resolves the open design
+questions by grounding each decision in the actual source code.
+
+Source roots examined:
+- `intravox-source/lib/Controller/PeopleController.php`
+- `intravox-source/lib/Service/UserService.php`
+- `intravox-source/src/components/PeopleWidget.vue`
+- `intravox-source/src/components/PeopleWidgetEditor.vue`
+- `intravox-source/src/components/people/PersonItem.vue`
+- `intravox-source/src/components/people/PeopleLayoutCard.vue`
+- `intravox-source/src/components/people/PeopleLayoutGrid.vue`
+- `intravox-source/src/components/people/PeopleLayoutList.vue`
+- `intravox-source/appinfo/routes.php`
+
+## Goals / Non-Goals
+
+**Goals**: Resolve field set, privacy model, birthday source, group filter mechanics, layout
+modes, avatar sizes, and pagination strategy so the spec can be tightened to match
+implementable reality.
+
+**Non-Goals**: This document does not change the spec. Spec deltas are listed at the end.
+
+---
+
+## Decisions
+
+### D1: Field projection
+
+**Decision**: The concrete field set returned by the people endpoint is larger than the spec
+describes. The spec names `jobTitle` and `department` as two distinct fields, but the real
+implementation maps `PROPERTY_ROLE` → `role` (job title) and `PROPERTY_ORGANISATION` →
+`organisation` (used as department fallback). There is no `jobTitle` key or `department` key
+in the actual response. The full set of standard keys is:
+
+| Response key   | Source constant                         |
+|----------------|-----------------------------------------|
+| `uid`          | `IUser::getUID()`                       |
+| `displayName`  | `IUser::getDisplayName()`               |
+| `email`        | `IUser::getEMailAddress()`              |
+| `avatarUrl`    | URL-generator route (absolute)          |
+| `groups`       | `IGroupManager::getUserGroups()`        |
+| `status`       | `IUserStatusManager` (optional)         |
+| `displayname`  | `PROPERTY_DISPLAYNAME`                  |
+| `email`        | `PROPERTY_EMAIL`                        |
+| `phone`        | `PROPERTY_PHONE`                        |
+| `address`      | `PROPERTY_ADDRESS`                      |
+| `website`      | `PROPERTY_WEBSITE`                      |
+| `twitter`      | `PROPERTY_TWITTER`                      |
+| `bluesky`      | `PROPERTY_BLUESKY`                      |
+| `fediverse`    | `PROPERTY_FEDIVERSE`                    |
+| `organisation` | `PROPERTY_ORGANISATION`                 |
+| `role`         | `PROPERTY_ROLE`                         |
+| `headline`     | `PROPERTY_HEADLINE`                     |
+| `biography`    | `PROPERTY_BIOGRAPHY`                    |
+| `pronouns`     | `PROPERTY_PRONOUNS`                     |
+| `birthdate`    | `PROPERTY_BIRTHDATE`                    |
+| *(dynamic)*    | LDAP/OIDC extra properties via `getProperties()` |
+| *(dynamic)*    | App-level custom fields from user preferences |
+
+The `PROPERTY_BIRTHDATE` constant is confirmed present in `IAccountManager` and is explicitly
+handled in `STANDARD_PROPERTIES`.
+
+The spec's `jobTitle` field does not exist. `PROPERTY_ROLE` is the NC standard for job title.
+`department` in the spec maps to `organisation` in the source (the `PersonItem` component
+renders `user.organisation || user.department` — it tries `organisation` first).
+
+**Source evidence**:
+- `intravox-source/lib/Service/UserService.php:35-50` — `STANDARD_PROPERTIES` constant
+- `intravox-source/lib/Service/UserService.php:400-484` — `buildUserProfile()` method
+- `intravox-source/src/components/people/PersonItem.vue:33` — `user.organisation || user.department`
+
+---
+
+### D2: Privacy enforcement
+
+**Decision**: The source does **not** apply NC's `IAccountManager` field-level visibility
+(scope: private/contacts/local/public). It calls `$account->getProperty($property)` and reads
+`$prop->getValue()` unconditionally, without checking `$prop->getScope()` against the
+requesting user. All standard properties are included in every response regardless of the
+user's privacy settings. The only filter is a truthy check (`$value ?: null`).
+
+This is a privacy bypass relative to what the spec requires. The spec mandates that hidden
+fields must be omitted entirely (REQ-PPL-004). The implementation does not do this.
+
+There is a 1-hour distributed APCu cache on the non-group-filter path
+(`intravox-source/lib/Service/UserService.php:256-263`) keyed only on filter + sort, not on
+requesting user. Results from this cache will leak fields regardless of privacy settings.
+
+The spec requirement REQ-PPL-004 is therefore aspirational for v1 and needs a deliberate
+implementation decision: either adopt NC scope-based visibility or document it as out-of-scope
+with a warning.
+
+**Source evidence**:
+- `intravox-source/lib/Service/UserService.php:414-435` — reads value with no scope check
+- `intravox-source/lib/Service/UserService.php:256-263` — shared cache ignores requesting user
+
+---
+
+### D3: Birthday source and computation
+
+**Decision**: `birthdate` is sourced directly from `IAccountManager::PROPERTY_BIRTHDATE` —
+confirmed by presence in `STANDARD_PROPERTIES` and explicit ISO normalization logic. The raw
+value may be stored in locale-specific formats (DD-MM-YYYY, DD/MM/YYYY, DD.MM.YYYY) and is
+normalized to ISO 8601 server-side before being returned.
+
+The source does **not** compute `daysToBirthday` on the backend. The `buildUserProfile()`
+method returns the ISO date string as `birthdate`. Birthday filtering (upcoming birthday
+detection) is implemented via two filter operators on the frontend editor side:
+`is_today` and `within_next_days`. The `within_next_days` operator is computed server-side
+only inside `matchesSingleFilter()` — but only as a filter predicate, not as a returned field.
+
+The `daysToBirthday` response field named in the spec does not exist in the source. The source
+returns the raw `birthdate` string; the Vue component formats it for display
+(`PersonItem.vue:304-315`), showing month + day (e.g., "June 10") using `toLocaleDateString`.
+
+Leap-year handling in the `within_next_days` operator constructs `YYYY-MM-DD` directly from
+the birthday's month-day without special Feb-29 logic; this will throw on non-leap years.
+
+**Source evidence**:
+- `intravox-source/lib/Service/UserService.php:49` — `PROPERTY_BIRTHDATE` in standard set
+- `intravox-source/lib/Service/UserService.php:425-430` — ISO normalization
+- `intravox-source/lib/Service/UserService.php:750-755` — `within_next_days` logic (no Feb-29 guard)
+- `intravox-source/src/components/people/PersonItem.vue:304-315` — `formatBirthdate()`
+
+---
+
+### D4: Group filter mechanics
+
+**Decision**: Group filtering is not a top-level query parameter. It is expressed as a filter
+object in the `filters` JSON array, where `fieldName === 'group'`. The backend detects this
+special case and uses `IGroupManager::get($groupId)->getUsers()` for efficiency (avoiding a
+full user scan). Multiple group values use a union (OR) strategy: deduplicated via a `$seen`
+map. Other filters are then applied on top of the group-scoped set.
+
+There is no separate `groupFilter` query param as the spec describes. The frontend sends
+`filters=[{"fieldName":"group","operator":"in","values":["management","product"]}]`.
+
+The `IGroupManager::get()` approach (not `displayNamesInGroup()`) is what is used. An unknown
+group returns an empty result (the `$group === null` check silently yields zero users).
+
+**Source evidence**:
+- `intravox-source/lib/Service/UserService.php:208-246` — group filter detection + union loop
+- `intravox-source/lib/Controller/PeopleController.php:210-228` — `filters` JSON param
+- `intravox-source/appinfo/routes.php:155` — `GET /api/people` (no separate groupFilter route)
+
+---
+
+### D5: Layout modes
+
+**Decision**: All three layout modes — `card`, `list`, `grid` — are **confirmed implemented**
+in shipping code. They are three separate Vue components backed by a shared `PersonItem`
+component that switches behavior based on a `layout` prop.
+
+Key differences from the spec's described dimensions:
+
+| Layout | Avatar size (actual) | Notes |
+|--------|---------------------|-------|
+| `card` | 80 px               | Spec said 64 px; actual is 80 px |
+| `list` | 44 px               | Spec said 32 px; actual is 44 px |
+| `grid` | 64 px               | Spec said 48 px; actual is 64 px |
+
+The card and grid layouts support a configurable column count (2/3/4) via `widget.columns`.
+The spec does not mention `columns` as a separate config key. Default is 3 for card, 4 for
+grid.
+
+The spec describes birthday badges ("🎂 in N days") overlaid on cards and grid cells. These
+are **not implemented** in the source. There is no `daysToBirthday` badge rendering in any
+layout component. Birthdate is rendered as a formatted date string in the contact section only
+(card layout only for biography; birthdate appears in contact block across all layouts when
+`showFields.birthdate` is true).
+
+The `click → /u/{userId}` navigation (REQ-PPL-010) is **not implemented** in PersonItem or
+any layout component. The `PersonItem` component renders no click handlers on the card/name.
+
+**Source evidence**:
+- `intravox-source/src/components/people/PersonItem.vue:212-222` — avatarSize computed
+- `intravox-source/src/components/people/PeopleLayoutCard.vue` — card layout, columns from `widget.columns`
+- `intravox-source/src/components/people/PeopleLayoutGrid.vue` — grid default 4 columns
+- `intravox-source/src/components/people/PersonItem.vue:1-145` — no birthday badge, no click handler
+
+---
+
+### D6: Avatar and pagination
+
+**Avatar decision**: Avatar URLs are generated via `IURLGenerator::linkToRouteAbsolute()` for
+the route `core.avatar.getAvatar` with hardcoded size 128, not the configurable 64 px the
+spec describes. There is no app config key `mydash.people_widget_avatar_size` in the source.
+The `NcAvatar` component in the frontend then receives the avatar size prop per-layout (80, 44,
+or 64 px) for display, but the actual avatar route always fetches 128 px resolution.
+
+**Pagination decision**: The source uses **offset-based pagination**, not cursor-based. The
+`getPeople` endpoint accepts `limit` (max 100) and `offset` integer params. The response shape
+is `{users: [...], total: N, hasMore: boolean}` — not `{users: [...], nextCursor: string}` as
+the spec specifies.
+
+The frontend `PeopleWidget.vue` uses `users.length` as the offset for "load more" requests.
+This is efficient enough for the expected use case but not cursor-stable under concurrent edits.
+
+The spec's cursor-based pagination (REQ-PPL-003) is aspirational; the source implements
+offset-based with `hasMore` boolean.
+
+**Source evidence**:
+- `intravox-source/lib/Service/UserService.php:405-408` — hardcoded size 128 in avatar URL
+- `intravox-source/lib/Controller/PeopleController.php:177-185` — `limit` + `offset` params
+- `intravox-source/lib/Controller/PeopleController.php:234-238` — `{users, total, hasMore}` response
+- `intravox-source/src/components/PeopleWidget.vue:249-253` — `fetchPeople(this.users.length)`
+
+---
+
+## Spec changes implied
+
+The following changes are needed to align the spec with implementable reality. Do NOT edit
+the spec yet — these are deltas to apply in a follow-up task.
+
+- **REQ-PPL-003** (response shape): Replace `nextCursor` with `hasMore: boolean` and `total: number`. Remove cursor-based pagination text. Pagination is offset-based (`limit` + `offset` integers). Max `limit` is 100.
+- **REQ-PPL-003** (route): The endpoint is `GET /api/people?userIds=...&filters=...&limit=50&offset=0`, not `/api/widgets/people/{placementId}/users`. There is no `placementId` path param; filter config is passed per-request.
+- **REQ-PPL-004** (privacy): Add a warning that NC scope-based visibility is NOT currently enforced; all `IAccountManager` fields are returned unconditionally. Either implement scope checking or downgrade the MUST to SHOULD for v1 and add a follow-up item.
+- **REQ-PPL-005** (birthday): Rename `daysToBirthday: integer` to `birthdate: string (ISO 8601 or null)`. The backend returns a date string, not a days-countdown. Compute `daysToBirthday` display client-side if needed. Add note about missing Feb-29 guard in `within_next_days` filter operator.
+- **REQ-PPL-007** (avatar): Change default size from 64 px to 128 px (route fetch) / layout-dependent display (80 card / 64 grid / 44 list). Remove `mydash.people_widget_avatar_size` config key — it does not exist.
+- **REQ-PPL-008** (layout sizes): Correct avatar sizes to 80/64/44 (card/grid/list). Add `columns` as a per-layout config key (2/3/4 options). Remove birthday-badge overlay requirement — not implemented, move to follow-up.
+- **REQ-PPL-010** (click-through): Mark as NOT implemented in the reference source; must be added fresh in MyDash.
+- **Field names**: Replace `jobTitle` with `role` (maps to `PROPERTY_ROLE`) and `department` with `organisation` (maps to `PROPERTY_ORGANISATION`). The `PersonItem` falls back `user.organisation || user.department`.
+- **Config shape** (REQ-PPL-002): The actual config uses `selectionMode: 'manual'|'filter'`, `selectedUsers: string[]`, `filters: FilterObject[]`, `filterOperator: 'AND'|'OR'`, `columns: 2|3|4`, `showFields: {...}` — not `cardFields: string[]`. Replace `cardFields` with `showFields` map.
+- **Shared backend cache**: The non-group-filter path uses a 1-hour shared APCu cache that ignores the requesting user. This is a privacy risk when scope-based visibility is eventually enforced. Add to open follow-ups.
+
+---
+
+## Open follow-ups
+
+- **Privacy**: Implement `IAccountManager` scope-based visibility (`$prop->getScope()` check against viewer) before the shared filter cache is safe to keep.
+- **Feb-29 birthday**: The `within_next_days` filter operator constructs dates with `new \DateTime($currentYear . '-' . $date->format('m-d'))` — this throws on Feb 29 in non-leap years. Add a guard.
+- **Click-through to `/u/{userId}`**: Not present in the reference source; must be added to `PersonItem.vue`.
+- **Birthday badge overlay**: "🎂 in N days" badge rendering is not present; to be added if desired (spec's REQ-PPL-008 scenario).
+- **Avatar size config**: `mydash.people_widget_avatar_size` app config key is not implemented; decide whether to add it or fix the spec.
+- **Status integration**: `IUserStatusManager` is already wired and populates `status` in the profile. The spec does not mention status — worth deciding whether to expose it in v1.
+- **Public share access**: The source exposes people data via `GET /api/share/{token}/people` — the spec does not address this route. Decide scope.

--- a/openspec/changes/people-widget/proposal.md
+++ b/openspec/changes/people-widget/proposal.md
@@ -9,22 +9,26 @@ MyDash dashboards need a discoverable people directory as a core widget capabili
 ## What Changes
 
 - **NEW** `POST /appinfo/dashboard.php` registers widget id `mydash_people` via `OCP\Dashboard\IManager::registerWidget()`.
-- **NEW** `GET /api/widgets/people/{placementId}/users` endpoint returns paginated user list `{users: [{userId, displayName, jobTitle, department, email, phone, avatarUrl, groups, daysToBirthday|null}], nextCursor}`.
+- **NEW** `GET /api/people?filters=...&limit=50&offset=0` endpoint returns paginated user list `{users: [{uid, displayName, role, organisation, email, phone, avatarUrl, groups, birthdate|omitted, status?}], total, hasMore}`. Pagination is offset-based (max limit 100).
 - **NEW** per-placement config in `widgetContent JSON`:
   - `layout: 'card'|'grid'|'list'` (default `grid`)
-  - `groupFilter: string[]` — empty = all visible users, non-empty = intersection with named NC groups
+  - `selectionMode: 'manual'|'filter'` (default `filter`)
+  - `selectedUsers: string[]` (default `[]`)
+  - `filters: FilterObject[]` — group filtering expressed as `{fieldName: "group", operator: "in", values: [...]}` (default `[]` = all visible users)
+  - `filterOperator: 'AND'|'OR'` (default `'AND'`)
   - `excludeDisabled: boolean` (default `true`)
   - `showBirthdays: boolean` (default `true`)
-  - `birthdayWindowDays: number` (default 7, range 0..30) — "🎂 in N days" badges
+  - `birthdayWindowDays: number` (default 7, range 0..30)
   - `sortBy: 'displayName'|'group'|'recent-activity'` (default `displayName`)
-  - `cardFields: string[]` — subset of `['displayName', 'jobTitle', 'department', 'email', 'phone', 'avatar']` (default all)
-- **NEW** Vue 3 SFC `PeopleWidget.vue` with three layout modes (card ~200×280px, grid ~80×120px, list single-line) and optional in-widget search (client-side substring filter).
-- **NEW** birthday computation: read from `OCP\Accounts\IAccountManager`'s `birthdate` property if visible, compute next birthday modulo year, return `null` if not set or not visible.
-- **NEW** avatar URL via NC's standard route at 64×64 px (configurable via `mydash.people_widget_avatar_size`).
-- **NEW** profile visibility enforcement: only return fields the viewer is allowed to see; hidden fields are omitted entirely.
-- **NEW** group-filter intersection: display only users in any of the configured groups (validated via `IGroupManager::displayNamesInGroup()`).
+  - `columns: 2|3|4` (default 3 for card, 4 for grid)
+  - `showFields: object` — map of field name to boolean (default all `true`)
+- **NEW** Vue 3 SFC `PeopleWidget.vue` with three layout modes (card ~200×280px / avatar 80 px, grid ~80×120px / avatar 64 px, list single-line / avatar 44 px) and optional in-widget search (client-side substring filter).
+- **NEW** birthday field: read from `OCP\Accounts\IAccountManager`'s `PROPERTY_BIRTHDATE`, normalized to ISO 8601 string. Returned as `birthdate: "YYYY-MM-DD"` or omitted. Days-to-birthday display computed client-side. Birthday window filtering via `within_next_days` filter operator (server-side predicate only).
+- **NEW** avatar URL via NC's standard `core.avatar.getAvatar` route at 128 px resolution; display size is layout-dependent (80/64/44 px). No configurable size app config key.
+- **NEW** profile visibility: v1 returns all non-empty `IAccountManager` fields unconditionally. Scope-based visibility enforcement is a planned follow-up.
+- **NEW** group-filter: expressed as a filter object in `filters` array; uses `IGroupManager::get($groupId)->getUsers()` with deduplication via `$seen` map.
 - **NEW** 60-second client-side cache with force-refresh button in widget header.
-- **NEW** click on profile card → opens `/u/{userId}` standard NC profile page in same tab.
+- **NEW** click on profile card → opens `/u/{uid}` standard NC profile page in same tab (must be added fresh — not in reference source).
 - **NEW** empty state: "No matching users."
 
 ## Capabilities
@@ -59,10 +63,10 @@ The people widget is a self-contained feature: registration, endpoint, service l
 
 - Widget registration via `appinfo/dashboard.php` (standard NC approach).
 - Config stored in widget placement's `widgetContent` JSON field (no separate config table).
-- Endpoint returns paginated list (cursor-based for efficient large-org queries).
-- Profile visibility enforced via `IAccountManager`'s per-field visibility flags — hidden fields are omitted, never nulled.
-- Birthdays computed server-side at request time (not cached; next upcoming birthday from today).
-- Avatar URLs point to NC's standard `avatar.php` endpoint.
+- Endpoint returns paginated list (offset-based, max 100 per page; `{users, total, hasMore}`).
+- Profile visibility: v1 returns all non-empty `IAccountManager` fields unconditionally; scope-based visibility is a planned follow-up.
+- Birthday field returned as ISO 8601 string; days-to-birthday computed client-side. Server-side `within_next_days` filter predicate used for birthday window queries.
+- Avatar URLs point to NC's standard `core.avatar.getAvatar` route at 128 px; display size is layout-dependent.
 - Client-side search filters current page only (not all users — efficient for large orgs).
 - Click → `/u/{userId}` opens user's NC profile in same tab.
 

--- a/openspec/changes/people-widget/proposal.md
+++ b/openspec/changes/people-widget/proposal.md
@@ -1,0 +1,75 @@
+# People Widget
+
+A new dashboard widget that displays a directory of Nextcloud users with profile cards, filters, and birthday tracking. The widget registers via `OCP\Dashboard\IManager`, supports per-placement configuration (layout, group filters, profile field visibility), and provides a paginated API endpoint for user lookup. Results respect user profile visibility settings, and birthdays are computed at request time.
+
+## Why
+
+MyDash dashboards need a discoverable people directory as a core widget capability — users want to browse colleagues, see contact info and department, and get nudges for upcoming birthdays. Unlike static directory features, the people widget must be configurable per-placement (some dashboards show only management group, others show all visible users), respect privacy settings (hidden fields are omitted entirely, not nulled), and support efficient pagination for orgs with hundreds of users.
+
+## What Changes
+
+- **NEW** `POST /appinfo/dashboard.php` registers widget id `mydash_people` via `OCP\Dashboard\IManager::registerWidget()`.
+- **NEW** `GET /api/widgets/people/{placementId}/users` endpoint returns paginated user list `{users: [{userId, displayName, jobTitle, department, email, phone, avatarUrl, groups, daysToBirthday|null}], nextCursor}`.
+- **NEW** per-placement config in `widgetContent JSON`:
+  - `layout: 'card'|'grid'|'list'` (default `grid`)
+  - `groupFilter: string[]` — empty = all visible users, non-empty = intersection with named NC groups
+  - `excludeDisabled: boolean` (default `true`)
+  - `showBirthdays: boolean` (default `true`)
+  - `birthdayWindowDays: number` (default 7, range 0..30) — "🎂 in N days" badges
+  - `sortBy: 'displayName'|'group'|'recent-activity'` (default `displayName`)
+  - `cardFields: string[]` — subset of `['displayName', 'jobTitle', 'department', 'email', 'phone', 'avatar']` (default all)
+- **NEW** Vue 3 SFC `PeopleWidget.vue` with three layout modes (card ~200×280px, grid ~80×120px, list single-line) and optional in-widget search (client-side substring filter).
+- **NEW** birthday computation: read from `OCP\Accounts\IAccountManager`'s `birthdate` property if visible, compute next birthday modulo year, return `null` if not set or not visible.
+- **NEW** avatar URL via NC's standard route at 64×64 px (configurable via `mydash.people_widget_avatar_size`).
+- **NEW** profile visibility enforcement: only return fields the viewer is allowed to see; hidden fields are omitted entirely.
+- **NEW** group-filter intersection: display only users in any of the configured groups (validated via `IGroupManager::displayNamesInGroup()`).
+- **NEW** 60-second client-side cache with force-refresh button in widget header.
+- **NEW** click on profile card → opens `/u/{userId}` standard NC profile page in same tab.
+- **NEW** empty state: "No matching users."
+
+## Capabilities
+
+### New Capabilities
+- `people-widget`: Dashboard widget displaying a user directory with customizable layout, group filters, profile field visibility, birthday tracking, and pagination.
+
+### Modified Capabilities
+- (none — widget integrates with core `widgets` capability via standard `OCP\Dashboard\IManager` registration.)
+
+## Impact
+
+- New files: `appinfo/dashboard.php`, `lib/Controller/PeopleWidgetController.php`, `lib/Service/PeopleWidgetService.php`, `src/components/PeopleWidget.vue`, plus typed exception classes.
+- Routes: one new `GET /api/widgets/people/{placementId}/users` entry in `appinfo/routes.php`.
+- Database: NO new tables — widget placements stored in core `oc_mydash_widget_placements` table with `widgetContent` JSON field.
+- Frontend: `PeopleWidget.vue` component with layout variants (card/grid/list), search input, pagination, and 60-second cache.
+- Dependencies: uses built-in `OCP\IUserManager`, `OCP\Accounts\IAccountManager`, `OCP\IGroupManager`, no new external libraries.
+
+## Affected code units
+
+- `appinfo/dashboard.php` — widget registration via `IManager::registerWidget()`
+- `lib/Controller/PeopleWidgetController.php` — `GET /api/widgets/people/{placementId}/users`
+- `lib/Service/PeopleWidgetService.php` — user lookup, pagination, visibility filtering, birthday computation
+- `src/components/PeopleWidget.vue` — three layout modes (card/grid/list), search, cache, click-through
+- `appinfo/routes.php` — add GET route for people widget users API
+
+## Why a new capability
+
+The people widget is a self-contained feature: registration, endpoint, service layer, and Vue component. It has no dependency on other widgets and can be disabled/enabled independently. Folding it into the core `widgets` capability would obscure the contract; keeping it standalone lets us add features (per-user filter, export, presence status) independently.
+
+## Approach
+
+- Widget registration via `appinfo/dashboard.php` (standard NC approach).
+- Config stored in widget placement's `widgetContent` JSON field (no separate config table).
+- Endpoint returns paginated list (cursor-based for efficient large-org queries).
+- Profile visibility enforced via `IAccountManager`'s per-field visibility flags — hidden fields are omitted, never nulled.
+- Birthdays computed server-side at request time (not cached; next upcoming birthday from today).
+- Avatar URLs point to NC's standard `avatar.php` endpoint.
+- Client-side search filters current page only (not all users — efficient for large orgs).
+- Click → `/u/{userId}` opens user's NC profile in same tab.
+
+## Notes
+
+- Per-user ACL (e.g., only show HR to HR staff) is OUT of scope for v1 — group filtering is the primary privacy lever.
+- Presence status integration is OUT of scope for v1 — tracked as a follow-up.
+- History/activity-based sorting ("who did I chat with recently") requires `OCP\Activity` integration — OUT of scope for v1; `sortBy: 'recent-activity'` is reserved but not yet implemented.
+- Export (CSV of people + birthdays) is OUT of scope for v1.
+- Intravox, intra, voxcloud terminology is NOT used — widget is purely for Nextcloud user directory.

--- a/openspec/changes/people-widget/specs/people-widget/spec.md
+++ b/openspec/changes/people-widget/specs/people-widget/spec.md
@@ -1,0 +1,489 @@
+---
+status: draft
+---
+
+# People Widget Specification
+
+## Purpose
+
+The `people-widget` capability registers a dashboard widget that displays a discoverable directory of Nextcloud users with customizable layout (card/grid/list), profile field visibility control, group filtering, and birthday tracking. The widget integrates with Nextcloud's Dashboard Widget API via `OCP\Dashboard\IManager`, stores configuration in the widget placement's JSON config, and provides a paginated API endpoint for user lookup. Results respect each user's profile visibility settings, and birthdays are computed at request time to ensure accuracy.
+
+## Data Model
+
+User listings are stateless and fetched per-request via `GET /api/widgets/people/{placementId}/users`. Results include:
+
+- **userId**: Unique NC user ID
+- **displayName**: User's configured display name
+- **jobTitle**: From `OCP\Accounts\IAccountManager` (if visible)
+- **department**: From `OCP\Accounts\IAccountManager` (if visible)
+- **email**: From `OCP\Accounts\IAccountManager` (if visible)
+- **phone**: From `OCP\Accounts\IAccountManager` (if visible)
+- **avatarUrl**: NC's standard avatar endpoint at configured size (default 64×64)
+- **groups**: Array of NC group names the user belongs to
+- **daysToBirthday**: Integer (0..365) or null. Null if birthdate not set, not visible to viewer, or `showBirthdays: false`.
+
+Widget configuration is stored in the placement's `widgetContent` JSON:
+
+```json
+{
+  "layout": "grid",
+  "groupFilter": [],
+  "excludeDisabled": true,
+  "showBirthdays": true,
+  "birthdayWindowDays": 7,
+  "sortBy": "displayName",
+  "cardFields": ["displayName", "jobTitle", "department", "email", "phone", "avatar"]
+}
+```
+
+## ADDED Requirements
+
+### Requirement: Widget registration via dashboard API (REQ-PPL-001)
+
+The system MUST register a widget with id `mydash_people` via `OCP\Dashboard\IManager::registerWidget()` in `appinfo/dashboard.php`. The widget MUST have:
+- **id**: `mydash_people`
+- **title**: Translated string (e.g., "People" / "Personen")
+- **icon_url**: Path to SVG icon representing user directory
+- Widget MUST be discoverable via Nextcloud's Dashboard widget discovery mechanism
+
+#### Scenario: Widget is registered on app load
+- **GIVEN** MyDash is installed and enabled
+- **WHEN** Nextcloud boots and calls `IManager::getWidgets()`
+- **THEN** widget `mydash_people` MUST appear in the list
+- **AND** the widget's title and icon MUST be correctly set
+
+#### Scenario: Widget can be added to a dashboard
+- **GIVEN** a user wants to add a widget
+- **WHEN** they open the widget picker
+- **THEN** "People" (or localized variant) MUST be available
+- **AND** clicking "Add" MUST create a placement with `widgetId: "mydash_people"`
+
+#### Scenario: Widget icon is valid SVG
+- **GIVEN** the widget's icon_url
+- **WHEN** the dashboard renders
+- **THEN** the SVG MUST load without errors
+- **AND** the icon MUST follow Conduction brand guidelines (solid shapes, hex colors, no gradients)
+
+### Requirement: Per-placement configuration (REQ-PPL-002)
+
+Each widget placement MUST support configuration stored in the placement's `widgetContent` JSON field. Configuration keys and defaults:
+- `layout: 'card'|'grid'|'list'` (default `grid`)
+- `groupFilter: string[]` (default `[]` — all visible users)
+- `excludeDisabled: boolean` (default `true`)
+- `showBirthdays: boolean` (default `true`)
+- `birthdayWindowDays: number` (default `7`, valid range 0..30)
+- `sortBy: 'displayName'|'group'|'recent-activity'` (default `displayName`)
+- `cardFields: string[]` (default all 6: `displayName`, `jobTitle`, `department`, `email`, `phone`, `avatar`)
+
+The frontend MUST validate `birthdayWindowDays` is between 0 and 30 (inclusive) before saving.
+
+#### Scenario: Config saved to placement
+- **GIVEN** user configures widget layout to "card" with `groupFilter: ["management"]`
+- **WHEN** they save
+- **THEN** the placement's `widgetContent` JSON MUST contain `{"layout": "card", "groupFilter": ["management"], ...}`
+
+#### Scenario: Invalid birthdayWindowDays rejected
+- **GIVEN** user sets `birthdayWindowDays: 50`
+- **WHEN** they save
+- **THEN** the frontend MUST show validation error "Must be between 0 and 30"
+- **AND** the save MUST NOT proceed
+
+#### Scenario: Unknown sortBy value rejected
+- **GIVEN** user sets `sortBy: "unknown-field"`
+- **WHEN** they save
+- **THEN** the frontend MUST reject with error message
+- **AND** fall back to `displayName`
+
+#### Scenario: cardFields subset validated
+- **GIVEN** user configures `cardFields: ["displayName", "email"]` (omitting others)
+- **WHEN** they save and the widget renders
+- **THEN** only displayName and email MUST be shown on cards
+- **AND** other fields MUST NOT appear
+
+### Requirement: Paginated users API endpoint (REQ-PPL-003)
+
+The system MUST expose `GET /api/widgets/people/{placementId}/users?cursor=&limit=50` returning a paginated list of users matching the placement's configuration.
+
+Response shape:
+```json
+{
+  "users": [
+    {
+      "userId": "alice",
+      "displayName": "Alice Smith",
+      "jobTitle": "Product Manager",
+      "department": "Product",
+      "email": "alice@example.com",
+      "phone": "+31612345678",
+      "avatarUrl": "/avatar/alice?size=64",
+      "groups": ["management", "product"],
+      "daysToBirthday": 5
+    }
+  ],
+  "nextCursor": "alice_001"
+}
+```
+
+#### Scenario: Fetch first page of users
+- **GIVEN** a placement with 150 visible users
+- **WHEN** user sends `GET /api/widgets/people/5/users?limit=50` (no cursor)
+- **THEN** the system MUST return HTTP 200 with the first 50 users
+- **AND** `nextCursor` MUST be set (non-null) to fetch the next page
+- **AND** each user object MUST include all fields (subject to visibility rules)
+
+#### Scenario: Fetch second page via cursor
+- **GIVEN** `nextCursor` from the first page
+- **WHEN** user sends `GET /api/widgets/people/5/users?cursor=alice_001&limit=50`
+- **THEN** the system MUST return the next 50 users
+- **AND** pagination MUST not overlap or skip users
+
+#### Scenario: Last page returns null nextCursor
+- **GIVEN** the last page of results (fewer than limit)
+- **WHEN** user fetches that page
+- **THEN** `nextCursor` MUST be `null`
+- **AND** the response MUST indicate no more users available
+
+#### Scenario: Placement not found returns 404
+- **GIVEN** a non-existent placement ID
+- **WHEN** user sends `GET /api/widgets/people/99999/users`
+- **THEN** the system MUST return HTTP 404
+
+#### Scenario: Invalid cursor gracefully handled
+- **GIVEN** a malformed or expired cursor
+- **WHEN** user sends `GET /api/widgets/people/5/users?cursor=invalid`
+- **THEN** the system MUST either restart pagination from the beginning OR return HTTP 400 with clear error message
+
+### Requirement: Profile visibility enforcement (REQ-PPL-004)
+
+The system MUST only return profile fields the requesting viewer is allowed to see, per Nextcloud's `IAccountManager` field-level visibility settings. Hidden fields MUST be omitted entirely from the response (not included with null value).
+
+#### Scenario: Viewer cannot see hidden email
+- **GIVEN** user "alice" has set her email visibility to "private" (not visible to others)
+- **AND** user "bob" is viewing the people widget
+- **WHEN** bob fetches the user list
+- **THEN** alice's entry MUST NOT have an `email` field
+- **AND** the `email` key MUST NOT appear in the response object (not `email: null`)
+
+#### Scenario: Viewer can see visible email
+- **GIVEN** user "alice" has set her email visibility to "public" or "organization"
+- **WHEN** bob fetches the user list
+- **THEN** alice's entry MUST include `email: "alice@example.com"`
+
+#### Scenario: Admin viewing their own profile sees all fields
+- **GIVEN** admin "charlie" requests the people list (viewing themselves)
+- **WHEN** charlie is in the results
+- **THEN** charlie MUST see all their own fields regardless of privacy settings
+- **NOTE**: Users may see all their own fields; privacy is for viewing others.
+
+#### Scenario: Missing birthdate returns null or omits field
+- **GIVEN** user "dave" has not set a birthdate
+- **WHEN** bob fetches the people list with `showBirthdays: true`
+- **THEN** dave's entry MUST have `daysToBirthday: null`
+- **OR** the `daysToBirthday` field MUST be omitted entirely
+
+### Requirement: Birthday computation (REQ-PPL-005)
+
+The system MUST compute `daysToBirthday` at request time from the user's `birthdate` (stored in `IAccountManager`). The value MUST be the number of days until the next upcoming birthday (modulo year), or `null` if:
+- Birthdate not set
+- Birthdate not visible to the viewer
+- `showBirthdays: false` in widget config
+
+Leap-year dates (Feb 29) MUST be handled correctly (celebrated on Feb 28 in non-leap years, or Feb 29 in leap years).
+
+#### Scenario: Upcoming birthday in current year
+- **GIVEN** today is 2026-05-15
+- **AND** user "alice" has birthdate 1990-06-10
+- **WHEN** system computes `daysToBirthday`
+- **THEN** result MUST be 26 (days until June 10, 2026)
+
+#### Scenario: Past birthday this year wraps to next year
+- **GIVEN** today is 2026-06-15
+- **AND** user "bob" has birthdate 1990-05-10 (birthday was 36 days ago)
+- **WHEN** system computes `daysToBirthday`
+- **THEN** result MUST be 330 (days until May 10, 2027)
+
+#### Scenario: Birthday today returns 0
+- **GIVEN** today is 2026-06-10
+- **AND** user "charlie" has birthdate 1990-06-10
+- **WHEN** system computes `daysToBirthday`
+- **THEN** result MUST be 0
+
+#### Scenario: Leap-year birthday in non-leap-year
+- **GIVEN** today is 2025-02-27
+- **AND** user "dave" has birthdate 1990-02-29
+- **WHEN** system computes `daysToBirthday` in 2025 (non-leap year)
+- **THEN** result MUST be 1 (Feb 29 celebrated on Feb 28; tomorrow is Feb 28, 2025)
+
+#### Scenario: Birthdate hidden from viewer returns null
+- **GIVEN** user "eve" has marked her birthdate as private
+- **AND** user "frank" is the viewer
+- **WHEN** frank requests the people list
+- **THEN** eve's entry MUST have `daysToBirthday: null`
+
+#### Scenario: showBirthdays disabled returns null
+- **GIVEN** placement config has `showBirthdays: false`
+- **WHEN** system computes results
+- **THEN** all entries MUST have `daysToBirthday: null`
+- **AND** birthday information MUST NOT be sent to the frontend
+
+### Requirement: Group filtering (REQ-PPL-006)
+
+The system MUST apply the `groupFilter` configuration to restrict results to users in any of the specified Nextcloud groups. An empty `groupFilter: []` means all visible users. A non-empty filter MUST intersect: only users in ANY of the listed groups are returned.
+
+#### Scenario: Empty group filter returns all visible users
+- **GIVEN** placement config has `groupFilter: []`
+- **WHEN** system fetches user list
+- **THEN** all NC users visible to the viewer MUST be returned (subject to `excludeDisabled`, `showBirthdays`, field visibility)
+
+#### Scenario: Single group filter
+- **GIVEN** `groupFilter: ["management"]`
+- **WHEN** system fetches user list
+- **THEN** only users in the "management" group MUST be returned
+- **AND** users in other groups MUST be excluded
+- **AND** `groups` field MUST show all groups the user belongs to (not just the matched group)
+
+#### Scenario: Multiple group filter (union)
+- **GIVEN** `groupFilter: ["management", "product"]`
+- **WHEN** system fetches user list
+- **THEN** users in either "management" OR "product" MUST be returned
+- **AND** users in both groups appear only once (not duplicated)
+
+#### Scenario: Unknown group name handled gracefully
+- **GIVEN** `groupFilter: ["nonexistent-group"]`
+- **WHEN** system fetches user list
+- **THEN** no users MUST be returned (intersection is empty)
+- **OR** the system MUST return HTTP 400 with error message "Unknown group: nonexistent-group"
+
+#### Scenario: Users in group appear in results with group list
+- **GIVEN** user "alice" is in groups ["management", "product"]
+- **AND** `groupFilter: ["management"]`
+- **WHEN** system returns alice
+- **THEN** alice's `groups` array MUST show `["management", "product"]` (all her groups)
+
+### Requirement: Avatar URLs (REQ-PPL-007)
+
+The system MUST provide avatar URLs via Nextcloud's standard avatar endpoint. The avatar size MUST be configurable via the app config key `mydash.people_widget_avatar_size` (default 64 pixels). URLs MUST point to `/avatar/{userId}?size={pixelSize}` and MUST always succeed (Nextcloud returns a placeholder for missing avatars).
+
+#### Scenario: Avatar URL for existing user
+- **GIVEN** user "alice" with avatar
+- **AND** config `mydash.people_widget_avatar_size: 64`
+- **WHEN** system returns alice in the user list
+- **THEN** `avatarUrl` MUST be `/avatar/alice?size=64`
+
+#### Scenario: Avatar URL for user without avatar
+- **GIVEN** user "bob" with no avatar uploaded
+- **WHEN** system returns bob
+- **THEN** `avatarUrl` MUST still be `/avatar/bob?size=64`
+- **AND** Nextcloud MUST serve a default placeholder
+
+#### Scenario: Custom avatar size from config
+- **GIVEN** admin sets `mydash.people_widget_avatar_size: 128`
+- **WHEN** system fetches user list
+- **THEN** all `avatarUrl` values MUST have `?size=128`
+
+#### Scenario: Avatar size bounds validation
+- **GIVEN** admin sets `mydash.people_widget_avatar_size: -5` or `50000`
+- **WHEN** system fetches user list
+- **THEN** invalid sizes MUST be clamped to a reasonable range (e.g., 16..1024)
+- **AND** the widget MUST still render without error
+
+### Requirement: Three layout modes (REQ-PPL-008)
+
+The frontend MUST support three layout modes: `card`, `grid`, and `list`. Each layout MUST respect the `cardFields` configuration for which fields to display.
+
+**Card layout** (`layout: 'card'`):
+- Displays full profile cards (~200×280 px each)
+- Avatar: ~64 px, top/center
+- Fields stacked vertically below avatar (displayName, jobTitle, department, email, phone)
+- Birthday badge "🎂 in N days" overlaid on avatar (if applicable)
+- Hover effect (optional): subtle shadow/scale
+
+**Grid layout** (`layout: 'grid'`):
+- Compact grid of small cards (~80×120 px each)
+- Avatar: ~48 px centered
+- Display name below avatar (1-2 lines, truncated if needed)
+- Birthday badge "🎂 in N days" small, bottom-right of avatar (if applicable)
+- Optimized for many users on a narrow dashboard
+
+**List layout** (`layout: 'list'`):
+- Single-line rows (height ~40 px)
+- Avatar: ~32 px, left side
+- Name + optional secondary field (email or department, configured via `cardFields`)
+- Hover: highlight row background
+- Birthday badge: "🎂 in N days" on the right side (if applicable)
+
+#### Scenario: Card layout displays full profile
+- **GIVEN** `layout: 'card'`, `cardFields: ["displayName", "jobTitle", "department", "email"]`
+- **WHEN** widget renders 10 users
+- **THEN** each card MUST show avatar + all 4 configured fields
+- **AND** cards MUST be approximately 200×280 px each
+- **AND** cards MUST stack vertically or in a shallow grid
+
+#### Scenario: Grid layout shows avatar + name only
+- **GIVEN** `layout: 'grid'`, any `cardFields` value
+- **WHEN** widget renders 20 users
+- **THEN** each cell MUST show avatar (~48 px) + display name (2 lines max, truncated)
+- **AND** cells MUST be approximately 80×120 px each
+- **AND** cells MUST fit 3-4 per row on a typical dashboard
+
+#### Scenario: List layout shows compact rows
+- **GIVEN** `layout: 'list'`, `cardFields: ["displayName", "email"]`
+- **WHEN** widget renders 50 users
+- **THEN** each row MUST be a single line (~40 px height)
+- **AND** row MUST show avatar (~32 px) + name + email
+- **AND** rows MUST be scrollable if they exceed widget height
+
+#### Scenario: Birthday badge displays when applicable
+- **GIVEN** user "alice" has `daysToBirthday: 5`, `birthdayWindowDays: 7`
+- **WHEN** widget renders alice in any layout
+- **THEN** a "🎂 in 5 days" badge MUST appear (exact emoji/text configurable)
+- **AND** badge position MUST adapt to layout (card: top-right, grid: bottom-right, list: right side)
+
+#### Scenario: cardFields filtered per layout
+- **GIVEN** `cardFields: ["displayName", "department"]` (omitting email, phone, jobTitle)
+- **WHEN** card layout renders
+- **THEN** only displayName and department MUST be shown
+- **AND** email, phone, jobTitle MUST NOT appear
+
+### Requirement: Empty state and error handling (REQ-PPL-009)
+
+The widget MUST display a user-friendly message when no results are available.
+
+#### Scenario: No users match filter
+- **GIVEN** `groupFilter: ["nonexistent-group"]` (no users in group)
+- **WHEN** widget renders
+- **THEN** text "No matching users." MUST be displayed (localized to user's language)
+- **AND** no broken/empty grid MUST appear
+
+#### Scenario: Failed API request
+- **GIVEN** the `/api/widgets/people/{placementId}/users` endpoint returns 500 error
+- **WHEN** widget renders
+- **THEN** error message "Failed to load users" MUST be displayed
+- **AND** a "Retry" button MUST be provided
+- **AND** widget MUST NOT crash or show raw error traces
+
+#### Scenario: Placement not found
+- **GIVEN** placement has been deleted
+- **WHEN** widget tries to fetch users via invalid placement ID
+- **THEN** widget MUST show "Widget configuration missing or invalid"
+- **AND** user MUST be able to remove/reconfigure the widget
+
+#### Scenario: Empty result after search
+- **GIVEN** user searches for "zzz" (no matching names/emails)
+- **WHEN** search is applied
+- **THEN** message "No users match your search" MUST appear
+
+### Requirement: Click-through to user profile (REQ-PPL-010)
+
+Clicking on a user profile card (or avatar, or name in list view) MUST open Nextcloud's standard user profile page.
+
+#### Scenario: Card click opens profile
+- **GIVEN** user "alice" is displayed in card layout
+- **WHEN** user clicks the card (or avatar or name)
+- **THEN** browser MUST navigate to `/u/alice` in the SAME tab (not new tab)
+- **AND** Nextcloud's user profile page MUST load
+
+#### Scenario: List item click opens profile
+- **GIVEN** user "bob" is displayed in list layout
+- **WHEN** user clicks the row (or name)
+- **THEN** browser MUST navigate to `/u/bob` in the same tab
+
+#### Scenario: Avatar click opens profile
+- **GIVEN** any layout
+- **WHEN** user clicks the avatar image
+- **THEN** browser MUST navigate to `/u/{userId}` in the same tab
+
+#### Scenario: Profile page respects access control
+- **GIVEN** user "charlie" does not have access to see user "dave"'s profile
+- **WHEN** charlie tries to navigate to `/u/dave` (via widget or manually)
+- **THEN** Nextcloud MUST return appropriate error page (access denied)
+- **NOTE**: The widget's visibility filtering prevents dave appearing in the list if charlie cannot see them; this scenario is a safety check for direct URL access.
+
+### Requirement: In-widget search (REQ-PPL-011)
+
+The widget MUST provide a search input that filters displayed users by substring match on `displayName` and `email` (case-insensitive). Search operates on the current page only; pagination is not affected by search results.
+
+#### Scenario: Search filters current page
+- **GIVEN** widget is showing page 1 of 50 users
+- **AND** user types "john" in search box
+- **WHEN** search is applied
+- **THEN** only users on the current page with "john" in displayName or email MUST be shown
+- **AND** pagination to page 2 MUST NOT be affected by search
+
+#### Scenario: Search is case-insensitive
+- **GIVEN** search box contains "ALICE"
+- **WHEN** search is applied
+- **THEN** user "alice smith" and "Alice Johnson" MUST both match
+
+#### Scenario: Search on email
+- **GIVEN** user types "example.com" in search box
+- **WHEN** search is applied
+- **THEN** all users with "example.com" in their email MUST be shown
+
+#### Scenario: Clear search restores all users
+- **GIVEN** search is active and filtering results
+- **WHEN** user clears the search box
+- **THEN** all users on current page MUST be shown again
+
+#### Scenario: Search input UI affordance
+- **GIVEN** widget renders
+- **WHEN** user looks at the widget
+- **THEN** a search input MUST be visible (e.g., in the widget header or body, with placeholder "Search by name or email...")
+
+### Requirement: Client-side caching and refresh (REQ-PPL-012)
+
+The widget MUST cache results in memory for 60 seconds per placement. A force-refresh button MUST clear the cache and immediately re-fetch user list from the backend.
+
+#### Scenario: Results cached for 60 seconds
+- **GIVEN** user fetches the people list (first load)
+- **WHEN** user closes and reopens the widget within 60 seconds
+- **THEN** the second open MUST use cached results (no new API call)
+- **AND** displayed data MUST match the first fetch
+
+#### Scenario: Cache expires after 60 seconds
+- **GIVEN** results were fetched at time T
+- **WHEN** user opens widget at time T + 61 seconds
+- **THEN** a fresh API call MUST be made
+- **AND** results MAY differ if users/profiles have changed
+
+#### Scenario: Force-refresh clears cache
+- **GIVEN** cached results are displayed
+- **WHEN** user clicks "Refresh" button in widget header
+- **THEN** cache MUST be cleared immediately
+- **AND** new API call MUST be made to backend
+- **AND** results MUST update to latest state
+
+#### Scenario: Tab/browser focus refreshes cache
+- **GIVEN** user switches away from browser tab and back
+- **WHEN** user returns to the tab
+- **THEN** cache MAY be invalidated (optional)
+- **AND** widget SHOULD refetch on re-focus (recommended UX)
+
+## Non-Functional Requirements
+
+- **Performance**: `GET /api/widgets/people/{placementId}/users` MUST return within 1 second for orgs with <1000 users. Pagination with limit=50 MUST be efficient (cursor-based, not offset-based).
+- **Compatibility**: Widget MUST work with all Nextcloud versions supported by MyDash (currently 25+).
+- **Data integrity**: User list MUST reflect real-time group membership (no stale cache on backend).
+- **Accessibility**: Widget MUST support keyboard navigation (Tab through users, Enter to open profile). All fields MUST have accessible labels. Avatar images MUST have alt text.
+- **Localization**: All user-facing strings MUST support English and Dutch (nl/en). Birthday computation MUST work with any user's locale.
+- **Privacy**: Hidden profile fields MUST NEVER be returned to the client (not even nulled). Birthday information MUST respect visibility settings.
+
+## Current Implementation Status
+
+**Not yet implemented**: This is a new capability for v1 of the people widget.
+
+**Planned follow-ups** (separate changes):
+- `people-widget-presence`: Show online/away/do-not-disturb status via `OCP\UserStatus`
+- `people-widget-activity`: Implement `sortBy: 'recent-activity'` via `OCP\Activity\IManager`
+- `people-widget-export`: CSV export of visible users + birthdays
+- `people-widget-acl`: Per-user visibility rules (e.g., HR department only)
+
+### Standards & References
+
+- Nextcloud Dashboard Widget API: `OCP\Dashboard\IManager::registerWidget()`, `IWidget` interface
+- Nextcloud User Management: `OCP\IUserManager::getUsers()`, `OCP\IGroupManager::displayNamesInGroup()`
+- Nextcloud Profile: `OCP\Accounts\IAccountManager` (field-level visibility, birthdate storage)
+- Nextcloud User Status: `OCP\UserStatus\IManager` (for presence, future feature)
+- Avatar serving: `/avatar/{userId}?size=N` standard NC endpoint
+- WCAG 2.1 AA: Alt text for avatars, keyboard navigation, color contrast for badges
+- WAI-ARIA: List roles, button semantics for profile clicks and search

--- a/openspec/changes/people-widget/specs/people-widget/spec.md
+++ b/openspec/changes/people-widget/specs/people-widget/spec.md
@@ -6,33 +6,57 @@ status: draft
 
 ## Purpose
 
-The `people-widget` capability registers a dashboard widget that displays a discoverable directory of Nextcloud users with customizable layout (card/grid/list), profile field visibility control, group filtering, and birthday tracking. The widget integrates with Nextcloud's Dashboard Widget API via `OCP\Dashboard\IManager`, stores configuration in the widget placement's JSON config, and provides a paginated API endpoint for user lookup. Results respect each user's profile visibility settings, and birthdays are computed at request time to ensure accuracy.
+The `people-widget` capability registers a dashboard widget that displays a discoverable directory of Nextcloud users with customizable layout (card/grid/list), profile field visibility control, group filtering, and birthday tracking. The widget integrates with Nextcloud's Dashboard Widget API via `OCP\Dashboard\IManager`, stores configuration in the widget placement's JSON config, and provides a paginated API endpoint for user lookup. Results expose each user's profile fields as returned by `OCP\Accounts\IAccountManager`; scope-based visibility filtering is a planned follow-up (see REQ-PPL-004).
 
 ## Data Model
 
-User listings are stateless and fetched per-request via `GET /api/widgets/people/{placementId}/users`. Results include:
+User listings are stateless and fetched per-request via `GET /api/people`. Results include:
 
-- **userId**: Unique NC user ID
-- **displayName**: User's configured display name
-- **jobTitle**: From `OCP\Accounts\IAccountManager` (if visible)
-- **department**: From `OCP\Accounts\IAccountManager` (if visible)
-- **email**: From `OCP\Accounts\IAccountManager` (if visible)
-- **phone**: From `OCP\Accounts\IAccountManager` (if visible)
-- **avatarUrl**: NC's standard avatar endpoint at configured size (default 64×64)
+- **uid**: Unique NC user ID
+- **displayName**: User's configured display name (from `IUser::getDisplayName()`)
+- **email**: From `OCP\Accounts\IAccountManager` (if non-empty)
+- **phone**: From `OCP\Accounts\IAccountManager` (if non-empty)
+- **avatarUrl**: NC's standard avatar endpoint, always fetched at 128 px resolution; display size is layout-dependent (80 px card / 64 px grid / 44 px list)
 - **groups**: Array of NC group names the user belongs to
-- **daysToBirthday**: Integer (0..365) or null. Null if birthdate not set, not visible to viewer, or `showBirthdays: false`.
+- **role**: From `IAccountManager::PROPERTY_ROLE` (job title / function)
+- **organisation**: From `IAccountManager::PROPERTY_ORGANISATION`
+- **pronouns**: From `IAccountManager::PROPERTY_PRONOUNS` (if non-empty)
+- **headline**: From `IAccountManager::PROPERTY_HEADLINE` (if non-empty)
+- **biography**: From `IAccountManager::PROPERTY_BIOGRAPHY` (if non-empty)
+- **address**: From `IAccountManager::PROPERTY_ADDRESS` (if non-empty)
+- **website**: From `IAccountManager::PROPERTY_WEBSITE` (if non-empty)
+- **twitter**: From `IAccountManager::PROPERTY_TWITTER` (if non-empty)
+- **bluesky**: From `IAccountManager::PROPERTY_BLUESKY` (if non-empty)
+- **fediverse**: From `IAccountManager::PROPERTY_FEDIVERSE` (if non-empty)
+- **birthdate**: ISO 8601 date string or null. Null if birthdate not set. Days-to-birthday display is computed client-side from this value.
+- **status**: User status string from `IUserStatusManager` (optional, omitted if not available)
+- *(dynamic)*: LDAP/OIDC extra properties and app-level custom fields may appear as additional keys
+
+Fields are omitted from the response when their value is empty or null; they are never included with a null value unless explicitly noted.
 
 Widget configuration is stored in the placement's `widgetContent` JSON:
 
 ```json
 {
   "layout": "grid",
-  "groupFilter": [],
+  "selectionMode": "filter",
+  "selectedUsers": [],
+  "filters": [{"fieldName": "group", "operator": "in", "values": ["management"]}],
+  "filterOperator": "AND",
   "excludeDisabled": true,
   "showBirthdays": true,
   "birthdayWindowDays": 7,
   "sortBy": "displayName",
-  "cardFields": ["displayName", "jobTitle", "department", "email", "phone", "avatar"]
+  "columns": 3,
+  "showFields": {
+    "displayName": true,
+    "role": true,
+    "organisation": true,
+    "email": true,
+    "phone": true,
+    "avatar": true,
+    "birthdate": true
+  }
 }
 ```
 
@@ -68,19 +92,23 @@ The system MUST register a widget with id `mydash_people` via `OCP\Dashboard\IMa
 
 Each widget placement MUST support configuration stored in the placement's `widgetContent` JSON field. Configuration keys and defaults:
 - `layout: 'card'|'grid'|'list'` (default `grid`)
-- `groupFilter: string[]` (default `[]` — all visible users)
+- `selectionMode: 'manual'|'filter'` (default `filter`)
+- `selectedUsers: string[]` (default `[]` — used when `selectionMode: 'manual'`)
+- `filters: FilterObject[]` (default `[]` — filter objects with `fieldName`, `operator`, `values`; group filtering is expressed here as `{fieldName: "group", operator: "in", values: [...]}`)
+- `filterOperator: 'AND'|'OR'` (default `'AND'`)
 - `excludeDisabled: boolean` (default `true`)
 - `showBirthdays: boolean` (default `true`)
 - `birthdayWindowDays: number` (default `7`, valid range 0..30)
 - `sortBy: 'displayName'|'group'|'recent-activity'` (default `displayName`)
-- `cardFields: string[]` (default all 6: `displayName`, `jobTitle`, `department`, `email`, `phone`, `avatar`)
+- `columns: 2|3|4` (default `3` for card, `4` for grid; not applicable to list layout)
+- `showFields: object` (map of field name to boolean; default all fields `true`)
 
 The frontend MUST validate `birthdayWindowDays` is between 0 and 30 (inclusive) before saving.
 
 #### Scenario: Config saved to placement
-- **GIVEN** user configures widget layout to "card" with `groupFilter: ["management"]`
+- **GIVEN** user configures widget layout to "card" with a group filter for "management"
 - **WHEN** they save
-- **THEN** the placement's `widgetContent` JSON MUST contain `{"layout": "card", "groupFilter": ["management"], ...}`
+- **THEN** the placement's `widgetContent` JSON MUST contain `{"layout": "card", "filters": [{"fieldName": "group", "operator": "in", "values": ["management"]}], ...}`
 
 #### Scenario: Invalid birthdayWindowDays rejected
 - **GIVEN** user sets `birthdayWindowDays: 50`
@@ -94,77 +122,86 @@ The frontend MUST validate `birthdayWindowDays` is between 0 and 30 (inclusive) 
 - **THEN** the frontend MUST reject with error message
 - **AND** fall back to `displayName`
 
-#### Scenario: cardFields subset validated
-- **GIVEN** user configures `cardFields: ["displayName", "email"]` (omitting others)
+#### Scenario: showFields subset validated
+- **GIVEN** user configures `showFields: {"displayName": true, "email": true}` (omitting others)
 - **WHEN** they save and the widget renders
 - **THEN** only displayName and email MUST be shown on cards
 - **AND** other fields MUST NOT appear
 
 ### Requirement: Paginated users API endpoint (REQ-PPL-003)
 
-The system MUST expose `GET /api/widgets/people/{placementId}/users?cursor=&limit=50` returning a paginated list of users matching the placement's configuration.
+The system MUST expose `GET /api/people?filters=...&limit=50&offset=0` returning a paginated list of users matching the request parameters. Pagination is offset-based. Maximum `limit` is 100.
 
 Response shape:
 ```json
 {
   "users": [
     {
-      "userId": "alice",
+      "uid": "alice",
       "displayName": "Alice Smith",
-      "jobTitle": "Product Manager",
-      "department": "Product",
+      "role": "Product Manager",
+      "organisation": "Product",
       "email": "alice@example.com",
       "phone": "+31612345678",
-      "avatarUrl": "/avatar/alice?size=64",
+      "avatarUrl": "https://example.com/avatar/alice/128",
       "groups": ["management", "product"],
-      "daysToBirthday": 5
+      "birthdate": "1990-06-10",
+      "status": "online"
     }
   ],
-  "nextCursor": "alice_001"
+  "total": 150,
+  "hasMore": true
 }
 ```
 
 #### Scenario: Fetch first page of users
-- **GIVEN** a placement with 150 visible users
-- **WHEN** user sends `GET /api/widgets/people/5/users?limit=50` (no cursor)
+- **GIVEN** 150 visible users
+- **WHEN** client sends `GET /api/people?limit=50&offset=0`
 - **THEN** the system MUST return HTTP 200 with the first 50 users
-- **AND** `nextCursor` MUST be set (non-null) to fetch the next page
-- **AND** each user object MUST include all fields (subject to visibility rules)
+- **AND** `hasMore` MUST be `true`
+- **AND** `total` MUST be `150`
+- **AND** each user object MUST include all non-empty fields
 
-#### Scenario: Fetch second page via cursor
-- **GIVEN** `nextCursor` from the first page
-- **WHEN** user sends `GET /api/widgets/people/5/users?cursor=alice_001&limit=50`
+#### Scenario: Fetch second page via offset
+- **GIVEN** a first page of 50 users was fetched
+- **WHEN** client sends `GET /api/people?limit=50&offset=50`
 - **THEN** the system MUST return the next 50 users
-- **AND** pagination MUST not overlap or skip users
+- **AND** results MUST NOT overlap with the first page
 
-#### Scenario: Last page returns null nextCursor
-- **GIVEN** the last page of results (fewer than limit)
-- **WHEN** user fetches that page
-- **THEN** `nextCursor` MUST be `null`
-- **AND** the response MUST indicate no more users available
+#### Scenario: Last page returns hasMore false
+- **GIVEN** the last page of results (fewer users remaining than limit)
+- **WHEN** client fetches that page
+- **THEN** `hasMore` MUST be `false`
+- **AND** `total` MUST reflect the full result count
 
-#### Scenario: Placement not found returns 404
-- **GIVEN** a non-existent placement ID
-- **WHEN** user sends `GET /api/widgets/people/99999/users`
-- **THEN** the system MUST return HTTP 404
+#### Scenario: limit exceeds maximum returns 400
+- **GIVEN** client sends `GET /api/people?limit=200`
+- **WHEN** request is processed
+- **THEN** the system MUST return HTTP 400
+- **AND** response MUST contain a clear error message indicating the maximum is 100
 
-#### Scenario: Invalid cursor gracefully handled
-- **GIVEN** a malformed or expired cursor
-- **WHEN** user sends `GET /api/widgets/people/5/users?cursor=invalid`
-- **THEN** the system MUST either restart pagination from the beginning OR return HTTP 400 with clear error message
+#### Scenario: Invalid offset or limit type handled
+- **GIVEN** a malformed offset or limit (e.g. negative or non-integer)
+- **WHEN** client sends the request
+- **THEN** the system MUST return HTTP 400 with a clear error message
 
 ### Requirement: Profile visibility enforcement (REQ-PPL-004)
 
-The system MUST only return profile fields the requesting viewer is allowed to see, per Nextcloud's `IAccountManager` field-level visibility settings. Hidden fields MUST be omitted entirely from the response (not included with null value).
+The system MUST NOT return empty or null field values — all returned fields MUST have a non-empty value. The system SHOULD only return profile fields the requesting viewer is allowed to see, per Nextcloud's `IAccountManager` field-level visibility settings. Hidden fields SHOULD be omitted entirely from the response (not included with null value).
 
-#### Scenario: Viewer cannot see hidden email
+**NOTE (v1 limitation)**: The current implementation reads `IAccountManager` properties unconditionally via `$account->getProperty($property)->getValue()` without checking `$prop->getScope()`. All non-empty profile fields are returned to any authenticated viewer regardless of the user's privacy settings. Enforcing NC scope-based visibility is a planned follow-up (see Open Follow-Ups).
+
+**NOTE (caching risk)**: The non-group-filter path uses a 1-hour shared APCu cache keyed only on filter + sort parameters, not on the requesting user. If scope-based visibility is enforced in a future revision, this cache MUST be made per-viewer or disabled to prevent data leakage.
+
+#### Scenario: Viewer cannot see hidden email (future)
 - **GIVEN** user "alice" has set her email visibility to "private" (not visible to others)
 - **AND** user "bob" is viewing the people widget
 - **WHEN** bob fetches the user list
-- **THEN** alice's entry MUST NOT have an `email` field
-- **AND** the `email` key MUST NOT appear in the response object (not `email: null`)
+- **THEN** alice's entry SHOULD NOT have an `email` field
+- **AND** the `email` key SHOULD NOT appear in the response object (not `email: null`)
+- **NOTE**: This scenario describes the target state; scope-based filtering is not enforced in v1.
 
-#### Scenario: Viewer can see visible email
+#### Scenario: Viewer can see visible email (future)
 - **GIVEN** user "alice" has set her email visibility to "public" or "organization"
 - **WHEN** bob fetches the user list
 - **THEN** alice's entry MUST include `email: "alice@example.com"`
@@ -175,198 +212,177 @@ The system MUST only return profile fields the requesting viewer is allowed to s
 - **THEN** charlie MUST see all their own fields regardless of privacy settings
 - **NOTE**: Users may see all their own fields; privacy is for viewing others.
 
-#### Scenario: Missing birthdate returns null or omits field
+#### Scenario: Missing birthdate returns omitted field
 - **GIVEN** user "dave" has not set a birthdate
 - **WHEN** bob fetches the people list with `showBirthdays: true`
-- **THEN** dave's entry MUST have `daysToBirthday: null`
-- **OR** the `daysToBirthday` field MUST be omitted entirely
+- **THEN** dave's entry MUST NOT include a `birthdate` field (omitted, not nulled)
 
-### Requirement: Birthday computation (REQ-PPL-005)
+### Requirement: Birthday field (REQ-PPL-005)
 
-The system MUST compute `daysToBirthday` at request time from the user's `birthdate` (stored in `IAccountManager`). The value MUST be the number of days until the next upcoming birthday (modulo year), or `null` if:
-- Birthdate not set
-- Birthdate not visible to the viewer
-- `showBirthdays: false` in widget config
+The system MUST return `birthdate` as an ISO 8601 date string (e.g. `"1990-06-10"`) when the user has a birthdate set in `IAccountManager::PROPERTY_BIRTHDATE`. The raw value may be stored in locale-specific formats (DD-MM-YYYY, DD/MM/YYYY, DD.MM.YYYY) and MUST be normalized to ISO 8601 server-side before being returned. If the birthdate is not set the field MUST be omitted from the response.
 
-Leap-year dates (Feb 29) MUST be handled correctly (celebrated on Feb 28 in non-leap years, or Feb 29 in leap years).
+Birthday window filtering (e.g. "upcoming birthdays in next N days") is expressed as a filter object `{fieldName: "birthday", operator: "within_next_days", values: [7]}`. This filter is computed server-side as a predicate but the `birthdate` string (not a days-countdown) is what is returned in the response.
 
-#### Scenario: Upcoming birthday in current year
+Days-to-birthday display logic MUST be computed client-side from the returned `birthdate` string.
+
+**NOTE (Feb-29 guard)**: The `within_next_days` filter operator constructs the current-year birthday date as `YYYY-MM-DD` from the stored month-day without a Feb-29 guard. This will throw an exception on non-leap years for users with a Feb-29 birthday. A guard must be added (see Open Follow-Ups).
+
+#### Scenario: Upcoming birthday returned as ISO string
 - **GIVEN** today is 2026-05-15
-- **AND** user "alice" has birthdate 1990-06-10
-- **WHEN** system computes `daysToBirthday`
-- **THEN** result MUST be 26 (days until June 10, 2026)
+- **AND** user "alice" has birthdate stored as "10-06-1990"
+- **WHEN** system returns alice's profile
+- **THEN** `birthdate` MUST be `"1990-06-10"` (ISO 8601 normalized)
 
-#### Scenario: Past birthday this year wraps to next year
-- **GIVEN** today is 2026-06-15
-- **AND** user "bob" has birthdate 1990-05-10 (birthday was 36 days ago)
-- **WHEN** system computes `daysToBirthday`
-- **THEN** result MUST be 330 (days until May 10, 2027)
+#### Scenario: Birthday filter within_next_days
+- **GIVEN** placement config requests birthday filter `within_next_days: 7`
+- **AND** today is 2026-05-15
+- **WHEN** system fetches user list
+- **THEN** only users whose birthday falls between 2026-05-15 and 2026-05-22 MUST be included
+- **AND** each included user's `birthdate` MUST be the ISO date string of their birthday
 
-#### Scenario: Birthday today returns 0
+#### Scenario: Birthday today is included
 - **GIVEN** today is 2026-06-10
 - **AND** user "charlie" has birthdate 1990-06-10
-- **WHEN** system computes `daysToBirthday`
-- **THEN** result MUST be 0
+- **WHEN** system applies `within_next_days: 7` filter
+- **THEN** charlie MUST be included in results
+- **AND** `birthdate` MUST be `"1990-06-10"`
 
-#### Scenario: Leap-year birthday in non-leap-year
-- **GIVEN** today is 2025-02-27
-- **AND** user "dave" has birthdate 1990-02-29
-- **WHEN** system computes `daysToBirthday` in 2025 (non-leap year)
-- **THEN** result MUST be 1 (Feb 29 celebrated on Feb 28; tomorrow is Feb 28, 2025)
+#### Scenario: Missing birthdate omits field
+- **GIVEN** user "dave" has not set a birthdate
+- **WHEN** any request is processed
+- **THEN** dave's entry MUST NOT include a `birthdate` field
 
-#### Scenario: Birthdate hidden from viewer returns null
-- **GIVEN** user "eve" has marked her birthdate as private
-- **AND** user "frank" is the viewer
-- **WHEN** frank requests the people list
-- **THEN** eve's entry MUST have `daysToBirthday: null`
-
-#### Scenario: showBirthdays disabled returns null
+#### Scenario: showBirthdays false omits birthdate
 - **GIVEN** placement config has `showBirthdays: false`
 - **WHEN** system computes results
-- **THEN** all entries MUST have `daysToBirthday: null`
+- **THEN** all entries MUST NOT include a `birthdate` field
 - **AND** birthday information MUST NOT be sent to the frontend
 
 ### Requirement: Group filtering (REQ-PPL-006)
 
-The system MUST apply the `groupFilter` configuration to restrict results to users in any of the specified Nextcloud groups. An empty `groupFilter: []` means all visible users. A non-empty filter MUST intersect: only users in ANY of the listed groups are returned.
+The system MUST apply group filters expressed as filter objects in the `filters` array (where `fieldName === 'group'`) to restrict results to users in any of the specified Nextcloud groups. An empty `filters` array means all visible users. A group filter MUST use a union (OR) strategy: users in ANY of the listed group values are included. Deduplication MUST be applied so users appearing in multiple groups appear only once.
 
-#### Scenario: Empty group filter returns all visible users
-- **GIVEN** placement config has `groupFilter: []`
+Group filtering is implemented via `IGroupManager::get($groupId)->getUsers()`. An unknown group name MUST yield zero users for that group value (no error), and the results from other group values in the filter are still returned.
+
+#### Scenario: Empty filters returns all visible users
+- **GIVEN** placement config has `filters: []`
 - **WHEN** system fetches user list
-- **THEN** all NC users visible to the viewer MUST be returned (subject to `excludeDisabled`, `showBirthdays`, field visibility)
+- **THEN** all NC users visible to the viewer MUST be returned (subject to `excludeDisabled` and field visibility)
 
 #### Scenario: Single group filter
-- **GIVEN** `groupFilter: ["management"]`
+- **GIVEN** `filters: [{"fieldName": "group", "operator": "in", "values": ["management"]}]`
 - **WHEN** system fetches user list
 - **THEN** only users in the "management" group MUST be returned
 - **AND** users in other groups MUST be excluded
 - **AND** `groups` field MUST show all groups the user belongs to (not just the matched group)
 
-#### Scenario: Multiple group filter (union)
-- **GIVEN** `groupFilter: ["management", "product"]`
+#### Scenario: Multiple group values (union)
+- **GIVEN** `filters: [{"fieldName": "group", "operator": "in", "values": ["management", "product"]}]`
 - **WHEN** system fetches user list
 - **THEN** users in either "management" OR "product" MUST be returned
-- **AND** users in both groups appear only once (not duplicated)
+- **AND** users belonging to both groups MUST appear only once (deduplicated)
 
 #### Scenario: Unknown group name handled gracefully
-- **GIVEN** `groupFilter: ["nonexistent-group"]`
+- **GIVEN** `filters: [{"fieldName": "group", "operator": "in", "values": ["nonexistent-group"]}]`
 - **WHEN** system fetches user list
-- **THEN** no users MUST be returned (intersection is empty)
-- **OR** the system MUST return HTTP 400 with error message "Unknown group: nonexistent-group"
+- **THEN** no users MUST be returned (the unknown group yields zero users)
+- **AND** the system MUST return HTTP 200 with an empty `users` array (not HTTP 400 or 500)
 
-#### Scenario: Users in group appear in results with group list
+#### Scenario: Users in group appear with full group list
 - **GIVEN** user "alice" is in groups ["management", "product"]
-- **AND** `groupFilter: ["management"]`
+- **AND** `filters: [{"fieldName": "group", "operator": "in", "values": ["management"]}]`
 - **WHEN** system returns alice
 - **THEN** alice's `groups` array MUST show `["management", "product"]` (all her groups)
 
 ### Requirement: Avatar URLs (REQ-PPL-007)
 
-The system MUST provide avatar URLs via Nextcloud's standard avatar endpoint. The avatar size MUST be configurable via the app config key `mydash.people_widget_avatar_size` (default 64 pixels). URLs MUST point to `/avatar/{userId}?size={pixelSize}` and MUST always succeed (Nextcloud returns a placeholder for missing avatars).
+The system MUST provide absolute avatar URLs via Nextcloud's standard avatar route (`core.avatar.getAvatar`). The avatar route MUST always be fetched at 128 px resolution. Display size is layout-dependent and controlled by the frontend component (80 px for card, 64 px for grid, 44 px for list). There is no app config key for avatar size. Nextcloud returns a generated placeholder avatar for users without an uploaded avatar, so URLs MUST always succeed.
 
 #### Scenario: Avatar URL for existing user
-- **GIVEN** user "alice" with avatar
-- **AND** config `mydash.people_widget_avatar_size: 64`
+- **GIVEN** user "alice" with an uploaded avatar
 - **WHEN** system returns alice in the user list
-- **THEN** `avatarUrl` MUST be `/avatar/alice?size=64`
+- **THEN** `avatarUrl` MUST be an absolute URL to the NC avatar route at size 128
 
 #### Scenario: Avatar URL for user without avatar
 - **GIVEN** user "bob" with no avatar uploaded
 - **WHEN** system returns bob
-- **THEN** `avatarUrl` MUST still be `/avatar/bob?size=64`
-- **AND** Nextcloud MUST serve a default placeholder
+- **THEN** `avatarUrl` MUST still be a valid absolute URL pointing to NC's avatar route
+- **AND** Nextcloud MUST serve a generated placeholder avatar
 
-#### Scenario: Custom avatar size from config
-- **GIVEN** admin sets `mydash.people_widget_avatar_size: 128`
-- **WHEN** system fetches user list
-- **THEN** all `avatarUrl` values MUST have `?size=128`
-
-#### Scenario: Avatar size bounds validation
-- **GIVEN** admin sets `mydash.people_widget_avatar_size: -5` or `50000`
-- **WHEN** system fetches user list
-- **THEN** invalid sizes MUST be clamped to a reasonable range (e.g., 16..1024)
-- **AND** the widget MUST still render without error
+#### Scenario: Avatar displayed at layout-appropriate size
+- **GIVEN** widget is rendering in card layout
+- **WHEN** frontend receives `avatarUrl` (128 px source)
+- **THEN** the avatar MUST be displayed at 80 px in card layout
+- **AND** at 64 px in grid layout
+- **AND** at 44 px in list layout
 
 ### Requirement: Three layout modes (REQ-PPL-008)
 
-The frontend MUST support three layout modes: `card`, `grid`, and `list`. Each layout MUST respect the `cardFields` configuration for which fields to display.
+The frontend MUST support three layout modes: `card`, `list`, and `grid`. Each layout MUST respect the `showFields` configuration for which fields to display.
 
 **Card layout** (`layout: 'card'`):
 - Displays full profile cards (~200×280 px each)
-- Avatar: ~64 px, top/center
-- Fields stacked vertically below avatar (displayName, jobTitle, department, email, phone)
-- Birthday badge "🎂 in N days" overlaid on avatar (if applicable)
+- Avatar: 80 px, top/center
+- Fields stacked vertically below avatar (displayName, role, organisation, email, phone, and any enabled showFields)
 - Hover effect (optional): subtle shadow/scale
+- Supports configurable column count via `columns` key (2/3/4, default 3)
 
 **Grid layout** (`layout: 'grid'`):
 - Compact grid of small cards (~80×120 px each)
-- Avatar: ~48 px centered
+- Avatar: 64 px centered
 - Display name below avatar (1-2 lines, truncated if needed)
-- Birthday badge "🎂 in N days" small, bottom-right of avatar (if applicable)
+- Supports configurable column count via `columns` key (2/3/4, default 4)
 - Optimized for many users on a narrow dashboard
 
 **List layout** (`layout: 'list'`):
 - Single-line rows (height ~40 px)
-- Avatar: ~32 px, left side
-- Name + optional secondary field (email or department, configured via `cardFields`)
+- Avatar: 44 px, left side
+- Name + optional secondary field (email or organisation, configured via `showFields`)
 - Hover: highlight row background
-- Birthday badge: "🎂 in N days" on the right side (if applicable)
 
 #### Scenario: Card layout displays full profile
-- **GIVEN** `layout: 'card'`, `cardFields: ["displayName", "jobTitle", "department", "email"]`
+- **GIVEN** `layout: 'card'`, `showFields: {"displayName": true, "role": true, "organisation": true, "email": true}`
 - **WHEN** widget renders 10 users
-- **THEN** each card MUST show avatar + all 4 configured fields
+- **THEN** each card MUST show avatar (80 px) + all 4 configured fields
 - **AND** cards MUST be approximately 200×280 px each
-- **AND** cards MUST stack vertically or in a shallow grid
+- **AND** cards MUST be arranged according to the `columns` config (default 3 per row)
 
 #### Scenario: Grid layout shows avatar + name only
-- **GIVEN** `layout: 'grid'`, any `cardFields` value
+- **GIVEN** `layout: 'grid'`, any `showFields` value
 - **WHEN** widget renders 20 users
-- **THEN** each cell MUST show avatar (~48 px) + display name (2 lines max, truncated)
+- **THEN** each cell MUST show avatar (64 px) + display name (2 lines max, truncated)
 - **AND** cells MUST be approximately 80×120 px each
-- **AND** cells MUST fit 3-4 per row on a typical dashboard
+- **AND** cells MUST be arranged according to the `columns` config (default 4 per row)
 
 #### Scenario: List layout shows compact rows
-- **GIVEN** `layout: 'list'`, `cardFields: ["displayName", "email"]`
+- **GIVEN** `layout: 'list'`, `showFields: {"displayName": true, "email": true}`
 - **WHEN** widget renders 50 users
 - **THEN** each row MUST be a single line (~40 px height)
-- **AND** row MUST show avatar (~32 px) + name + email
+- **AND** row MUST show avatar (44 px) + name + email
 - **AND** rows MUST be scrollable if they exceed widget height
 
-#### Scenario: Birthday badge displays when applicable
-- **GIVEN** user "alice" has `daysToBirthday: 5`, `birthdayWindowDays: 7`
-- **WHEN** widget renders alice in any layout
-- **THEN** a "🎂 in 5 days" badge MUST appear (exact emoji/text configurable)
-- **AND** badge position MUST adapt to layout (card: top-right, grid: bottom-right, list: right side)
-
-#### Scenario: cardFields filtered per layout
-- **GIVEN** `cardFields: ["displayName", "department"]` (omitting email, phone, jobTitle)
+#### Scenario: showFields filtered per layout
+- **GIVEN** `showFields: {"displayName": true, "organisation": true}` (omitting email, phone, role)
 - **WHEN** card layout renders
-- **THEN** only displayName and department MUST be shown
-- **AND** email, phone, jobTitle MUST NOT appear
+- **THEN** only displayName and organisation MUST be shown
+- **AND** email, phone, and role MUST NOT appear
 
 ### Requirement: Empty state and error handling (REQ-PPL-009)
 
 The widget MUST display a user-friendly message when no results are available.
 
 #### Scenario: No users match filter
-- **GIVEN** `groupFilter: ["nonexistent-group"]` (no users in group)
+- **GIVEN** `filters: [{"fieldName": "group", "operator": "in", "values": ["nonexistent-group"]}]` (no users in group)
 - **WHEN** widget renders
 - **THEN** text "No matching users." MUST be displayed (localized to user's language)
 - **AND** no broken/empty grid MUST appear
 
 #### Scenario: Failed API request
-- **GIVEN** the `/api/widgets/people/{placementId}/users` endpoint returns 500 error
+- **GIVEN** the `/api/people` endpoint returns 500 error
 - **WHEN** widget renders
 - **THEN** error message "Failed to load users" MUST be displayed
 - **AND** a "Retry" button MUST be provided
 - **AND** widget MUST NOT crash or show raw error traces
-
-#### Scenario: Placement not found
-- **GIVEN** placement has been deleted
-- **WHEN** widget tries to fetch users via invalid placement ID
-- **THEN** widget MUST show "Widget configuration missing or invalid"
-- **AND** user MUST be able to remove/reconfigure the widget
 
 #### Scenario: Empty result after search
 - **GIVEN** user searches for "zzz" (no matching names/emails)
@@ -376,6 +392,8 @@ The widget MUST display a user-friendly message when no results are available.
 ### Requirement: Click-through to user profile (REQ-PPL-010)
 
 Clicking on a user profile card (or avatar, or name in list view) MUST open Nextcloud's standard user profile page.
+
+**NOTE**: This feature is NOT present in the reference implementation. It must be added fresh in MyDash.
 
 #### Scenario: Card click opens profile
 - **GIVEN** user "alice" is displayed in card layout
@@ -391,7 +409,7 @@ Clicking on a user profile card (or avatar, or name in list view) MUST open Next
 #### Scenario: Avatar click opens profile
 - **GIVEN** any layout
 - **WHEN** user clicks the avatar image
-- **THEN** browser MUST navigate to `/u/{userId}` in the same tab
+- **THEN** browser MUST navigate to `/u/{uid}` in the same tab
 
 #### Scenario: Profile page respects access control
 - **GIVEN** user "charlie" does not have access to see user "dave"'s profile
@@ -461,12 +479,22 @@ The widget MUST cache results in memory for 60 seconds per placement. A force-re
 
 ## Non-Functional Requirements
 
-- **Performance**: `GET /api/widgets/people/{placementId}/users` MUST return within 1 second for orgs with <1000 users. Pagination with limit=50 MUST be efficient (cursor-based, not offset-based).
+- **Performance**: `GET /api/people` MUST return within 1 second for orgs with <1000 users. Pagination with limit=50 MUST be efficient (offset-based, max 100 per page).
 - **Compatibility**: Widget MUST work with all Nextcloud versions supported by MyDash (currently 25+).
-- **Data integrity**: User list MUST reflect real-time group membership (no stale cache on backend).
+- **Data integrity**: User list MUST reflect real-time group membership (no stale cache on backend for group-filtered paths).
 - **Accessibility**: Widget MUST support keyboard navigation (Tab through users, Enter to open profile). All fields MUST have accessible labels. Avatar images MUST have alt text.
-- **Localization**: All user-facing strings MUST support English and Dutch (nl/en). Birthday computation MUST work with any user's locale.
-- **Privacy**: Hidden profile fields MUST NEVER be returned to the client (not even nulled). Birthday information MUST respect visibility settings.
+- **Localization**: All user-facing strings MUST support English and Dutch (nl/en). Birthday display formatting MUST work with any user's locale.
+- **Privacy**: Scope-based field filtering is a planned follow-up. The shared backend APCu cache (keyed on filter + sort only) MUST be made per-viewer before scope-based visibility is enforced to prevent data leakage.
+
+## Open Follow-Ups
+
+- **Privacy — scope enforcement**: Implement `IAccountManager` scope-based visibility (`$prop->getScope()` check against viewer) before the shared filter cache is safe to retain.
+- **Privacy — per-viewer cache**: The 1-hour shared APCu cache ignores the requesting user. When scope-based visibility is enforced, the cache key MUST include the viewer's uid (or the cache must be disabled).
+- **Feb-29 birthday guard**: The `within_next_days` filter operator constructs dates with `new \DateTime($currentYear . '-' . $date->format('m-d'))` — this throws on Feb 29 in non-leap years. A guard (substitute Feb 28 in non-leap years) must be added.
+- **Click-through to `/u/{uid}`**: Not present in the reference implementation; must be added to the frontend card/list components.
+- **Birthday badge overlay**: "🎂 in N days" badge rendering is not in the reference source; to be added if desired.
+- **Status integration**: `IUserStatusManager` is wired and populates `status` in the profile. Expose and document `status` field fully in a follow-up.
+- **Public share access**: The reference source exposes people data via `GET /api/share/{token}/people` — the spec does not address this route. Decide scope.
 
 ## Current Implementation Status
 
@@ -481,9 +509,9 @@ The widget MUST cache results in memory for 60 seconds per placement. A force-re
 ### Standards & References
 
 - Nextcloud Dashboard Widget API: `OCP\Dashboard\IManager::registerWidget()`, `IWidget` interface
-- Nextcloud User Management: `OCP\IUserManager::getUsers()`, `OCP\IGroupManager::displayNamesInGroup()`
+- Nextcloud User Management: `OCP\IUserManager::getUsers()`, `OCP\IGroupManager`
 - Nextcloud Profile: `OCP\Accounts\IAccountManager` (field-level visibility, birthdate storage)
 - Nextcloud User Status: `OCP\UserStatus\IManager` (for presence, future feature)
-- Avatar serving: `/avatar/{userId}?size=N` standard NC endpoint
-- WCAG 2.1 AA: Alt text for avatars, keyboard navigation, color contrast for badges
+- Avatar serving: `core.avatar.getAvatar` route, 128 px fetch size
+- WCAG 2.1 AA: Alt text for avatars, keyboard navigation, color contrast
 - WAI-ARIA: List roles, button semantics for profile clicks and search

--- a/openspec/changes/people-widget/tasks.md
+++ b/openspec/changes/people-widget/tasks.md
@@ -1,0 +1,102 @@
+# Tasks — people-widget
+
+## 1. Backend
+
+- [ ] Create `lib/Service/PeopleWidgetService.php` with methods:
+  - `getUsersForPlacement(string $placementId, string $cursor = null, int $limit = 50): array` returning `{users: [{userId, displayName, jobTitle, department, email, phone, avatarUrl, groups, daysToBirthday|null}], nextCursor|null}`
+  - `getVisibleFields(string $userId, string $viewerId): array` — returns subset of profile fields viewer is allowed to see
+  - `computeDaysToBirthday(string $birthdate): ?int` — returns days until next birthday (modulo year) or null if invalid
+  - `filterByGroups(string[] $userIds, string[] $groupNames): string[]` — intersection with NC groups
+- [ ] Create `lib/Controller/PeopleWidgetController.php::getUsers` mapped to `GET /api/widgets/people/{placementId}/users?cursor=&limit=50`
+- [ ] Load placement config from `widgetContent` JSON: `layout`, `groupFilter`, `excludeDisabled`, `showBirthdays`, `birthdayWindowDays`, `sortBy`, `cardFields`
+- [ ] Resolve placement from `{placementId}` via `PlacementService` or similar
+- [ ] Use `OCP\IUserManager::getUsers()` to fetch NC users
+- [ ] Apply `groupFilter` via `IGroupManager::displayNamesInGroup()` intersection
+- [ ] Filter disabled users if `excludeDisabled: true`
+- [ ] Resolve profile data via `OCP\Accounts\IAccountManager` for `jobTitle`, `department`, `email`, `phone`, `birthdate`
+- [ ] Enforce visibility: only return fields the viewer is allowed to see (via `IAccountManager`'s per-field visibility flags)
+- [ ] Compute `daysToBirthday` if `showBirthdays: true` and birthdate is visible
+- [ ] Sort by `displayName` (default), `group`, or stub `recent-activity` (returns error "not yet implemented")
+- [ ] Paginate: return up to `limit` users with `nextCursor` for next page
+- [ ] Avatar URL: NC's standard `/avatar/<userId>?size=64` (size configurable via `mydash.people_widget_avatar_size` app config, default 64)
+- [ ] Define typed exceptions: `PlacementNotFoundException`, `InvalidGroupFilterException`
+
+## 2. Frontend
+
+- [ ] Create `src/components/PeopleWidget.vue` Vue 3 SFC
+  - Props: `widgetContent` (JSON config), `placementId`
+  - Fetch: `GET /api/widgets/people/{placementId}/users?cursor=&limit=50`
+  - Render three layouts:
+    - `card`: full profile cards (avatar + all configured fields, ~200×280 px each), avatar ~64 px, fields stacked vertically
+    - `grid`: avatar + display name only (~80×120 px each), avatar ~48 px
+    - `list`: single-line rows with avatar + name + optional secondary field (email or department), avatar ~32 px
+  - Search input: client-side substring filter on `displayName` + `email` (case-insensitive), filters current page only
+  - Birthday badges: "🎂 in N days" on card/grid/list if `daysToBirthday` <= `birthdayWindowDays`
+  - Pagination: "Load more" button or infinite scroll, maintains scroll position
+  - Cache: 60-second in-memory cache per placement, clear on re-focus or manual refresh
+  - Force-refresh button in widget header (clear cache + refetch)
+  - Empty state: "No matching users." (for search or filters)
+  - Click on profile → opens `/u/{userId}` in same tab
+  - Error handling: "Failed to load users" message with retry button
+
+- [ ] Widget registration: add entry to `appinfo/dashboard.php` registering widget id `mydash_people`
+
+## 3. Tests
+
+- [ ] PHPUnit: `PeopleWidgetService::getUsersForPlacement()`:
+  - Returns paginated list (limit 50 default, cursor-based next page)
+  - Applies `groupFilter` intersection (empty array = all visible, non-empty = intersection with NC groups)
+  - Filters disabled users if `excludeDisabled: true`
+  - Computes `daysToBirthday` only if visible + `showBirthdays: true`
+  - Returns only fields the viewer is allowed to see (hidden fields omitted)
+  - Sorts by `displayName` (default), `group`, or rejects `recent-activity` with error message
+  - Returns `null` `nextCursor` on last page
+
+- [ ] PHPUnit: `computeDaysToBirthday()`:
+  - Returns int (0..365) for upcoming birthday this year
+  - Returns int for past-year birthday (wraps to next year)
+  - Returns null for invalid/missing birthdate
+  - Handles leap years correctly (Feb 29)
+
+- [ ] PHPUnit: `getVisibleFields()`:
+  - Only returns fields viewer is allowed to see
+  - Omits hidden fields entirely (not null)
+  - Respects `IAccountManager` visibility flags
+
+- [ ] PHPUnit: `filterByGroups()`:
+  - Returns intersection of users in any listed group
+  - Returns empty array if no users match
+  - Returns all users if groupFilter is empty
+
+- [ ] PHPUnit: `PeopleWidgetController::getUsers`:
+  - Returns HTTP 200 with paginated list
+  - Returns HTTP 404 if placement not found
+  - Returns HTTP 400 if `groupFilter` contains unknown group name
+
+- [ ] Playwright: render PeopleWidget in all three layout modes (card/grid/list)
+  - Card layout displays avatar + all configured fields, ~200×280 px cards
+  - Grid layout displays avatar + name only, ~80×120 px cards
+  - List layout displays rows with avatar + name + optional secondary field
+  - Birthday badge "🎂 in N days" shown if within `birthdayWindowDays`
+
+- [ ] Playwright: search input filters users by displayName/email (case-insensitive, current page only)
+- [ ] Playwright: pagination works (load more / infinite scroll)
+- [ ] Playwright: click on profile card opens `/u/{userId}` in same tab
+- [ ] Playwright: force-refresh button clears cache + refetches
+- [ ] Playwright: empty state shown when no results
+
+## 4. Quality
+
+- [ ] `composer check:strict` passes
+- [ ] OpenAPI updated for `GET /api/widgets/people/{placementId}/users` endpoint
+- [ ] Translation entries for all user-facing strings (layout names, field labels, error messages, empty state)
+- [ ] Widget icon (SVG) in `img/people-widget.svg` (solid user group symbol, Conduction brand colors)
+- [ ] No raw exception messages returned to client
+- [ ] Avatar URLs handle missing/invalid users gracefully (fallback to placeholder)
+
+## 5. Follow-ups (separate changes)
+
+- [ ] `people-widget-presence` — integrate `OCP\UserStatus` for online/away/do-not-disturb badges
+- [ ] `people-widget-activity` — implement `sortBy: 'recent-activity'` via `OCP\Activity\IManager`
+- [ ] `people-widget-export` — CSV export of people + birthdays
+- [ ] `people-widget-acl` — per-user visibility control (e.g., HR-only view)

--- a/openspec/changes/quicklinks-widget/design.md
+++ b/openspec/changes/quicklinks-widget/design.md
@@ -1,0 +1,89 @@
+# Design — Quicklinks Widget
+
+## Context
+
+A flat grid of icon-and-label shortcuts is the most common widget pattern on intranet
+home pages. Unlike `links-widget` (which groups links into labelled sections) and the
+existing `tiles` capability (one tile per grid placement), the quicklinks widget is a
+single widget owning a self-contained icon grid. An admin configures all shortcuts in
+one place; the widget renders them as a responsive tile mosaic.
+
+Icon quality and consistent sizing matter more than prose — the primary use case is
+"top 8 shortcuts for all staff": dense, scannable, low-click. Bulk-add via CSV paste is
+first-class for admins migrating dozens of links from a spreadsheet.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Render a flat grid of icon+label shortcuts from widget config.
+- Support icon size and shape configuration.
+- Allow fixed or auto column count.
+- Sanitise destination URLs.
+- Provide bulk-add via CSV paste.
+
+**Non-Goals:**
+- Section groupings (use `links-widget` instead).
+- Per-user personalisation or hiding of tiles.
+- Drag-to-reorder in read mode (edit mode only).
+
+## Decisions
+
+### D1: Icon source — platform icon name OR URL
+**Decision:** Each link accepts either a named icon from the platform icon set or a
+fully-qualified image URL. Named icons are rendered via the existing icon component;
+URL icons are rendered as `<img>` with the same allow-list pattern as `link-button-widget`.
+**Alternatives considered:** URL-only (simpler); icon name only (requires hosted images
+for branded shortcuts).
+**Rationale:** Named icons are zero-maintenance for common destinations; URL icons let
+admins use product logos without needing icon-set contributions.
+
+### D2: Icon size enum (`small | medium | large | xlarge` → 32/48/64/96 px)
+**Decision:** Single widget-level size setting applies to all icons in the grid.
+**Alternatives considered:** Per-icon size; continuous slider.
+**Rationale:** Uniform size preserves visual rhythm in the grid. Four T-shirt sizes
+cover the range from dense information panels to hero-style shortcuts.
+
+### D3: Icon shape enum (`square | rounded | circle` → 0 / 8 px / 50% border-radius)
+**Decision:** Widget-level shape applies to all icon containers.
+**Alternatives considered:** Per-icon shape; free border-radius input.
+**Rationale:** Consistent shape across the grid is a design constraint, not a
+per-link choice. Three named shapes map to recognisable UI conventions and require no
+custom rendering.
+
+### D4: Columns — `auto` flex-wrap OR `1..12` fixed CSS grid
+**Decision:** Default `auto` uses `flex-wrap` with a minimum tile width of 80 px so
+icons fill the available width naturally. Fixed values `1`–`12` switch to CSS grid with
+that column count; the grid collapses by one column at each defined breakpoint below
+768 px.
+**Alternatives considered:** Fixed count only (less flexible); auto only (admin cannot
+guarantee a 4-across layout on large screens).
+**Rationale:** `auto` is the right default for unknown content counts; fixed count is
+needed when the admin wants precise alignment with adjacent widgets.
+
+### D5: URL sanitisation
+**Decision:** On save, reject any URL whose scheme is not `http`, `https`, `mailto`, or
+`tel`. Validation runs client-side on blur and server-side on config save.
+**Alternatives considered:** Warn but allow; server-side only.
+**Rationale:** Consistent with the `links-widget` policy; `javascript:` and `data:` URIs
+are XSS vectors and must not be stored in widget config.
+
+### D6: Bulk-add via CSV paste
+**Decision:** An "Add multiple" button opens a textarea accepting `label,url` CSV (one
+row per link, header row optional). Rows are parsed, validated, and appended; malformed
+rows are highlighted; valid rows are added immediately.
+**Alternatives considered:** File upload (requires multipart handling); no bulk mode.
+**Rationale:** Paste is zero-friction — admins can paste directly from a spreadsheet.
+Inline validation feedback before commit prevents silent data loss.
+
+## Risks / Trade-offs
+
+- URL icons from external hosts degrade the widget if a host is slow or unavailable;
+  implement a fallback icon for failed image loads.
+- CSV parsing must handle quoted fields with commas — use a proper tokeniser, not a
+  naive comma split.
+
+## Open follow-ups
+
+- Drag-to-reorder in the editor (consistent with `links-widget`).
+- Dynamic source mode: import from a URL returning a JSON link list.
+- Fallback icon rendering when an image URL returns a non-2xx response.

--- a/openspec/changes/quicklinks-widget/proposal.md
+++ b/openspec/changes/quicklinks-widget/proposal.md
@@ -1,0 +1,62 @@
+# Quicklinks widget
+
+## Why
+
+MyDash users need a compact, high-density way to organize frequently accessed URLs on their dashboard. Today, they must place individual link-button widgets (one per placement) or use the links-widget (which spreads items across a multi-column section with descriptions). Neither scales well for 20+ bookmarks. A quicklinks widget fills this gap: a flat grid of small clickable icons, all inside ONE placement, with configurable sizing, shape, label position, and hover effects. Think "app launcher" or "favourites bar" — many shortcuts in a tight, flexible layout.
+
+## What Changes
+
+- Register a new dashboard widget with id `mydash_quicklinks` via `OCP\Dashboard\IManager` that appears in the widget picker.
+- Add per-placement configuration stored in `widgetContent JSON` with:
+  - `links: [{label, url, icon, color?: string}]` — flat array of shortcuts.
+  - `iconSize: 'small'|'medium'|'large'|'xlarge'` (default `medium`) — renders as 32/48/64/96 px.
+  - `iconShape: 'square'|'rounded'|'circle'` (default `rounded`) — border-radius 0 / 8px / 50%.
+  - `showLabels: boolean` (default `true`) — toggle label visibility.
+  - `labelPosition: 'below'|'overlay'` (default `below`) — `overlay` hides labels until hover, saving vertical space.
+  - `columns: number` (default `'auto'` — flex-wrap; accepts 1..12 for fixed CSS Grid columns).
+  - `tileBackgroundStyle: 'transparent'|'solid'|'gradient'` (default `transparent`) — optional icon background.
+  - `hoverEffect: 'lift'|'fade'|'border'|'none'` (default `lift`) — hover animation style.
+- Implement renderer `QuicklinksWidget.vue` (Vue 3 SFC) using CSS Flexbox for `auto` columns and CSS Grid for fixed columns, with per-link hover effects.
+- Icon resolution: same precedence as link-button-widget (REQ-LBN-002) — built-in NC icon name → IconRenderer; URL → `<img>`; blank → fallback "link" icon.
+- Color: optional per-link `color` field sets icon background tint when `tileBackgroundStyle = 'solid'`.
+- Edit form: simple table of links (label + URL + icon picker + optional color picker) with drag-to-reorder. Bulk-add via paste CSV `label,url` to create multiple links at once.
+- Click → navigates. External URLs carry `rel="noopener noreferrer" target="_blank"`. Internal Nextcloud URLs detect context (configurable per-link via `openInNewTab: boolean` defaulting to auto-detect).
+- URL sanitisation on save: reject non-HTTP(S) and non-relative URLs with HTTP 400 — no `javascript:`, `data:`.
+- Accessibility: each link is an `<a>` with descriptive `aria-label`; keyboard Tab navigation.
+- Empty state: "No quicklinks yet — click the gear icon to add some."
+- Default sizing: `gridWidth = 4`, `gridHeight = 2` (compact by default).
+
+## Capabilities
+
+### New Capabilities
+
+- `quicklinks-widget` — adds REQ-QLNK-001 (registration and widget id), REQ-QLNK-002 (per-placement config shape), REQ-QLNK-003 (icon resolution), REQ-QLNK-004 (icon sizes and shapes), REQ-QLNK-005 (label position control), REQ-QLNK-006 (column layout flexibility), REQ-QLNK-007 (hover effects), REQ-QLNK-008 (URL sanitisation), REQ-QLNK-009 (click and navigation), REQ-QLNK-010 (accessibility), REQ-QLNK-011 (empty state and default sizing).
+
+### Modified Capabilities
+
+(none — this change is fully additive)
+
+## Impact
+
+**Affected code:**
+
+- `src/components/Widgets/Renderers/QuicklinksWidget.vue` — new renderer with Flexbox + Grid layout, icon rendering, hover effects
+- `src/components/Widgets/Forms/QuicklinksForm.vue` — new add/edit sub-form with link table, drag-to-reorder, CSV bulk-add
+- `src/constants/widgetRegistry.js` — register `type: 'quicklinks'` with default content shape
+- `lib/Controller/WidgetController.php` — new `validateUrls` action mapped to `POST /api/widgets/quicklinks/validate-urls` (optional; for real-time validation in edit form)
+- `src/composables/useUrlSanitiser.js` — shared composable for URL validation/sanitisation (reusable by other widgets)
+- `l10n/en.js`, `l10n/nl.js` — translation strings for all new labels, placeholders, and empty state
+
+**Affected APIs:**
+
+- 1 optional new route (`POST /api/widgets/quicklinks/validate-urls`) — no existing routes changed
+
+**Dependencies:**
+
+- `IconRenderer` (existing MyDash component) — reused from link-button-widget
+- No new composer or npm dependencies
+
+**Migration:**
+
+- Zero schema changes — widget shape lives inside the existing `content` JSON blob on widget placements.
+- Existing dashboards continue to work unchanged; the `quicklinks` type only appears once an admin explicitly adds a Quicklinks widget.

--- a/openspec/changes/quicklinks-widget/specs/quicklinks-widget/spec.md
+++ b/openspec/changes/quicklinks-widget/specs/quicklinks-widget/spec.md
@@ -1,0 +1,386 @@
+---
+capability: quicklinks-widget
+delta: false
+status: draft
+---
+
+# Quicklinks Widget
+
+## ADDED Requirements
+
+### Requirement: REQ-QLNK-001 Registration and widget id
+
+The system MUST register a new dashboard widget with id `mydash_quicklinks` via `OCP\Dashboard\IManager::registerWidget()`. The widget MUST appear in the widget picker under a translatable name `t('Quicklinks')` and MUST have a default grid size of `gridWidth = 4` and `gridHeight = 2`.
+
+#### Scenario: Widget registered and appears in picker
+
+- GIVEN the MyDash app has been installed and the widget is properly registered
+- WHEN a user opens the widget picker
+- THEN the picker MUST display an entry for `Quicklinks` (or locale-translated equivalent)
+- AND selecting it MUST add a new widget placement with default config
+
+#### Scenario: Default sizing is compact
+
+- GIVEN a new quicklinks widget has been added to an empty dashboard
+- WHEN the widget renders
+- THEN it MUST occupy a 4-column × 2-row grid cell by default
+- AND users can resize it via the grid-layout resize handles
+
+### Requirement: REQ-QLNK-002 Per-placement configuration shape
+
+The `widgetContent` JSON blob for a quicklinks widget MUST contain all of the following fields:
+
+- `links: Array<{label: string, url: string, icon: string, color?: string, openInNewTab?: boolean}>` — array of link objects (required; empty array is valid).
+- `iconSize: 'small'|'medium'|'large'|'xlarge'` (default `medium`) — controls icon rendering size.
+- `iconShape: 'square'|'rounded'|'circle'` (default `rounded`) — controls border-radius of icon container.
+- `showLabels: boolean` (default `true`) — toggles label text visibility.
+- `labelPosition: 'below'|'overlay'` (default `below`) — `below` = labels under icons; `overlay` = labels appear on hover only.
+- `columns: number | 'auto'` (default `'auto'`) — `'auto'` triggers flex-wrap; a number 1..12 triggers CSS Grid with fixed columns.
+- `tileBackgroundStyle: 'transparent'|'solid'|'gradient'` (default `transparent`) — background behind each icon.
+- `hoverEffect: 'lift'|'fade'|'border'|'none'` (default `lift`) — hover animation style.
+
+The form MUST preserve all fields on save; omitted fields MUST be populated with defaults when loading.
+
+#### Scenario: New widget receives all defaults
+
+- GIVEN a new quicklinks widget is created
+- WHEN the backend saves the initial `widgetContent` with only `links: []`
+- THEN the renderer MUST apply all remaining field defaults
+- AND the form MUST pre-fill all fields with defaults when editing
+
+#### Scenario: Config round-trip preserves all fields
+
+- GIVEN saved content `{links: [...], iconSize: 'large', iconShape: 'circle', showLabels: false, labelPosition: 'overlay', columns: 6, tileBackgroundStyle: 'solid', hoverEffect: 'fade'}`
+- WHEN the form loads and saves without changes
+- THEN all eight fields MUST be persisted exactly as input
+- AND no defaults MUST override user choices
+
+### Requirement: REQ-QLNK-003 Icon resolution
+
+Each link's `icon` field MUST follow the same dual-mode convention as link-button-widget (REQ-LBN-002):
+
+- A custom URL (starts with `/` or `http(s)://`) MUST render as `<img>` inside the icon container.
+- A bare name (e.g., `folder`, `calendar`, `mail`) MUST render via the shared `IconRenderer` (built-in MDI component).
+- An empty or null value MUST render a fallback "link" icon (MDI `link` icon or similar).
+
+Icon size is controlled by the `iconSize` field (REQ-QLNK-004); label rendering by `showLabels` and `labelPosition` (REQ-QLNK-005).
+
+#### Scenario: Custom URL icon renders as image
+
+- GIVEN content `{links: [{label: 'Docs', url: 'https://example.com', icon: '/apps/mydash/resource/docs.png'}]}`
+- WHEN the widget renders with `iconSize: 'medium'`
+- THEN the icon container MUST display `<img src="/apps/mydash/resource/docs.png">` sized 48 px square
+- AND the label `Docs` MUST appear below (or overlay on hover, depending on `labelPosition`)
+
+#### Scenario: MDI icon name renders via IconRenderer
+
+- GIVEN content `{links: [{label: 'Calendar', url: 'https://nc/calendar', icon: 'calendar'}]}`
+- WHEN the widget renders
+- THEN the icon container MUST render the calendar icon via `<IconRenderer :name="calendar" />`
+- AND at the size specified by `iconSize`
+
+#### Scenario: Empty icon renders fallback
+
+- GIVEN content `{links: [{label: 'Quick link', url: 'https://example.com', icon: ''}]}`
+- WHEN the widget renders
+- THEN the icon container MUST display the fallback "link" icon (MDI `link`)
+
+### Requirement: REQ-QLNK-004 Icon sizes and shapes
+
+The `iconSize` field MUST map to pixel dimensions as follows:
+
+- `small` → 32 px square
+- `medium` → 48 px square
+- `large` → 64 px square
+- `xlarge` → 96 px square
+
+The `iconShape` field MUST control the CSS `border-radius` of the icon container as follows:
+
+- `square` → `border-radius: 0`
+- `rounded` → `border-radius: 8px`
+- `circle` → `border-radius: 50%`
+
+When `tileBackgroundStyle = 'transparent'`, the shape only affects the icon's background clip (no visible border). When `tileBackgroundStyle = 'solid'` or `'gradient'`, the shape is visually prominent.
+
+#### Scenario: Icon size small renders 32px
+
+- GIVEN content with `iconSize: 'small'` and `iconShape: 'circle'`
+- WHEN the widget renders
+- THEN each icon container MUST be exactly 32 px × 32 px with `border-radius: 50%`
+
+#### Scenario: Icon size xlarge with rounded shape
+
+- GIVEN `iconSize: 'xlarge'` and `iconShape: 'rounded'`
+- WHEN the widget renders
+- THEN each icon container MUST be 96 px × 96 px with `border-radius: 8px`
+
+#### Scenario: Shape has no effect when background is transparent
+
+- GIVEN `tileBackgroundStyle: 'transparent'` and `iconShape: 'circle'`
+- WHEN the widget renders
+- THEN the icon container MUST use `border-radius: 50%` but no visible background fill
+- AND only the icon itself is visible (no coloured tile behind it)
+
+### Requirement: REQ-QLNK-005 Label position control
+
+When `showLabels: true`, each link MUST display a label. The `labelPosition` field MUST control where and when the label appears:
+
+- `below` → label appears directly below the icon at all times; each link cell occupies `iconSize + label height` vertical space.
+- `overlay` → label appears centred over the icon only on hover (`:hover`, keyboard focus); default rendering shows icon only; hovering or focusing the link shows the label centred over the icon.
+
+When `showLabels: false`, no label MUST be rendered regardless of `labelPosition`.
+
+The label text MUST be the link's `label` field, truncated to a sensible max length (e.g., 20 chars) and wrapped if `labelPosition: 'below'`.
+
+#### Scenario: Labels below icons
+
+- GIVEN content with `showLabels: true`, `labelPosition: 'below'`, and three links with labels `Docs`, `Calendar`, `Team`
+- WHEN the widget renders
+- THEN each link MUST display its label directly below the icon, visible at all times
+- AND the vertical space consumed is `iconSize (48px) + label area (approx 20px)` ≈ 68 px per row
+
+#### Scenario: Labels overlay on hover
+
+- GIVEN `showLabels: true`, `labelPosition: 'overlay'`, and `iconSize: 'medium'`
+- WHEN the widget renders without hover
+- THEN icons are visible but labels are hidden
+- AND the vertical space consumed is only `iconSize (48px)` per row
+- AND when the user hovers over a link, the label MUST appear centred over the icon
+- AND the label MUST disappear when hover ends
+
+#### Scenario: showLabels false suppresses all labels
+
+- GIVEN `showLabels: false`, regardless of `labelPosition`
+- WHEN the widget renders
+- THEN no label text MUST appear, even on hover
+- AND the vertical footprint is minimized
+
+### Requirement: REQ-QLNK-006 Column layout flexibility
+
+The `columns` field MUST control the layout grid as follows:
+
+- `'auto'` (default) → CSS Flexbox with `flex-wrap: wrap`. Items flow left-to-right, wrapping to the next row when the widget width is exhausted. Item width is elastic based on `iconSize + label area`.
+- A number `1..12` → CSS Grid with `grid-template-columns: repeat(N, 1fr)`, where `N` is the specified number. Each item occupies exactly `1/N` of the widget's width.
+
+The renderer MUST ignore invalid values (e.g., `columns: 13` or `columns: 'invalid'`) and fall back to `'auto'`.
+
+#### Scenario: Auto columns with wrap
+
+- GIVEN a 300px-wide widget, `columns: 'auto'`, and `iconSize: 'medium'` (48px + label ≈ 60px wide)
+- WHEN the widget renders five links
+- THEN the layout MUST flow left-to-right:
+  - Row 1: links 1, 2, 3, 4, 5 (if width permits) or wrap when insufficient space
+  - Each row wraps automatically based on available width
+
+#### Scenario: Fixed columns with grid
+
+- GIVEN `columns: 3` and `iconSize: 'large'` (64px + label ≈ 80px wide)
+- WHEN the widget renders nine links
+- THEN the layout MUST be a 3-column grid:
+  - Row 1: links 1, 2, 3
+  - Row 2: links 4, 5, 6
+  - Row 3: links 7, 8, 9
+- AND each column occupies exactly `1/3` of the widget width
+
+#### Scenario: Invalid column value falls back to auto
+
+- GIVEN `columns: 0` or `columns: 'invalid'` or `columns: 15`
+- WHEN the widget renders
+- THEN the system MUST fall back to `columns: 'auto'` (flex-wrap)
+- AND log a console warning (optional)
+
+### Requirement: REQ-QLNK-007 Hover effects
+
+The `hoverEffect` field MUST control the CSS animation when a user hovers over a link:
+
+- `lift` (default) → translate the icon upward by 2–4 px and add a subtle box-shadow (e.g., `0 4px 8px rgba(0, 0, 0, 0.1)`). Transition duration ≈ 200ms.
+- `fade` → reduce opacity of non-hovered links to 0.6 while hovered link remains 1.0. Transition duration ≈ 150ms.
+- `border` → add a 2–3 px border or outline to the hovered icon container (colour: primary brand colour or icon `color` if set). Transition duration ≈ 100ms.
+- `none` → no hover effect; link remains identical on hover (only cursor changes to pointer).
+
+Effects MUST apply only to the hovered link, not the entire widget.
+
+#### Scenario: Lift effect on hover
+
+- GIVEN `hoverEffect: 'lift'` and a widget with five links
+- WHEN the user hovers over link 3
+- THEN link 3 MUST translate upward 2–4 px and display a soft shadow
+- AND links 1, 2, 4, 5 remain unmoved
+- AND the transition duration MUST be ~200ms
+
+#### Scenario: Fade effect on hover
+
+- GIVEN `hoverEffect: 'fade'` and five links
+- WHEN the user hovers over link 2
+- THEN link 2 MUST remain at opacity 1.0
+- AND links 1, 3, 4, 5 MUST fade to opacity 0.6
+- AND the transition duration MUST be ~150ms
+
+#### Scenario: Border effect on hover
+
+- GIVEN `hoverEffect: 'border'` and `iconShape: 'rounded'`
+- WHEN the user hovers over a link
+- THEN a 2–3 px border MUST appear around the icon container
+- AND the border colour MUST be the link's `color` field (if set) or the primary brand colour
+- AND the border MUST disappear when hover ends
+
+#### Scenario: No hover effect
+
+- GIVEN `hoverEffect: 'none'`
+- WHEN the user hovers over a link
+- THEN the link rendering MUST be identical (no transform, opacity change, or border)
+- AND only the cursor MUST change to `pointer`
+
+### Requirement: REQ-QLNK-008 URL sanitisation on save
+
+When the edit form submits, the system MUST validate each link's `url` field. Invalid URLs MUST be rejected with an HTTP 400 response and a user-friendly error message. The validation rules are:
+
+- MUST start with `http://`, `https://`, or `/` (relative Nextcloud URLs).
+- MUST NOT contain `javascript:`, `data:`, `vbscript:`, or other dangerous protocols.
+- MUST NOT be empty or null.
+- MUST NOT exceed 2048 characters.
+
+The form MUST display inline validation feedback (red border + error text) on the URL field before the user submits. On server-side save failure, the form MUST display a toast: `t('Invalid URL in one or more links')`.
+
+#### Scenario: Valid HTTP URL accepted
+
+- GIVEN a link with `url: 'https://example.com/page?param=value'`
+- WHEN the form submits
+- THEN the URL MUST be accepted and saved
+- AND no error MUST be displayed
+
+#### Scenario: Relative Nextcloud URL accepted
+
+- GIVEN a link with `url: '/apps/files/'`
+- WHEN the form submits
+- THEN the URL MUST be accepted and saved
+
+#### Scenario: JavaScript protocol rejected
+
+- GIVEN a link with `url: 'javascript:void(0)'` or `url: 'javascript:alert("xss")'`
+- WHEN the form submits
+- THEN the system MUST return HTTP 400 with error `{error: 'Invalid URL'}`
+- AND the form MUST display a red border on the URL field and the inline error message
+
+#### Scenario: Data URL rejected
+
+- GIVEN a link with `url: 'data:text/html,<img src=x onerror=alert(1)>'`
+- WHEN the form submits
+- THEN HTTP 400 MUST be returned
+- AND the URL field MUST be highlighted as invalid
+
+#### Scenario: Empty URL rejected
+
+- GIVEN a link with `url: ''` or `url: null`
+- WHEN the form submits or validates
+- THEN an error MUST be displayed (inline in the form, or on submit)
+- AND the link MUST not be saved
+
+### Requirement: REQ-QLNK-009 Click and navigation
+
+When a user clicks a link in the rendered widget, the system MUST navigate based on the link's `url` and `openInNewTab` fields:
+
+- If `url` starts with `/` (relative, internal Nextcloud URL) and `openInNewTab: false` (or not set and auto-detect resolves to same-tab), navigate in the same tab via `router.push(url)` or `window.location.href = url`.
+- If `url` starts with `http(s)://` (external) OR `openInNewTab: true`, open in a new tab via `window.open(url, '_blank', 'noopener,noreferrer')`.
+- The system MUST NOT navigate if the surrounding dashboard is in edit mode (admin/edit context), matching the pattern from link-button-widget.
+
+Auto-detect for `openInNewTab` when not specified: if the URL is external (`http(s)://`), default to `true`; if relative (`/`), default to `false`.
+
+#### Scenario: External URL opens in new tab
+
+- GIVEN a link with `url: 'https://example.com'` and no `openInNewTab` field
+- WHEN the user clicks the link (not in edit mode)
+- THEN the system MUST call `window.open('https://example.com', '_blank', 'noopener,noreferrer')`
+- AND a new tab MUST open
+
+#### Scenario: Internal URL opens in same tab
+
+- GIVEN a link with `url: '/apps/files/'` and no `openInNewTab` field
+- WHEN the user clicks the link (not in edit mode)
+- THEN the system MUST navigate to `/apps/files/` in the same tab
+- AND no new tab MUST be opened
+
+#### Scenario: Click suppressed in edit mode
+
+- GIVEN the dashboard is in edit mode (admin context, `canEdit: true`)
+- WHEN the user clicks a link
+- THEN no navigation MUST occur (no `window.open`, no router navigation)
+- AND the cursor MUST change to `not-allowed` or similar, indicating the link is inactive
+
+#### Scenario: Explicit openInNewTab overrides auto-detect
+
+- GIVEN a link with `url: '/apps/files/'` and `openInNewTab: true`
+- WHEN the user clicks the link
+- THEN the system MUST open the URL in a new tab (even though it's internal)
+
+### Requirement: REQ-QLNK-010 Accessibility
+
+Each link in the rendered widget MUST be an HTML `<a>` element (not a `<button>` or `<div>`). The `<a>` MUST have:
+
+- `href` attribute set to the link's `url`.
+- `aria-label` set to a descriptive label. If `showLabels: true` and `labelPosition: 'below'`, use the visible label. Otherwise, use `url` hostname or a fallback like `t('Link to') + ' ' + extractHostname(url)`.
+- `target="_blank"` and `rel="noopener noreferrer"` when the link opens in a new tab.
+- Keyboard accessibility: Tab navigation MUST cycle through all links in the widget in source order.
+- Focus styles: links MUST have a visible focus indicator (e.g., outline or border) matching Nextcloud design standards.
+
+#### Scenario: Link is keyboard accessible
+
+- GIVEN the widget is rendered and has focus outside
+- WHEN the user presses Tab
+- THEN focus MUST move to the first link in the widget
+- AND subsequent Tab presses MUST cycle through all links
+- AND pressing Shift+Tab MUST move backwards through links
+
+#### Scenario: Aria-label uses visible label when available
+
+- GIVEN `showLabels: true`, `labelPosition: 'below'`, and a link with `label: 'Docs'`
+- WHEN the widget renders
+- THEN the `<a>` MUST have `aria-label="Docs"`
+
+#### Scenario: Aria-label uses hostname for overlay labels
+
+- GIVEN `showLabels: true`, `labelPosition: 'overlay'`, and a link with `label: 'Docs'` and `url: 'https://docs.example.com'`
+- WHEN the widget renders
+- THEN the `<a>` MUST have `aria-label` similar to `'Link to docs.example.com'` (hostname extracted)
+- NOTE: The visible label `Docs` is only shown on hover; the screen reader must have a full context via aria-label
+
+#### Scenario: Focus visible on keyboard navigation
+
+- GIVEN a link in the widget
+- WHEN the user navigates to it via Tab
+- THEN a visible focus indicator MUST be present (outline, border, or similar)
+- AND the focus style MUST meet WCAG AA contrast requirements
+
+### Requirement: REQ-QLNK-011 Empty state and default sizing
+
+When a quicklinks widget has zero links (`links: []`), the renderer MUST display an empty state message. The message MUST be:
+
+- Translatable: `t('No quicklinks yet — click the gear icon to add some.')` (or similar in Dutch: `t('Nog geen snelkoppelingen — klik op het tandwielpictogram om er enkele toe te voegen.')`).
+- Centred horizontally and vertically in the widget's viewport.
+- Styled with a light text colour (e.g., `var(--color-text-maxcontrast)`) and icon (gear or edit icon).
+
+When a user clicks the gear/edit icon displayed in the empty state OR the widget's edit button, the edit form MUST open.
+
+By default, new quicklinks widgets MUST be sized to `gridWidth = 4` and `gridHeight = 2`. Users can resize via the grid-layout resize handles.
+
+#### Scenario: Empty widget shows empty state
+
+- GIVEN a new quicklinks widget with `links: []`
+- WHEN the widget renders
+- THEN the empty state message `'No quicklinks yet — click the gear icon to add some.'` MUST be displayed
+- AND a gear icon or similar affordance MUST be visible
+
+#### Scenario: Clicking empty state affordance opens edit form
+
+- GIVEN the empty state is displayed
+- WHEN the user clicks the gear icon or empty state text
+- THEN the edit form MUST open
+- AND the form MUST display an empty links table ready for the user to add links
+
+#### Scenario: Default widget size is compact
+
+- GIVEN a new quicklinks widget is added to a dashboard
+- WHEN the widget is placed
+- THEN it MUST default to `gridWidth = 4` and `gridHeight = 2`
+- AND users can drag the resize handle to adjust size
+

--- a/openspec/changes/quicklinks-widget/tasks.md
+++ b/openspec/changes/quicklinks-widget/tasks.md
@@ -1,0 +1,136 @@
+# Tasks — quicklinks-widget
+
+## 1. Widget registration and setup
+
+- [ ] 1.1 Create `src/constants/widgetRegistry.js` entry for `type: 'quicklinks'` with default content shape (REQ-QLNK-002)
+- [ ] 1.2 Register the widget in `WidgetController.php` or entry point via `OCP\Dashboard\IManager::registerWidget()` with id `mydash_quicklinks` and default `gridWidth = 4`, `gridHeight = 2` (REQ-QLNK-001)
+- [ ] 1.3 Add translation entries in `l10n/en.js` and `l10n/nl.js`: `Quicklinks`, `No quicklinks yet — click the gear icon to add some.`
+
+## 2. Renderer (QuicklinksWidget.vue)
+
+- [ ] 2.1 Create `src/components/Widgets/Renderers/QuicklinksWidget.vue` as a Vue 3 SFC
+- [ ] 2.2 Import and use existing `IconRenderer` component for MDI icon resolution (REQ-QLNK-003)
+- [ ] 2.3 Implement CSS Flexbox layout for `columns: 'auto'` with `flex-wrap: wrap` (REQ-QLNK-006)
+- [ ] 2.4 Implement CSS Grid layout for `columns: 1..12` with `grid-template-columns: repeat(N, 1fr)` (REQ-QLNK-006)
+- [ ] 2.5 Map `iconSize` field to pixel dimensions: `small` 32px, `medium` 48px, `large` 64px, `xlarge` 96px (REQ-QLNK-004)
+- [ ] 2.6 Map `iconShape` field to CSS `border-radius`: `square` 0, `rounded` 8px, `circle` 50% (REQ-QLNK-004)
+- [ ] 2.7 Implement `labelPosition: 'below'` — labels visible at all times below icons (REQ-QLNK-005)
+- [ ] 2.8 Implement `labelPosition: 'overlay'` — labels hidden by default, visible on `:hover` and `:focus` (REQ-QLNK-005)
+- [ ] 2.9 Respect `showLabels: false` to suppress all labels regardless of position (REQ-QLNK-005)
+- [ ] 2.10 Implement `hoverEffect: 'lift'` — translate up 2–4px + drop shadow on hover (REQ-QLNK-007)
+- [ ] 2.11 Implement `hoverEffect: 'fade'` — non-hovered links fade to 0.6 opacity on hover (REQ-QLNK-007)
+- [ ] 2.12 Implement `hoverEffect: 'border'` — add 2–3px border to hovered link (REQ-QLNK-007)
+- [ ] 2.13 Implement `hoverEffect: 'none'` — no visual change on hover except cursor to pointer (REQ-QLNK-007)
+- [ ] 2.14 Render each link as an `<a>` element with `href` and `aria-label` (REQ-QLNK-010)
+- [ ] 2.15 Set `target="_blank"` and `rel="noopener noreferrer"` for external URLs (REQ-QLNK-009)
+- [ ] 2.16 Suppress all click handlers when `isAdmin === true` and surrounding dashboard is in edit mode (REQ-QLNK-009)
+- [ ] 2.17 Implement empty state: display `t('No quicklinks yet — click the gear icon to add some.')` when `links.length === 0` (REQ-QLNK-011)
+- [ ] 2.18 Empty state MUST include a clickable gear icon that opens the edit form (REQ-QLNK-011)
+- [ ] 2.19 Icon resolution: custom URL → `<img>`, MDI name → `<IconRenderer>`, empty → fallback "link" icon (REQ-QLNK-003)
+- [ ] 2.20 Apply icon background colour when `tileBackgroundStyle: 'solid'` and link's `color` field is set (REQ-QLNK-002, REQ-QLNK-004)
+
+## 3. Edit form (QuicklinksForm.vue)
+
+- [ ] 3.1 Create `src/components/Widgets/Forms/QuicklinksForm.vue` as a Vue 3 SFC
+- [ ] 3.2 Implement link management table with columns: label, URL, icon picker, optional color picker (REQ-QLNK-002)
+- [ ] 3.3 Implement drag-to-reorder: links array MUST be reorderable via drag handles (REQ-QLNK-002)
+- [ ] 3.4 Implement row add/delete buttons to add new links and delete existing links (REQ-QLNK-002)
+- [ ] 3.5 Implement bulk-add via CSV paste: accept comma-separated `label,url` lines, parse and append to links array (REQ-QLNK-002)
+- [ ] 3.6 Implement icon picker: click → opens modal to select built-in MDI name or upload custom URL (REQ-QLNK-003)
+- [ ] 3.7 Implement colour picker for per-link `color` field (optional; only show if `tileBackgroundStyle: 'solid'` is selected) (REQ-QLNK-002)
+- [ ] 3.8 Implement per-URL validation: inline red border + error text for invalid URLs (REQ-QLNK-008)
+- [ ] 3.9 Implement URL sanitisation: reject `javascript:`, `data:`, `vbscript:` and non-HTTP(S)/relative URLs (REQ-QLNK-008)
+- [ ] 3.10 On form submit with invalid URLs, display toast: `t('Invalid URL in one or more links')` (REQ-QLNK-008)
+- [ ] 3.11 `validate()` method MUST return non-empty error array if any link has empty or invalid URL (REQ-QLNK-008)
+- [ ] 3.12 Implement dropdowns for all enum fields: `iconSize`, `iconShape`, `showLabels`, `labelPosition`, `columns`, `tileBackgroundStyle`, `hoverEffect` (REQ-QLNK-002)
+- [ ] 3.13 Pre-fill all form fields from `editingWidget.content` when editing (REQ-QLNK-002)
+
+## 4. URL sanitisation composable
+
+- [ ] 4.1 Create `src/composables/useUrlSanitiser.js` exporting `sanitiseUrl(url)` and `validateUrl(url)` (REQ-QLNK-008)
+- [ ] 4.2 `sanitiseUrl()` MUST reject dangerous protocols: `javascript:`, `data:`, `vbscript:` (REQ-QLNK-008)
+- [ ] 4.3 `validateUrl()` MUST require `http://`, `https://`, or `/` prefix (REQ-QLNK-008)
+- [ ] 4.4 `validateUrl()` MUST reject empty, null, or oversized (>2048 char) URLs (REQ-QLNK-008)
+- [ ] 4.5 Both functions MUST be used by the form (client-side) and a backend route (if implemented) (REQ-QLNK-008)
+
+## 5. Optional server-side validation endpoint
+
+- [ ] 5.1 Create `lib/Controller/WidgetController.php::validateUrls` mapped to `POST /api/widgets/quicklinks/validate-urls` (optional; use for real-time form validation)
+- [ ] 5.2 Accept request body `{urls: []}` and return `{valid: boolean[], errors: string[]}` (REQ-QLNK-008)
+- [ ] 5.3 Reuse sanitisation logic from composable (shared via a PHP utility class) (REQ-QLNK-008)
+
+## 6. Translations
+
+- [ ] 6.1 Add translation entries in `l10n/en.js`:
+  - `Quicklinks`
+  - `No quicklinks yet — click the gear icon to add some.`
+  - `Add link`
+  - `Delete link`
+  - `Label`
+  - `URL`
+  - `Icon`
+  - `Color (optional)`
+  - `Icon Size`
+  - `Icon Shape`
+  - `Show Labels`
+  - `Label Position`
+  - `Columns`
+  - `Tile Background`
+  - `Hover Effect`
+  - `Paste CSV (label,url)`
+  - `Invalid URL in one or more links`
+  - `Small`
+  - `Medium`
+  - `Large`
+  - `Extra Large`
+  - `Square`
+  - `Rounded`
+  - `Circle`
+  - `Below`
+  - `Overlay`
+  - `Auto`
+  - `Transparent`
+  - `Solid`
+  - `Gradient`
+  - `Lift`
+  - `Fade`
+  - `Border`
+  - `None`
+  - `Link to`
+
+- [ ] 6.2 Add Dutch translations in `l10n/nl.js` with equivalent keys and locale-appropriate text
+
+## 7. Tests
+
+- [ ] 7.1 Vitest: icon size mapping (32, 48, 64, 96 px) renders correctly
+- [ ] 7.2 Vitest: icon shape CSS values (`border-radius: 0 / 8px / 50%`)
+- [ ] 7.3 Vitest: label position `below` renders labels visible; `overlay` hides labels (visible only on `:hover`)
+- [ ] 7.4 Vitest: `showLabels: false` suppresses all labels
+- [ ] 7.5 Vitest: flex-wrap layout for `columns: 'auto'`; CSS Grid for `columns: 3` (e.g.)
+- [ ] 7.6 Vitest: hover effects — `lift` translates, `fade` reduces opacity, `border` adds outline, `none` is noop
+- [ ] 7.7 Vitest: click navigation — external URL calls `window.open(..., '_blank')`, internal URL navigates in same tab
+- [ ] 7.8 Vitest: click suppressed in edit mode (admin + `canEdit: true`)
+- [ ] 7.9 Vitest: empty state renders when `links.length === 0`; gear icon opens edit form
+- [ ] 7.10 Vitest: icon resolution — custom URL renders `<img>`, MDI name renders `<IconRenderer>`, empty renders fallback
+- [ ] 7.11 Vitest: form validation rejects empty URL, `javascript:` protocol, `data:` protocol
+- [ ] 7.12 Vitest: form drag-to-reorder reorders links array correctly
+- [ ] 7.13 Vitest: form bulk-add parses CSV `label,url` lines and appends to array
+- [ ] 7.14 Vitest: aria-label uses visible label when available, hostname when overlay
+- [ ] 7.15 Vitest: keyboard Tab navigation cycles through links in source order
+- [ ] 7.16 Playwright: E2E flow — add new widget, add 3 links via form, save, render shows all 3 with correct icons and labels
+- [ ] 7.17 Playwright: E2E bulk-add — paste CSV `"Docs,https://docs.example.com\nCalendar,/apps/calendar"`, verify 2 links added
+- [ ] 7.18 Playwright: E2E hover effects — hover link with `lift` effect, verify translate + shadow
+- [ ] 7.19 Playwright: E2E click external link, verify `window.open` in new tab
+- [ ] 7.20 Playwright: E2E click internal link, verify same-tab navigation
+
+## 8. Quality
+
+- [ ] 8.1 ESLint clean (no warnings or errors)
+- [ ] 8.2 All Vue 3 SFCs use script setup syntax (if preferred by codebase) or `<script>` + `<template>`
+- [ ] 8.3 Accessibility: all links are `<a>` with `aria-label`, keyboard navigation works, focus styles visible
+- [ ] 8.4 CSS uses Nextcloud design tokens (variables) for colours, spacing, fonts
+- [ ] 8.5 OpenAPI spec updated for optional `POST /api/widgets/quicklinks/validate-urls` endpoint (if implemented)
+- [ ] 8.6 No console errors or warnings when widget renders
+- [ ] 8.7 Responsive design: widget scales correctly from small (mobile) to large (desktop) widths
+- [ ] 8.8 WCAG AA contrast ratio for all text, focus indicators, and hover states
+

--- a/openspec/changes/setup-wizard/design.md
+++ b/openspec/changes/setup-wizard/design.md
@@ -1,0 +1,118 @@
+# Design — Setup wizard
+
+## Context
+
+The source app ships a CLI-only setup flow: `occ intravox:setup [--language=nl] [--skip-demo] [--force-demo]`. The underlying `SetupService` creates a GroupFolder, configures three Nextcloud groups, sets folder permissions, and optionally seeds demo data. No HTTP endpoint, no Vue component, and no first-run detection flag exist in the source. `SetupService::migrateTemplatesFolders()` handles brownfield installs but is likewise CLI-driven.
+
+The setup wizard defined in this spec is an entirely new MyDash invention. Non-CLI administrators — the majority of self-hosted customers — have no guided path through the suite of configuration decisions that a healthy intranet requires: storage backend, group routing order, demo data, admin role assignment, and footer customization. Today they navigate five separate admin sections in isolation with no indication of what a proper setup sequence looks like.
+
+MyDash adds a 7-step frontend wizard that walks admins through these decisions in one modal flow. Each step embeds the canonical admin UI component from the corresponding sibling capability rather than duplicating it — the wizard is a thin orchestrator, not a parallel settings surface. Choices are persisted immediately to the underlying admin settings on each step commit, so the wizard's own state is derived heuristically from those settings rather than tracked in a separate state machine.
+
+The source CLI pattern is adopted as the model for a parallel `occ mydash:setup` command (defined in the `cli-commands` sibling capability). Both surfaces call the same underlying service methods; the wizard adds UX, not new business logic.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Provide a guided first-run experience for admins who do not use OCC.
+- Track first-run state with a single boolean flag (`mydash.setup_wizard_complete`) rather than a separate wizard state table.
+- Embed existing sibling-capability admin UI components per step — no duplication of settings surfaces.
+- Persist each step's choices immediately to the underlying admin settings so navigating away mid-wizard loses no work.
+- Expose two admin-only API endpoints (`GET /state`, `POST /complete`) so the frontend can drive the wizard reactively.
+- Support re-running the wizard after completion for guided reconfiguration.
+- Provide CLI parity via the `cli-commands` sibling spec.
+
+**Non-Goals:**
+
+- Replicating any wizard-step values in a separate wizard state machine — the underlying admin settings are the source of truth; the wizard derives its step statuses heuristically from them.
+- Porting or reusing source code from the source CLI command — the wizard is net-new; it models the CLI pattern, not the implementation.
+- Undoing previous configuration choices when re-running — re-running re-walks steps showing current state and allows updates, it does not reset.
+- Real-time push of wizard completion state to non-admin users.
+- Making wizard step ordering configurable per install.
+
+## Decisions
+
+### D1: Net-new frontend wizard — no source counterpart
+
+**Decision**: The 7-step wizard is an entirely new MyDash design. The source app ships CLI-only setup. MyDash adds the frontend flow on top of the same underlying service primitives.
+
+**Source evidence (what the source has)**:
+- `intravox-source/lib/Command/SetupCommand.php` — CLI: `intravox:setup` with `--language`, `--skip-demo`, `--force-demo` flags
+- `intravox-source/lib/Service/SetupService.php:1-80` — creates GroupFolder, configures groups, seeds demo data
+- `intravox-source/lib/AppInfo/Application.php` — no `IInitialState` flag, no wizard route, no onboarding component registered
+
+**Rationale**: The frontend wizard reduces setup friction for admins who don't use OCC. The CLI command remains available and is the appropriate tool for IaC and scripted installs. Both surfaces co-exist; neither replaces the other.
+
+### D2: First-run detection flag — `mydash.setup_wizard_complete` boolean
+
+**Decision**: A single admin setting `mydash.setup_wizard_complete` (boolean, default `false`) tracks completion. When `false`, the MyDash admin section displays a "Run setup wizard" banner. When `true`, the banner is hidden but a "Run setup wizard again" link remains visible in the admin section.
+
+**Rationale**: A single flag keeps the persistence model trivial and survives the wizard being re-run any number of times. The flag signals intent, not content — the actual configuration is in the sibling capabilities' own settings.
+
+### D3: 7-step flow — embed pattern, not duplication
+
+**Decision**: Seven steps as described in the spec. Steps 2–6 each embed the existing admin UI component from the corresponding sibling capability. The wizard owns step sequencing and the completion flag; each sibling capability owns its own settings persistence.
+
+| Step | Sibling capability |
+|------|--------------------|
+| 2 — Storage backend | `groupfolder-storage-backend` (writes `mydash.content_storage`) |
+| 3 — Group order | `group-priority-order` (writes `mydash.group_priority_order`) |
+| 4 — Demo data | `demo-data-showcases` (installs selected packages) |
+| 5 — Admin roles | `admin-roles` (creates role assignment in `oc_mydash_role_assignments`) |
+| 6 — Footer config | `footer-customization` (writes `mydash.footer_config`) |
+
+All five sibling slugs exist in `openspec/changes/` and are confirmed present.
+
+**Rationale**: Embedding keeps the wizard a thin orchestrator. A developer maintaining the group-priority-order admin UI does not need to touch wizard code, and vice versa. There is one canonical UI per setting, reachable both from the wizard and from the standalone admin section.
+
+### D4: Per-step skip / immediate persistence
+
+**Decision**: Each step (except Welcome and Done) has Skip / Back / Next buttons. Clicking Next on a step immediately persists any committed values to the underlying admin settings. Skipping a step does NOT mark the wizard incomplete — only the Done step's "Finish" button writes `mydash.setup_wizard_complete = true`.
+
+**Rationale**: Immediate persistence means navigating away mid-wizard, closing the browser, or clicking Back never causes data loss. The skip/finish distinction avoids a scenario where an admin who skips optional steps 5 and 6 cannot complete the wizard — skipped steps are valid completion states.
+
+### D5: Re-runnable flow — shows current state, does not reset
+
+**Decision**: An admin may click "Run setup wizard again" at any time after completion. Re-running opens the wizard with each step showing current settings values, not a blank form. No existing configuration is reset. The admin may update any step's values; clicking "Finish" again writes `complete = true` (already true — idempotent).
+
+**Rationale**: Guided reconfiguration is a real use case for admins who want to change storage backend or re-assign roles months after initial setup. The wizard provides a more guided experience than navigating individual admin sections.
+
+### D6: Auto-launch heuristic — SHOULD, not MUST
+
+**Decision**: When an admin first opens `/apps/mydash/admin/dashboards`, if `setup_wizard_complete = false` AND no dashboards exist AND no admin settings have been written, the page SHOULD auto-open the wizard. This is a soft UX recommendation, not a mandatory requirement. The banner-link fallback is always available regardless of whether auto-launch fires.
+
+**Rationale**: Auto-launch removes one click for the common fresh-install case. Making it SHOULD rather than MUST avoids breaking edge cases (e.g., headless installs via CLI where an admin views the page mid-setup before completing the OCC command).
+
+### D7: CLI parity via sibling `cli-commands` capability
+
+**Decision**: A `php occ mydash:setup --config=<yaml>` command defined in the `cli-commands` sibling spec executes the equivalent flow non-interactively from a YAML file. The command calls the same service methods as the wizard steps and sets `setup_wizard_complete = true` on success.
+
+**Source evidence**:
+- `intravox-source/lib/Command/SetupCommand.php` — CLI pattern to model (flag names, OCC registration, console output conventions)
+
+**Rationale**: CLI parity makes MyDash deployable via Ansible, Docker init scripts, and other IaC tooling without requiring a browser session. The YAML config schema covers all five configurable steps; optional steps may be omitted.
+
+### D8: State endpoint — `GET /api/admin/setup-wizard/state`
+
+**Decision**: Returns `{complete: bool, currentRecommendedStep: 1..7, stepStatuses: {1: 'done'|'skipped'|'pending', ...}}`. The `currentRecommendedStep` heuristic selects the first step whose status is not `'done'`, so re-runs land on the right step without forcing the admin to re-walk completed ones. Step 1 (Welcome) is always `'done'`.
+
+**Rationale**: The state endpoint gives the frontend a single reactive source for rendering the wizard's progress indicator and for determining where to resume on re-open. Step statuses are derived from sibling settings reads, not from a separate wizard state table — consistent with D4's no-separate-state-machine principle.
+
+### D9: Idempotent completion — `POST /api/admin/setup-wizard/complete`
+
+**Decision**: `POST /api/admin/setup-wizard/complete` writes `mydash.setup_wizard_complete = true` and returns the current wizard state (same structure as GET). Calling it when already `true` returns HTTP 200 with current state — no error, no side effects.
+
+**Rationale**: Idempotency allows the Finish button and the CLI command to call the same endpoint without defensive guards. Callers do not need to check current state before posting.
+
+## Spec changes implied
+
+- Add a NOTE to REQ-WIZ-001 confirming this is a net-new MyDash capability with no source counterpart; the source ships CLI-only via `intravox:setup`.
+- REQ-WIZ-002 (7 steps): add a NOTE pinning the embed pattern from D3 — wizard embeds canonical sibling admin UI, does not duplicate it.
+- REQ-WIZ-010 (CLI): cross-reference the `cli-commands` sibling spec and note that the YAML config schema covers all five configurable steps; optional steps may be omitted.
+- REQ-WIZ-008 (auto-launch): the existing scenario already uses "MAY" — add a NOTE clarifying this is intentionally SHOULD/MAY to avoid breaking mid-setup CLI installs.
+
+## Open follow-ups
+
+- Whether the wizard should detect an existing GroupFolder configuration (e.g., from a previous install or an unrelated Nextcloud GroupFolder setup) and skip Step 2 with an informational notice rather than presenting a blank radio choice.
+- Whether the `--config` YAML schema for the CLI command should be versioned (e.g., `apiVersion: v1`) to support forward compatibility as new wizard steps are added.
+- Whether step ordering should be customisable per install — current recommendation is fixed order for customer-support predictability; revisit if customers request it.

--- a/openspec/changes/setup-wizard/proposal.md
+++ b/openspec/changes/setup-wizard/proposal.md
@@ -1,0 +1,76 @@
+# Setup Wizard
+
+## Why
+
+A freshly installed MyDash instance requires several configuration decisions to establish a healthy intranet: storage backend selection (Database vs. GroupFolder), default group priority order, demo data installation, admin role assignments, and footer configuration. Today, administrators must navigate multiple admin sections in isolation, without guidance on what a proper setup entails. A multi-step wizard walks admins through these choices, explains the implications, and persists decisions immediately, reducing setup friction and ensuring instances are properly configured from day one.
+
+## What Changes
+
+- Add an admin-setting flag `mydash.setup_wizard_complete` (boolean, default `false`) to track first-run completion. When `false`, the MyDash admin section displays a "Run setup wizard" banner.
+- Implement a multi-step Vue 3 modal/screen wizard in the MyDash admin section:
+  - **Step 1 — Welcome**: Overview of what the wizard configures.
+  - **Step 2 — Storage backend**: Radio choice of "Database (default)" or "GroupFolder (recommended for org use)". GroupFolder option disabled with tooltip if the `groupfolders` NC app is not installed. Writes `mydash.content_storage` admin setting.
+  - **Step 3 — Group order**: Pick priority order of NC groups for dashboard routing. Reuses existing `group-priority-order` admin UI as an embedded component.
+  - **Step 4 — Demo data**: Optional checkboxes per showcase. Reuses existing `demo-data-showcases` admin UI as an embedded component.
+  - **Step 5 — Admin roles**: Optional — assign "Dashboard Admin" role to one NC group (depends on `admin-roles` capability). Skippable.
+  - **Step 6 — Footer config**: Optional — open "Structured mode" footer editor (depends on `footer-customization`). Skippable.
+  - **Step 7 — Done**: Summary screen. "Finish" button writes `mydash.setup_wizard_complete = true` and dismisses banner.
+- Each step has Skip / Back / Next buttons. Skipping does not mark wizard incomplete; only "Finish" marks complete.
+- Wizard is re-runnable: admins can click "Run setup wizard again" even after completion. Re-running does not undo earlier choices; it re-walks the steps showing current state.
+- Each step's completion (committed values) is persisted immediately, so navigating away mid-wizard does not lose work.
+- Expose `GET /api/admin/setup-wizard/state` → `{complete: bool, currentRecommendedStep: 1..7, stepStatuses: {1: 'done'|'skipped'|'pending', ...}}`. The `currentRecommendedStep` heuristically picks "first non-done step" for re-runs.
+- Expose `POST /api/admin/setup-wizard/complete` → marks `setup_wizard_complete = true`. NC-admin only. Idempotent: writing when already true returns 200.
+- CLI command `php occ mydash:setup --config=/path/setup.yaml` performs wizard non-interactively, reading a YAML config file describing every step's choices (IaC-friendly).
+- Optional auto-launch: when an admin first opens `/apps/mydash/admin/dashboards`, if `setup_wizard_complete` is false AND no dashboards exist AND no admin settings have been written, the page MAY auto-open the wizard (recommended UX but not required).
+
+## Capabilities
+
+### New Capabilities
+
+- `setup-wizard`: First-run admin wizard with state tracking, step progression, immediate persistence, re-runnable flow, API endpoints, and CLI command.
+
+### Modified Capabilities
+
+- `groupfolder-storage-backend` (ref: `openspec/changes/groupfolder-storage-backend/specs/groupfolder-storage-backend/spec.md`): Step 2 writes the `mydash.content_storage` setting that this capability defines. No schema changes; wizard is a consumer.
+- `group-priority-order` (ref: `openspec/changes/group-priority-order/specs/admin-settings/spec.md`): Step 3 embeds this existing admin UI. No changes to the capability itself.
+- `demo-data-showcases` (ref: `openspec/changes/demo-data-showcases/specs/demo-data-showcases/spec.md`): Step 4 embeds this existing admin UI. No changes to the capability itself.
+- `admin-roles` (ref: `openspec/changes/admin-roles/specs/admin-roles/spec.md`): Step 5 allows assigning "Dashboard Admin" role to a group. No changes; wizard is a convenience consumer.
+- `footer-customization` (ref: `openspec/changes/footer-customization/specs/footer-customization/spec.md`): Step 6 opens the footer editor. No changes; wizard is a convenience consumer.
+
+## Impact
+
+**Affected code:**
+
+- `lib/Service/SetupWizardService.php` — new service with `getWizardState()`, `markWizardComplete()`, `validateStep()`, `persistStepChoice()` methods.
+- `lib/Controller/AdminController.php` (extend) — two new endpoints: `GET /api/admin/setup-wizard/state`, `POST /api/admin/setup-wizard/complete`.
+- `lib/Command/SetupCommand.php` — new CLI command `php occ mydash:setup --config=/path/setup.yaml`.
+- `appinfo/routes.php` (extend) — register the two new routes.
+- `src/views/admin/SetupWizardModal.vue` — new Vue 3 component with 7-step flow, Skip/Back/Next buttons, progress tracking.
+- `src/views/admin/AdminDashboards.vue` (extend) — add "Run setup wizard" banner when `setup_wizard_complete` is false.
+- `l10n/en.json`, `l10n/nl.json` — translations for wizard labels, steps, and button text.
+
+**Affected APIs:**
+
+- 2 new routes: `GET /api/admin/setup-wizard/state`, `POST /api/admin/setup-wizard/complete`
+- 1 new CLI command: `mydash:setup`
+
+**Dependencies:**
+
+- `admin-roles` capability (Step 5 depends on it; optional step)
+- `footer-customization` capability (Step 6 depends on it; optional step)
+- `groupfolder-storage-backend` capability (Step 2 writes setting defined by it)
+- `group-priority-order` capability (Step 3 embeds its admin UI)
+- `demo-data-showcases` capability (Step 4 embeds its admin UI)
+- `OCP\IAppConfig` — for reading/writing admin settings
+- `OCP\IUserManager`, `OCP\IGroupManager` — for validating group choices in Step 5
+- No new composer or npm dependencies beyond existing MyDash stack
+
+**Migration:**
+
+- Zero-impact: no schema changes, only new admin-setting flag
+- New instances start with `setup_wizard_complete = false`; admins see banner on first login
+- Existing instances (already have settings) can opt-in to running wizard; completion flag defaults to false (wizard remains available until explicitly completed)
+
+## Front-end Concern (Not in Scope)
+
+The admin UI MUST provide an accessible, mobile-friendly modal with clear explanations for each step, disabled-state tooltips for unavailable options (e.g., GroupFolder option when app not installed), and a visual progress indicator. Steps 3–6 embed existing admin UI components and MUST remain functional within the wizard context.

--- a/openspec/changes/setup-wizard/specs/setup-wizard/spec.md
+++ b/openspec/changes/setup-wizard/specs/setup-wizard/spec.md
@@ -29,6 +29,8 @@ Wizard progress (per-step completion status) is derived heuristically from the s
 
 The system MUST detect whether a MyDash instance is being initialized for the first time by consulting the `mydash.setup_wizard_complete` boolean flag. When the flag is `false`, the admin section MUST display a banner prompting the admin to run the wizard.
 
+> NOTE: This is a net-new MyDash capability with no counterpart in the source app. The source ships CLI-only setup via `intravox:setup`; no frontend first-run detection, wizard route, or onboarding component exists in the source. MyDash adds this flag and banner on top of the same underlying service primitives.
+
 #### Scenario: Fresh instance shows banner
 - GIVEN a freshly installed MyDash with `mydash.setup_wizard_complete = false`
 - WHEN an NC admin opens `/apps/mydash/admin/dashboards`
@@ -60,6 +62,8 @@ The system MUST detect whether a MyDash instance is being initialized for the fi
 ### Requirement: REQ-WIZ-002 Multi-Step Wizard Flow with 7 Steps
 
 The wizard MUST guide the admin through a linear, skippable sequence of 7 steps, each with Skip / Back / Next buttons. Only the "Finish" button on Step 7 marks the wizard complete.
+
+> NOTE: Steps 2–6 each embed the canonical admin UI component from the corresponding sibling capability (`groupfolder-storage-backend`, `group-priority-order`, `demo-data-showcases`, `admin-roles`, `footer-customization`). The wizard is a thin orchestrator — it owns step sequencing and the completion flag; each sibling capability owns its own settings persistence. No settings surfaces are duplicated.
 
 #### Scenario: Wizard starts at Step 1
 - GIVEN the banner's "Run setup wizard" button is clicked
@@ -281,6 +285,8 @@ Step 6 MUST allow the admin to optionally open and configure the footer using th
 
 The system MUST expose a `GET /api/admin/setup-wizard/state` endpoint that returns the wizard's completion status, current recommended step for re-runs, and per-step status.
 
+> NOTE: Auto-launch behaviour (opening the wizard automatically when `setup_wizard_complete = false`) is intentionally SHOULD/MAY, not MUST. CLI-provisioned installs may set settings incrementally mid-`occ` run, meaning an admin who views the page before the CLI command finishes would see `complete = false` with settings partially applied. The banner-link fallback is always available and is the reliable path; auto-launch is a UX convenience for fresh browser sessions only.
+
 #### Scenario: Endpoint returns complete state on fresh instance
 - GIVEN a fresh MyDash instance with `mydash.setup_wizard_complete = false`
 - WHEN an NC admin calls `GET /api/admin/setup-wizard/state`
@@ -357,6 +363,8 @@ The system MUST expose a `POST /api/admin/setup-wizard/complete` endpoint that i
 ### Requirement: REQ-WIZ-010 CLI Command for Non-Interactive Setup (IaC-Friendly)
 
 The system MUST expose a CLI command `php occ mydash:setup` that accepts a `--config=/path/setup.yaml` argument to perform wizard setup non-interactively, ideal for Infrastructure-as-Code deployments.
+
+> NOTE: The YAML config schema (fields: `storage_backend`, `group_priority_order`, `demo_packages`, `admin_role_group`, `footer_config`) is formally defined in the `cli-commands` sibling spec. Optional steps (admin roles, footer) may be omitted from the config file entirely; omitting them is equivalent to skipping those steps in the wizard and does not cause an error.
 
 #### Scenario: CLI command accepts YAML config file
 - GIVEN a YAML file `/tmp/setup.yaml` with content:

--- a/openspec/changes/setup-wizard/specs/setup-wizard/spec.md
+++ b/openspec/changes/setup-wizard/specs/setup-wizard/spec.md
@@ -1,0 +1,450 @@
+---
+status: draft
+---
+
+# Setup Wizard Specification
+
+## Purpose
+
+The Setup Wizard is a multi-step first-run configuration flow for freshly installed MyDash instances. It guides administrators through selecting a storage backend, setting group priority order, installing optional demo data, assigning admin roles, and configuring footer content. The wizard detects first-run state via an admin-setting flag, supports both interactive and non-interactive (CLI) flows, and ensures all choices are persisted immediately so progress is not lost.
+
+## Data Model
+
+The setup wizard does not define a new persistent table; it tracks state via existing admin settings and a single new boolean flag:
+
+- **mydash.setup_wizard_complete**: Boolean (default `false`). Set to `true` when the wizard completes via "Finish" button or CLI command.
+
+Wizard progress (per-step completion status) is derived heuristically from the state of underlying settings:
+- Step 1 (Welcome): always "done" (no choice to persist)
+- Step 2 (Storage): "done" if `mydash.content_storage` is set; "pending" otherwise
+- Step 3 (Group order): "done" if `mydash.group_priority_order` is set; "pending" otherwise
+- Step 4 (Demo data): "done" if at least one demo package has been installed; "pending" otherwise
+- Step 5 (Admin roles): "skipped" if not visited; "done" if a "Dashboard Admin" role assignment exists
+- Step 6 (Footer): "skipped" if not visited; "done" if `mydash.footer_config` is set
+- Step 7 (Done): "pending" until wizard completes
+
+## ADDED Requirements
+
+### Requirement: REQ-WIZ-001 Detect First-Run State via Admin Setting Flag
+
+The system MUST detect whether a MyDash instance is being initialized for the first time by consulting the `mydash.setup_wizard_complete` boolean flag. When the flag is `false`, the admin section MUST display a banner prompting the admin to run the wizard.
+
+#### Scenario: Fresh instance shows banner
+- GIVEN a freshly installed MyDash with `mydash.setup_wizard_complete = false`
+- WHEN an NC admin opens `/apps/mydash/admin/dashboards`
+- THEN the page MUST display a prominent banner: "Run setup wizard" with a button linking to the wizard flow
+- AND the banner MUST remain visible until the admin clicks "Finish" in the wizard
+
+#### Scenario: Completed instance hides banner
+- GIVEN a MyDash instance with `mydash.setup_wizard_complete = true`
+- WHEN an NC admin opens `/apps/mydash/admin/dashboards`
+- THEN the banner MUST NOT be displayed
+- AND the admin section loads normally
+
+#### Scenario: Banner includes descriptive text
+- GIVEN a fresh MyDash instance showing the setup banner
+- WHEN the admin views the banner
+- THEN the banner MUST include text explaining: "Get your intranet started: choose storage, configure groups, install demo data, and set up admin roles."
+- NOTE: Banner style and wording are implementation-specific; requirement mandates presence and visibility only
+
+#### Scenario: Banner has explicit "Run setup wizard" call-to-action
+- GIVEN the banner is displayed
+- WHEN the admin clicks the "Run setup wizard" button
+- THEN the wizard modal MUST open and begin at Step 1 (Welcome)
+
+#### Scenario: Admin can dismiss and re-access banner
+- GIVEN an admin who dismissed the banner or navigated away
+- WHEN the admin returns to `/apps/mydash/admin/dashboards`
+- THEN if `mydash.setup_wizard_complete = false`, the banner MUST reappear
+
+### Requirement: REQ-WIZ-002 Multi-Step Wizard Flow with 7 Steps
+
+The wizard MUST guide the admin through a linear, skippable sequence of 7 steps, each with Skip / Back / Next buttons. Only the "Finish" button on Step 7 marks the wizard complete.
+
+#### Scenario: Wizard starts at Step 1
+- GIVEN the banner's "Run setup wizard" button is clicked
+- WHEN the wizard modal opens
+- THEN Step 1 (Welcome / Overview) MUST be displayed
+- AND the step counter MUST show "1 / 7"
+
+#### Scenario: Next button advances to next step
+- GIVEN the wizard is on Step 1
+- WHEN the admin clicks "Next"
+- THEN the wizard advances to Step 2 (Storage backend)
+- AND the step counter MUST show "2 / 7"
+- AND the Back button MUST become active
+
+#### Scenario: Back button returns to previous step
+- GIVEN the wizard is on Step 3
+- WHEN the admin clicks "Back"
+- THEN the wizard returns to Step 2
+- AND no data loss occurs (Step 3 values are preserved if re-visited)
+
+#### Scenario: Skip button jumps to next step without commitment
+- GIVEN the wizard is on Step 5 (Admin roles, optional)
+- WHEN the admin clicks "Skip"
+- THEN the wizard advances to Step 6
+- AND the wizard completion status for Step 5 is marked "skipped" (not "done")
+- NOTE: Skipping a step does not prevent the wizard from eventually marking complete
+
+#### Scenario: Step 1 has no form; only explanatory text
+- GIVEN Step 1 (Welcome) is displayed
+- WHEN the admin views the step
+- THEN the step MUST show text explaining the wizard's purpose: "Configure your MyDash instance with storage, group ordering, demo data, admin roles, and footer settings."
+- AND there are no form fields to fill
+- AND clicking "Next" advances without persisting any choice
+
+#### Scenario: Step 7 shows summary and Finish button
+- GIVEN the wizard reaches Step 7 (Done)
+- WHEN the admin views the step
+- THEN the step MUST display a summary: "Your setup is complete. Click Finish to save changes and dismiss the setup banner."
+- AND a "Finish" button (not "Next") MUST be present
+- AND clicking "Finish" executes the completion action
+
+#### Scenario: Finish button completes wizard
+- GIVEN the admin is on Step 7 with the "Finish" button visible
+- WHEN the admin clicks "Finish"
+- THEN the system MUST set `mydash.setup_wizard_complete = true`
+- AND the wizard modal MUST close
+- AND the admin section MUST reload, banner gone
+
+#### Scenario: Wizard progress persists across Back navigation
+- GIVEN the wizard is on Step 3 with group order selected
+- WHEN the admin clicks Back to Step 2, modifies storage backend, then clicks Next to Step 3
+- THEN the group order selection from Step 3 MUST still be present (no data loss)
+
+### Requirement: REQ-WIZ-003 Step 2 — Storage Backend Choice with GroupFolder Dependency Tooltip
+
+Step 2 MUST present two radio options: "Database (default)" and "GroupFolder (recommended for org use)". The GroupFolder option MUST be disabled with a tooltip if the `groupfolders` Nextcloud app is not installed.
+
+#### Scenario: Storage backend selection shows two options
+- GIVEN Step 2 is displayed
+- WHEN the admin views the step
+- THEN two radio buttons MUST be visible:
+  - "Database (default)" — with description "Store dashboard content in MyDash database table"
+  - "GroupFolder (recommended for org use)" — with description "Store dashboard content in Nextcloud GroupFolders for collaborative access"
+- AND exactly one option MUST be pre-selected (default to "Database")
+
+#### Scenario: GroupFolder option disabled if app not installed
+- GIVEN the `groupfolders` Nextcloud app is NOT installed
+- WHEN Step 2 is displayed
+- THEN the "GroupFolder" radio option MUST be disabled (grayed out)
+- AND a tooltip MUST appear on hover: "GroupFolder app is not installed. Install 'Nextcloud GroupFolders' to use this option."
+- NOTE: Disabled state prevents selection; tooltip explains why
+
+#### Scenario: GroupFolder option enabled if app installed
+- GIVEN the `groupfolders` Nextcloud app IS installed
+- WHEN Step 2 is displayed
+- THEN the "GroupFolder" radio option MUST be enabled
+- AND the option is selectable
+
+#### Scenario: Storage choice persists immediately
+- GIVEN Step 2 is displayed with "Database" selected
+- WHEN the admin selects "GroupFolder" and clicks Next
+- THEN the system MUST immediately write `mydash.content_storage = "groupfolder"` to admin settings
+- AND if the admin navigates away (Back, Browser close, etc.), the choice MUST be persisted (not lost)
+
+#### Scenario: Default is Database
+- GIVEN a fresh instance where no storage backend has been chosen
+- WHEN Step 2 is displayed
+- THEN "Database (default)" MUST be pre-selected
+- NOTE: This reflects the safe, always-available default
+
+### Requirement: REQ-WIZ-004 Step 3 — Group Priority Order (Embedded Component Reuse)
+
+Step 3 MUST embed the existing `group-priority-order` admin UI component, allowing the admin to configure the priority order of Nextcloud groups for dashboard routing.
+
+#### Scenario: Step 3 embeds existing group-priority-order admin component
+- GIVEN Step 3 is displayed
+- WHEN the admin views the step
+- THEN the existing `group-priority-order` admin UI MUST be visible and functional within the wizard modal
+- NOTE: The component is not duplicated; the wizard embeds the canonical admin component
+
+#### Scenario: Group order choice persists immediately
+- GIVEN the admin reorders groups in Step 3 (e.g., "engineering" moved above "sales")
+- WHEN the admin clicks Next
+- THEN the system MUST immediately persist the new order to `mydash.group_priority_order`
+- AND navigating away does not lose the change
+
+#### Scenario: Step 3 allows drag-and-drop reordering (existing UI behavior)
+- GIVEN the group-priority-order component is displayed
+- WHEN the admin drags a group to a new position
+- THEN the reorder MUST be reflected in the UI
+- NOTE: Exact interaction (drag, arrow buttons, etc.) is determined by the embedded component's design
+
+### Requirement: REQ-WIZ-005 Step 4 — Demo Data Installation (Embedded Component Reuse)
+
+Step 4 MUST embed the existing `demo-data-showcases` admin UI component, allowing the admin to optionally select and install demo packages.
+
+#### Scenario: Step 4 embeds demo-data-showcases admin component
+- GIVEN Step 4 is displayed
+- WHEN the admin views the step
+- THEN the existing `demo-data-showcases` admin UI MUST be visible within the wizard modal
+- AND the component displays all available demo packages with checkboxes
+- NOTE: The component is the canonical admin UI; wizard embeds it without duplication
+
+#### Scenario: Demo data installation is optional
+- GIVEN Step 4 is displayed with zero demo packages selected
+- WHEN the admin clicks "Skip" or "Next"
+- THEN the wizard MUST advance without requiring any demo to be installed
+- NOTE: Step 4 is not skippable via a Skip button; all steps are traversed. However, selecting zero demos and clicking Next is equivalent to skipping.
+
+#### Scenario: Checked demos are installed on Next
+- GIVEN the admin selects checkboxes for "Engineering Demo" and "Sales Demo" on Step 4
+- WHEN the admin clicks "Next"
+- THEN the system MUST trigger the installation of both demo packages
+- AND the wizard advances to Step 5 (installation happens asynchronously or blocks until done, implementation choice)
+- NOTE: The demo-data-showcases component handles the actual installation logic
+
+#### Scenario: Demo selection is persisted
+- GIVEN the admin selected "Engineering Demo" on Step 4 and advanced to Step 5
+- WHEN the admin navigates Back to Step 4
+- THEN the "Engineering Demo" checkbox MUST remain checked
+- AND no re-installation happens (idempotent)
+
+### Requirement: REQ-WIZ-006 Step 5 — Admin Roles (Optional, Depends on admin-roles Capability)
+
+Step 5 MUST allow the admin to optionally assign the "Dashboard Admin" role to one Nextcloud group. This step is skippable via a Skip button.
+
+#### Scenario: Step 5 shows group selector for admin role
+- GIVEN the `admin-roles` capability is available
+- AND Step 5 is displayed
+- WHEN the admin views the step
+- THEN a dropdown or multi-select MUST display all Nextcloud groups
+- AND a description MUST explain: "Assign 'Dashboard Admin' role to a group to delegate MyDash administration to group members."
+
+#### Scenario: Admin can select one group for Dashboard Admin role
+- GIVEN Step 5 is displayed with groups ["engineering", "sales", "marketing"]
+- WHEN the admin selects "engineering"
+- AND clicks "Next"
+- THEN the system MUST call `RoleService::assignRole(groupId="engineering", role="admin", assignedBy=<current-admin>)`
+- AND the role assignment MUST be created in `oc_mydash_role_assignments`
+
+#### Scenario: Step 5 is skippable
+- GIVEN Step 5 is displayed
+- WHEN the admin clicks "Skip"
+- THEN no role assignment is made
+- AND the wizard advances to Step 6
+- AND the completion status for Step 5 MUST be marked "skipped"
+
+#### Scenario: No group selected is equivalent to skip
+- GIVEN Step 5 with no group selected
+- WHEN the admin clicks "Next"
+- THEN no role assignment is made (equivalent to Skip)
+- AND the wizard advances to Step 6
+
+#### Scenario: Step 5 unavailable if admin-roles capability missing
+- GIVEN the `admin-roles` capability is NOT implemented or not available
+- WHEN the wizard would display Step 5
+- THEN Step 5 MUST be skipped automatically
+- AND the step counter jumps from Step 4 to Step 6
+- NOTE: Capability dependency is gracefully handled; missing capability does not break wizard
+
+#### Scenario: Only one group can have admin role per wizard run
+- GIVEN Step 5 is displayed
+- WHEN the admin selects "engineering" and clicks "Next"
+- THEN only the "engineering" group receives the admin role (not multiple groups)
+- NOTE: If the admin wishes to assign admin role to multiple groups, they must run the wizard again or use the admin roles management UI directly
+
+### Requirement: REQ-WIZ-007 Step 6 — Footer Configuration (Optional, Depends on footer-customization Capability)
+
+Step 6 MUST allow the admin to optionally open and configure the footer using the "Structured mode" editor. This step is skippable via a Skip button.
+
+#### Scenario: Step 6 shows footer editor
+- GIVEN the `footer-customization` capability is available
+- AND Step 6 is displayed
+- WHEN the admin views the step
+- THEN the "Structured mode" footer editor MUST be visible and functional
+- AND a description MUST explain: "Customize the footer content and appearance for your intranet."
+
+#### Scenario: Footer edits persist immediately
+- GIVEN the admin edits footer content in Step 6
+- WHEN the admin clicks "Next"
+- THEN the footer configuration MUST be saved to `mydash.footer_config` or equivalent setting
+- AND navigating away does not lose the changes
+
+#### Scenario: Step 6 is skippable
+- GIVEN Step 6 is displayed
+- WHEN the admin clicks "Skip"
+- THEN no footer changes are made
+- AND the wizard advances to Step 7
+- AND the completion status for Step 6 MUST be marked "skipped"
+
+#### Scenario: Step 6 unavailable if footer-customization capability missing
+- GIVEN the `footer-customization` capability is NOT implemented or not available
+- WHEN the wizard would display Step 6
+- THEN Step 6 MUST be skipped automatically
+- AND the step counter jumps from Step 5 to Step 7
+- NOTE: Capability dependency is gracefully handled; missing capability does not break wizard
+
+### Requirement: REQ-WIZ-008 Get Wizard State via API Endpoint
+
+The system MUST expose a `GET /api/admin/setup-wizard/state` endpoint that returns the wizard's completion status, current recommended step for re-runs, and per-step status.
+
+#### Scenario: Endpoint returns complete state on fresh instance
+- GIVEN a fresh MyDash instance with `mydash.setup_wizard_complete = false`
+- WHEN an NC admin calls `GET /api/admin/setup-wizard/state`
+- THEN the response MUST be HTTP 200 with JSON:
+  ```json
+  {
+    "complete": false,
+    "currentRecommendedStep": 1,
+    "stepStatuses": {
+      "1": "done",
+      "2": "pending",
+      "3": "pending",
+      "4": "pending",
+      "5": "pending",
+      "6": "pending",
+      "7": "pending"
+    }
+  }
+  ```
+- NOTE: Step 1 is always "done" (no choice required). Steps 2–7 start "pending".
+
+#### Scenario: Endpoint returns recommended step for re-runs
+- GIVEN a MyDash instance with storage backend set but group order not yet set
+- WHEN an NC admin calls `GET /api/admin/setup-wizard/state`
+- THEN the response MUST include `currentRecommendedStep: 3`
+- NOTE: The heuristic picks the first step with status != "done"
+
+#### Scenario: Endpoint returns complete=true when wizard finished
+- GIVEN a MyDash instance with `mydash.setup_wizard_complete = true`
+- WHEN an NC admin calls `GET /api/admin/setup-wizard/state`
+- THEN the response MUST include `complete: true`
+- AND `currentRecommendedStep` MAY be 1 (optional) or reflect the last visited step (implementation choice)
+
+#### Scenario: Non-admin requests receive 403
+- GIVEN a non-admin user
+- WHEN they call `GET /api/admin/setup-wizard/state`
+- THEN the system MUST return HTTP 403 (Forbidden)
+
+#### Scenario: Endpoint includes skipped step status
+- GIVEN the wizard has been run with Step 5 skipped
+- WHEN an NC admin calls `GET /api/admin/setup-wizard/state`
+- THEN the response MUST include `"5": "skipped"` in stepStatuses
+- NOTE: Skipped status indicates the step was traversed but no action taken; does not block wizard completion
+
+### Requirement: REQ-WIZ-009 Mark Wizard Complete via API Endpoint
+
+The system MUST expose a `POST /api/admin/setup-wizard/complete` endpoint that idempotently sets `mydash.setup_wizard_complete = true` and returns the current wizard state.
+
+#### Scenario: Endpoint sets complete flag
+- GIVEN a MyDash instance with `mydash.setup_wizard_complete = false`
+- WHEN an NC admin calls `POST /api/admin/setup-wizard/complete`
+- THEN the system MUST set `mydash.setup_wizard_complete = true`
+- AND the response MUST be HTTP 200 with the current wizard state (same structure as GET endpoint)
+
+#### Scenario: Endpoint is idempotent
+- GIVEN a MyDash instance with `mydash.setup_wizard_complete = true`
+- WHEN an NC admin calls `POST /api/admin/setup-wizard/complete` again
+- THEN the system MUST return HTTP 200
+- AND `complete` in the response MUST be true
+- AND no error is raised
+
+#### Scenario: Non-admin requests receive 403
+- GIVEN a non-admin user
+- WHEN they call `POST /api/admin/setup-wizard/complete`
+- THEN the system MUST return HTTP 403 (Forbidden)
+- AND the flag MUST NOT change
+
+#### Scenario: Completion returns full state
+- GIVEN the request succeeds
+- WHEN the response is examined
+- THEN it MUST contain the full wizard state (complete, currentRecommendedStep, stepStatuses)
+- NOTE: Return format is identical to GET endpoint for consistency
+
+### Requirement: REQ-WIZ-010 CLI Command for Non-Interactive Setup (IaC-Friendly)
+
+The system MUST expose a CLI command `php occ mydash:setup` that accepts a `--config=/path/setup.yaml` argument to perform wizard setup non-interactively, ideal for Infrastructure-as-Code deployments.
+
+#### Scenario: CLI command accepts YAML config file
+- GIVEN a YAML file `/tmp/setup.yaml` with content:
+  ```yaml
+  storage_backend: "groupfolder"
+  group_priority_order: ["engineering", "sales"]
+  demo_packages: ["engineering-demo", "sales-demo"]
+  admin_role_group: "engineering"
+  footer_config:
+    layout: "structured"
+    items: [...]
+  ```
+- WHEN an admin runs `php occ mydash:setup --config=/tmp/setup.yaml`
+- THEN the system MUST:
+  - Set `mydash.content_storage = "groupfolder"` (Step 2)
+  - Set `mydash.group_priority_order = ["engineering", "sales"]` (Step 3)
+  - Install "engineering-demo" and "sales-demo" (Step 4)
+  - Assign "Dashboard Admin" role to "engineering" (Step 5)
+  - Set `mydash.footer_config` with provided config (Step 6)
+  - Set `mydash.setup_wizard_complete = true` (Step 7)
+
+#### Scenario: CLI command validates YAML schema
+- GIVEN a malformed YAML file (e.g., missing required fields)
+- WHEN `php occ mydash:setup --config=/tmp/setup.yaml` is run
+- THEN the system MUST output an error: "Invalid setup.yaml: missing field 'storage_backend'"
+- AND the command MUST exit with non-zero status
+- AND no settings are applied
+
+#### Scenario: CLI command is verbose by default
+- GIVEN the command runs successfully
+- WHEN the output is examined
+- THEN it MUST show progress: "Step 1: Welcome... done", "Step 2: Storage backend... done", etc.
+- AND final message: "Setup wizard completed successfully."
+
+#### Scenario: CLI command skips optional steps if not in config
+- GIVEN a YAML file with only `storage_backend` and `group_priority_order`
+- WHEN the command runs
+- THEN Steps 5 and 6 MUST be skipped (no error)
+- AND Steps 2 and 3 MUST execute with provided values
+- AND the wizard completes
+
+#### Scenario: CLI command is idempotent
+- GIVEN a YAML config that was applied once
+- WHEN the same command runs again with the same config
+- THEN the system MUST return success (HTTP 200 equivalent)
+- AND no duplicate role assignments or demo installations occur
+- NOTE: The system MUST detect existing assignments/installations and skip them
+
+### Requirement: REQ-WIZ-011 Wizard is Re-Runnable
+
+The wizard MUST be re-runnable even after `mydash.setup_wizard_complete = true`. Re-running MUST NOT undo earlier choices; it MUST re-walk the steps showing current state and allowing updates.
+
+#### Scenario: Admin can run wizard again after completion
+- GIVEN a MyDash instance with `mydash.setup_wizard_complete = true`
+- WHEN an NC admin navigates to `/apps/mydash/admin` and clicks "Run setup wizard again" (or uses a Re-run button in a separate admin UI section)
+- THEN the wizard modal MUST open
+- AND all step values MUST reflect current settings (storage backend, group order, etc.)
+- AND the admin can make changes
+
+#### Scenario: Re-running from Step 2 updates storage backend
+- GIVEN the instance has `mydash.content_storage = "database"`
+- AND the admin re-runs the wizard and navigates to Step 2
+- WHEN the admin selects "GroupFolder" and clicks Next
+- THEN the system MUST update `mydash.content_storage = "groupfolder"`
+- AND the previous choice "database" is overwritten (not appended or merged)
+
+#### Scenario: Re-running does not re-install demo packages
+- GIVEN the instance has already installed "engineering-demo"
+- AND the admin re-runs the wizard to Step 4
+- WHEN the admin unchecks "engineering-demo" and clicks Next
+- THEN the system MUST NOT re-install the demo (it's already there)
+- NOTE: Demo installation is one-time; re-running the wizard does not trigger redundant installations. If the admin wishes to un-install, they must use a separate admin UI for demo management.
+
+#### Scenario: Re-running preserves skipped steps
+- GIVEN the wizard was run previously with Step 5 skipped
+- AND the admin re-runs the wizard
+- WHEN Step 5 is displayed
+- THEN the step MUST show "Skip" button as before
+- AND if the admin clicks Skip again, the behavior is consistent with the first run
+
+#### Scenario: Step 1 is always done on re-run
+- GIVEN a re-run of the wizard
+- WHEN Step 1 is displayed
+- THEN no new action is required; clicking Next immediately advances
+
+#### Scenario: API endpoint reports re-runnable state
+- GIVEN the instance has `mydash.setup_wizard_complete = true`
+- WHEN an NC admin calls `GET /api/admin/setup-wizard/state`
+- THEN the response MUST indicate `complete: true`
+- AND the admin UI MUST show a "Run setup wizard again" button (not a "Run setup wizard" banner)
+- NOTE: The UI signals that re-running is available and safe

--- a/openspec/changes/setup-wizard/tasks.md
+++ b/openspec/changes/setup-wizard/tasks.md
@@ -1,0 +1,93 @@
+# Tasks — setup-wizard
+
+## 1. Admin-setting flag and banner
+
+- [ ] 1.1 Register `mydash.setup_wizard_complete` as a boolean admin-setting key (default `false`) via `IAppConfig`; document the key alongside other `mydash.*` config keys
+- [ ] 1.2 Read the flag in `AdminController` (or a new `SetupWizardController`) and expose it on the admin page's initial state so the frontend can decide whether to show the banner
+- [ ] 1.3 Implement the "Run setup wizard" banner in `src/views/admin/AdminDashboards.vue`: visible when `setup_wizard_complete = false`, hidden otherwise
+- [ ] 1.4 Clicking the banner button MUST open `SetupWizardModal.vue` at Step 1
+- [ ] 1.5 After the wizard completes the banner MUST disappear without requiring a full page reload (reactive store update)
+- [ ] 1.6 Add `i18n` keys for banner text and button label in both `l10n/en.json` and `l10n/nl.json`
+
+## 2. Multi-step wizard shell (Vue component)
+
+- [ ] 2.1 Create `src/views/admin/SetupWizardModal.vue`: a 7-step modal with a step counter ("N / 7"), Skip / Back / Next button row, and a slot per step
+- [ ] 2.2 Implement step navigation state machine: `currentStep` (1–7), transitions forward (Next/Skip) and backward (Back), no free-jump
+- [ ] 2.3 Replace "Next" label with "Finish" on Step 7 only; "Finish" triggers `POST /api/admin/setup-wizard/complete`
+- [ ] 2.4 Step 1 (Welcome): static explanatory text, no form; Next advances immediately
+- [ ] 2.5 Step 7 (Done): static summary text ("Your setup is complete. Click Finish to save changes and dismiss the setup banner."); Finish button calls the complete endpoint and closes modal
+- [ ] 2.6 On modal close (X or Finish), emit an event to `AdminDashboards.vue` so it can re-check wizard state and hide the banner
+- [ ] 2.7 Add `i18n` keys for all step titles, button labels, and summary text in `l10n/en.json` and `l10n/nl.json`
+
+## 3. Step 2 — Storage backend
+
+- [ ] 3.1 Implement Step 2 UI in the wizard: two radio buttons ("Database (default)" / "GroupFolder (recommended for org use)") with descriptions
+- [ ] 3.2 Check via `OCP\App\IAppManager::isInstalled('groupfolders')` in `SetupWizardService::getGroupfolderAvailability()` and expose it in the wizard state; disable the GroupFolder radio when `false`
+- [ ] 3.3 Add a tooltip on the disabled GroupFolder radio: "GroupFolder app is not installed. Install 'Nextcloud GroupFolders' to use this option."
+- [ ] 3.4 On clicking Next from Step 2 persist the selected value immediately via `POST /api/admin/settings` to write `mydash.content_storage`
+- [ ] 3.5 Pre-populate the radio on re-run: read current `mydash.content_storage` from the wizard state endpoint
+
+## 4. Step 3 — Group priority order
+
+- [ ] 4.1 Embed the existing `group-priority-order` admin UI component in Step 3 (import and mount inside wizard modal; do not duplicate it)
+- [ ] 4.2 Confirm the component emits or writes directly to `mydash.group_priority_order` on change; if not, add a thin wrapper that calls the admin settings PUT on Next
+- [ ] 4.3 Verify Back/Next preserves the order selection (no re-render resets the component state)
+
+## 5. Step 4 — Demo data
+
+- [ ] 5.1 Embed the existing `demo-data-showcases` admin UI component in Step 4 (import and mount inside wizard modal)
+- [ ] 5.2 Confirm Next triggers installation of checked demos via the demo-data-showcases service; wizard advances after install completes (or asynchronously; document the choice)
+- [ ] 5.3 On re-run: mark already-installed demos as checked and non-reinstallable; verify the component exposes an `installed` state per package
+
+## 6. Step 5 — Admin roles (optional)
+
+- [ ] 6.1 Implement Step 5 UI: dropdown listing all Nextcloud groups; description text explaining "Dashboard Admin" role delegation
+- [ ] 6.2 On Next with a group selected: call `RoleService::assignRole(groupId, role='admin', assignedBy=<current-admin>)` (from the `admin-roles` capability)
+- [ ] 6.3 If no group selected and admin clicks Next: treat as skip (no role assignment, same as clicking Skip)
+- [ ] 6.4 If `admin-roles` capability is not available at runtime: skip Step 5 automatically; adjust step counter display
+- [ ] 6.5 Add `i18n` keys for group-selector label and description text
+
+## 7. Step 6 — Footer configuration (optional)
+
+- [ ] 7.1 Implement Step 6 UI: embed the "Structured mode" footer editor from the `footer-customization` capability
+- [ ] 7.2 Footer edits MUST persist immediately via the footer-customization service; Next only advances without re-saving
+- [ ] 7.3 If `footer-customization` capability is not available at runtime: skip Step 6 automatically; adjust step counter display
+- [ ] 7.4 Add `i18n` keys for step description text
+
+## 8. Backend service and API endpoints
+
+- [ ] 8.1 Create `lib/Service/SetupWizardService.php` with methods:
+  - `getWizardState(): array` — reads `mydash.setup_wizard_complete` and per-step heuristics; returns `{complete, currentRecommendedStep, stepStatuses}`
+  - `markWizardComplete(): array` — idempotently sets `mydash.setup_wizard_complete = true`; returns updated state
+  - `getGroupfolderAvailability(): bool` — delegates to `IAppManager::isInstalled('groupfolders')`
+- [ ] 8.2 Add `AdminController::getWizardState()` mapped to `GET /api/admin/setup-wizard/state` (NC-admin only)
+- [ ] 8.3 Add `AdminController::completeWizard()` mapped to `POST /api/admin/setup-wizard/complete` (NC-admin only, idempotent)
+- [ ] 8.4 Register both routes in `appinfo/routes.php` with appropriate admin-only auth constraints
+- [ ] 8.5 Add PHPUnit tests for `SetupWizardService::getWizardState()`: fresh instance, partial completion, fully done, and re-run scenarios
+- [ ] 8.6 Add PHPUnit tests for `SetupWizardService::markWizardComplete()`: first call sets flag; second call (idempotent) returns same state without error
+
+## 9. CLI command
+
+- [ ] 9.1 Create `lib/Command/SetupCommand.php` implementing `OC\Command\Base` with command name `mydash:setup` and a `--config=` option
+- [ ] 9.2 Parse the YAML file (using Symfony Yaml component, already available in NC) and validate the schema: required key `storage_backend`; optional keys `group_priority_order`, `demo_packages`, `admin_role_group`, `footer_config`
+- [ ] 9.3 Fail fast on invalid YAML: output "Invalid setup.yaml: missing field '…'" and exit 1; no settings applied
+- [ ] 9.4 Execute each step in order, logging progress: "Step N: <name>... done" (verbose by default)
+- [ ] 9.5 Handle idempotency: detect already-applied settings and skip without error; log "Step N: <name>... already configured, skipping"
+- [ ] 9.6 Register `SetupCommand` in `lib/AppInfo/Application.php` via the `RegisterCommand` event
+- [ ] 9.7 Add a functional test (PHPUnit, CLI context) that runs the command with a fixture YAML and verifies the resulting admin settings
+
+## 10. Auto-launch behavior
+
+- [ ] 10.1 In `AdminDashboards.vue` on page mount: if `setup_wizard_complete = false` AND dashboard count === 0 AND no admin settings have been written → automatically open `SetupWizardModal.vue`
+- [ ] 10.2 Auto-launch MUST only fire once per page load (no loop); if the admin closes the modal, subsequent loads still show the banner but do not auto-open
+- [ ] 10.3 The auto-launch check MUST be client-side only (no backend behavior change required); the banner and state endpoint provide sufficient data
+- [ ] 10.4 Add a Playwright test: fresh install → admin opens `/apps/mydash/admin/dashboards` → wizard opens automatically
+
+## 11. Quality gates
+
+- [ ] 11.1 `composer check:strict` (PHPCS, PHPMD, Psalm, PHPStan) passes — fix any pre-existing issues encountered along the way
+- [ ] 11.2 ESLint + Stylelint clean on all touched Vue/JS files
+- [ ] 11.3 Update generated OpenAPI spec / Postman collection so external API consumers see the two new endpoints
+- [ ] 11.4 `i18n` keys for all new strings in both `l10n/en.json` and `l10n/nl.json` per the i18n requirement; verify Dutch translations are accurate
+- [ ] 11.5 SPDX headers on every new PHP file (inside the docblock per the SPDX-in-docblock convention) — gate-spdx must pass
+- [ ] 11.6 Run all `hydra-gates` locally before opening PR

--- a/openspec/changes/text-widget-markdown/design.md
+++ b/openspec/changes/text-widget-markdown/design.md
@@ -1,0 +1,80 @@
+# Design — Text Widget Markdown
+
+## Context
+
+The text-display-widget capability stores and renders pre-authored HTML content. Authors who want headings, lists, or links must write HTML directly, which is a barrier for non-technical users. This change extends the widget with an alternative `inputMode: 'markdown'` that converts CommonMark-compliant markdown to HTML server-side before saving. The converted HTML then travels through the same sanitisation pipeline that already handles the `inputMode: 'html'` path, so both modes share a single trust boundary.
+
+This is an extension of the `text-display-widget` capability (currently in `openspec/changes/`, not yet promoted). It does not change the rendering contract — widgets still persist and display HTML. What changes is how that HTML is produced when the author writes markdown. The sibling `text-widget-tables` spec covers the structured table editor; this spec only owns the markdown parser and heading-downscale rule.
+
+Existing placements are untouched. The `inputMode` field defaults to `'html'` so every widget created before this change continues to work without any migration.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Add `inputMode: 'markdown'` as a recognised value on text-widget placements.
+- Convert CommonMark markdown to HTML server-side using the library already in the vendor tree.
+- Pass the resulting HTML through the existing HTML sanitiser without a separate sanitisation path.
+- Downscale H1 headings in markdown output to H2 to protect the dashboard's document outline.
+- Default `inputMode` to `'html'` so existing widgets are unaffected.
+
+**Non-Goals:**
+- A rich in-widget markdown editor or preview (edit box is a plain textarea; rendering happens on save).
+- Client-side markdown parsing (server-side conversion is the only supported path in this spec).
+- Table-insertion UX — that is the `text-widget-tables` spec.
+- Changing the sanitiser allow-list (reuse the existing one).
+
+## Decisions
+
+### D1: Markdown library selection
+**Decision**: Use the CommonMark library already present in the vendor tree; enable the GFM tables extension.
+**Alternatives considered**:
+- A lightweight custom regex parser — rejected: brittle and not CommonMark-spec-compliant.
+- A different third-party library — rejected: adds a new dependency when a compliant one already exists.
+**Rationale**: Reusing an already-vendored library adds zero installation cost and guarantees spec-compliant parsing. The GFM tables extension is needed for the sibling `text-widget-tables` spec to share the same renderer.
+
+### D2: Conversion timing — server-side before save
+**Decision**: Markdown is converted to HTML on the server when the placement is saved, not at render time.
+**Alternatives considered**:
+- Convert at render time on every page load — rejected: wastes CPU per-request and complicates caching.
+- Convert client-side in the browser — rejected: introduces a JS parser dependency and breaks server-side render paths.
+**Rationale**: Converting once on save means the stored value is always HTML, so the renderer has no awareness of the original mode. This minimises blast radius if the markdown library is ever swapped out.
+
+### D3: Sanitisation pipeline — single shared path
+**Decision**: Markdown-derived HTML and author-supplied HTML both pass through the same sanitiser; no second pipeline.
+**Alternatives considered**: none
+**Rationale**: A second sanitiser would require its own allow-list maintenance and could drift from the primary. Sharing the pipeline guarantees that markdown cannot introduce tags or attributes that raw HTML cannot.
+
+### D4: Heading downscale rule
+**Decision**: `# Heading` in markdown produces `<h2>`, `## Heading` produces `<h3>`, and so on; no `<h1>` ever appears in rendered output.
+**Alternatives considered**:
+- Allow `<h1>` and rely on CSS to suppress it — rejected: produces invalid document outlines and fails WCAG 1.3.1.
+- Strip all headings — rejected: removes author intent entirely.
+**Rationale**: A dashboard page always has exactly one `<h1>` (the page title). Widget content is subordinate and must start at `<h2>`.
+
+### D5: Backward compatibility via `inputMode` default
+**Decision**: `inputMode` is absent on all existing placements; the renderer treats absence as `'html'`.
+**Alternatives considered**: none
+**Rationale**: A zero-migration approach eliminates risk to existing content and allows the feature to ship without a database migration step.
+
+### D6: Table syntax parsing scope
+**Decision**: This spec enables `<table>` output when the author writes GFM table syntax; the structured table editor is deferred to `text-widget-tables`.
+**Alternatives considered**:
+- Disable table parsing in this spec and add it with `text-widget-tables` — rejected: the GFM extension is already present once the library is enabled; artificially blocking it would require extra code to strip tables.
+**Rationale**: Parsing and editing are separate concerns. The parser can produce tables even before the editor UX exists; authors can hand-write markdown table syntax in the textarea.
+
+### D7: Admin default for new widgets
+**Decision**: An admin setting `mydash.text_widget_default_mode` (`'html'` or `'markdown'`, default `'markdown'`) controls which mode is pre-selected when a new text widget is added.
+**Alternatives considered**:
+- Hard-code the default to `'markdown'` — rejected: organisations already using markdown-aware tools may want `'html'` as the default.
+**Rationale**: Gives administrators control without exposing per-user preferences.
+
+## Risks / Trade-offs
+
+- **Markdown with embedded HTML** → The author may write raw `<script>` inside a markdown block. The sanitiser strips it, but authors may be confused. Mitigation: UI copy explains that output is sanitised.
+- **Heading shift surprises** → Authors writing `# My Title` expecting a large heading will see `<h2>`. Mitigation: the edit form shows a note explaining the downscale rule.
+
+## Open follow-ups
+
+- Decide whether the edit form should show a live preview of the rendered markdown.
+- Define whether `inputMode` should be editable after initial creation (changing from markdown to html after conversion would require re-saving the original markdown source, which is not retained).
+- Confirm that the sanitiser allow-list covers `<table>`, `<thead>`, `<tbody>`, `<tr>`, `<th>`, `<td>` before shipping.

--- a/openspec/changes/text-widget-markdown/proposal.md
+++ b/openspec/changes/text-widget-markdown/proposal.md
@@ -1,0 +1,57 @@
+# Text-Widget Markdown
+
+## Why
+
+The text-display widget currently renders only HTML content. Users who need to author structured text (headings, lists, emphasis, links) must learn HTML syntax or hand-craft the HTML. Markdown is the de-facto standard for lightweight structured text entry and is more intuitive for non-technical users. This change extends the widget's rendering pipeline to accept either HTML or Markdown input, with automatic parsing and safe sanitisation, while maintaining full backward compatibility.
+
+## What Changes
+
+- Add a `contentMode` field to text-widget config (either `'html'` or `'markdown'`), stored in `styleConfig.content.contentMode`.
+- When `contentMode = 'markdown'`, parse the widget's text content using a CommonMark-compliant renderer (server-side via `league/commonmark` or client-side via `marked`) and render the parsed HTML.
+- Sanitise all output (both HTML and parsed-markdown) through the same allow-list so XSS vectors are blocked uniformly.
+- Add a UI toggle in the text-widget edit form: `Mode: [HTML | Markdown]`.
+- Existing widgets default to `html` mode (backward compat). New widgets default to `markdown` mode.
+- Introduce an admin setting `mydash.text_widget_default_mode` (string, `'html'` or `'markdown'`) to control the system-wide default for newly-added widgets.
+- Support heading shortcuts: `# H1`, `## H2`, ..., `###### H6`.
+- Support inline marks: `**bold**`, `*italic*`, `` `code` ``, `[link text](url)`, `> quote`, `- bullet`, `1. ordered`.
+- Table syntax in markdown MUST render to `<table>` (in-place table editing is out of scope — that is covered by a sibling `text-widget-tables` capability).
+
+## Capabilities
+
+### New Capabilities
+
+- `text-widget-markdown`: Markdown content mode for text-display widgets with CommonMark parsing, safe sanitisation, heading shortcuts, inline marks, and admin default-mode control.
+
+### Modified Capabilities
+
+- `text-display-widget`: adds optional markdown mode via REQ-TXMD-001..007. Existing HTML mode (REQ-TXT-001..005) is unchanged; both coexist in the same widget.
+
+## Impact
+
+**Affected code:**
+
+- `lib/Service/TextWidgetService.php` (if it exists, or inline widget rendering) — add markdown parsing logic when `contentMode = 'markdown'`
+- Text-widget Vue template — detect contentMode and route to markdown renderer when applicable
+- `src/components/TextWidgetForm.vue` — add contentMode toggle to edit form
+- `lib/AppConfig.php` or equivalent — add `mydash.text_widget_default_mode` admin setting with default `'markdown'`
+- `src/components/widgets/TextWidget.vue` — extend to handle both HTML and Markdown rendering paths
+- `openspec/specs/text-display-widget/spec.md` (pending promotion to `openspec/specs/`) — will adopt REQ-TXMD-001..007 as a delta change once text-display-widget is promoted
+
+**Affected schemas:**
+
+- `oc_mydash_widget_placements.styleConfig` — add `content.contentMode: 'html' | 'markdown'` field (already a JSON blob, no migration required for schema structure; values are additive)
+
+**Dependencies:**
+
+- `league/commonmark` (already vendored in nextcloud-vue for OpenRegister specs; reuse from there if feasible)
+- OR `marked` (lightweight client-side CommonMark library; add via npm if server-side lib unavailable)
+- No new Nextcloud capabilities required
+
+**Migration:**
+
+- Zero-impact on existing data: existing widgets have `styleConfig.content.contentMode` unset, which the renderer interprets as `'html'` (backward compat).
+- New widgets get `contentMode = <admin-setting>` at creation time (default `'markdown'`).
+
+**Interoperability:**
+
+- Renderer choice (server vs client) is an implementation detail. Server-side parsing offers better cacheability and UX (no JS parsing lag); client-side offers runtime flexibility. The spec requires CommonMark compliance and consistent sanitisation, but not the engine choice.

--- a/openspec/changes/text-widget-markdown/specs/text-widget-markdown/spec.md
+++ b/openspec/changes/text-widget-markdown/specs/text-widget-markdown/spec.md
@@ -1,0 +1,253 @@
+---
+status: draft
+---
+
+# Text-Widget Markdown
+
+## ADDED Requirements
+
+### Requirement: REQ-TXMD-001 Add contentMode field to text-widget config
+
+The text-widget MUST support a new `contentMode` field in its `styleConfig.content` object, with permitted values `'html'` or `'markdown'`. The field is optional; when absent, it defaults to `'html'` (backward compatibility with existing widgets). New widgets MUST receive a default determined by the admin setting `mydash.text_widget_default_mode` (see REQ-TXMD-007).
+
+#### Scenario: Existing widgets retain html mode
+
+- GIVEN a text-widget created before markdown support, with `styleConfig.content` and no `contentMode` key
+- WHEN the widget is rendered
+- THEN the renderer MUST treat the content as HTML (REQ-TXT-001 behavior applies)
+- AND the widget MUST display correctly on next load
+
+#### Scenario: New widget receives admin-controlled default
+
+- GIVEN the admin setting `mydash.text_widget_default_mode = 'markdown'`
+- WHEN a user creates a new text-widget via AddWidgetModal
+- THEN the widget's `styleConfig.content.contentMode` MUST be set to `'markdown'`
+- AND subsequent renders MUST parse the text as markdown
+
+#### Scenario: Widget can be manually switched to html mode
+
+- GIVEN a widget with `contentMode = 'markdown'`
+- WHEN the user edits the widget and selects `Mode: HTML` in the toggle
+- THEN the widget's `contentMode` MUST be updated to `'html'` in styleConfig
+- AND the text content MUST be re-rendered as HTML (markdown syntax is no longer parsed)
+
+#### Scenario: Explicit html mode overrides admin default
+
+- GIVEN the admin setting `mydash.text_widget_default_mode = 'markdown'`
+- WHEN a user creates a new text-widget and explicitly selects `Mode: HTML` before saving
+- THEN the widget's `contentMode` MUST be set to `'html'` (explicit choice overrides the default)
+
+### Requirement: REQ-TXMD-002 CommonMark-compliant markdown parsing
+
+When `contentMode = 'markdown'`, the renderer MUST parse the widget text using a CommonMark-compliant parser and convert it to HTML. The parser MUST handle headings (H1–H6 via `#...######` syntax), emphasis (`**bold**`, `*italic*`, `***bold-italic***`), code (inline `` `code` `` and code blocks), links, lists (bullet and ordered), block quotes, and tables.
+
+#### Scenario: Heading shortcuts render to semantic heading tags
+
+- GIVEN `text = "# Main\n## Sub\n### Deep"`
+- WHEN the widget renders with `contentMode = 'markdown'`
+- THEN the DOM MUST contain `<h1>Main</h1>`, `<h2>Sub</h2>`, `<h3>Deep</h3>` in sequence
+- AND all heading levels H1–H6 MUST be supported
+
+#### Scenario: Emphasis marks render to inline tags
+
+- GIVEN `text = "**bold** and *italic* and ***both***"`
+- WHEN the widget renders
+- THEN the DOM MUST contain `<strong>bold</strong>`, `<em>italic</em>`, `<strong><em>both</em></strong>` (or equivalent semantic nesting)
+- AND the visual output MUST show the correct emphasis styling
+
+#### Scenario: Inline code renders to code tag
+
+- GIVEN `text = "Use \`npm install\` to set up"`
+- WHEN the widget renders
+- THEN the DOM MUST contain `<code>npm install</code>` with appropriate styling
+- AND the code MUST NOT be executed as JavaScript
+
+#### Scenario: Links preserve href and render anchor tag
+
+- GIVEN `text = "[OpenRegister](https://openregister.nl)"`
+- WHEN the widget renders
+- THEN the DOM MUST contain `<a href="https://openregister.nl">OpenRegister</a>`
+- AND the link MUST be clickable
+
+#### Scenario: Bullet lists render as ul/li
+
+- GIVEN `text = "- Item A\n- Item B\n- Item C"`
+- WHEN the widget renders
+- THEN the DOM MUST contain `<ul>` with three `<li>` children
+- AND nested lists MUST be supported (indentation creates nested `<ul>` or `<ol>`)
+
+#### Scenario: Ordered lists render as ol/li
+
+- GIVEN `text = "1. First\n2. Second\n3. Third"`
+- WHEN the widget renders
+- THEN the DOM MUST contain `<ol>` with three `<li>` children in sequence
+
+#### Scenario: Block quotes render as blockquote
+
+- GIVEN `text = "> This is a quote\n> from someone"`
+- WHEN the widget renders
+- THEN the DOM MUST contain `<blockquote>` with the quoted text
+
+#### Scenario: Tables render to semantic table markup
+
+- GIVEN `text = "| Header A | Header B |\n|---|---|\n| Cell A1 | Cell B1 |"`
+- WHEN the widget renders
+- THEN the DOM MUST contain `<table>` with `<thead>`, `<tbody>`, and appropriate `<tr>`, `<th>`, `<td>` elements
+- NOTE: In-place table editing UI is not required (see `text-widget-tables` capability)
+
+### Requirement: REQ-TXMD-003 Sanitisation of parsed markdown output
+
+All HTML output produced by the markdown parser MUST be passed through the same XSS allow-list sanitiser used by REQ-TXT-001 (HTML mode). Tags and attributes that pose security risk MUST be stripped. Safe tags (heading, emphasis, link, list, blockquote, table) MUST be preserved. Attributes on links MUST include `rel="noopener noreferrer"` for `target="_blank"` links to prevent opener hijacking.
+
+#### Scenario: Script tags in markdown are stripped
+
+- GIVEN `text = "<script>alert(1)</script> and **bold**"`
+- WHEN the widget renders with `contentMode = 'markdown'`
+- THEN the DOM MUST NOT contain a `<script>` element
+- AND the visible text MUST be " and **bold**" (script is stripped, markdown bold is parsed)
+
+#### Scenario: Event handlers are removed from parsed elements
+
+- GIVEN `text = "[Click me](javascript:alert(1))"`
+- WHEN the widget renders
+- THEN the `<a>` element's `href` attribute MUST NOT start with `javascript:`
+- AND the link MUST be either stripped entirely or converted to a safe no-op
+
+#### Scenario: Data attributes are removed from links
+
+- GIVEN `text = "<a href='http://example.com' data-malicious='xss'>link</a>" (HTML in markdown)`
+- WHEN the widget renders
+- THEN the sanitiser MUST remove the `data-malicious` attribute
+- AND the `href` MUST be preserved (if it is safe)
+
+#### Scenario: target="_blank" links get rel attribute
+
+- GIVEN `text = "[External](https://example.com){target=_blank}" (or per the markdown parser's syntax for target)`
+- WHEN the widget renders
+- THEN the `<a>` element MUST have `target="_blank"` AND `rel="noopener noreferrer"`
+
+### Requirement: REQ-TXMD-004 Mode toggle in the edit form
+
+The text-widget edit sub-form MUST display a `Mode` toggle or radio button group with two options: `HTML` and `Markdown`. The toggle's state MUST be bound to `contentMode` in the widget's `styleConfig.content` object. Switching modes MUST NOT lose the text content — only the parsing behavior changes.
+
+#### Scenario: HTML mode is shown by default for existing widgets
+
+- GIVEN the edit form opens for a widget with no explicit `contentMode` (or `contentMode = 'html'`)
+- WHEN the form renders
+- THEN the Mode toggle MUST default to `HTML` (selected/checked state)
+
+#### Scenario: Markdown mode is shown for markdown-mode widgets
+
+- GIVEN the edit form opens for a widget with `contentMode = 'markdown'`
+- WHEN the form renders
+- THEN the Mode toggle MUST show `Markdown` as selected
+
+#### Scenario: Toggling mode preserves text content
+
+- GIVEN a widget with `contentMode = 'markdown'` and `text = "# Heading"`
+- WHEN the user switches the Mode toggle to `HTML`
+- THEN the `text` field value MUST remain `"# Heading"` (unchanged)
+- AND on next render, the text MUST be displayed as literal HTML (the `#` is rendered as-is, not parsed as markdown)
+
+#### Scenario: Mode change is saved with other form fields
+
+- GIVEN the user changes `contentMode` from `HTML` to `Markdown`
+- WHEN they click Save in the edit form
+- THEN the PUT request MUST include the updated `styleConfig.content.contentMode` field
+- AND the widget MUST render in markdown mode on next load
+
+#### Scenario: New widgets default to admin-controlled mode
+
+- GIVEN the admin setting `mydash.text_widget_default_mode = 'markdown'`
+- WHEN the AddWidgetModal form opens to add a new text-widget
+- THEN the Mode toggle MUST default to `Markdown` (not HTML)
+
+### Requirement: REQ-TXMD-005 Admin setting for default content mode
+
+The system MUST provide an admin-configurable setting `mydash.text_widget_default_mode` with permitted values `'html'` or `'markdown'`. This setting controls the default `contentMode` for newly-created text-widgets. The setting MUST be stored in Nextcloud's app config (e.g., via `IAppConfig` or equivalent) and MUST default to `'markdown'` (Markdown is the primary mode).
+
+#### Scenario: Setting is read from app config
+
+- GIVEN the admin setting `mydash.text_widget_default_mode` is set to `'html'`
+- WHEN a new text-widget is created via POST /api/widgets
+- THEN the widget MUST receive `styleConfig.content.contentMode = 'html'`
+
+#### Scenario: Default is markdown if setting is unset
+
+- GIVEN the admin setting `mydash.text_widget_default_mode` is not explicitly configured
+- WHEN a new text-widget is created
+- THEN the widget MUST receive `contentMode = 'markdown'` (system default)
+
+#### Scenario: Invalid setting values are rejected
+
+- GIVEN an admin attempts to set `mydash.text_widget_default_mode = 'rst'` (invalid value)
+- WHEN the value is persisted
+- THEN the system MUST reject the write with a validation error OR silently coerce to `'markdown'`
+- AND no widget creation MUST be affected by the invalid write
+
+#### Scenario: Setting affects only new widgets, not existing ones
+
+- GIVEN existing widgets already have `contentMode = 'html'`
+- WHEN the admin changes `mydash.text_widget_default_mode` from `'html'` to `'markdown'`
+- THEN all existing widgets MUST continue to render in their original mode
+- AND only widgets created after the change MUST use the new default
+
+### Requirement: REQ-TXMD-006 Backward compatibility — existing HTML-mode widgets unaffected
+
+All widgets with `contentMode = 'html'` (the default for existing widgets) MUST continue to render exactly as before per REQ-TXT-001..005. The markdown parser MUST NOT be invoked. The introduction of markdown mode MUST NOT degrade or change the behavior of HTML mode.
+
+#### Scenario: Existing widget renders unchanged
+
+- GIVEN a widget created before markdown support with `styleConfig.content = {text: '<b>bold</b>'}`
+- WHEN it is rendered after the markdown feature is deployed
+- THEN the DOM MUST contain `<b>bold</b>` exactly
+- AND the visual output MUST be identical to before
+
+#### Scenario: HTML mode ignores markdown syntax
+
+- GIVEN a widget explicitly set to `contentMode = 'html'` with `text = "# Heading"`
+- WHEN the widget renders
+- THEN the visible output MUST be `# Heading` (literal text, not parsed as markdown)
+- AND no `<h1>` tag MUST appear
+
+#### Scenario: Existing sanitisation rules apply to HTML mode
+
+- GIVEN a widget with `contentMode = 'html'` and `text = "<script>alert(1)</script>"`
+- WHEN the widget renders
+- THEN the same XSS stripping rules from REQ-TXT-001 MUST apply
+- AND no `<script>` element MUST appear
+
+### Requirement: REQ-TXMD-007 Heading levels H1–H6 with markdown shortcuts
+
+The markdown parser MUST recognise and render heading levels via the standard `#`-prefix syntax: `#` for H1, `##` for H2, ..., `######` for H6. Each heading level MUST produce a corresponding semantic HTML tag (`<h1>` through `<h6>`).
+
+#### Scenario: Single hash produces h1
+
+- GIVEN `text = "# Main Title"`
+- WHEN the widget renders with `contentMode = 'markdown'`
+- THEN the DOM MUST contain exactly `<h1>Main Title</h1>`
+
+#### Scenario: Double hash produces h2
+
+- GIVEN `text = "## Subsection"`
+- WHEN the widget renders
+- THEN the DOM MUST contain exactly `<h2>Subsection</h2>`
+
+#### Scenario: Up to six hashes for h6
+
+- GIVEN `text = "###### Tiny"`
+- WHEN the widget renders
+- THEN the DOM MUST contain exactly `<h6>Tiny</h6>`
+
+#### Scenario: Seven or more hashes treated as literal text
+
+- GIVEN `text = "####### Too many"`
+- WHEN the widget renders
+- THEN CommonMark parsing MUST treat `####### Too many` as a paragraph (not a heading)
+- AND the output MUST be `<p>####### Too many</p>` or equivalent
+
+#### Scenario: Heading followed by content
+
+- GIVEN `text = "# Title\nThis is content.\n## Subsection\nMore content."`
+- WHEN the widget renders
+- THEN the DOM MUST contain `<h1>Title</h1><p>This is content.</p><h2>Subsection</h2><p>More content.</p>` (or semantic equivalent)

--- a/openspec/changes/text-widget-markdown/tasks.md
+++ b/openspec/changes/text-widget-markdown/tasks.md
@@ -1,0 +1,89 @@
+# Tasks — text-widget-markdown
+
+## 1. Admin configuration
+
+- [ ] 1.1 Add `mydash.text_widget_default_mode` to app config store (e.g., `lib/AppConfig.php` or equivalent Nextcloud IAppConfig usage)
+- [ ] 1.2 Default the setting to `'markdown'` (primary mode) if not explicitly set
+- [ ] 1.3 Expose the setting to the Nextcloud admin panel (Settings UI is deferred to follow-up `admin-text-widget-settings` change; only the config backend is required here)
+- [ ] 1.4 Add validation that only `'html'` and `'markdown'` are accepted values; reject or coerce invalid values
+
+## 2. Domain and widget schema updates
+
+- [ ] 2.1 Update text-widget data model to add `contentMode` field to `styleConfig.content` schema (no database migration required; JSON-on-read parsing)
+- [ ] 2.2 Add getter/helper in TextWidget entity or service to retrieve current `contentMode` (defaulting to `'html'` for backward compat)
+- [ ] 2.3 Update widget creation to populate `contentMode` from the admin setting at add time
+
+## 3. Markdown parser integration
+
+- [ ] 3.1 Add `league/commonmark` to `composer.json` (or reuse if already vendored in nextcloud-vue; check dependencies first)
+- [ ] 3.2 Create `lib/Service/MarkdownParserService.php` with public method `parse(string $markdown): string` that returns sanitised HTML
+- [ ] 3.3 Wire the parser to use the same sanitiser as REQ-TXT-001 (inspect existing HTML sanitiser; add `<table>`, `<thead>`, `<tbody>`, `<tr>`, `<th>`, `<td>` to the allow-list)
+- [ ] 3.4 Add unit tests for parser: headings (H1–H6), emphasis (bold, italic), code (inline and blocks), links, lists (bullet and ordered), block quotes, tables
+
+## 4. Text-widget renderer update
+
+- [ ] 4.1 Update the text-widget renderer (Vue component or server-side template) to check `contentMode` field
+- [ ] 4.2 When `contentMode = 'markdown'`, call `MarkdownParserService::parse()` before rendering
+- [ ] 4.3 When `contentMode = 'html'` or unset, use the existing HTML sanitiser from REQ-TXT-001 (no change)
+- [ ] 4.4 Ensure both paths go through the same XSS allow-list (both branches sanitise)
+
+## 5. Text-widget edit form UI
+
+- [ ] 5.1 Add Mode toggle/radio to `src/components/TextWidgetForm.vue`: `[HTML] [Markdown]` with options clearly labeled
+- [ ] 5.2 Bind the toggle to `content.contentMode` in the form's data object
+- [ ] 5.3 Set the toggle's default based on: existing `contentMode` if present, else admin setting, else `'markdown'`
+- [ ] 5.4 Ensure toggling modes preserves the text content (no clearing or transformation)
+- [ ] 5.5 Include the updated `contentMode` in the form payload when saving
+
+## 6. AddWidgetModal update
+
+- [ ] 6.1 When the text-widget sub-form is mounted for a NEW widget, pre-populate the Mode toggle with the admin setting `mydash.text_widget_default_mode`
+- [ ] 6.2 Allow the user to explicitly select a different mode before adding the widget
+- [ ] 6.3 Pass the selected `contentMode` to the widget creation payload
+
+## 7. Sanitiser enhancements
+
+- [ ] 7.1 Review the existing HTML sanitiser (from REQ-TXT-001) and verify it allows `<h1>` through `<h6>` tags
+- [ ] 7.2 Extend the allow-list to include table-related tags: `<table>`, `<thead>`, `<tbody>`, `<tfoot>`, `<tr>`, `<th>`, `<td>`, `<caption>`
+- [ ] 7.3 Ensure all table attributes (colspan, rowspan, etc.) are appropriately whitelisted or stripped per security policy
+- [ ] 7.4 Verify that link sanitisation adds `rel="noopener noreferrer"` to any `target="_blank"` anchors (from markdown or HTML)
+- [ ] 7.5 Add unit test for sanitiser round-trip: XSS attempts (scripts, event handlers, `javascript:` URLs) are stripped; safe tags and attributes pass through
+
+## 8. Frontend store / API integration
+
+- [ ] 8.1 Ensure `src/stores/dashboards.js` or widget store passes through the `contentMode` field from API responses without loss
+- [ ] 8.2 Confirm the widget serialise/deserialise cycle preserves `contentMode` (JSON round-trip)
+
+## 9. PHPUnit tests
+
+- [ ] 9.1 `MarkdownParserServiceTest::testParseHeadings` — verify H1–H6 syntax
+- [ ] 9.2 `MarkdownParserServiceTest::testParseEmphasis` — bold, italic, combined
+- [ ] 9.3 `MarkdownParserServiceTest::testParseCode` — inline and blocks
+- [ ] 9.4 `MarkdownParserServiceTest::testParseLinks` — href and text
+- [ ] 9.5 `MarkdownParserServiceTest::testParseLists` — bullets and ordered, nested
+- [ ] 9.6 `MarkdownParserServiceTest::testParseBlockQuotes`
+- [ ] 9.7 `MarkdownParserServiceTest::testParseTables`
+- [ ] 9.8 `MarkdownParserServiceTest::testSanitisesScriptTags` — XSS stripping
+- [ ] 9.9 `MarkdownParserServiceTest::testSanitisesEventHandlers` — onclick, onload, etc. removed
+- [ ] 9.10 `MarkdownParserServiceTest::testSanitisesJavascriptUrls` — javascript: protocol stripped from links
+- [ ] 9.11 `TextWidgetServiceTest::testRendersHtmlModeUnchanged` — existing behavior preserved when `contentMode = 'html'` or unset
+- [ ] 9.12 `TextWidgetServiceTest::testRendersMarkdownMode` — markdown is parsed when `contentMode = 'markdown'`
+- [ ] 9.13 `WidgetControllerTest::testNewWidgetReceivesAdminDefaultMode` — newly added widgets get the correct default contentMode
+
+## 10. End-to-end Playwright tests
+
+- [ ] 10.1 User creates a new text-widget, sees Mode toggle defaulting to `Markdown` (or admin default), toggles to `HTML`, adds widget
+- [ ] 10.2 User edits an existing widget, changes Mode from `HTML` to `Markdown`, content (with markdown syntax) is parsed and rendered correctly
+- [ ] 10.3 User enters markdown syntax (`# Heading`, `**bold**`, `[link](url)`) in a markdown-mode widget, saves, and views the rendered HTML output
+- [ ] 10.4 User creates a markdown-mode widget with table syntax, sees the table rendered correctly on the dashboard
+- [ ] 10.5 Admin changes `mydash.text_widget_default_mode` setting to `'html'`, creates a new text-widget, and it defaults to HTML mode (existing widgets unaffected)
+- [ ] 10.6 Existing widget with `contentMode = 'html'` and HTML content continues to render unchanged after feature is deployed
+
+## 11. Quality gates
+
+- [ ] 11.1 `composer check:strict` (PHPCS, PHPMD, Psalm, PHPStan) passes — fix any pre-existing issues encountered
+- [ ] 11.2 ESLint + Stylelint clean on all touched Vue/JS files
+- [ ] 11.3 `i18n` keys for Mode toggle labels (`Mode`, `HTML`, `Markdown`) in both `nl` and `en` per the i18n requirement
+- [ ] 11.4 SPDX headers on every new PHP file (inside the docblock per the SPDX-in-docblock convention) — gate-spdx must pass
+- [ ] 11.5 Verify markdown parser dependencies (composer.json and npm versions) are stable and security-audited
+- [ ] 11.6 Run all relevant `hydra-gates` locally before opening PR

--- a/openspec/changes/text-widget-tables/design.md
+++ b/openspec/changes/text-widget-tables/design.md
@@ -1,0 +1,83 @@
+# Design — Text Widget Tables
+
+## Context
+
+The text-display-widget accepts HTML content authored by hand or via the markdown mode introduced in `text-widget-markdown`. Neither path gives non-technical authors a way to build a table without knowing markdown or HTML table syntax. This change adds a structured table editor that lets authors define rows, columns, and cell content through a Vue form, then serialises the result as a GFM markdown table inside the widget's HTML body.
+
+The stored format is markdown table syntax, not a separate JSON blob. This keeps the data model flat and identical to what the `text-widget-markdown` parser already handles: the serialised table is handed to the same markdown-to-HTML conversion path before the placement is saved. Authors editing an existing table are presented with the editor re-populated from the stored markdown; there is no parallel JSON representation to keep in sync.
+
+This spec depends on `text-widget-markdown` being in place. Without the markdown parser, the serialised table would be stored as raw text and not rendered as HTML.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Provide a row/column editor for inserting a table into a text-display widget.
+- Serialise the table to GFM markdown table syntax on save.
+- Enforce soft and hard dimension limits (20 rows × 10 columns) with HTTP 400 enforcement at the hard limit.
+- Support a header-row toggle that controls whether the first row renders as `<th>` elements.
+- Reuse the `text-widget-markdown` parse-and-sanitise pipeline; no separate HTML generation path.
+
+**Non-Goals:**
+- Rich text (bold, links, etc.) inside individual table cells — cells accept plain text only.
+- Column width or alignment controls in v1.
+- Merging cells (colspan/rowspan).
+- Importing data from CSV or spreadsheet files.
+
+## Decisions
+
+### D1: Storage format — markdown table syntax inside the HTML body
+**Decision**: Tables are serialised as GFM markdown table syntax and stored in `styleConfig.content.body` alongside any other widget text; `inputMode` is set to `'markdown'`.
+**Alternatives considered**:
+- A separate `tableData` JSON field alongside `body` — rejected: introduces a second source of truth and requires a custom renderer path.
+- HTML `<table>` stored directly — rejected: bypasses the sanitiser pipeline and would need its own sanitisation rules.
+**Rationale**: Using existing markdown storage and parsing means zero new backend endpoints and zero new sanitiser rules. The editor produces text; the existing pipeline handles the rest.
+
+### D2: Editor UX — Vue component with add/delete rows and columns
+**Decision**: A dedicated `TableEditorForm.vue` component provides a grid of text inputs, plus buttons to add/delete rows and columns at the end of each axis.
+**Alternatives considered**:
+- A contenteditable `<table>` — rejected: browser contenteditable table editing has long-standing cross-browser bugs.
+- Exposing the raw markdown table syntax for the author to type — rejected: defeats the purpose of the structured editor.
+**Rationale**: A plain grid of `<input>` elements is predictable, accessible, and straightforward to serialise.
+
+### D3: Dimension limits — 20 rows × 10 columns
+**Decision**: The editor enforces a soft cap of 20 × 10 via disabled add-buttons; the API returns HTTP 400 if a placement payload exceeds this.
+**Alternatives considered**:
+- No limit — rejected: very large tables break dashboard layout and create excessive DOM.
+- Smaller limits — rejected: 20 × 10 covers the vast majority of real use cases found in the showcase data.
+**Rationale**: A soft cap improves UX (buttons grey out) while the hard cap prevents abuse via API.
+
+### D4: Header-row toggle
+**Decision**: A single boolean `headerRow` on the table config controls whether the first row is treated as a header; when `true`, the first markdown table row renders as `<th>` elements.
+**Alternatives considered**:
+- No header row support — rejected: a table without headers is an accessibility fail under WCAG 1.3.1.
+- Per-column header configuration — rejected: over-engineered for the target use case.
+**Rationale**: One boolean maps directly to the GFM table syntax, which mandates a separator row after the header. The serialiser emits or omits the separator row based on this flag.
+
+### D5: Cell content — plain text only
+**Decision**: Cell inputs accept plain text; markdown inline syntax inside cells is not supported and is escaped on serialisation.
+**Alternatives considered**:
+- Allow markdown inside cells — rejected: makes the editor significantly more complex and the rendered output harder to predict.
+**Rationale**: Plain text is sufficient for most tabular data. Authors who need styled cells can use the raw markdown textarea path.
+
+### D6: Edit round-trip — parse markdown back into the editor
+**Decision**: When an author re-opens the table editor, the stored markdown table is parsed back into the row/column grid using a client-side GFM table parser.
+**Alternatives considered**:
+- Store a separate JSON representation alongside the markdown — rejected: two sources of truth.
+**Rationale**: GFM table syntax is simple enough that a lightweight client-side parser can reconstruct the grid reliably. The editor does not need to handle arbitrary markdown; only the table block it produced is parsed.
+
+### D7: Insert vs replace behaviour
+**Decision**: "Insert table" replaces the entire widget body with the table markdown; widgets cannot mix free text and a table in the same editor session.
+**Alternatives considered**:
+- Insert the table at cursor position within a larger text body — rejected: requires a full rich-text editor integration, which is out of scope.
+**Rationale**: The table editor is a modal; when it closes, the output is the full `body`. Authors who want text above or below the table can switch to the markdown textarea view and edit manually.
+
+## Risks / Trade-offs
+
+- **Round-trip fidelity** → If a human edits the stored markdown outside the editor and introduces non-standard table syntax, the client-side parser may misinterpret it. Mitigation: the editor shows a warning if the stored body does not parse as a valid table and falls back to a blank grid.
+- **Dimension limit bypass via API** → The HTTP 400 guard must be enforced in the controller, not only in the Vue form. Mitigation: server-side validation mirrors the client-side limit check.
+
+## Open follow-ups
+
+- Decide whether to surface column alignment (left/center/right) via the GFM alignment marker — low effort, adds polish.
+- Determine whether the table editor should be reachable from within the markdown textarea (e.g., a toolbar button) or only from a separate "Insert table" entry point.
+- Confirm that the `<th>` elements produced by the renderer receive appropriate `scope="col"` attributes for WCAG 1.3.1 compliance.

--- a/openspec/changes/text-widget-tables/proposal.md
+++ b/openspec/changes/text-widget-tables/proposal.md
@@ -1,0 +1,55 @@
+# Text-widget-tables
+
+## Why
+
+The text-display widget currently supports markdown text rendering and inline HTML formatting, covering annotations and rich text callouts. However, structured tabular data lacks a native editor within the dashboard — users must either (a) paste a pre-formatted markdown table (render-only, no in-place editing) or (b) embed an external spreadsheet widget. This change introduces a visual table editor into the text widget, allowing users to create and modify tables cell-by-cell directly in the dashboard without leaving the app.
+
+## What Changes
+
+- Extend `text-display-widget` with a new `tableMode: boolean` toggle (or a content-type selector: "Text | Table").
+- Add a `tableData` JSON schema to the widget's `styleConfig` blob, storing header-row flag, column alignments, and a 2D row/cell matrix with `rowSpan` / `colSpan` metadata.
+- When `tableMode = true`, the renderer draws an HTML `<table>` with `<th>` for the header row (if enabled), `<td>` otherwise, respecting cell merging and per-column text alignment.
+- When `tableMode = false`, render the existing markdown/HTML text path (unchanged).
+- Editor modal gains a table-editing UI with operations: add/delete row, add/delete column, merge/split cells, set alignment, toggle header row.
+- Validation on save: grid must be rectangular (accounting for merged cells), cell spans must not overflow bounds.
+- Cell text sanitised the same way as text-widget HTML (DOMPurify, no `<script>`, safe tags preserved).
+- Empty-table placeholder: a freshly toggled `tableMode = true` defaults to a 1×1 cell grid.
+- Optional: bulk paste TSV/CSV into the editor auto-parses into rows and columns.
+
+## Capabilities
+
+### New Capabilities
+
+- `text-widget-tables`: a standalone new capability covering table data model, editor operations, rendering, and validation. Reason: the parent `text-display-widget` capability is not yet promoted to `openspec/specs/`; sibling `text-widget-markdown` is also a new capability in the same change. Keeping these as separate new capabilities allows independent merging and avoids coupling.
+
+## Impact
+
+**Affected code:**
+
+- `src/components/WidgetEditors/TextWidgetEditor.vue` — add `tableMode` toggle and conditional table editor sub-component
+- `src/components/WidgetEditors/TextTableEditor.vue` (new) — visual table editor with row/column add/delete, cell merge/split, alignment controls
+- `src/components/WidgetRenderers/TextWidgetRenderer.vue` — render either text or table based on `tableMode`
+- `src/stores/widgets.js` — track `tableData` in widget state alongside existing `text`, `fontSize`, `color` fields
+- `lib/Service/TextWidgetService.php` (new or extend existing) — validate table grid shape, cell span bounds, merge cell logic
+- `appinfo/styles.css` — table styling (border, cell padding, header background, hover states)
+
+**Affected APIs:**
+
+- None — the table data lives entirely within the widget's `styleConfig` JSON blob (no new endpoints)
+
+**Dependencies:**
+
+- DOMPurify (already vendored for text sanitisation) — reused for table cell text
+- No new Composer or npm dependencies
+
+**Migration:**
+
+- Zero-impact: existing widgets get `tableMode = false` (text mode), so `tableData` is ignored until the user explicitly toggles `tableMode = true`. No data backfill needed.
+
+## Scope Boundary
+
+This change covers the data model, editor operations, render path, and validation for table mode. It does NOT cover:
+
+- Bulk copy/paste from external spreadsheets (optional per spec; can be added in a follow-up if deemed high-value).
+- Export to CSV/Excel (out of scope — text widget is annotation/display, not reporting).
+- Advanced spreadsheet features (formulas, auto-sum, conditional formatting) — the widget is a simple table editor, not a calculation engine.

--- a/openspec/changes/text-widget-tables/specs/text-widget-tables/spec.md
+++ b/openspec/changes/text-widget-tables/specs/text-widget-tables/spec.md
@@ -1,0 +1,398 @@
+---
+status: draft
+---
+
+# Text-Widget Tables — New Capability
+
+## ADDED Requirements
+
+### Requirement: REQ-TBLE-001 Table Data Model
+
+The widget MUST store table content in a `tableData` JSON object within `styleConfig`, with the schema:
+
+```jsonc
+{
+  "headerRow": boolean (default false),
+  "columnAlignments": ["left"|"center"|"right", ...],
+  "rows": [
+    [
+      {
+        "text": "string (may contain HTML, required)",
+        "rowSpan": 1 (default),
+        "colSpan": 1 (default)
+      },
+      ...
+    ],
+    ...
+  ]
+}
+```
+
+All fields MUST be present on save; no partial updates.
+
+#### Scenario: Minimal 1x1 table
+
+- GIVEN a freshly-toggled `tableMode = true` widget
+- WHEN the editor initializes
+- THEN `tableData` MUST equal:
+  ```json
+  {"headerRow": false, "columnAlignments": ["left"], "rows": [[{"text": "", "rowSpan": 1, "colSpan": 1}]]}
+  ```
+- AND the user sees a single empty cell in the editor
+
+#### Scenario: Multi-row, multi-column table
+
+- GIVEN `tableData` with `rows = [[{text:"A"}, {text:"B"}], [{text:"C"}, {text:"D"}]]` and `columnAlignments = ["left", "center"]`
+- WHEN the table is rendered
+- THEN the output MUST be a 2×2 grid with content A, B (top row) and C, D (bottom row)
+- AND column 1 MUST have `text-align: center` applied
+
+#### Scenario: Merged cells with span metadata
+
+- GIVEN `rows = [[{text:"Header", "colSpan": 2}, {text:"X"}], [{text:"A"}, {text:"B"}, {text:"C"}]]`
+- WHEN the editor loads
+- THEN the first row's first cell MUST show `colSpan: 2`, and subsequent rows MUST account for the wider first cell
+- NOTE: This scenario documents the data structure; merged-cell layout rules are covered in REQ-TBLE-007.
+
+#### Scenario: Column alignment array length matches columns
+
+- GIVEN a table with 3 columns
+- WHEN `columnAlignments.length === 3`
+- THEN rendering proceeds normally
+- AND if `columnAlignments.length !== 3` (ragged), validation in REQ-TBLE-008 MUST reject on save
+
+### Requirement: REQ-TBLE-002 Table Mode Toggle
+
+The editor MUST expose a `tableMode` boolean flag (or "Text | Table" mode selector) that switches rendering between markdown/HTML text and structured table data.
+
+#### Scenario: Switch from text to table mode
+
+- GIVEN a widget with `tableMode = false` and `text = "Some text"`
+- WHEN the user toggles `tableMode = true` in the editor
+- THEN `tableData` MUST be initialized to a 1×1 empty table (per REQ-TBLE-001 minimal default)
+- AND the `text` field MUST remain unchanged (preserved for toggling back)
+- AND the editor UI MUST switch to table editor controls
+
+#### Scenario: Switch from table to text mode
+
+- GIVEN a widget with `tableMode = true` and an active `tableData` object
+- WHEN the user toggles `tableMode = false`
+- THEN the editor UI MUST switch to text controls (textarea, font size, color, alignment)
+- AND the `tableData` field MUST remain in the widget state (preserved for toggling back)
+
+#### Scenario: Render respects tableMode flag
+
+- GIVEN a widget placement with both `text` and `tableData` populated
+- WHEN `tableMode = false`, the renderer MUST draw text (ignore `tableData`)
+- AND when `tableMode = true`, the renderer MUST draw table (ignore `text`)
+
+### Requirement: REQ-TBLE-003 Add Row Operation
+
+The editor MUST provide controls to insert a new row above or below the current selection.
+
+#### Scenario: Add row below current row
+
+- GIVEN a table with 2 rows and 3 columns, user has selected row index 0
+- WHEN the user clicks "Add Row Below"
+- THEN a new row with 3 empty cells MUST be inserted at index 1
+- AND `rows.length` MUST equal 3
+- AND the new row's cells MUST have `rowSpan: 1, colSpan: 1`
+
+#### Scenario: Add row above current row
+
+- GIVEN a table with 2 rows, user has selected row index 1
+- WHEN the user clicks "Add Row Above"
+- THEN a new row MUST be inserted at index 1, shifting the old index-1 row to index 2
+- AND `rows.length` MUST equal 3
+
+#### Scenario: Add row with default alignment
+
+- GIVEN a table with `columnAlignments = ["left", "center", "right"]`
+- WHEN a new row is added
+- THEN the new row's cells MUST match the `columnAlignments` length (3 columns)
+- AND alignment rendering in REQ-TBLE-007 applies to the new row
+
+#### Scenario: Add row into merged-cell context
+
+- GIVEN a table where row 0, column 0 has `colSpan: 2`
+- WHEN a new row is added below
+- THEN the new row MUST also have 2 cells in column 0/1 (not 3, accounting for the merge)
+- NOTE: Grid accounting is tested in REQ-TBLE-008 validation
+
+### Requirement: REQ-TBLE-004 Add Column Operation
+
+The editor MUST provide controls to insert a new column left or right of the current selection.
+
+#### Scenario: Add column right of current column
+
+- GIVEN a table with 2 rows and 2 columns, user has selected column index 0
+- WHEN the user clicks "Add Column Right"
+- THEN a new column MUST be inserted at index 1
+- AND every row MUST have a new empty cell at index 1
+- AND `columnAlignments.length` MUST equal 3 (was 2)
+- AND the new column's alignment MUST default to `"left"`
+
+#### Scenario: Add column left of current column
+
+- GIVEN a table with 2 rows and 2 columns, user has selected column index 1
+- WHEN the user clicks "Add Column Left"
+- THEN a new column MUST be inserted at index 1, shifting the old index-1 column to index 2
+- AND every row's cell count MUST increase by 1
+- AND `columnAlignments.length` MUST equal 3
+
+#### Scenario: Add column with cell initialization
+
+- GIVEN any table with N rows
+- WHEN a new column is added
+- THEN each of the N rows MUST receive a new cell object: `{text: "", rowSpan: 1, colSpan: 1}`
+
+### Requirement: REQ-TBLE-005 Delete Row and Delete Column Operations
+
+The editor MUST provide controls to remove rows or columns, with confirmation if the target contains text.
+
+#### Scenario: Delete empty row
+
+- GIVEN a table with 3 rows, row 1 is empty (all cells have `text: ""`)
+- WHEN the user selects row 1 and clicks "Delete Row" WITHOUT a confirmation prompt
+- THEN row 1 MUST be removed
+- AND `rows.length` MUST equal 2
+
+#### Scenario: Delete row with text — confirmation required
+
+- GIVEN a table with 3 rows, row 1 has at least one cell with non-empty `text`
+- WHEN the user selects row 1 and clicks "Delete Row"
+- THEN a confirmation dialog MUST appear with message (translated): "This row contains text. Delete?"
+- AND deletion proceeds only if the user confirms
+- AND the row MUST be removed on confirmation
+
+#### Scenario: Delete column with confirmation
+
+- GIVEN a table with 3 columns, column 1 has any cell with non-empty `text`
+- WHEN the user selects column 1 and clicks "Delete Column"
+- THEN a confirmation dialog MUST appear
+- AND `columnAlignments` MUST have the item at index 1 removed
+- AND every row MUST have the cell at index 1 removed
+
+#### Scenario: Cancel deletion
+
+- GIVEN a confirmation dialog is open for delete row
+- WHEN the user cancels
+- THEN the row MUST remain unchanged
+- AND `rows.length` MUST not change
+
+### Requirement: REQ-TBLE-006 Merge and Split Cells
+
+The editor MUST allow users to merge multiple selected cells horizontally or vertically, and to split a merged cell back to 1×1.
+
+#### Scenario: Merge 2 horizontal cells
+
+- GIVEN a table with row 0 containing 4 cells, user selects cells at column 0 and column 1
+- WHEN the user clicks "Merge Cells"
+- THEN cell[0][0] MUST have `colSpan: 2`
+- AND cell[0][1] MUST be emptied (text cleared, kept as placeholder to maintain column count)
+- AND rendering in REQ-TBLE-007 MUST skip cell[0][1] (HTML colspan spans over it)
+
+#### Scenario: Merge 2 vertical cells
+
+- GIVEN a table with 3 rows and 2 columns, user selects cell[0][0] and cell[1][0]
+- WHEN the user clicks "Merge Cells"
+- THEN cell[0][0] MUST have `rowSpan: 2`
+- AND cell[1][0] MUST be emptied (placeholder)
+
+#### Scenario: Merge 2x2 block
+
+- GIVEN a table with 3×3 grid, user selects a 2×2 block (cells [0,0], [0,1], [1,0], [1,1])
+- WHEN the user clicks "Merge Cells"
+- THEN cell[0][0] MUST have `rowSpan: 2, colSpan: 2`
+- AND cells [0][1], [1][0], [1][1] MUST be emptied (placeholders)
+
+#### Scenario: Split merged cell
+
+- GIVEN cell[0][0] has `colSpan: 2, rowSpan: 1`
+- WHEN the user selects that cell and clicks "Split Cell"
+- THEN cell[0][0] MUST reset to `colSpan: 1, rowSpan: 1`
+- AND cell[0][1] (the placeholder) MUST also have `colSpan: 1, rowSpan: 1`
+- AND the user-visible table MUST revert to 1×1 per cell
+
+#### Scenario: Split without merge (idempotent)
+
+- GIVEN cell[0][0] has `colSpan: 1, rowSpan: 1` (not merged)
+- WHEN the user clicks "Split Cell"
+- THEN nothing MUST change (idempotent)
+
+### Requirement: REQ-TBLE-007 Column Alignment and Header Row Toggle
+
+The editor MUST expose per-column alignment controls and a header-row flag toggle.
+
+#### Scenario: Set column alignment to center
+
+- GIVEN a table with 3 columns, all aligned "left"
+- WHEN the user selects column 1 and sets alignment to "center"
+- THEN `columnAlignments[1]` MUST equal `"center"`
+- AND the renderer MUST apply `style="text-align: center"` to all `<td>` or `<th>` in column 1 (REQ-TBLE-007 render rule)
+
+#### Scenario: Set multiple columns to different alignments
+
+- GIVEN a 3-column table
+- WHEN the user sets column 0 to "left", column 1 to "center", column 2 to "right"
+- THEN `columnAlignments` MUST equal `["left", "center", "right"]`
+- AND rendering MUST apply the correct alignment to each column
+
+#### Scenario: Toggle header row flag
+
+- GIVEN a table with `headerRow: false`
+- WHEN the user clicks the "Header Row" checkbox
+- THEN `headerRow` MUST be set to `true`
+- AND the renderer MUST render row[0] as `<th>` instead of `<td>` (REQ-TBLE-007 render rule)
+
+#### Scenario: Header row toggle is independent of content
+
+- GIVEN any table with any content
+- WHEN the user toggles `headerRow` on or off
+- THEN the cell text MUST remain unchanged
+- AND only the rendering format (th vs td) MUST change
+
+### Requirement: REQ-TBLE-008 Table Validation — Grid Integrity
+
+On save, the system MUST validate that the table grid is rectangular and cell spans do not exceed bounds.
+
+#### Scenario: Valid rectangular grid without merges
+
+- GIVEN `tableData` with 3 rows, each with exactly 3 cells, `columnAlignments.length = 3`, all cells have `rowSpan: 1, colSpan: 1`
+- WHEN the user saves the widget
+- THEN validation MUST pass (HTTP 201 or 200 returned)
+- AND `tableData` MUST be persisted unchanged
+
+#### Scenario: Ragged rows rejected
+
+- GIVEN `tableData` with row[0] containing 3 cells and row[1] containing 2 cells (and no merges to account for the difference)
+- WHEN the user saves
+- THEN validation MUST fail with error message (translated): "Grid is not rectangular"
+- AND the save MUST be blocked (HTTP 400 returned)
+- NOTE: Client-side validation in REQ-TBLE-003/004/005 should prevent this, but server-side validation is defensive.
+
+#### Scenario: Cell span exceeds grid bounds
+
+- GIVEN `tableData` with `rows.length = 2` and cell[1][0] has `rowSpan: 2` (exceeds from row 1 by 2 rows total = 3, but grid only has 2 rows)
+- WHEN the user saves
+- THEN validation MUST fail with error message (translated): "Cell span exceeds grid bounds"
+- AND HTTP 400 returned
+
+#### Scenario: Column alignment length mismatch
+
+- GIVEN a table with 3 actual columns (accounting for merges) but `columnAlignments.length = 2`
+- WHEN the user saves
+- THEN validation MUST fail
+- AND save MUST be blocked
+
+#### Scenario: Valid table with merged cells
+
+- GIVEN `tableData` with a valid 3×3 grid where cell[0][0] has `colSpan: 2`, and rows[0] is laid out as `[{colSpan:2}, {text:...}, {text:...}]` (3 columns spanned), `columnAlignments.length = 3`
+- WHEN the user saves
+- THEN validation MUST pass (grid is logically rectangular when spans are accounted for)
+
+### Requirement: REQ-TBLE-009 Render HTML Table with Cell Merging
+
+The renderer MUST output an HTML `<table>` with correct `<th>` / `<td>` elements, `rowspan` / `colspan` attributes, and per-column text alignment.
+
+#### Scenario: Render basic 2x2 table
+
+- GIVEN `tableData = {headerRow: false, columnAlignments: ["left", "left"], rows: [[{text:"A"}, {text:"B"}], [{text:"C"}, {text:"D"}]]}`
+- WHEN the widget renders
+- THEN the output MUST be:
+  ```html
+  <table>
+    <tr><td style="text-align: left">A</td><td style="text-align: left">B</td></tr>
+    <tr><td style="text-align: left">C</td><td style="text-align: left">D</td></tr>
+  </table>
+  ```
+
+#### Scenario: Render with header row
+
+- GIVEN `tableData = {headerRow: true, columnAlignments: ["left", "center"], rows: [[{text:"Name"}, {text:"Score"}], [{text:"Alice"}, {text:"95"}]]}`
+- WHEN the widget renders
+- THEN row[0] MUST use `<th>` elements:
+  ```html
+  <table>
+    <tr><th style="text-align: left">Name</th><th style="text-align: center">Score</th></tr>
+    <tr><td style="text-align: left">Alice</td><td style="text-align: center">95</td></tr>
+  </table>
+  ```
+
+#### Scenario: Render with colspan
+
+- GIVEN cell[0][0] has `text: "Header", colSpan: 2` and cell[0][1] is a placeholder `{text: "", colSpan: 1}`
+- WHEN the widget renders
+- THEN cell[0][0] MUST render as `<td colspan="2">Header</td>` and cell[0][1] MUST NOT be rendered (skipped due to colspan span)
+- AND the table MUST be visually rectangular
+
+#### Scenario: Render with rowspan
+
+- GIVEN cell[0][0] has `rowSpan: 2` and cell[1][0] is a placeholder
+- WHEN the widget renders
+- THEN cell[0][0] MUST render as `<td rowspan="2">...</td>` and cell[1][0] MUST NOT be rendered in the HTML
+
+#### Scenario: Alignment applied per column
+
+- GIVEN `columnAlignments = ["left", "center", "right"]`
+- WHEN any row is rendered
+- THEN all `<td>` / `<th>` in column 0 MUST have `style="text-align: left"`
+- AND all in column 1 MUST have `style="text-align: center"`
+- AND all in column 2 MUST have `style="text-align: right"`
+
+### Requirement: REQ-TBLE-010 Cell Text Sanitisation
+
+Cell text MUST be sanitised using DOMPurify before rendering to prevent XSS attacks.
+
+#### Scenario: Safe HTML tags preserved
+
+- GIVEN cell `{text: "Hello <b>world</b> and <i>thanks</i>"}`
+- WHEN the table is rendered
+- THEN the DOM MUST contain `<b>world</b>` and `<i>thanks</i>` exactly
+- AND the visual output MUST show "world" in bold and "thanks" in italics
+
+#### Scenario: Script tag removed
+
+- GIVEN cell `{text: "<script>alert(1)</script> text"}`
+- WHEN the table is rendered
+- THEN the DOM MUST NOT contain a `<script>` element
+- AND the visible text MUST be "text" (script and contents stripped)
+
+#### Scenario: Event handler stripped
+
+- GIVEN cell `{text: '<a href="#" onclick="alert(1)">link</a>'}`
+- WHEN the table is rendered
+- THEN the `<a>` element MUST NOT have an `onclick` attribute
+- AND the `href="#"` attribute MUST be preserved
+
+#### Scenario: javascript: URL stripped
+
+- GIVEN cell `{text: '<a href="javascript:alert(1)">click</a>'}`
+- WHEN the table is rendered
+- THEN the `<a>` element MUST NOT have an `href` starting with `javascript:`
+
+### Requirement: REQ-TBLE-011 Empty-Table Placeholder
+
+When a table is freshly created (empty cells, no user text), the renderer MUST display a subtle placeholder to indicate the table is empty.
+
+#### Scenario: Empty 1x1 table shows placeholder
+
+- GIVEN `tableData = {headerRow: false, columnAlignments: ["left"], rows: [[{text: ""}]]}`
+- WHEN the widget renders
+- THEN the cell MUST display a translated placeholder text (e.g., `t('mydash', 'Empty table')`)
+- AND the placeholder text MUST be styled with `color: var(--color-text-maxcontrast)` and `font-style: italic`
+- AND the placeholder MUST NOT be persisted (if the user saves, cell still has `text: ""`)
+
+#### Scenario: Placeholder disappears on user input
+
+- GIVEN the renderer displays a placeholder in an empty cell
+- WHEN the user clicks the cell and types text in edit mode
+- THEN the placeholder MUST disappear
+- AND the user's text MUST be visible
+
+#### Scenario: Table with any non-empty cell hides placeholder
+
+- GIVEN a 2×2 table where only cell[0][0] has `text: "Data"`
+- WHEN the widget renders
+- THEN cells[0][1], [1][0], [1][1] MAY show placeholder (per-cell), but the table overall is not empty
+- NOTE: Placeholder is per-cell, not per-table.

--- a/openspec/changes/text-widget-tables/tasks.md
+++ b/openspec/changes/text-widget-tables/tasks.md
@@ -1,0 +1,125 @@
+# Tasks — text-widget-tables
+
+## 1. Data model and schema
+
+- [ ] 1.1 Define `tableData` JSON schema in proposal or spec as canonical reference:
+  ```jsonc
+  {
+    "headerRow": boolean,
+    "columnAlignments": ["left"|"center"|"right", ...],
+    "rows": [
+      [{"text": "...", "rowSpan": 1, "colSpan": 1}, ...],
+      ...
+    ]
+  }
+  ```
+- [ ] 1.2 No database schema change needed — `tableData` lives in `styleConfig` JSON blob alongside existing text widget fields
+- [ ] 1.3 Update domain model (`TextWidgetData` or similar DTO) to support both text mode and table mode with explicit union type or mode flag
+
+## 2. Editor component
+
+- [ ] 2.1 Extend `src/components/WidgetEditors/TextWidgetEditor.vue` with `tableMode` toggle (radio buttons: "Text | Table" or checkbox "Table mode")
+- [ ] 2.2 Add conditional rendering: when `tableMode = false`, show existing text controls (textarea, font size, color, alignment); when `tableMode = true`, show table editor component
+- [ ] 2.3 Create `src/components/WidgetEditors/TextTableEditor.vue` with:
+  - A grid view rendering rows/columns as HTML table with content-editable cells (or input fields per cell)
+  - Add Row Above / Below buttons
+  - Add Column Left / Right buttons
+  - Delete Row button (with confirmation if any cell contains text)
+  - Delete Column button (with confirmation if any cell contains text)
+  - Merge Selected Cells button (multi-cell selection via Shift+Click or drag)
+  - Split Cell button (enabled only if selected cell has `rowSpan > 1` or `colSpan > 1`)
+  - Set Column Alignment dropdown (per-column selector: left / center / right)
+  - Toggle Header Row checkbox
+- [ ] 2.4 Keyboard support: Tab moves focus between cells, Delete key in a cell clears text (not the cell itself)
+
+## 3. Validation and data integrity
+
+- [ ] 3.1 In TextTableEditor or a dedicated `TextTableValidator` class, implement:
+  - Grid is rectangular: `rows[i].length === columnAlignments.length` for all i, accounting for merged cells
+  - Merged cell spans: `cell.rowSpan + rowIndex <= rows.length` and `cell.colSpan + colIndex <= rows[0].length`
+  - Reject on validation failure: modal shows error banner
+- [ ] 3.2 On save (modal Add / Update button), run validation; HTTP 400 returned by backend if invalid (defensive, should not happen due to client-side validation)
+- [ ] 3.3 Empty-table placeholder: when user toggles `tableMode = false → true`, initialize `tableData` with a single 1×1 cell with empty text
+
+## 4. Renderer component
+
+- [ ] 4.1 Update `src/components/WidgetRenderers/TextWidgetRenderer.vue`:
+  - Accept `tableMode` flag and `tableData` object
+  - If `tableMode = false`, render text path (existing code, unchanged)
+  - If `tableMode = true`, render HTML `<table>` with:
+    - `<thead><tr>` containing `<th>` elements if `headerRow = true` and index 0
+    - Otherwise, all rows use `<tr><td>`
+    - Each cell applies `rowspan` / `colspan` from metadata
+    - Per-column `style="text-align: left|center|right"` based on `columnAlignments`
+    - Cells are read-only in render mode (no content-editable)
+- [ ] 4.2 Cell text must pass through DOMPurify (same sanitisation as text widget) before rendering via `v-html`
+- [ ] 4.3 Table styling: `border-collapse: collapse`, borders on all cells, padding 8px, header background `var(--color-background-hover)`, hover effect on data cells
+
+## 5. Store integration
+
+- [ ] 5.1 Update `src/stores/widgets.js` to include `tableMode: boolean` and `tableData: object` fields in widget state
+- [ ] 5.2 Emit updates reactively as user edits table in TextTableEditor (live sync to parent modal)
+- [ ] 5.3 On mount, pre-populate TextTableEditor with existing `tableData` if present; else use empty 1×1 default
+
+## 6. Backend service (optional, PHP validation)
+
+- [ ] 6.1 If implementing server-side validation, create `lib/Service/TextTableValidator.php` with `validate(array $tableData): array` returning list of errors (empty if valid)
+- [ ] 6.2 Called during widget update via controller before save
+- [ ] 6.3 Return HTTP 400 on validation failure with error message
+
+## 7. Bulk paste (optional)
+
+- [ ] 7.1 (Optional) Add paste-to-table handler in TextTableEditor: on Ctrl+V, detect if clipboard is TSV/CSV
+- [ ] 7.2 Parse clipboard text into rows/columns, auto-create cells, update editor state
+- [ ] 7.3 Fallback: if paste is not TSV/CSV, insert text into focused cell
+
+## 8. PHPUnit tests
+
+- [ ] 8.1 If server-side validator created: `TextTableValidatorTest::testValidGrid` — rectangular grid passes
+- [ ] 8.2 `TextTableValidatorTest::testInvalidGridRagged` — ragged row lengths fail validation
+- [ ] 8.3 `TextTableValidatorTest::testMergedCellOverflow` — cell with `rowSpan` exceeding grid height fails
+- [ ] 8.4 `TextTableValidatorTest::testValidHeaderRow` — `headerRow = true` passes
+- [ ] 8.5 Integration test via WidgetController: create widget with `tableMode = true` and valid tableData, assert HTTP 201 returned
+
+## 9. Frontend component tests (Vitest/Jest)
+
+- [ ] 9.1 `TextTableEditor.test.js` — add row updates rows array
+- [ ] 9.2 Delete row removes correct index, shifts remaining rows
+- [ ] 9.3 Merge cells sets `rowSpan`/`colSpan`, clears merged-into cells
+- [ ] 9.4 Split cell resets `rowSpan`/`colSpan` to 1
+- [ ] 9.5 Toggle header row updates `headerRow` flag
+- [ ] 9.6 Set alignment updates `columnAlignments` array
+- [ ] 9.7 Renderer displays `<th>` when `headerRow = true`
+- [ ] 9.8 Renderer applies `rowspan`/`colspan` HTML attributes correctly
+
+## 10. End-to-end Playwright tests
+
+- [ ] 10.1 User toggles `tableMode = false → true`, sees 1×1 empty table
+- [ ] 10.2 User adds a row, adds a column, grid is now 2×2
+- [ ] 10.3 User types in cells, renders with text visible
+- [ ] 10.4 User merges 2 cells horizontally, HTML shows `colspan="2"` on first cell
+- [ ] 10.5 User deletes row, confirms deletion prompt, row disappears
+- [ ] 10.6 User toggles header row, saves widget, page reload shows `<th>` in first row
+- [ ] 10.7 User sets column 1 to center alignment, renders with `text-align: center` on column 1 cells
+- [ ] 10.8 User types `<script>alert(1)</script>` in a cell, saves, renders without script tag (sanitised)
+
+## 11. Quality gates
+
+- [ ] 11.1 `composer check:strict` (PHPCS, PHPMD, Psalm, PHPStan) passes — fix any pre-existing issues encountered
+- [ ] 11.2 ESLint + Stylelint clean on all touched Vue/JS files
+- [ ] 11.3 All new PHP files have SPDX headers inside docblock (per convention)
+- [ ] 11.4 i18n keys for all user-facing strings:
+  - "Add row above" / "Add row below"
+  - "Add column left" / "Add column right"
+  - "Delete row" / "Delete column"
+  - "Merge cells" / "Split cell"
+  - "Header row"
+  - "Left" / "Center" / "Right" (alignment options)
+  - "Text is required to delete" (confirmation prompt)
+  - Validation errors: "Grid is not rectangular", "Cell span exceeds grid bounds"
+  - All keys in both `en` and `nl` locales
+
+## 12. Documentation
+
+- [ ] 12.1 Update widget README / developer guide with table mode example and schema
+- [ ] 12.2 Add user-facing help text in the editor modal explaining table operations

--- a/openspec/changes/video-widget/design.md
+++ b/openspec/changes/video-widget/design.md
@@ -1,0 +1,95 @@
+# Design — Video Widget
+
+## Context
+
+The video widget allows dashboard editors to embed video content directly on a MyDash dashboard from four source types: two major hosted platforms, self-hosted open-source video instances, and internal file storage. The widget is a MyDash-native invention — it has no sibling dependency on existing background jobs or external data pipelines.
+
+Security is the dominant concern for embedded video. Hosted-platform embeds use a sandboxed iframe with a minimal capability set; the embed URL is extracted and canonicalised server-side at save time so the frontend never re-parses raw user-supplied URLs at render time. An admin-controlled domain allow-list governs which hosted origins may be embedded; an empty list means "allow nothing" rather than "allow all", so a freshly cleared setting fails safe.
+
+Internal file storage video is handled differently: a native HTML5 video element is used instead of an iframe, and the file is served via a streaming endpoint that enforces viewer ACL before returning data. This avoids the cross-origin complexity of iframes for content that lives within the same origin.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Support four source types behind a single widget: two hosted platforms, self-hosted instances, and internal file storage.
+- Extract and canonicalise embed URLs server-side at save time; the frontend reads the stored canonical URL directly.
+- Enforce an admin domain allow-list for all hosted-platform sources; default to a known-safe set.
+- Use a sandboxed iframe for hosted platforms and a native video element for internal files.
+- Default to privacy-preserving embed mode for applicable hosted platforms.
+
+**Non-Goals:**
+- Transcoding, re-encoding, or processing of video files is not in scope.
+- Playlist or chapter support is not provided in this iteration.
+- Analytics or view-tracking within the widget is out of scope.
+
+## Decisions
+
+### D1: Source type enum
+
+**Decision:** The `sourceType` placement config field accepts exactly `youtube | vimeo | peertube | nc-file`. The backend service dispatches URL parsing and embed URL construction based on this enum. Adding a new source type in future requires a backend service change and a frontend branch — there is no dynamic plugin mechanism.
+
+**Alternatives considered:** Open-ended URL field with server-side domain matching to infer type. Simpler configuration UX but ambiguous when a domain could match multiple source types (e.g., a self-hosted instance on a generic domain).
+
+**Rationale:** An explicit enum makes source type unambiguous, simplifies the parsing dispatch table, and allows the admin allow-list to use type-specific defaults without inferencing.
+
+### D2: Server-side URL parsing at save time — store canonical embed URL
+
+**Decision:** When a placement is saved, the backend parses the raw video URL, extracts the video ID, validates the domain against the allow-list, and stores the canonical embed URL in the `embedUrl` field of `widgetContent`. At render time, the frontend reads `embedUrl` directly and constructs the iframe `src` from it without re-parsing.
+
+**Alternatives considered:** Re-parse the raw URL at render time in the frontend. Moves security-sensitive parsing into client-side JavaScript and requires shipping URL-parsing logic for each source type to the browser.
+
+**Rationale:** Server-side parsing at save time is the correct security boundary: domain validation and ID extraction happen once, in a controlled environment, before the URL is stored. The frontend becomes a thin renderer with no knowledge of URL formats.
+
+### D3: Admin domain allow-list — empty means deny-all
+
+**Decision:** Admin setting `mydash.video_widget_allowed_domains` is a JSON array of permitted hostnames for hosted-platform embeds. The default value includes a small set of well-known hostnames. An empty array means no hosted-platform embeds are permitted. A non-existent or null setting is treated as the default, not as "allow all".
+
+**Alternatives considered:** Empty value means "allow all" — simpler for administrators who want open embedding. Creates an unsafe default when the setting is accidentally cleared.
+
+**Rationale:** The allow-list's security value comes from its restrictive default. "Empty = deny all" is the fail-safe interpretation that matches OWASP guidance for allowlist-based controls. Administrators who want unrestricted embedding must explicitly enumerate permitted domains.
+
+### D4: Iframe sandbox attributes for hosted platforms
+
+**Decision:** All hosted-platform iframes use `sandbox="allow-scripts allow-same-origin allow-presentation"`. No additional capabilities (`allow-forms`, `allow-popups`, `allow-top-navigation`) are granted.
+
+**Alternatives considered:** Full `sandbox` (allow everything). Defeats the purpose of sandboxing.
+
+**Alternatives considered:** No sandbox attribute. Maximum compatibility with platform players but no CSP isolation.
+
+**Rationale:** `allow-scripts` and `allow-same-origin` are the minimum required for hosted video players to initialise and play. `allow-presentation` supports fullscreen. Excluding `allow-popups` and `allow-top-navigation` prevents embedded content from redirecting the outer page, which is the primary iframe injection risk.
+
+### D5: Native video element for internal file storage sources
+
+**Decision:** When `sourceType = nc-file`, the widget renders an HTML5 `<video controls>` element whose `src` points to a streaming endpoint (`GET /api/widgets/video/file/{fileId}`). The streaming endpoint verifies viewer ACL before serving the file and returns HTTP 403 if the viewer lacks read access.
+
+**Alternatives considered:** Serve internal files via an iframe pointing to the built-in media viewer. Adds a full viewer shell around what the widget needs as a simple playback element, and the iframe approach requires cross-frame ACL coordination.
+
+**Rationale:** A native video element is simpler, accessible (native browser controls, captions support), and works without cross-origin complexity since the streaming endpoint shares the same origin as the dashboard.
+
+### D6: Privacy-preserving mode for applicable hosted platforms — opt-out
+
+**Decision:** Admin setting `mydash.video_widget_use_nocookie_youtube` defaults to `true`. When enabled, the URL parser substitutes the standard domain with the privacy-enhanced equivalent for applicable platforms at save time, so the stored `embedUrl` already reflects the privacy-preserving variant.
+
+**Alternatives considered:** Default to `false` (standard domain). Reduces tracking only for admins who discover and enable the setting.
+
+**Rationale:** Dashboard content is often viewed by many users. Defaulting to privacy-preserving mode protects viewers who have not opted into tracking by the hosted platform, without requiring each viewer to take action. Administrators with strong integration requirements (e.g., analytics-based features) can opt out by changing the setting.
+
+### D7: Autoplay and mute interaction rule
+
+**Decision:** If `autoplay = true` and `muted = false`, the backend coerces `muted = true` before storing the placement config, and logs a notice. Autoplay without mute is blocked by all major browser autoplay policies and would silently fail; the coercion makes the intended behaviour explicit and prevents "why won't my video autoplay?" support requests.
+
+**Alternatives considered:** Reject the configuration and return a validation error. Interrupts the save flow for a common misconfiguration that has a clear correct resolution.
+
+**Rationale:** Silent coercion with a saved-config note is friendlier than a hard error for an easily-fixed misconfiguration. The coercion is documented in the config UI with an inline hint.
+
+## Risks / Trade-offs
+
+- **Hosted platform embed URL format changes** → Parser logic must be updated per source type when platforms change their embed schemes; integration tests must cover known URL format variations.
+- **Allow-list maintenance for self-hosted instances** → Admins must add each instance domain manually; provide a parse-test endpoint (`GET /api/widgets/video/parse?url=...`) so admins can validate before saving.
+- **Sandbox compatibility with future platform player features** → Features requiring `allow-popups` (share dialogs, some quality pickers) will not function; this is an accepted trade-off for the security boundary.
+
+## Open follow-ups
+
+- Evaluate whether `allow-fullscreen` belongs in the sandbox attribute set — currently absent; some browsers block fullscreen without it even when `allow-presentation` is present.
+- Confirm whether self-hosted instances require individual domain entries in the allow-list or whether a subdomain wildcard pattern is needed.
+- Specify captions / subtitle support for internal file sources (WebVTT sidecar files alongside the video).

--- a/openspec/changes/video-widget/proposal.md
+++ b/openspec/changes/video-widget/proposal.md
@@ -1,0 +1,74 @@
+# Video widget
+
+## Why
+
+Dashboard users want to embed video content directly on their dashboards — whether from popular platforms like YouTube and Vimeo, self-hosted PeerTube instances, or internal Nextcloud Files storage. Currently there is no built-in video widget, forcing users to use generic iframes or external embedding plugins. This change introduces a first-class `video-widget` capability that registers a standardized Nextcloud dashboard widget with:
+
+- Support for multiple video sources (YouTube, Vimeo, PeerTube, Nextcloud Files)
+- Admin-controlled domain allowlist for embedded videos (security gate)
+- Per-placement configuration: autoplay, muting, looping, controls, aspect ratio, poster image
+- Server-side URL parsing to extract video IDs and validate against allowed domains
+- HTML5 `<video>` tag for internal files with ACL checks; `<iframe>` with CSP-safe sandbox attributes for hosted platforms
+- Optional YouTube no-cookie domain support to reduce tracking
+- Responsive aspect-ratio enforcement via CSS
+
+## What Changes
+
+- Register a new widget `mydash_video` with Nextcloud's Dashboard API via `OCP\Dashboard\IManager`
+- Add global admin setting `mydash.video_widget_allowed_domains` (JSON array, default: `["youtube.com","www.youtube.com","youtu.be","vimeo.com","player.vimeo.com"]`)
+- Add optional admin setting `mydash.video_widget_use_nocookie_youtube` (boolean, default: `false`)
+- Widget placement's `widgetContent` JSON stores:
+  - `sourceType`: `'youtube' | 'vimeo' | 'peertube' | 'nc-file'`
+  - `videoUrl` (for hosted) or `fileId` (for `nc-file`)
+  - `autoplay`, `muted`, `loop`, `controls`, `aspectRatio`, `posterUrl`
+- VideoWidgetController handles:
+  - GET `/api/widgets/video/parse` — extract video ID from URL, return canonical embed URL, validate domain
+  - GET `/api/widgets/video/file/{fileId}` — resolve Nextcloud file, check viewer ACL, return streaming URL
+- VideoWidget.vue renders:
+  - Hosted platforms (YouTube/Vimeo/PeerTube) via iframe with sandbox
+  - Nextcloud Files via HTML5 video tag
+  - Empty state, failure state, invalid-domain state
+
+## Capabilities
+
+### New Capabilities
+
+- `video-widget`: REQ-VID-001 through REQ-VID-011 (registration, config schema, source-type handling, allowed-domains enforcement, URL parsing, nc-file ACL, iframe sandbox, autoplay+mute interaction, aspect-ratio, nocookie option, empty/failure states)
+
+### Modified Capabilities
+
+- (none — widget ecosystem already exists; this is a new widget plugin)
+
+## Impact
+
+**Affected code:**
+
+- `lib/Service/VideoParsingService.php` — URL extraction, ID validation, domain checking against allowlist
+- `lib/Controller/VideoWidgetController.php` — parse endpoint + file access endpoint
+- `lib/Dashboard/VideoWidgetProvider.php` — Nextcloud Dashboard API registration
+- `src/components/widgets/VideoWidget.vue` — frontend render logic (iframe, video tag, error states)
+- `src/stores/widgets.js` — optional computed property for widget config helpers
+- `appinfo/routes.php` — register two new controller routes
+- `appinfo/info.xml` — declare `video-widget` capability
+- No schema changes to MyDash tables (widget config is stored in existing `widgetContent` JSON)
+
+**Affected APIs:**
+
+- 2 new routes: `GET /api/widgets/video/parse` (public?) and `GET /api/widgets/video/file/{fileId}` (logged-in)
+- Nextcloud Dashboard API registration adds widget to discovery list
+
+**Dependencies:**
+
+- No new Composer or npm dependencies (uses built-in PHP URL parsing, Nextcloud File API)
+
+**Migration:**
+
+- Zero-impact: no database schema changes. Existing dashboards continue to work. The video widget is opt-in at placement time.
+
+## Standards & References
+
+- OpenSpec: `openspec/specs/widgets/spec.md` — widget discovery and placement
+- Nextcloud Dashboard API: `OCP\Dashboard\IManager`, `OCP\Dashboard\IWidget`, registration in `lib/AppManager.php`
+- OWASP: iframe sandbox attribute for embedded content security (CSP-friendly)
+- WCAG 2.1 AA: video controls, poster image for accessibility
+- i18n requirement: all messages in English and Dutch

--- a/openspec/changes/video-widget/specs/video-widget/spec.md
+++ b/openspec/changes/video-widget/specs/video-widget/spec.md
@@ -1,0 +1,433 @@
+---
+status: draft
+---
+
+# Video Widget Specification
+
+## ADDED Requirements
+
+### Requirement: REQ-VID-001 Register Video Widget with Nextcloud Dashboard API
+
+The system MUST register a video widget with Nextcloud's Dashboard API so it appears in widget discovery and can be added to dashboards.
+
+#### Scenario: Widget is discovered in the widget list
+- GIVEN Nextcloud has the Dashboard Widget API enabled
+- WHEN a user navigates to the dashboard widget picker via MyDash
+- THEN GET /api/widgets MUST include a widget with `id: "mydash_video"`, `title: "Video"`, and an icon
+- AND the widget MUST be registered via `OCP\Dashboard\IManager::registerWidget()` in `VideoWidgetProvider`
+- AND the widget MUST implement `OCP\Dashboard\IWidget`
+
+#### Scenario: Widget metadata is localized
+- GIVEN the video widget is registered
+- WHEN a user requests the widget list
+- THEN the widget title MUST be localized to English ("Video") and Dutch ("Video")
+- AND the description MUST be localized (English: "Embed video from YouTube, Vimeo, PeerTube, or Nextcloud Files")
+
+#### Scenario: Widget icon is visually distinct
+- GIVEN the video widget is displayed in the widget picker
+- WHEN rendered alongside other widgets
+- THEN the icon MUST be a clear video-player symbol (play button or film reel)
+- AND the icon file MUST be stored at `img/widgets/video.svg`
+
+#### Scenario: Widget registration occurs on app boot
+- GIVEN the MyDash app is installed and enabled
+- WHEN Nextcloud boots and initializes app managers
+- THEN `VideoWidgetProvider::load()` MUST be called by Nextcloud's AppManager
+- AND the video widget registration MUST complete without errors
+
+### Requirement: REQ-VID-002 Store Video Widget Configuration per Placement
+
+The widget placement's `widgetContent` JSON MUST store source type, URL/file ID, and display options.
+
+#### Scenario: Widget stores YouTube URL
+- GIVEN a user adds the video widget to their dashboard
+- WHEN they configure it with `sourceType: 'youtube'` and `videoUrl: 'https://youtube.com/watch?v=ABC123'`
+- THEN a widget placement is created with `widgetContent` containing:
+  ```json
+  {
+    "sourceType": "youtube",
+    "videoUrl": "https://www.youtube.com/embed/ABC123",
+    "autoplay": false,
+    "muted": true,
+    "loop": false,
+    "controls": true,
+    "aspectRatio": "16:9",
+    "posterUrl": null
+  }
+  ```
+- AND `videoUrl` MUST be stored as the canonical embed URL (server-side parsed, not user-entered raw form)
+
+#### Scenario: Widget stores Nextcloud file reference
+- GIVEN a user selects a video file from their Nextcloud storage
+- WHEN they add the video widget with `sourceType: 'nc-file'` and `fileId: 12345`
+- THEN `widgetContent` MUST contain:
+  ```json
+  {
+    "sourceType": "nc-file",
+    "fileId": 12345,
+    "autoplay": false,
+    "muted": true,
+    "loop": false,
+    "controls": true,
+    "aspectRatio": "16:9"
+  }
+  ```
+- AND `posterUrl` MUST be absent for `nc-file` type (or null)
+
+#### Scenario: Placement update modifies video config
+- GIVEN a widget placement with a stored video URL
+- WHEN the user sends PUT /api/widgets/{placementId} with updated `widgetContent`
+- THEN the new config (including revalidation of domain, re-parsing of URL if changed) MUST be stored
+- AND the change MUST take effect on the next render
+
+#### Scenario: Config defaults are applied
+- GIVEN a user submits a new widget placement with minimal config
+- WHEN only `sourceType` and `videoUrl` are provided
+- THEN the backend MUST apply defaults:
+  - `autoplay: false`
+  - `muted: true`
+  - `loop: false`
+  - `controls: true`
+  - `aspectRatio: "16:9"`
+  - `posterUrl: null`
+
+### Requirement: REQ-VID-003 Support Multiple Video Source Types
+
+The widget MUST handle YouTube, Vimeo, PeerTube, and Nextcloud Files as distinct source types with appropriate rendering logic.
+
+#### Scenario: YouTube URL is normalized to embed form
+- GIVEN a user submits raw YouTube URLs in various formats:
+  - `https://www.youtube.com/watch?v=ABC123`
+  - `https://youtu.be/ABC123`
+  - `https://youtube.com/watch?v=ABC123&t=30s`
+- WHEN `VideoParsingService::parseYouTubeUrl()` processes each
+- THEN each MUST extract the video ID `ABC123` and return canonical form `https://www.youtube.com/embed/ABC123`
+- AND time offset (`t=30s`) MAY be appended as `?start=30` to the embed URL
+
+#### Scenario: Vimeo URL is normalized
+- GIVEN raw Vimeo URLs:
+  - `https://vimeo.com/12345`
+  - `https://player.vimeo.com/video/12345`
+- WHEN parsed
+- THEN the video ID `12345` MUST be extracted and returned as `https://player.vimeo.com/video/12345`
+
+#### Scenario: PeerTube URL is preserved and validated
+- GIVEN a PeerTube instance URL like `https://peertube.example.com/w/abc123`
+- WHEN `VideoParsingService::parsePeerTubeUrl()` processes it
+- THEN the domain and UUID/path MUST be extracted and validated as a PeerTube-compatible embed form
+- AND the domain MUST be checked against the allowed domains list
+- AND the returned URL MUST be suitable for iframe embedding
+
+#### Scenario: Nextcloud file is resolved with ACL
+- GIVEN a file ID `12345` in the user's Nextcloud instance
+- WHEN the widget render logic calls `VideoFileService::getAccessibleUrl(12345, userId)`
+- THEN the system MUST:
+  - Load the file metadata via `RootFolder::getById()`
+  - Check if the viewing user has `\OCP\Constants::PERMISSION_READ` on the file
+  - Return the streaming URL if accessible, or throw `AccessDeniedException` if not
+
+### Requirement: REQ-VID-004 Enforce Admin-Controlled Domain Allowlist
+
+The system MUST prevent embedding videos from arbitrary domains unless explicitly allowed by the administrator.
+
+#### Scenario: Allowed domains setting exists
+- GIVEN no `mydash.video_widget_allowed_domains` setting is configured
+- WHEN the system boots
+- THEN the default allowlist MUST be:
+  ```json
+  ["youtube.com", "www.youtube.com", "youtu.be", "vimeo.com", "player.vimeo.com"]
+  ```
+- AND the admin MUST be able to override this via MyDash admin settings page
+
+#### Scenario: Widget save rejects disallowed domain
+- GIVEN admin has set `mydash.video_widget_allowed_domains` to only `["youtube.com", "www.youtube.com", "youtu.be"]`
+- WHEN a user attempts to save a widget with `sourceType: 'vimeo'` and `videoUrl: 'https://vimeo.com/12345'`
+- THEN the backend MUST return HTTP 400 with error message (English): "Domain not allowed by administrator"
+- AND the widget MUST NOT be created/updated
+
+#### Scenario: Admin adds a custom PeerTube instance to allowlist
+- GIVEN admin edits MyDash settings to add `"peertube.example.com"` to the allowed list
+- WHEN a user submits a widget with `sourceType: 'peertube'` and `videoUrl: 'https://peertube.example.com/w/abc123'`
+- THEN the domain check MUST succeed and the widget MUST be saved
+
+#### Scenario: Widget render shows domain-blocked error
+- GIVEN an existing widget placement with a video URL from a now-blocked domain
+- WHEN the dashboard is rendered
+- THEN the widget MUST display an error message (English): "Video domain is no longer allowed by administrator"
+- AND the video MUST NOT be embedded
+- AND the error MUST be localized to Dutch
+
+#### Scenario: Nextcloud file type always allowed
+- GIVEN `sourceType: 'nc-file'`
+- WHEN the widget is created
+- THEN domain allowlist checks MUST be skipped (only ACL matters)
+- AND the widget MUST be stored without domain validation
+
+### Requirement: REQ-VID-005 Parse and Validate Video URLs Server-Side
+
+The backend MUST extract video IDs from user-provided URLs and validate format before storage.
+
+#### Scenario: URL parsing endpoint is available
+- GIVEN a user is editing a widget config in the frontend
+- WHEN they type or paste a URL and click "Validate" or on blur
+- THEN POST /api/widgets/video/parse MUST be called with `{"sourceType": "youtube", "videoUrl": "https://..."}`
+- AND the endpoint MUST return `{"videoId": "ABC123", "canonicalUrl": "https://...", "isValid": true}`
+- OR return `{"isValid": false, "error": "..."}` if parsing fails
+
+#### Scenario: Invalid URL format is rejected early
+- GIVEN a user submits `videoUrl: "not-a-url"`
+- WHEN the parse endpoint processes it
+- THEN it MUST return HTTP 400 with `{"isValid": false, "error": "Invalid URL format"}`
+
+#### Scenario: Domain validation happens at parse time
+- GIVEN a user submits a URL from a blocked domain
+- WHEN POST /api/widgets/video/parse is called
+- THEN it MUST return `{"isValid": false, "error": "Domain not allowed by administrator"}`
+- AND the domain MUST be extracted and checked against the allowlist
+
+#### Scenario: Canonical URL is cached in widget config
+- GIVEN a parsed and validated YouTube URL
+- WHEN the widget is created
+- THEN the stored `videoUrl` in `widgetContent` MUST be the canonical embed form
+- AND on render, the backend MUST NOT re-parse; it uses the cached canonical URL directly
+
+#### Scenario: Time offsets are preserved for YouTube
+- GIVEN a YouTube URL with time offset: `https://www.youtube.com/watch?v=ABC123&t=120s`
+- WHEN parsed
+- THEN the canonical URL MUST be `https://www.youtube.com/embed/ABC123?start=120`
+- AND the render MUST jump to 120 seconds on play
+
+### Requirement: REQ-VID-006 Check File Access Control for Nextcloud Files
+
+When `sourceType` is `nc-file`, the system MUST verify the viewing user can read the file before allowing playback.
+
+#### Scenario: File is readable by viewer
+- GIVEN a widget with `sourceType: 'nc-file'` and `fileId: 12345`
+- AND user "alice" owns the file and has read permission
+- WHEN the dashboard renders for "alice"
+- THEN the render MUST call `VideoFileService::getAccessibleUrl(12345, "alice")`
+- AND it MUST return a valid URL like `/index.php/apps/files/api/v1/files/12345/content`
+- AND the video MUST embed successfully
+
+#### Scenario: File is not readable by viewer
+- GIVEN a widget with `sourceType: 'nc-file'` and `fileId: 12345`
+- AND user "bob" has no read permission on the file
+- WHEN the dashboard renders for "bob"
+- THEN `VideoFileService::getAccessibleUrl()` MUST throw `AccessDeniedException`
+- AND the widget MUST display an error message: "Video not accessible"
+- AND no download URL MUST be leaked to the frontend
+
+#### Scenario: File MIME type is video
+- GIVEN `fileId: 12345` points to a file `movie.mp4` with MIME type `video/mp4`
+- WHEN the file service checks the file
+- THEN it MUST accept the file and proceed with URL generation
+- AND the following MIME types MUST be accepted: `video/mp4`, `video/webm`, `video/ogg`, `video/quicktime`, `video/x-msvideo`
+
+#### Scenario: File MIME type is not video
+- GIVEN `fileId: 12345` points to a file `document.pdf` with MIME type `application/pdf`
+- WHEN the file service checks the file
+- THEN it MUST reject the file and return an error
+- AND the widget MUST display: "File is not a video"
+
+#### Scenario: File is deleted
+- GIVEN a widget references a deleted file via `fileId: 12345`
+- WHEN the dashboard renders
+- THEN `RootFolder::getById()` MUST throw or return null
+- AND the widget MUST display: "Video file not found"
+
+### Requirement: REQ-VID-007 Use iframe with CSP-Safe Sandbox Attributes
+
+Hosted video platforms (YouTube, Vimeo, PeerTube) MUST be embedded via iframe with strict sandbox restrictions.
+
+#### Scenario: YouTube iframe uses proper sandbox
+- GIVEN a widget with `sourceType: 'youtube'` and canonical URL `https://www.youtube.com/embed/ABC123`
+- WHEN the widget renders
+- THEN the HTML MUST include:
+  ```html
+  <iframe
+    src="https://www.youtube.com/embed/ABC123"
+    sandbox="allow-scripts allow-same-origin"
+    allowfullscreen
+  ></iframe>
+  ```
+- AND `sandbox` MUST NOT include `allow-top-navigation` (prevents video from breaking out)
+- AND `sandbox` MUST NOT include `allow-forms` (no form submission from iframe)
+
+#### Scenario: Vimeo iframe sandbox
+- GIVEN a widget with `sourceType: 'vimeo'` and URL `https://player.vimeo.com/video/12345`
+- WHEN rendered
+- THEN the iframe MUST have `sandbox="allow-scripts allow-same-origin" allowfullscreen`
+
+#### Scenario: CSP compliance
+- GIVEN the app's Content-Security-Policy header
+- WHEN an iframe embeds an external URL
+- THEN the iframe source domain MUST be in the CSP `frame-src` directive
+- NOTE: YouTube, Vimeo, PeerTube are typically already in CSP; app MUST document any domains needing CSP updates
+
+#### Scenario: iframes respect aspect ratio
+- GIVEN an iframe with `aspectRatio: '4:3'`
+- WHEN rendered
+- THEN the iframe container MUST use CSS `padding-bottom` trick to maintain 4:3 ratio
+- AND the iframe itself MUST have `width: 100%` and `height: 100%` to fill the container
+
+### Requirement: REQ-VID-008 Respect Autoplay, Muting, and Loop Settings
+
+The widget MUST apply user-selected playback options while respecting browser autoplay policies.
+
+#### Scenario: Autoplay with muted enforces mute
+- GIVEN a user sets `autoplay: true` and `muted: false`
+- WHEN the widget saves
+- THEN the backend MUST enforce `muted: true` (browsers block autoplay of unmuted video)
+- AND the frontend MUST inform the user: "Autoplay requires muting"
+- NOTE: This is a client-side UX nicety; server always enforces the invariant
+
+#### Scenario: YouTube iframe autoplay
+- GIVEN a widget with `autoplay: true`, `muted: true`, `sourceType: 'youtube'`
+- WHEN the render generates the iframe URL
+- THEN it MUST append `?autoplay=1&mute=1` to the embed URL: `https://www.youtube.com/embed/ABC123?autoplay=1&mute=1`
+
+#### Scenario: HTML5 video autoplay
+- GIVEN a widget with `sourceType: 'nc-file'`, `autoplay: true`, `muted: true`
+- WHEN the video tag is rendered
+- THEN it MUST include attributes: `autoplay muted` (both required for browser autoplay policy)
+
+#### Scenario: Loop is applied per platform
+- GIVEN a widget with `loop: true`
+- WHEN rendered:
+  - For HTML5 video: add `loop` attribute to `<video>` tag
+  - For YouTube: append `&loop=1&playlist=ABC123` to iframe URL
+  - For Vimeo/PeerTube: may not be supported; append if platform supports it
+- THEN the video MUST repeat indefinitely
+
+#### Scenario: Controls toggle
+- GIVEN a widget with `controls: false`
+- WHEN rendered:
+  - For HTML5 video: omit `controls` attribute
+  - For iframes: no standard way to hide controls; document this limitation
+- THEN playback controls visibility MUST be honored for HTML5
+
+### Requirement: REQ-VID-009 Enforce Aspect Ratio via CSS
+
+The widget MUST apply the configured aspect ratio using modern CSS and fallback techniques.
+
+#### Scenario: Aspect ratio options
+- GIVEN a user selects `aspectRatio` from a dropdown
+- WHEN rendering
+- THEN the following options MUST be supported: `"16:9"`, `"4:3"`, `"1:1"`, `"9:16"`
+- AND each MUST render correctly in both desktop and mobile viewports
+
+#### Scenario: Aspect ratio CSS property (modern)
+- GIVEN a widget with `aspectRatio: '16:9'`
+- WHEN rendered in a modern browser (Chrome 88+, Firefox 89+, Safari 15+)
+- THEN the container MUST use: `aspect-ratio: 16 / 9;`
+- AND the iframe/video MUST stretch to fill: `width: 100%; height: 100%;`
+
+#### Scenario: Aspect ratio padding fallback
+- GIVEN a widget needs to support older browsers
+- WHEN the container doesn't support `aspect-ratio` CSS
+- THEN the backend SHOULD render a fallback with `padding-bottom: calc(9 / 16 * 100%)` technique
+- AND a sentinel class MUST allow frontend to detect modern support and override padding-bottom
+
+#### Scenario: Portrait video (9:16)
+- GIVEN a user selects `aspectRatio: '9:16'` for vertical video
+- WHEN rendered
+- THEN the container height MUST be constrained relative to width (e.g., max-width: 360px for full viewport)
+- AND the video MUST not distort
+
+### Requirement: REQ-VID-010 Support No-Cookie YouTube Embedding
+
+The system MUST support an optional admin setting to enable YouTube no-cookie embedding to reduce tracking.
+
+#### Scenario: No-cookie setting default
+- GIVEN `mydash.video_widget_use_nocookie_youtube` is not configured
+- WHEN a widget with `sourceType: 'youtube'` is created
+- THEN the system MUST use the standard `https://www.youtube.com/embed/ABC123`
+- AND YouTube's tracking cookies MUST be enabled by default
+
+#### Scenario: Admin enables no-cookie mode
+- GIVEN admin sets `mydash.video_widget_use_nocookie_youtube = true`
+- WHEN a widget with `sourceType: 'youtube'` is created
+- THEN the system MUST rewrite the embed URL to: `https://www.youtube-nocookie.com/embed/ABC123`
+- AND the no-cookie domain MUST be used for all subsequent renders
+
+#### Scenario: Existing widgets respect no-cookie toggle
+- GIVEN an existing widget with URL `https://www.youtube.com/embed/ABC123`
+- WHEN the admin toggles `use_nocookie_youtube` from false to true
+- THEN on next render, the URL MUST be dynamically rewritten to `youtube-nocookie.com` if applicable
+- NOTE: Stored URL is `www.youtube.com`; render-time transformation happens via controller logic
+
+#### Scenario: No-cookie does not affect Vimeo/PeerTube
+- GIVEN widgets with `sourceType: 'vimeo'` or `sourceType: 'peertube'`
+- WHEN the no-cookie setting is toggled
+- THEN only YouTube URLs are affected
+- AND Vimeo/PeerTube render URLs MUST NOT change
+
+### Requirement: REQ-VID-011 Display Appropriate Empty and Error States
+
+The widget MUST show user-friendly messages for missing config, access issues, and invalid domains.
+
+#### Scenario: Empty state - no video configured
+- GIVEN a widget placement with `sourceType: null` or missing `videoUrl`/`fileId`
+- WHEN the dashboard renders
+- THEN the widget MUST display a centered message: "No video URL configured"
+- AND a help text: "Edit the widget to add a video"
+- AND a clickable "Configure now" link (in edit mode)
+
+#### Scenario: Invalid URL error
+- GIVEN a user attempts to save a widget with `videoUrl: "not a valid URL"`
+- WHEN the parse endpoint is called
+- THEN it MUST return `{"isValid": false, "error": "Invalid URL format"}`
+- AND the frontend form MUST show the error below the URL field
+- AND the save button MUST be disabled
+
+#### Scenario: Domain not allowed error
+- GIVEN a user attempts to save a widget with a blocked domain
+- WHEN the parse endpoint is called
+- THEN it MUST return `{"isValid": false, "error": "Domain not allowed by administrator"}`
+- AND the frontend MUST display this error
+- AND the admin SHOULD be prompted to check MyDash settings
+
+#### Scenario: File not found error
+- GIVEN a widget with `sourceType: 'nc-file'` and the file has been deleted
+- WHEN the dashboard renders
+- THEN the widget MUST display: "Video file not found"
+- AND in edit mode, a "Remove widget" button MUST be offered
+
+#### Scenario: File not accessible error
+- GIVEN a widget with `sourceType: 'nc-file'` and the user has lost read permission
+- WHEN the dashboard renders
+- THEN the widget MUST display: "Video not accessible"
+- AND the widget MUST NOT show the file URL in the DOM
+
+#### Scenario: Poster image fallback
+- GIVEN a widget with `posterUrl` set to a custom image URL
+- WHEN the widget renders before video loads (or on pause in some platforms)
+- THEN the poster image MUST be displayed as the preview
+- AND if the poster URL is broken, a generic video icon MUST be shown instead
+
+#### Scenario: All error messages are localized
+- GIVEN any error message displayed to the user
+- WHEN the user's Nextcloud language is set to Dutch
+- THEN error messages MUST be available in Dutch
+- AND English MUST be the fallback
+- AND i18n keys MUST be registered in `l10n/en.json` and `l10n/nl.json`
+
+## Non-Functional Requirements
+
+- **Performance**: Video URL parsing MUST complete in < 500ms even for external URLs (YouTube, Vimeo). Cached canonical URLs in widget config MUST NOT be re-parsed on every render.
+- **Security**: iframe sandbox MUST prevent form submission, navigation, and plugin execution. File access checks MUST honor Nextcloud ACLs. No tracking pixels or third-party scripts MUST be injected by MyDash itself (YouTube/Vimeo may add their own per their ToS).
+- **Compatibility**: Widget MUST work with all supported Nextcloud versions and all Dashboard API versions (v1, v2). HTML5 video MUST play in all modern browsers (Chrome, Firefox, Safari, Edge 88+).
+- **Accessibility**: Videos MUST have poster images or title text. Controls MUST be keyboard accessible. Error messages MUST be clear and visible to screen readers.
+- **Localization**: All UI text, error messages, and settings labels MUST support English and Dutch.
+
+## Standards & References
+
+- OpenSpec: `openspec/specs/widgets/spec.md` — widget placement and discovery
+- Nextcloud Dashboard API: `OCP\Dashboard\IManager`, `OCP\Dashboard\IWidget`, `OCP\Dashboard\IAPIWidget`
+- OWASP: iframe sandbox attribute guidelines (CSP-friendly, restrict privileges)
+- WCAG 2.1 AA: video controls, poster images, keyboard navigation
+- HTML Living Standard: `<video>` element, `<iframe>` sandbox attribute
+- YouTube Embed API: `youtube.com/embed/{VIDEO_ID}`, `youtube-nocookie.com` domain
+- Vimeo Embed API: `player.vimeo.com/video/{VIDEO_ID}`
+- PeerTube Embed API: `/w/{UUID}` path and custom domain support
+- i18n requirement: ADR-005 (English + Dutch minimum)

--- a/openspec/changes/video-widget/tasks.md
+++ b/openspec/changes/video-widget/tasks.md
@@ -1,0 +1,177 @@
+# Tasks — video-widget
+
+## 1. Video URL parsing and validation service
+
+- [ ] 1.1 Create `lib/Service/VideoParsingService.php` with static methods for each platform
+- [ ] 1.2 Implement `parseYouTubeUrl(string $url): string` — extract video ID, return `https://www.youtube.com/embed/{ID}`, preserve time offset via `?start=N` query param
+- [ ] 1.3 Implement `parseVimeoUrl(string $url): string` — extract video ID, return `https://player.vimeo.com/video/{ID}`
+- [ ] 1.4 Implement `parsePeerTubeUrl(string $url): string` — extract domain and UUID/path, return embed-compatible URL
+- [ ] 1.5 Implement `validateDomain(string $url, string $sourceType): bool` — extract hostname from URL, check against allowlist from `IAppConfig`, throw `DomainNotAllowedException` if blocked
+- [ ] 1.6 Implement `normalizeUrl(string $url, string $sourceType): string` — dispatcher to the platform-specific methods; handles URL format variations (trailing slashes, query params, etc.)
+
+## 2. File access service for Nextcloud videos
+
+- [ ] 2.1 Create `lib/Service/VideoFileService.php`
+- [ ] 2.2 Implement `getAccessibleUrl(int $fileId, string $userId): string` — load file via `RootFolder::getById()`, check MIME type is video, verify `PERMISSION_READ`, return streaming URL
+- [ ] 2.3 Implement `isVideoMimeType(string $mimeType): bool` — return true for `video/mp4`, `video/webm`, `video/ogg`, `video/quicktime`, `video/x-msvideo`
+- [ ] 2.4 Throw `AccessDeniedException` if user lacks read permission; throw `InvalidMimeTypeException` if file is not video; throw `FileNotFoundException` if file does not exist
+- [ ] 2.5 Use `IRootFolder` from Nextcloud's container to safely resolve files
+
+## 3. Video widget provider (Dashboard API registration)
+
+- [ ] 3.1 Create `lib/Dashboard/VideoWidgetProvider.php` implementing `OCP\Dashboard\IWidget`
+- [ ] 3.2 Implement `getId(): string` returning `"mydash_video"`
+- [ ] 3.3 Implement `getTitle(): string` returning localized "Video" (English/Dutch via `ITranslationManager`)
+- [ ] 3.4 Implement `getOrder(): int` returning a stable sort order (e.g., 40)
+- [ ] 3.5 Implement `getIconClass(): string` returning a Material Design icon class (e.g., `"icon-video"`)
+- [ ] 3.6 Implement `getUrl(): ?string` returning null (widget content is loaded via placements, not a separate URL)
+- [ ] 3.7 Register the provider in `lib/AppManager.php` via the Nextcloud `IManager::registerWidget()` API in a boot hook
+
+## 4. Video widget controller
+
+- [ ] 4.1 Create `lib/Controller/VideoWidgetController.php`
+- [ ] 4.2 Implement `parse(string $sourceType, string $videoUrl): JSONResponse` — POST `/api/widgets/video/parse`
+  - Input: `{"sourceType": "youtube", "videoUrl": "..."}`
+  - Call `VideoParsingService::validateDomain()` and `normalizeUrl()`
+  - Return: `{"videoId": "ABC123", "canonicalUrl": "...", "isValid": true}`
+  - On error: `{"isValid": false, "error": "Domain not allowed by administrator"}` (HTTP 400)
+- [ ] 4.3 Implement `getFileUrl(int $fileId): JSONResponse` — GET `/api/widgets/video/file/{fileId}`
+  - Call `VideoFileService::getAccessibleUrl($fileId, getCurrentUserId())`
+  - Return: `{"fileId": 12345, "streamingUrl": "...", "mimeType": "video/mp4", "isAccessible": true}`
+  - On error (access denied): return HTTP 403 without exposing the file URL
+  - On error (not video): return HTTP 400 with error message
+- [ ] 4.4 Add attribute `#[NoCSRFRequired]` to both endpoints (parse endpoint needs CSRF exemption for frontend validation calls)
+- [ ] 4.5 Add attribute `#[NoAdminRequired]` (both endpoints need to work for logged-in users, not admin-only)
+- [ ] 4.6 Inject `VideoParsingService`, `VideoFileService`, `IAppConfig`, `ILogger`, `IUserSession` into controller constructor
+
+## 5. Admin settings for allowed domains and nocookie
+
+- [ ] 5.1 Create or extend app settings UI to expose `mydash.video_widget_allowed_domains` (JSON array editor)
+- [ ] 5.2 Create or extend app settings UI to expose `mydash.video_widget_use_nocookie_youtube` (boolean toggle)
+- [ ] 5.3 Set default for `mydash.video_widget_allowed_domains` to:
+  ```json
+  ["youtube.com", "www.youtube.com", "youtu.be", "vimeo.com", "player.vimeo.com"]
+  ```
+- [ ] 5.4 Ensure `IAppConfig` can read both settings; fallback to defaults if not set
+- [ ] 5.5 Document the settings in the admin panel help text (English and Dutch)
+
+## 6. Frontend VideoWidget.vue component
+
+- [ ] 6.1 Create `src/components/widgets/VideoWidget.vue`
+- [ ] 6.2 Props: `widgetContent` (object), `placementId` (number)
+- [ ] 6.3 Implement empty state: display "No video URL configured" if `sourceType` is null or missing `videoUrl`/`fileId`
+- [ ] 6.4 Implement iframe rendering for `sourceType: 'youtube'`, `'vimeo'`, `'peertube'`:
+  - Build iframe URL with query params for autoplay, mute, loop, start (time offset)
+  - Apply sandbox attribute: `sandbox="allow-scripts allow-same-origin" allowfullscreen`
+  - Apply aspect ratio via CSS (modern `aspect-ratio` property + fallback `padding-bottom` trick)
+- [ ] 6.5 Implement HTML5 video rendering for `sourceType: 'nc-file'`:
+  - Call API endpoint to get streaming URL: `GET /api/widgets/video/file/{fileId}`
+  - Render `<video>` tag with `src`, `controls`, `autoplay`, `muted`, `loop` attributes as configured
+  - Add `poster` attribute if `posterUrl` is set
+  - Handle `canplay`, `error` events to show fallback error state
+- [ ] 6.6 Implement error states:
+  - Invalid URL: "Invalid video URL or domain not allowed."
+  - File not found: "Video file not found"
+  - File not accessible: "Video not accessible"
+  - Missing MIME type: "File is not a video"
+  - Render error: generic fallback
+- [ ] 6.7 Computed property `embedUrl()` — applies nocookie transform if admin setting is enabled (YouTube only)
+- [ ] 6.8 Computed property `videoStyles()` — generate CSS for aspect ratio enforcement
+- [ ] 6.9 Add i18n keys for all error messages in both English and Dutch
+- [ ] 6.10 Test responsive behavior on desktop (1920x1080) and mobile (375x667) viewports
+
+## 7. Routes and API endpoints
+
+- [ ] 7.1 Register `POST /api/widgets/video/parse` in `appinfo/routes.php` pointing to `VideoWidgetController::parse()`
+- [ ] 7.2 Register `GET /api/widgets/video/file/{fileId}` in `appinfo/routes.php` pointing to `VideoWidgetController::getFileUrl()`
+- [ ] 7.3 Both routes marked as `NoCSRFRequired`, `NoAdminRequired`
+- [ ] 7.4 Ensure routes are scoped to `/apps/mydash/` prefix for consistency
+
+## 8. Internationalization (i18n)
+
+- [ ] 8.1 Create or extend `l10n/en.json` with keys:
+  - `"No video URL configured"`
+  - `"Invalid URL format"`
+  - `"Invalid video URL or domain not allowed."`
+  - `"Domain not allowed by administrator"`
+  - `"Video not found"`
+  - `"Video file not found"`
+  - `"Video not accessible"`
+  - `"File is not a video"`
+  - `"Autoplay requires muting"`
+  - `"Configure now"` (link text in empty state)
+  - `"Video widget allowed domains"` (setting label)
+  - `"Use YouTube no-cookie embedding"` (setting label)
+- [ ] 8.2 Translate all keys to Dutch (`l10n/nl.json`)
+- [ ] 8.3 Ensure all error responses from controller use i18n keys via `$this->l10n->t()`
+- [ ] 8.4 Verify VideoWidget.vue imports and uses `$t()` for all user-facing text
+
+## 9. Unit tests (PHPUnit)
+
+- [ ] 9.1 `VideoParsingServiceTest`:
+  - `testParseYouTubeUrl` — multiple URL formats → same video ID
+  - `testParseYouTubeUrlWithTimeOffset` — preserve `t=30s` → `?start=30`
+  - `testParseVimeoUrl` — extract video ID correctly
+  - `testParsePeerTubeUrl` — extract domain + UUID
+  - `testValidateDomainAllowed` — allowed domain passes
+  - `testValidateDomainBlocked` — blocked domain throws `DomainNotAllowedException`
+  - `testValidateDomainCustomAllowlist` — admin-configured domains work
+  - `testNormalizeUrl` — dispatcher routes to correct platform parser
+- [ ] 9.2 `VideoFileServiceTest`:
+  - `testGetAccessibleUrlSuccess` — user can read file → return streaming URL
+  - `testGetAccessibleUrlAccessDenied` — user lacks permission → throw `AccessDeniedException`
+  - `testGetAccessibleUrlNotFound` — file deleted → throw `FileNotFoundException`
+  - `testGetAccessibleUrlNotVideo` — MIME type is PDF → throw `InvalidMimeTypeException`
+  - `testIsVideoMimeType` — video/* types accepted, others rejected
+- [ ] 9.3 `VideoWidgetControllerTest`:
+  - `testParseYouTubeSuccess` — POST `/api/widgets/video/parse` with YouTube URL → HTTP 200 with canonical URL
+  - `testParseDomainBlocked` — blocked domain → HTTP 400 with error message
+  - `testGetFileUrlSuccess` — user can read file → HTTP 200 with streaming URL
+  - `testGetFileUrlAccessDenied` — user lacks permission → HTTP 403
+  - `testGetFileUrlNotVideo` — PDF file → HTTP 400
+
+## 10. Frontend component tests (Vitest / Vue Test Utils)
+
+- [ ] 10.1 `VideoWidget.spec.js`:
+  - `testEmptyState` — no videoUrl → renders "No video URL configured"
+  - `testYouTubeRender` — sourceType='youtube' → iframe with sandbox, aspect ratio CSS
+  - `testVimeoRender` — sourceType='vimeo' → iframe with correct URL
+  - `testNcFileRender` — sourceType='nc-file' → video tag, calls file API
+  - `testAspectRatioCss` — CSS `aspect-ratio` property applied correctly
+  - `testErrorState` — API error → displays error message
+  - `testAutplayMute` — autoplay=true enforces muted=true in iframe params
+  - `testPosterImage` — posterUrl set → poster attribute on video tag
+
+## 11. End-to-end Playwright tests
+
+- [ ] 11.1 Create `tests/e2e/video-widget.spec.js`
+- [ ] 11.2 Setup: create dashboard, add video widget
+- [ ] 11.3 `testAddYouTubeWidget` — admin (alice) adds YouTube video, sees it render on dashboard
+- [ ] 11.4 `testValidationRejectsBlockedDomain` — user (bob) attempts Vimeo URL when Vimeo is blocked → form error
+- [ ] 11.5 `testAdminUnblocksVimeo` — admin adds Vimeo to allowlist, bob's subsequent save succeeds
+- [ ] 11.6 `testNcFileUploadAndEmbed` — user uploads video.mp4 to Files, adds via widget, plays successfully
+- [ ] 11.7 `testNcFileAccessDenied` — alice uploads private video, shares only with herself; bob views shared dashboard, sees "Video not accessible"
+- [ ] 11.8 `testNoLookupYouTubeToggle` — admin enables no-cookie YouTube, existing YouTube widget URL changes on render
+- [ ] 11.9 `testResponsiveAspectRatio` — widget maintains 16:9 ratio on desktop and mobile
+
+## 12. Quality gates
+
+- [ ] 12.1 `composer check:strict` (PHPCS, PHPMD, Psalm, PHPStan) passes — fix any pre-existing issues encountered
+- [ ] 12.2 ESLint + Stylelint on `src/components/widgets/VideoWidget.vue` — no warnings
+- [ ] 12.3 SPDX-License-Identifier + SPDX-FileCopyrightText inside docblock of every new PHP file (not line comments)
+- [ ] 12.4 All new i18n keys have both English and Dutch translations
+- [ ] 12.5 Update OpenAPI spec / Postman collection to reflect new `/api/widgets/video/*` endpoints
+- [ ] 12.6 Run all `hydra-gates` locally before opening PR
+- [ ] 12.7 Verify no hardcoded colors — use Nextcloud CSS variables and `nldesign` theme support
+
+## 13. Documentation
+
+- [ ] 13.1 Update `appinfo/info.xml` to list `video-widget` as a provided capability
+- [ ] 13.2 Add inline comments in `VideoParsingService`, `VideoFileService`, `VideoWidgetController` explaining each platform's URL format and edge cases
+- [ ] 13.3 Document admin settings in a dedicated section (English + Dutch) with examples of custom allowlists
+
+## 14. Migration / Backward compatibility
+
+- [ ] 14.1 No database schema changes required (widget config stored in existing `widgetContent` JSON)
+- [ ] 14.2 Zero-impact deployment: existing dashboards and widgets unaffected; video widget is opt-in
+- [ ] 14.3 No version constraints on Nextcloud (supported versions already have Dashboard API)


### PR DESCRIPTION
## Summary

41 OpenSpec change proposals derived from a clean-room behavioural analysis of the IntraVox Nextcloud app, reframed under the **unified-dashboard model** — IntraVox features land as widgets/extensions on existing MyDash dashboards rather than as a parallel "page" concept.

Each change folder contains: `proposal.md` + `tasks.md` + `specs/<cap>/spec.md`. **All 41 pass `openspec validate --strict`.**

This PR is **specs-only** — no implementation. Implementation will follow in dependency-aware waves once the proposals are reviewed.

## Capability inventory

**Foundation (3)** — everything else depends on these:
- `groupfolder-storage-backend` — abstract dashboard CONTENT storage so it CAN live as JSON in a managed GroupFolder
- `dashboard-tree` — parent/child hierarchy on dashboards, slugs, breadcrumbs (delta to `dashboards`, REQ-DASH-011..018)
- `dashboard-metadata-fields` — admin-defined custom fields per dashboard

**Lifecycle (5)**:
- `dashboard-templates` — gallery + save-as-template (delta to `admin-templates`, REQ-TMPL-012..015)
- `dashboard-locking` — concurrent-edit guard with admin override
- `dashboard-versioning` — version history + restore (delegates to NC Files versioning when on GroupFolder)
- `dashboard-draft-published` — draft / published / scheduled workflow (delta to `dashboards`, REQ-DASH-019..025)
- `dashboard-language-content` — per-language content variants (delta to `dashboards`, REQ-DASH-026..032)

**Engagement (4)**:
- `dashboard-comments` — threaded one-level-deep via NC `ICommentsManager`
- `dashboard-reactions` — emoji reactions with admin allow-list
- `dashboard-rss-feeds` — per-user RSS token; ACL-respecting public feed
- `dashboard-public-share` — anonymous render with optional password

**Widget extensions (4)** — each is a NEW capability since the parent widget isn't yet promoted to `openspec/specs/`:
- `text-widget-markdown`, `text-widget-tables`, `image-widget-media-picker`, `link-button-widget-list-mode`

**New widgets (10)**:
- `calendar-widget`, `people-widget`, `news-widget`, `files-widget`, `video-widget`, `divider-widget`, `links-widget`, `header-widget`, `menu-widget`, `quicklinks-widget`

**Org UX (5)**:
- `footer-customization`, `nc-unified-search-integration`, `navigation-editor-org`, `demo-data-showcases`, `admin-roles`

**Maintenance (5)**:
- `dashboard-export-import`, `confluence-html-import`, `dashboard-view-analytics`, `dashboard-bulk-operations`, `orphaned-data-cleanup`

**Glue (5)**:
- `setup-wizard`, `cli-commands`, `background-job-feed-refresh`, `activity-feed-integration`, `dashboard-cascade-events`

## Coordination

- REQ numbering deltas to existing `dashboards` capability are pre-allocated to avoid clash: `dashboard-tree` REQ-DASH-011..018, `dashboard-draft-published` 019..025, `dashboard-language-content` 026..032.
- Several glue specs reference siblings explicitly — e.g. `news-widget` reads from the cache populated by `background-job-feed-refresh`; `dashboard-cascade-events` defines `DashboardDeletedEvent` and the listener pattern that every dependent-data capability hooks into.

## Decisions baked in

- **Decision A (GroupFolders):** dashboard CONTENT can live as JSON in a managed GroupFolder. Adopted as an opt-in storage backend (`mydash.content_storage = groupfolder`) — DB-backed remains the default. See `groupfolder-storage-backend`.
- **Decision B (page ↔ dashboard):** dashboards ARE pages. IntraVox-style "header row", "menu", "quicklinks" become widgets on a dashboard rather than a parallel "page" concept.
- **Decision C (scope-trim):** LMS / OIDC token bridge / MetaVox import / license + telemetry from the source app are out of scope and not specced.

## Hygiene

- No vendor names ("intravox", "intra", "voxcloud") appear in any spec — capabilities are described in our own neutral terms.
- 123 files, ~12K lines of spec across the 41 changes.
- Each spec has 5–12 requirements with 3–5 GIVEN/WHEN/THEN scenarios per requirement.

## Test plan

- [ ] `cd mydash && openspec validate <slug> --strict` passes for each of the 41 slugs (already verified at author time).
- [ ] Spot-check 3–4 specs for correctness in modelling vs. the IntraVox source (analysis doc lives at `mydash/docs/intravox-analysis.md`, gitignored).
- [ ] Confirm the 41 capability names are acceptable; rename now if any feel off.
- [ ] Approve the dependency-aware wave plan for the implementation phase (foundation → lifecycle → engagement → widget extensions → widgets → org UX → maintenance → glue).