### PR TITLE
chore(test): bump Playwright navigationTimeout 15s → 60s

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -47,7 +47,7 @@ export default defineConfig({
 		screenshot: 'only-on-failure',
 		video: 'retain-on-failure',
 		actionTimeout: 10_000,
-		navigationTimeout: 15_000,
+		navigationTimeout: 60_000,
 	},
 	projects: [
 		{


### PR DESCRIPTION
## Summary

PR #100 wired up Playwright with a 15s `navigationTimeout`. In practice the dockerised Nextcloud test env reliably needs more than that for the full chrome + JS bundle to settle (the page itself returns HTTP 200 and the `#workspace-vue` mount renders, but the `load` event fires late because of long-tail XHRs to notifications/status/etc).

Bumps it to 60s. Result going from `14/14 failing on page.goto timeout` to `2/14 passing + 12 failing on real product assertions` — which is proper spec-debugging territory, not test-runner infra.

## Quality gates

- `npm test`: 299/299 vitest still passing (no Vitest impact)
- `npm run build`: clean
- `npm run test:e2e`: 2/14 passing (was 0/14); remaining 12 surfaced for follow-up

## Test plan

- [x] vitest unaffected
- [x] e2e progress (more tests reach assertions)
- [ ] CI green on `development`