### PR TITLE
feat(openspec): mydash-legacy-quality-cleanup tracking change

### DIFF
--- a/openspec/changes/mydash-legacy-quality-cleanup/proposal.md
+++ b/openspec/changes/mydash-legacy-quality-cleanup/proposal.md
@@ -1,0 +1,70 @@
+# MyDash Legacy Quality Cleanup
+
+## Why
+
+The OR-abstraction audit (2026-05-03, stream 3 + the quality-gates
+cleanup at session start) flagged that mydash's quality gates have
+some legacy debt absorbed via exclude patterns and a small PHPStan
+baseline. Burning these down keeps PR diffs honest — gates catch
+real regressions rather than silently absorbing already-broken code.
+
+MyDash has 3 phpcs.xml exclude-patterns and an 81-line
+phpstan-baseline.neon. PHPMD has no baseline yet. The work is small:
+clear PHPCS excludes, run PHPMD unified, and burn down the modest
+PHPStan baseline.
+
+This is a tracking change so the burn-down can be picked up later.
+It is spec-only; no code changes are proposed in this change.
+
+## What Changes
+
+- Inventory and clear the 3 phpcs.xml exclude-patterns. For each:
+  add proper docblocks + named-parameter call audits, then drop
+  the exclude.
+- Run PHPMD for the first time as a unified gate (phpmd.xml is
+  configured but no baseline exists). Capture surfacing violations
+  as a baseline OR fix outright depending on volume.
+- Burn down the 81-line phpstan-baseline.neon. Small enough to
+  clear in 1-2 PRs.
+- Wire phpcs/phpmd/phpstan into CI as the unified quality gate.
+
+## Problem
+
+Exclude-patterns and the small PHPStan baseline exist because the
+audit captured legacy files / errors that predated current quality
+conventions. MyDash is a small app — the entire burn-down should
+fit in 1-2 PRs.
+
+PHPMD baseline doesn't exist yet because the gate hasn't been run
+as part of unified `check:strict`. Capturing it (or fixing
+outright) is a Phase 1 activity.
+
+Note: per project memory, mydash must NOT depend on OR/openconnector
+at install-time (BI/dashboard surface; talks to OR via runtime
+GraphQL only). Quality cleanup is purely about code hygiene and
+does not affect this boundary.
+
+## Proposed Solution
+
+File-by-file cleanup. Phase 2 lists each excluded file; Phase 4 is
+a single-cluster burn-down because the baseline is small.
+
+Estimated effort: 1-2 PRs over 1 sprint.
+
+## Out of scope
+
+- Refactoring beyond what the sniff requires
+- New features (separate adoption-spec changes own those)
+- Adding install-time deps on OR / openconnector — explicitly
+  forbidden per the mydash boundary rule
+- Test additions (separate test-coverage spec change if needed)
+
+## See also
+
+- The canonical audit lives in openregister at
+  `.claude/audit-2026-05-03/03-repo-hygiene.md`. MyDash references
+  it from there.
+- `phpcs.xml` (the legacy-debt baseline section)
+- `phpstan-baseline.neon` (the PHPStan baseline file)
+- Hydra ADR-022 (apps consume OR abstractions) — quality conventions
+- `composer.json` `check:strict` script (the unified gate target)

--- a/openspec/changes/mydash-legacy-quality-cleanup/tasks.md
+++ b/openspec/changes/mydash-legacy-quality-cleanup/tasks.md
@@ -1,0 +1,70 @@
+# Tasks: MyDash Legacy Quality Cleanup
+
+## Phase 1 — Inventory + planning
+
+- [ ] Run `composer phpcs` and capture current baseline error count
+      (target: starting from 3 exclude-patterns in phpcs.xml)
+- [ ] Run `composer phpmd` for the first time as a unified gate
+      and capture violation count + categories
+- [ ] Run `composer phpstan` and capture current error count
+      (target: starting from 81-line phpstan-baseline.neon)
+- [ ] Decide PHPMD strategy: fix-outright or capture baseline
+- [ ] Confirm CI runs `composer check:strict` on every PR before
+      starting burn-down work
+
+## Phase 2 — PHPCS burn-down (per excluded file)
+
+For each file: fix errors, remove the phpcs.xml `<exclude-pattern>`
+entry, verify gate stays green.
+
+- [ ] Excluded file 1 — fix sniffs + drop exclude
+- [ ] Excluded file 2 — fix sniffs + drop exclude
+- [ ] Excluded file 3 — fix sniffs + drop exclude
+- [ ] Once all excludes are gone, drop the legacy-debt block from
+      phpcs.xml entirely
+
+## Phase 3 — PHPMD burn-down
+
+Contingent on Phase 1's first-run output. If volume is small, this
+phase collapses to a single fix-outright PR.
+
+- [ ] If baseline captured: ElseExpression — re-shape `if/else` to
+      early-return
+- [ ] If baseline captured: CyclomaticComplexity / NPathComplexity —
+      extract methods
+- [ ] If baseline captured: MissingImport — add `use` statements
+- [ ] If baseline captured: StaticAccess — replace with DI
+- [ ] If baseline captured: variable-naming sniffs (Long/Short/
+      Undefined/UnusedFormalParameter)
+- [ ] Once baseline reaches 0 lines: delete phpmd.baseline.xml and
+      drop `--baseline-file` from composer.json's phpmd script
+
+## Phase 4 — PHPStan burn-down (81 lines)
+
+Single-PR cluster — small baseline, no need to phase further.
+
+- [ ] Inventory phpstan errors by file/type
+- [ ] Common patterns to fix:
+  - [ ] Missing return-type / param-type declarations
+  - [ ] Mixed types (specify generic / union)
+  - [ ] Possibly-null dereferences
+  - [ ] Strict-comparison nudges (`==` to `===`)
+- [ ] Regenerate baseline; confirm 0 lines
+- [ ] Delete phpstan-baseline.neon
+
+## Phase 5 — CI integration
+
+- [ ] Verify `composer check:strict` runs in CI on every PR
+- [ ] Once all baselines are empty:
+  - [ ] Delete `phpmd.baseline.xml` (if it was created)
+  - [ ] Delete `phpstan-baseline.neon`
+  - [ ] Drop the legacy-debt section from `phpcs.xml`
+- [ ] Add a smoke-test cron that runs `composer check:strict`
+      weekly on `development`
+
+## Phase 6 — Documentation
+
+- [ ] Update README quality-gates section
+- [ ] Note in `app-config.json` that legacy quality cleanup is done
+- [ ] Close the burn-down tracking issue once the last baseline
+      line is removed


### PR DESCRIPTION
## Summary

Drafts the openspec change that captures mydash's legacy quality-debt cleanup as a tracked initiative. **Spec-only, markdown-only.**

Per the 2026-05-03 OR-abstraction audit, stream 3 (repo hygiene). Tracks the burn-down of any phpcs.xml exclude-pattern, phpmd.baseline.xml, or phpstan-baseline state so future PR diffs are gated against real issues only.

## Auto-merge rationale

Markdown-only per `feedback_pr-merge-authority.md`.