### PR TITLE
feat(openspec): mydash-adopt-or-abstractions — manifest + runtime-only OR

### DIFF
--- a/openspec/changes/mydash-adopt-or-abstractions/design.md
+++ b/openspec/changes/mydash-adopt-or-abstractions/design.md
@@ -1,0 +1,215 @@
+# Design — mydash-adopt-or-abstractions
+
+## Reuse analysis
+
+| Capability | Reuse from | Why |
+|------------|-----------|-----|
+| App-manifest schema | `@conduction/nextcloud-vue` `src/schemas/app-manifest.schema.json` | Single source of truth per `hydra/openspec/changes/adopt-app-manifest/`. MyDash MUST NOT fork or extend the schema in-tree — extensions go upstream. |
+| Manifest loader | `useAppManifest()` from nc-vue | Sync bundled load + async backend merge already implemented. Tier 1 only needs the import. |
+| Manifest validator | `validateManifest()` from nc-vue | Wired through `npm run check:manifest`; CI already calls `npm run lint`. |
+| Tenant context | `useTenantContext()` from nc-vue (pending `multi-tenancy-context` change) | When it ships, MyDash widgets reuse it instead of rolling org-scope logic. |
+| OR feature detect | `useAppStatus()` from nc-vue | Wraps `OCS /apps` enabled/installed status. New `useOrFeatureDetect()` composable is a thin façade so widget code reads `or.enabled.value` rather than `useAppStatus('openregister').enabled`. |
+| OR data access (runtime only) | OR REST `/index.php/apps/openregister/api/...` and OR GraphQL endpoint | No PHP-side coupling; runtime only. Widgets that need OR data fetch through the existing browser session (CSRF + cookie). |
+| Permission model on dashboards | MyDash own `oc_mydash_dashboards.permissions` column | Local concept (view_only / add_only / full) predates OR's per-object RBAC. Keep local; optional runtime delegation. |
+
+### What we deliberately do NOT reuse
+
+- **OR's `RegisterResolverService`** — MyDash has no PHP-side OR
+  consumption, so consolidating `getValueString(...register/schema)`
+  patterns is N/A. The audit's recommendation #5 lists opencatalogi (5
+  controllers) and pipelinq (8 services) — MyDash is not on that list.
+- **OR's lifecycle annotations** — MyDash dashboards are not
+  schema-driven and do not have a state machine. Lifecycle annotations
+  belong in apps with `processing/done/error` style status fields.
+- **OR's `Translation` table** — MyDash translations remain in
+  Nextcloud's `IL10N` system (`l10n/{nl,en}.js`). MyDash does not
+  store translatable user-authored content; widget labels are
+  developer-authored.
+- **Hydra's per-app `adr-000`** — per ADR-022, apps MUST NOT carry an
+  ADR that re-asserts cross-app conventions. MyDash already does not
+  have an `adr-000` and this change does NOT introduce one.
+
+## Public API / migration shape
+
+### `src/manifest.json` (new file)
+
+```json
+{
+  "$schema": "https://unpkg.com/@conduction/nextcloud-vue@latest/dist/schemas/app-manifest.schema.json",
+  "version": "0.1.0",
+  "dependencies": [],
+  "menu": [
+    {
+      "id": "dashboards",
+      "label": "mydash.menu.dashboards",
+      "icon": "icon-dashboard",
+      "route": "/dashboards",
+      "section": "main"
+    },
+    {
+      "id": "admin-templates",
+      "label": "mydash.menu.adminTemplates",
+      "icon": "icon-template",
+      "route": "/admin/templates",
+      "section": "settings",
+      "permission": "admin"
+    },
+    {
+      "id": "admin-settings",
+      "label": "mydash.menu.adminSettings",
+      "icon": "icon-settings",
+      "route": "/admin/settings",
+      "section": "settings",
+      "permission": "admin"
+    }
+  ],
+  "pages": [
+    {
+      "id": "dashboard-detail",
+      "route": "/dashboards/:id",
+      "type": "dashboard",
+      "title": "mydash.pages.dashboard",
+      "config": {
+        "widgets": "@runtime",
+        "layout": "@runtime"
+      }
+    },
+    {
+      "id": "admin-templates-index",
+      "route": "/admin/templates",
+      "type": "index",
+      "title": "mydash.pages.adminTemplates",
+      "config": {
+        "register": null,
+        "schema": null,
+        "source": "mydash:oc_mydash_admin_settings",
+        "columns": ["key", "value", "scope", "updated"]
+      }
+    },
+    {
+      "id": "admin-settings",
+      "route": "/admin/settings",
+      "type": "custom",
+      "title": "mydash.pages.adminSettings",
+      "component": "AdminSettingsPage"
+    }
+  ]
+}
+```
+
+Notes:
+- `config.source: "mydash:oc_mydash_admin_settings"` is a MyDash-local
+  source URN. The renderer treats it opaquely; only the
+  `AdminTemplatesIndexAdapter` MyDash registers via `customComponents`
+  understands it.
+- `config.{widgets, layout}: "@runtime"` is a sentinel meaning "fetch
+  from MyDash backend per-dashboard". The dashboard page-type
+  resolver (existing GridStack stack) consumes the dashboard ID from
+  the route and ignores the manifest config payload.
+
+### `src/composables/useOrFeatureDetect.js` (new file)
+
+Thin façade over nc-vue's `useAppStatus`. Returns
+`{ enabled: ComputedRef<boolean>, version: ComputedRef<string|null>,
+error: ComputedRef<Error|null> }`. Used by every OR-backed widget
+before any `axios.get('/index.php/apps/openregister/...')` call.
+
+### `src/main.js` (edit, additive)
+
+```js
+import bundledManifest from './manifest.json'
+import { useAppManifest } from '@conduction/nextcloud-vue/composables'
+
+useAppManifest('mydash', bundledManifest)
+```
+
+The vue-router definition stays as-is for Tier 1. Tier 3 (follow-up
+change) replaces hand-wired routes with manifest-driven routes.
+
+### Spec rewrites
+
+`openspec/specs/dashboard-sharing/spec.md` — full rewrite. New
+requirements:
+
+- **Permission levels** (`view_only` / `add_only` / `full`) live on
+  `oc_mydash_dashboards.permissions`.
+- **Runtime OR delegation (OPTIONAL)** — when a dashboard's
+  `permissions.delegate` field references an OR-backed object, MyDash
+  MAY at render time call `OR /api/objects/{id}/can?action={read|write}`
+  and AND the result with the local permission. If OR is absent the
+  delegation is silently skipped (degrades to local check).
+- **MUST NOT** declare an install-time dependency on OR.
+
+`openspec/specs/admin-templates/spec.md` — full rewrite. New
+requirements:
+
+- Templates persist in `oc_mydash_admin_settings`.
+- **MUST NOT** persist in OR.
+- Templates are exported / imported as JSON files (FILENAME_PATTERN
+  enforces the safe-name regex from Phase 5.3).
+
+### Migration risk surface
+
+| Risk | Mitigation |
+|------|-----------|
+| Manifest validation fails CI on first introduction (typos, schema drift) | Tier 1 keeps router hand-wired; failed manifest validation does NOT take the app down. Validator runs at build time. |
+| Backend `/api/manifest` endpoint returns 200 but with malformed data | nc-vue loader logs `console.warn` and falls back to bundled. No runtime crash. |
+| Operator runs MyDash without OR (intended path) | `useOrFeatureDetect()` returns `enabled.value === false`; widgets render empty state. Smoke tested in Phase 8.2. |
+| Operator runs MyDash with OR but tenant context absent | `useTenantContext()` (when shipped) exposes `null`; widgets render OR data without tenant filter (server still enforces per-session). |
+| Backwards compat with existing dashboards using GridStack | Untouched. Manifest's `type: "dashboard"` page-type adapter dispatches to the existing GridStack stack. |
+| Constants rename in Phase 5.2 breaks BC | Old constants kept as aliases; no consumers external to MyDash. |
+
+## Open design questions
+
+1. **Q1 — Page-type for the dashboard editor.** The Tier 1 manifest
+   uses `type: "dashboard"` for the *render* path. The dashboard
+   editor (drag-and-drop + widget palette) is a different surface.
+   Should it be a separate page (`type: "custom"`,
+   `component: "DashboardEditor"`) or an `actionsComponent` slot
+   override on the same `dashboard-detail` page? Recommend separate
+   page; an editor's URL needs its own deep-link.
+
+2. **Q2 — Backend `/api/manifest` endpoint.** Per
+   `hydra/openspec/changes/adopt-app-manifest/`, every app MAY
+   implement `GET /index.php/apps/{appId}/api/manifest` to return
+   admin-customised overrides (menu order, hidden pages). MyDash has
+   no admin-customisable menu today. Does this change scope adding
+   the endpoint as a stub returning 404, or skip until there's a
+   product reason? Recommend skip; the loader silently falls back on
+   404.
+
+3. **Q3 — `useTenantContext()` adoption timing.** The composable
+   ships in `nextcloud-vue/openspec/changes/multi-tenancy-context/`
+   which is merged in nc-vue PR #113 but not yet released as a
+   versioned package consumers can pin. Should this change pin the
+   nc-vue version that includes it (potentially a patch version), or
+   add the wiring conditionally? Recommend conditional wiring: import
+   guarded with `try { ... } catch { /* not yet available */ }` until
+   the version is released, then make it unconditional.
+
+4. **Q4 — Permission delegation default.** If an OR-backed object is
+   referenced in `permissions.delegate`, should delegation default to
+   ON (any OR-aware install gets cross-system perms automatically) or
+   OFF (operator opts in)? Recommend OFF — explicit opt-in matches
+   "no install-time OR dep" policy and prevents surprise auth
+   coupling.
+
+5. **Q5 — `runtime-or-consumption` spec home.** This change creates a
+   new local capability under `mydash/openspec/specs/`. Should it
+   instead live in `hydra/openspec/specs/` since other apps may
+   eventually adopt the same pattern? Recommend local for now;
+   promote to hydra if a second app adopts it.
+
+6. **Q6 — `ColumnTypeRegistry` future.** Stream 4 flagged the
+   constants as "hardcoded". Is there a future where MyDash column
+   types map onto JSON-schema `type` (and merge upward into OR)?
+   Recommend NO — column types model rendering choices (`integer` vs
+   `boolean` vs `string` UI affordance) and are deliberately not
+   data-typed. Add docblock and stop flagging.
+
+7. **Q7 — manifest version cadence.** ADR-024 specifies semver-on-
+   content for `manifest.version`. Should MyDash bump on every menu
+   change (chatty) or batch monthly? Recommend semver-on-content with
+   `version` only bumped when the *shape* of the manifest changes
+   (page added/removed, menu reordered). Pure i18n key updates do NOT
+   require a bump.

--- a/openspec/changes/mydash-adopt-or-abstractions/proposal.md
+++ b/openspec/changes/mydash-adopt-or-abstractions/proposal.md
@@ -1,0 +1,175 @@
+# MyDash — adopt OR abstractions (manifest, runtime-only OR consumption)
+
+## Why
+
+The 2026-05-03 OR-abstraction audit (`.claude/audit-2026-05-03/`) flagged
+adoption gaps across all eight Specter-pipeline apps. For MyDash the gaps
+fall into three categories:
+
+1. **Manifest adoption** — MyDash currently has no architectural
+   `src/manifest.json` and wires its router by hand. Per the
+   fleet-wide `adopt-app-manifest` change in `hydra/openspec/changes/`
+   and the migration order in **ADR-024**, MyDash is the recommended
+   *pilot* — smallest surface, dashboard-dominant, low risk.
+2. **Spec staleness** — `dashboard-sharing/spec.md` and
+   `admin-templates/spec.md` are flagged NEEDS-REWRITE by stream 2 of
+   the audit. The rewrites must clarify which storage layer (OR
+   per-object RBAC vs MyDash's own `oc_mydash_*` tables) owns each
+   capability, *without* introducing a hard dependency on OpenRegister
+   in the install graph.
+3. **Local hygiene** — stream 4 found a small cluster of hardcoded
+   constants (`ColumnTypeRegistry.php:31-45`, `AdminSetting.php:42-85`,
+   `FileService.php:62`). None of these are OR-related; they are
+   in-repo cleanup that this change folds in for completeness.
+
+### Special policy: no install-time OR dependency
+
+MyDash is a BI / dashboarding tool. Per
+`feedback_mydash-no-or-dependency.md`, MyDash MUST NOT declare a hard
+install-time dependency on `openregister` or `openconnector`. The
+manifest's `dependencies: []` array MUST stay empty for the OR family.
+Any OR data MyDash displays is consumed exclusively over the **runtime
+GraphQL / REST API** with graceful degradation when OR is absent.
+
+This makes MyDash structurally different from the other adoption
+changes (larpingapp, softwarecatalog, decidesk) which all declare
+`"dependencies": ["openregister"]` in their manifest.
+
+## What Changes
+
+### Manifest adoption (Tier 1 → Tier 3)
+
+- Add `src/manifest.json` describing the current MyDash UI: top-level
+  Dashboards menu, per-dashboard pages of `type: "dashboard"`, admin
+  templates index of `type: "index"`, settings page of `type: "custom"`.
+- Set `$schema` to the published `@conduction/nextcloud-vue`
+  app-manifest schema URL.
+- Set `dependencies: []` (explicit empty — no install-time OR/OC
+  dependency).
+- Wire `useAppManifest('mydash', bundled)` in `src/main.js`. Start at
+  Tier 1 (manifest loaded but not yet rendering routes); plan Tier 3
+  (`CnAppNav` + `CnPageRenderer` driving the shell) for a follow-up.
+- Add `npm run check:manifest` to `package.json` so CI fails on schema
+  errors.
+
+### Runtime-only OR consumption
+
+- Document the runtime consumption pattern: dashboards that surface OR
+  data MUST do so via authenticated calls to
+  `/index.php/apps/openregister/api/...` (REST) or the OR GraphQL
+  endpoint, gated on a runtime feature-detect (`useAppStatus('openregister')`
+  from `@conduction/nextcloud-vue`).
+- Adopt `useTenantContext()` from nc-vue once the
+  `nextcloud-vue/openspec/changes/multi-tenancy-context/` change ships
+  in v0.x — but only on widgets that actually surface OR objects, and
+  only when OR is enabled at runtime.
+- Adopt the OR `?_lang=` / `X-Translation-Target-Language` API
+  conventions from
+  `openregister/openspec/changes/i18n-api-language-negotiation/` for
+  any widget that fetches translatable OR objects.
+
+### Spec rewrites (NEEDS-REWRITE cohort)
+
+- Rewrite `openspec/specs/dashboard-sharing/spec.md` to describe MyDash
+  permission levels (`view_only` / `add_only` / `full`) as native
+  MyDash concepts (`oc_mydash_dashboards.permissions`), with an
+  optional **runtime** delegation to OR per-object RBAC when OR is
+  enabled. No backend-PHP dependency on OR.
+- Rewrite `openspec/specs/admin-templates/spec.md` to declare that
+  admin templates are stored in MyDash's own `oc_mydash_admin_settings`
+  table (NOT in OR) and document the rationale: MyDash must work
+  standalone without OR installed.
+
+### Local hygiene (stream 4 cleanups)
+
+- `ColumnTypeRegistry.php:31-45` — keep `TYPE_INTEGER`/`TYPE_BOOLEAN`/
+  `TYPE_STRING` constants local. They legitimately model MyDash column
+  types, which are independent of JSON-schema `type`. Document the
+  rationale inline so future audits stop flagging it.
+- `AdminSetting.php:42-85` — extract the eight `KEY_*` admin-config
+  constants to a single typed enum or const-list and document each.
+- `FileService.php:62` — extract `FILENAME_PATTERN` regex to a named
+  class constant with a unit test that pins the accepted/rejected
+  filename set.
+
+## Problem
+
+Every other Specter-pipeline app can simply declare
+`"dependencies": ["openregister"]` and rely on OR being present at
+boot. MyDash cannot. As a dashboarding tool it must:
+
+- Boot and render usable dashboards when OR is absent (e.g. a
+  Nextcloud install with only built-in widgets and Nextcloud Talk).
+- Feature-detect OR at runtime and unlock OR-backed widgets only when
+  available.
+- Avoid stamping OR identifiers (register IDs, schema IDs) in MyDash's
+  own database — MyDash dashboards that reference OR data store
+  references *symbolically* (e.g. `{"source": "openregister:register/schema"}`)
+  and resolve at render time.
+
+The current adoption gap means MyDash dashboards that surface OR data
+do so through ad-hoc widget-specific code paths with no unified
+runtime contract. The manifest gives us the contract; the runtime-only
+policy keeps MyDash deployable in OR-less Nextcloud installs.
+
+## Proposed Solution
+
+A single `mydash-adopt-or-abstractions` change that:
+
+1. Lands the manifest pilot at Tier 1, with a follow-up tracked in
+   tasks.md to graduate to Tier 3 once the dashboards page-type
+   contract stabilises in nc-vue.
+2. Documents (in a new shared `runtime-or-consumption` spec capability)
+   the pattern for *runtime-only* OR consumption that MyDash uses, so
+   future widgets follow it consistently.
+3. Rewrites the two NEEDS-REWRITE specs to make the
+   "no-install-OR-dep" policy explicit.
+4. Folds in the three small hygiene cleanups so they don't accumulate.
+
+No code outside MyDash changes. No PRs are opened by this change — it
+is spec-only and goes through the standard opsx flow
+(`/opsx-plan-to-issues` → `/opsx-apply` → `/opsx-verify`).
+
+## Out of Scope
+
+- Building OR-backed dashboard widgets in this change. Widget work
+  lands in follow-up changes that consume the runtime-OR pattern this
+  change documents.
+- Migrating MyDash's own data into OR. MyDash owns `oc_mydash_*`
+  tables; that ownership stays.
+- Tier 4 manifest adoption (full `CnAppRoot` shell). Tier 1 first;
+  Tier 3 in follow-up; Tier 4 only if/when MyDash's bespoke admin
+  pages can be modelled as `type: "custom"` cleanly.
+- Any change to the GraphQL or REST endpoints OR exposes — those
+  contracts are owned by OR.
+
+## See also
+
+- `openregister/openspec/changes/register-resolver-service/` — OR's
+  consolidated `getValueString(...register/schema...)` resolver. MyDash
+  does not consume it directly (no PHP-side OR dep) but downstream
+  apps that proxy MyDash-managed configs MAY.
+- `openregister/openspec/changes/pluggable-integration-registry/` —
+  ADR-019 registry. MyDash widgets that pull from third-party sources
+  (e.g. JIRA, n8n) MAY register as integration providers in a future
+  change.
+- `openregister/openspec/changes/i18n-source-of-truth/` (ADR-025) —
+  schema-level `sourceLanguage` + per-row source tracking. MyDash
+  reads this metadata when rendering OR-translatable fields in
+  dashboard widgets.
+- `openregister/openspec/changes/i18n-api-language-negotiation/`
+  (ADR-025) — `?_lang=` query param + `X-Translation-Target-Language`
+  header. MyDash widgets that read OR data SHOULD pass `?_lang=` so
+  multi-language dashboards render consistently.
+- `nextcloud-vue/openspec/changes/multi-tenancy-context/` —
+  `useTenantContext()` composable. MyDash widgets that surface
+  tenant-scoped OR data adopt this once it ships.
+- `hydra/openspec/changes/adopt-app-manifest/` — fleet-wide manifest
+  convention (ADR-024). MyDash is the recommended pilot.
+- ADR-022 — Apps consume OR abstractions (no duplication).
+- ADR-024 — App manifest fleet-wide adoption.
+- ADR-025 — i18n source-of-truth + API language negotiation.
+- `feedback_mydash-no-or-dependency.md` — the policy this change
+  encodes.
+- `.claude/audit-2026-05-03/` — source audit (research files
+  R2/R4/R5/R6 referenced throughout).

--- a/openspec/changes/mydash-adopt-or-abstractions/specs/mydash-adopt-or-abstractions/spec.md
+++ b/openspec/changes/mydash-adopt-or-abstractions/specs/mydash-adopt-or-abstractions/spec.md
@@ -1,0 +1,299 @@
+---
+status: draft
+---
+
+# MyDash — adopt OR abstractions
+
+## Purpose
+
+Specify the requirements for MyDash's adoption of the
+`@conduction/nextcloud-vue` app-manifest contract and the
+runtime-only consumption pattern for OpenRegister data, while
+explicitly forbidding install-time OR / OC dependencies.
+
+## ADDED Requirements
+
+### Requirement: MyDash MUST ship an architectural manifest at `src/manifest.json`
+
+MyDash MUST add `src/manifest.json` conforming to the JSON Schema
+published by `@conduction/nextcloud-vue` at
+`src/schemas/app-manifest.schema.json`. The manifest MUST be loaded
+via `useAppManifest('mydash', bundledManifest)` in `src/main.js`.
+
+The manifest MUST set:
+- `$schema` to the published nc-vue schema URL (for editor
+  validation)
+- `version` to a semver string, bumped on shape change
+- `dependencies: []` (explicit empty array)
+- a `menu` array with at least the Dashboards entry
+- a `pages` array including the per-dashboard page
+  (`type: "dashboard"`)
+
+#### Scenario: Manifest loads on app boot
+
+- GIVEN MyDash is installed and enabled
+- AND a user navigates to `/index.php/apps/mydash`
+- WHEN `src/main.js` runs
+- THEN `useAppManifest('mydash', bundledManifest)` MUST be called
+  before the vue-router instance mounts
+- AND the bundled manifest MUST be the immediate value of the
+  reactive `manifest` ref returned by the composable
+- AND the loader MUST attempt an async fetch of
+  `/index.php/apps/mydash/api/manifest`
+- AND on any non-200 response the loader MUST silently fall back to
+  the bundled value with a `console.warn` log entry
+
+#### Scenario: Manifest validation fails build
+
+- GIVEN a developer edits `src/manifest.json` and introduces an
+  unknown `type` value (e.g. `type: "kanban"`)
+- WHEN the developer runs `npm run check:manifest`
+- THEN the script MUST exit non-zero
+- AND the error MUST identify the offending JSON path
+- AND CI MUST fail on the same script
+
+#### Scenario: Manifest declares no install-time OR dependency
+
+- GIVEN the file `src/manifest.json`
+- WHEN `manifest.dependencies` is read
+- THEN it MUST be an empty array `[]`
+- AND no review MAY add `"openregister"`, `"openconnector"`, or any
+  other Conduction app ID to the array
+
+### Requirement: MyDash MUST NOT declare an install-time dependency on OpenRegister or OpenConnector
+
+This is a structural policy. MyDash MUST be installable and runnable
+on a Nextcloud instance that has neither OR nor OC enabled.
+
+#### Scenario: Install on OR-less Nextcloud
+
+- GIVEN a Nextcloud install with OR not present and OC not present
+- WHEN an admin enables MyDash via the apps page
+- THEN the enable action MUST succeed
+- AND the MyDash menu entry MUST appear
+- AND opening MyDash MUST render the dashboards index without error
+- AND any pre-installed dashboards that reference OR data MUST
+  render with a documented empty state (per the runtime consumption
+  requirement below)
+
+#### Scenario: appinfo.xml dependency check
+
+- GIVEN `appinfo/info.xml`
+- WHEN reading `<dependencies>` and `<types>` blocks
+- THEN no `<dependencies><app>openregister</app>...</app>` or
+  `openconnector` MUST be present
+- AND no soft-fail "recommended app" string MUST imply that OR is
+  required
+
+#### Scenario: Composer dependency check
+
+- GIVEN `composer.json`
+- WHEN reading `require` and `require-dev`
+- THEN no `conduction/openregister*` package MUST be required
+- AND no transitive PHP class import path MUST resolve through OR's
+  namespace (`OCA\OpenRegister\...`) outside of optional runtime
+  service-locator lookups
+
+### Requirement: MyDash widgets that surface OR data MUST feature-detect OR at runtime
+
+Any MyDash widget that reads or writes OR objects MUST guard the
+call with `useOrFeatureDetect()` and render a documented empty
+state when OR is absent or returns 5xx.
+
+#### Scenario: OR-backed widget on OR-less install
+
+- GIVEN OR is not installed on the Nextcloud instance
+- AND an operator has placed an OR-backed widget on a dashboard
+- WHEN the dashboard renders
+- THEN `useOrFeatureDetect()` MUST return `enabled.value === false`
+- AND the widget MUST render the empty state defined in
+  `docs/widgets/or-data.md`
+- AND no network call to `/index.php/apps/openregister/api/...`
+  MUST be issued
+- AND no console error MUST be raised
+
+#### Scenario: OR returns 5xx
+
+- GIVEN OR is installed and enabled
+- AND a transient OR error causes
+  `GET /index.php/apps/openregister/api/objects/{r}/{s}` to return
+  503
+- WHEN an OR-backed widget polls
+- THEN the widget MUST render the empty state with an
+  `aria-live="polite"` "Temporarily unavailable" message
+- AND MUST retry on the next poll interval (default 60 s)
+- AND MUST NOT crash the dashboard
+
+### Requirement: MyDash widgets MUST pass `?_lang=` when fetching translatable OR data
+
+When a widget fetches an OR object that exposes translatable
+properties, the request URL MUST include the `?_lang={BCP47}` query
+parameter set to the user's current Nextcloud locale.
+
+This is a downstream consumer of
+`openregister/openspec/changes/i18n-api-language-negotiation/`.
+
+#### Scenario: Locale stamping on OR fetch
+
+- GIVEN the user's Nextcloud locale is `en_GB`
+- AND a widget fetches OR object `register=cases, schema=melding,
+  uuid=abc`
+- WHEN the request is built
+- THEN the URL MUST be
+  `/index.php/apps/openregister/api/objects/cases/melding/abc?_lang=en`
+- AND no `Accept-Language` header MUST be relied upon as the sole
+  signal
+
+#### Scenario: Translation target on OR write
+
+- GIVEN the user is editing an OR object's `title` property in
+  English from a MyDash dashboard
+- WHEN the widget PATCHes the object
+- THEN the request MUST include the header
+  `X-Translation-Target-Language: en`
+- AND the body MUST send the English string under the `title` key
+  without language wrapping
+
+### Requirement: MyDash widgets MUST consume `useTenantContext()` from nc-vue when surfacing tenant-scoped OR data
+
+Once the `multi-tenancy-context` change in
+`nextcloud-vue/openspec/changes/` is released in a versioned
+package, MyDash widgets MUST adopt the composable to refetch on
+tenant switch and to stamp `X-OpenRegister-Organisation` on writes.
+
+#### Scenario: Tenant switch refetches widget data
+
+- GIVEN a dashboard with two OR-backed widgets and the user is
+  active in tenant A
+- WHEN the user switches to tenant B via the nc-vue tenant switcher
+- THEN both widgets MUST detect the change via
+  `useTenantContext().activeOrganisationUuid`
+- AND clear their cached collections
+- AND refetch their data using B's session
+
+#### Scenario: Pre-release fallback
+
+- GIVEN nc-vue does not yet export `useTenantContext`
+- WHEN MyDash imports the composable
+- THEN the import MUST be guarded with try/catch (or feature
+  detection) so that absence does not crash the app
+- AND the widget MUST behave as if a single-tenant install (no
+  refetch on switch, no header stamping)
+
+### Requirement: Dashboard sharing MUST keep the local permission model
+
+MyDash dashboard sharing MUST continue to use the
+`oc_mydash_dashboards.permissions` column with values
+`view_only`, `add_only`, `full`. Sharing MUST work without OR.
+
+OR per-object RBAC delegation MAY be wired as an OPTIONAL runtime
+delegation when a dashboard's `permissions.delegate` field
+references an OR object UUID and OR is enabled.
+
+#### Scenario: Sharing on OR-less install
+
+- GIVEN OR is not installed
+- AND a dashboard owner shares with permission level `add_only` to
+  group `kcc-team`
+- WHEN a `kcc-team` member opens the dashboard
+- THEN they MUST see the dashboard
+- AND they MUST be able to add new widgets
+- AND they MUST NOT be able to delete the dashboard or change its
+  permissions
+
+#### Scenario: Optional delegation when OR enabled
+
+- GIVEN OR is enabled
+- AND a dashboard's `permissions.delegate.objectUuid = "abc-123"`
+  (referencing an OR object)
+- WHEN a member of group `kcc-team` opens the dashboard
+- THEN MyDash MUST call
+  `GET /index.php/apps/openregister/api/objects/abc-123/can?action=read`
+- AND MUST AND the OR result with the local `view_only` check
+- AND MUST render the dashboard only if both pass
+- AND if the OR call fails, MUST fall back to the local check
+  silently
+
+### Requirement: Admin templates MUST persist in `oc_mydash_admin_settings`
+
+Admin dashboard templates (the named, exportable dashboard
+configurations admins distribute to groups) MUST persist in the
+local `oc_mydash_admin_settings` table.
+
+Admin templates MUST NOT be persisted in OR.
+
+#### Scenario: Template persistence
+
+- GIVEN an admin creates a template `Service Desk default v2`
+- WHEN the admin clicks save
+- THEN the template MUST insert one row into
+  `oc_mydash_admin_settings` with `key = "template:service-desk-default-v2"`
+  and a JSON blob in `value`
+- AND no row MUST be inserted into any OR table
+- AND no call to OR's `/api/objects/...` MUST be issued
+
+#### Scenario: Template export filename
+
+- GIVEN an admin exports the template `Service Desk default v2`
+- WHEN the file is generated
+- THEN the filename MUST match
+  `lib/Service/FileService.php::FILENAME_PATTERN`
+- AND the file MUST be a JSON document with the template body
+- AND on import, a filename that does not match the pattern MUST
+  be rejected with a 400 response
+
+### Requirement: ColumnTypeRegistry constants document their non-OR scope
+
+`lib/Db/ColumnTypeRegistry.php` MUST carry a class-level docblock
+explaining that its `TYPE_INTEGER`, `TYPE_BOOLEAN`, `TYPE_STRING`
+constants model UI rendering affordances and are deliberately
+independent of JSON-schema `type` semantics.
+
+#### Scenario: Future audit silenced
+
+- GIVEN a future OR-abstraction audit
+- WHEN it scans `lib/Db/ColumnTypeRegistry.php` for "hardcoded
+  constants"
+- THEN the docblock MUST satisfy the audit's "documented rationale"
+  exemption
+- AND the audit MUST NOT re-flag the constants
+
+### Requirement: AdminSetting keys MUST live under a single typed list
+
+The eight `KEY_*` admin-config keys in `lib/Db/AdminSetting.php`
+MUST be collected into a single `AdminSettingKey` const-list (or
+PHP 8.1 `enum`). Existing constants MAY be kept as aliases for BC.
+
+#### Scenario: Key list is single-source-of-truth
+
+- GIVEN the `AdminSettingKey` const-list
+- WHEN a new key is needed
+- THEN it MUST be added to the list and to the docblock
+- AND no other file in `lib/` MUST define a duplicate string literal
+  for the same logical key
+
+### Requirement: FILENAME_PATTERN regex MUST be a named class constant with a unit test
+
+`lib/Service/FileService.php::FILENAME_PATTERN` MUST be:
+
+- a named class constant (not an inline regex literal at line 62)
+- documented in the docblock with the accepted/rejected sets
+- covered by a unit test pinning at least:
+  - allowed: `dashboard-export.json`, `template_v2.json`,
+    `template-with-dashes.json`
+  - rejected: `../etc/passwd`, `name.with.two.dots.json`,
+    paths containing slashes (`a/b.json`), paths starting with `.`
+
+#### Scenario: Path traversal rejected
+
+- GIVEN `FILENAME_PATTERN`
+- WHEN the regex matches `../etc/passwd`
+- THEN the result MUST be no match
+- AND the unit test MUST assert `false`
+
+#### Scenario: Allowed filename
+
+- GIVEN `FILENAME_PATTERN`
+- WHEN the regex matches `template_v2.json`
+- THEN the result MUST be a match
+- AND the unit test MUST assert `true`

--- a/openspec/changes/mydash-adopt-or-abstractions/tasks.md
+++ b/openspec/changes/mydash-adopt-or-abstractions/tasks.md
@@ -1,0 +1,127 @@
+# Tasks — mydash-adopt-or-abstractions
+
+> Spec-only change. No PR / merge / archive tasks here — those belong
+> to Hydra coordination per `feedback_opsx-no-process-tasks.md`.
+
+## Phase 1 — Manifest pilot (Tier 1)
+
+- [ ] 1.1 Add `src/manifest.json` describing current MyDash UI:
+  - top-level Dashboards menu (i18n key `mydash.menu.dashboards`)
+  - per-dashboard pages (`type: "dashboard"`, route
+    `/dashboards/:id`, `config.{widgets, layout}` populated from the
+    existing GridStack model)
+  - admin templates index (`type: "index"`, route
+    `/admin/templates`)
+  - admin settings page (`type: "custom"`, route `/admin/settings`,
+    `component: "AdminSettingsPage"`)
+- [ ] 1.2 Set `$schema` to the published nc-vue
+  app-manifest schema URL.
+- [ ] 1.3 Set `dependencies: []` (explicit empty — verify in code review
+  that no follow-up commit silently adds `"openregister"`).
+- [ ] 1.4 Add `version: "0.1.0"` and bump on each manifest content
+  change.
+- [ ] 1.5 Wire `useAppManifest('mydash', bundled)` in `src/main.js`
+  alongside the existing router setup. Tier 1 — manifest loaded but
+  vue-router still hand-wired.
+- [ ] 1.6 Add `npm run check:manifest` script to `package.json` calling
+  the validator from `@conduction/nextcloud-vue`.
+- [ ] 1.7 Wire `npm run check:manifest` into the existing CI lint job.
+
+## Phase 2 — Runtime OR consumption pattern
+
+- [ ] 2.1 Add `src/composables/useOrFeatureDetect.js` that wraps
+  `useAppStatus('openregister')` from nc-vue and exposes
+  `{ enabled, version, error }`.
+- [ ] 2.2 Document in `docs/widgets/or-data.md` the canonical pattern
+  for an OR-backed widget: feature-detect → conditional render →
+  graceful empty state when OR is absent.
+- [ ] 2.3 Add a runtime-OR-consumption section to the new
+  `runtime-or-consumption` spec capability (see Phase 4).
+- [ ] 2.4 Audit existing widgets for ad-hoc OR calls; list each one
+  with file:line. Result lives in tasks.md as a checklist for
+  follow-up migration changes (no code edits in this change).
+
+## Phase 3 — Spec rewrites (NEEDS-REWRITE cohort)
+
+- [ ] 3.1 Rewrite `openspec/specs/dashboard-sharing/spec.md`:
+  - keep MyDash permission levels (view_only / add_only / full) as
+    native concepts on `oc_mydash_dashboards.permissions`
+  - add a "Runtime OR delegation (optional)" section describing how
+    a dashboard MAY delegate its row-level permission check to OR's
+    per-object RBAC at render time when OR is enabled
+  - explicit "MUST NOT add a hard OR dependency" requirement
+- [ ] 3.2 Rewrite `openspec/specs/admin-templates/spec.md`:
+  - declare admin templates persist in `oc_mydash_admin_settings`
+    (local table)
+  - explicit rationale: MyDash must work standalone
+  - explicit "MUST NOT store templates in OR" requirement
+- [ ] 3.3 Cross-link both rewritten specs from the new
+  `runtime-or-consumption` capability.
+
+## Phase 4 — New `runtime-or-consumption` spec capability
+
+- [ ] 4.1 Create `openspec/specs/runtime-or-consumption/spec.md` with:
+  - `Requirement: MyDash MUST NOT declare an install-time dependency
+    on openregister or openconnector`
+  - `Requirement: MyDash widgets that surface OR data MUST
+    feature-detect OR at runtime`
+  - `Requirement: MyDash widgets MUST pass ?_lang= when fetching
+    translatable OR data`
+  - `Requirement: MyDash widgets MUST consume useTenantContext() from
+    nc-vue when surfacing tenant-scoped OR data`
+  - `Requirement: MyDash widgets MUST render a documented empty
+    state when OR is absent or returns 5xx`
+- [ ] 4.2 Each requirement gets at least one
+  GIVEN / WHEN / THEN scenario.
+
+## Phase 5 — Local hygiene cleanups (stream 4)
+
+- [ ] 5.1 `lib/Db/ColumnTypeRegistry.php:31-45` — add a docblock
+  explaining why MyDash column types are intentionally separate
+  from JSON-schema `type`. Constants stay local. No code edit
+  required beyond the docblock.
+- [ ] 5.2 `lib/Db/AdminSetting.php:42-85` — collect the eight `KEY_*`
+  constants under a single `AdminSettingKey` const-list (or PHP 8.1
+  `enum`) with doc comments. Keep BC by aliasing the old constants.
+- [ ] 5.3 `lib/Service/FileService.php:62` — extract
+  `FILENAME_PATTERN` to a named class constant; add a unit test that
+  asserts:
+  - allowed: `dashboard-export.json`, `template_v2.json`,
+    `template-with-dashes.json`
+  - rejected: `../etc/passwd`, `name.with.two.dots.json`, paths
+    containing slashes, paths with leading dots
+- [ ] 5.4 Run `composer check:strict` and fix any pre-existing
+  PHPCS/PHPMD/Psalm/PHPStan warnings touched by the above edits
+  (per project policy in CLAUDE.md).
+
+## Phase 6 — Manifest Tier 3 graduation (follow-up tracking)
+
+- [ ] 6.1 Track in this tasks.md (no code in this change) the
+  prerequisites for Tier 3:
+  - dashboard `type: "dashboard"` page-type contract stable in nc-vue
+  - GridStack adapter component shipped in nc-vue or local
+  - admin pages converted from `type: "custom"` to declarative
+    config where possible
+- [ ] 6.2 Open a follow-up opsx change `mydash-manifest-tier-3`
+  once Phase 6 prerequisites are met. (Tracking only — do not
+  create the change in this proposal.)
+
+## Phase 7 — Documentation
+
+- [ ] 7.1 Update `docs/architecture.md` (or create) to describe:
+  - manifest as the single source of truth for routes / menu
+  - runtime-only OR consumption policy
+  - permission model on `oc_mydash_dashboards`
+- [ ] 7.2 Add `docs/widgets/or-data.md` (referenced from Phase 2.2).
+- [ ] 7.3 Cross-link the new docs from the app's README.
+
+## Phase 8 — Verification
+
+- [ ] 8.1 Run `npm run check:manifest` locally — must pass.
+- [ ] 8.2 Verify in a clean Nextcloud install (no OR, no OC) that
+  MyDash boots, renders empty dashboards, and shows graceful empty
+  states for any OR-backed widget the operator manually adds.
+- [ ] 8.3 Verify in a Nextcloud install with OR enabled that
+  OR-backed widgets surface data through the runtime API contract.
+- [ ] 8.4 Confirm `composer check:strict` and `npm run lint` pass.
+- [ ] 8.5 Confirm unit tests for the FILENAME_PATTERN regex pass.


### PR DESCRIPTION
## Summary

Phase 3 of the OR-abstraction audit (2026-05-03). Per-app adoption openspec change for **mydash** — spec-only, no code changes.

Drafts the change so the implementation phase can run `/opsx-apply` against it when scheduled. References Phase 2 OR/nc-vue/hydra specs (openregister#1420, nextcloud-vue#113, hydra#218) and ADRs 022/024/025.

## Test plan

- [x] No code changes; markdown-only.
- [x] References resolve to existing audit research at `.claude/audit-2026-05-03/` (in the openregister checkout).
- [x] Cited upstream specs exist on `development`.

## Auto-merge rationale

Markdown-only PR per `feedback_pr-merge-authority.md` — admin-merged on creation.