### PR TITLE
chore(deps): bump @conduction/nextcloud-vue to 0.1.0-beta.17 (clears all eslint Nc* errors)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
 			"name": "mydash",
 			"version": "1.0.0",
 			"dependencies": {
-				"@conduction/nextcloud-vue": "^0.1.0-beta.1",
+				"@conduction/nextcloud-vue": "^0.1.0-beta.17",
 				"@mdi/js": "^7.4.47",
 				"@nextcloud/axios": "^2.5.0",
 				"@nextcloud/dialogs": "^6.1.1",
@@ -2069,9 +2069,9 @@
 			}
 		},
 		"node_modules/@conduction/nextcloud-vue": {
-			"version": "0.1.0-beta.15",
-			"resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-0.1.0-beta.15.tgz",
-			"integrity": "sha512-d3TVxhcF/eD3JbRrFJaL+AE/w572ljl54W5nb/36wSQynKDwk9BgRqmaWEeuq3V4gqE8j5rlsaY3aJr6hJM8ew==",
+			"version": "0.1.0-beta.17",
+			"resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-0.1.0-beta.17.tgz",
+			"integrity": "sha512-xSi8nFVywWnmaXeZHRLzBu2Bq7ty5UUZih911eVPbsO18MmaIA93V3+OQ/v3HFMxBUvrJ2lDLlezXJe95ULxZQ==",
 			"license": "EUPL-1.2",
 			"dependencies": {
 				"@codemirror/lang-html": "^6.4.11",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
 		"test:coverage": "vitest run --coverage"
 	},
 	"dependencies": {
-		"@conduction/nextcloud-vue": "^0.1.0-beta.1",
+		"@conduction/nextcloud-vue": "^0.1.0-beta.17",
 		"@mdi/js": "^7.4.47",
 		"@nextcloud/axios": "^2.5.0",
 		"@nextcloud/dialogs": "^6.1.1",

--- a/src/components/admin/AdminSettings.vue
+++ b/src/components/admin/AdminSettings.vue
@@ -163,8 +163,8 @@
 </template>
 
 <script>
-import { CnSettingsSection } from '@conduction/nextcloud-vue'
 import {
+	CnSettingsSection,
 	NcButton,
 	NcSelect,
 	NcSelectTags,


### PR DESCRIPTION
## Why

Closes the eslint feedback loop opened by [hydra ADR-004](https://github.com/ConductionNL/hydra/blob/main/openspec/architecture/adr-004-frontend.md#L17):

> NEVER import from \`@nextcloud/vue\` directly — use \`@conduction/nextcloud-vue\` **which re-exports all**

PR #71 swapped every \`@nextcloud/vue\` import in mydash to \`@conduction/nextcloud-vue\` per the ADR. But the barrel never actually re-exported the Nc* components, only the Cn* ones — so 32 \`import/named\` errors landed on dev/beta/main. Today's nextcloud-vue PR [#102](https://github.com/ConductionNL/nextcloud-vue/pull/102) added \`export * from '@nextcloud/vue'\` to the barrel. The fix shipped in \`@conduction/nextcloud-vue@0.1.0-beta.16\` and \`0.1.0-beta.17\` (verified the dist contains the re-export — `tar -xzOf … nextcloud-vue.esm.js | head -3` shows `export * from '@nextcloud/vue';`).

## What changes

- \`package.json\` — bump from \`^0.1.0-beta.1\` to \`^0.1.0-beta.17\` (caret on prerelease still accepts beta.18+ as they ship)
- \`package-lock.json\` — refreshed via \`npm install @conduction/nextcloud-vue@^0.1.0-beta.17\` (1521 packages, no audit regressions, no peer-dep warnings beyond the existing eslint@8.57.1 deprecation notice)
- \`src/components/admin/AdminSettings.vue\` — collapse the two adjacent \`from '@conduction/nextcloud-vue'\` import statements (Cn + Nc groups) into one. eslint's \`import/no-duplicates\` correctly flagged them post-bump; pure cosmetic merge, no behavioural change.

## Lint impact

| | Before | After |
|---|---|---|
| Errors | **32** (all \`Nc<X> not found in '@conduction/nextcloud-vue' import/named\`) | **0** |
| Warnings | 24 | 24 (pre-existing JSDoc \`@spec\` tag — project convention, not standard JSDoc; out of scope) |

## Test plan

- [x] \`npm run lint\` → 0 errors (was 32)
- [ ] CI \`quality / Vue Quality (eslint)\` → green
- [ ] On next dev → beta → main release, the eslint failure that's been blocking #87 / #92 / #93's CI for the past hour disappears