### PR TITLE
fix(migration): replace named args on Doctrine + rename too-long translations table

### DIFF
--- a/lib/Db/DashboardTranslation.php
+++ b/lib/Db/DashboardTranslation.php
@@ -4,7 +4,7 @@
  * DashboardTranslation Entity
  *
  * Represents a per-language content variant for a dashboard — a single row
- * in the oc_mydash_dashboard_translations table holding the localised
+ * in the oc_mydash_dash_translations table holding the localised
  * widget tree, name, and description for one (dashboard, languageCode)
  * pair. REQ-DASH-038..044 (dashboard-language-content).
  *

--- a/lib/Db/DashboardTranslationMapper.php
+++ b/lib/Db/DashboardTranslationMapper.php
@@ -4,7 +4,7 @@
  * DashboardTranslationMapper
  *
  * Database mapper for {@see DashboardTranslation} entities. Owns the
- * oc_mydash_dashboard_translations table; implements per-language CRUD
+ * oc_mydash_dash_translations table; implements per-language CRUD
  * plus the locale-resolution lookup. REQ-DASH-038..044 (per-language
  * dashboard content variants).
  *
@@ -45,7 +45,7 @@ class DashboardTranslationMapper extends QBMapper
     {
         parent::__construct(
             db: $db,
-            tableName: 'mydash_dashboard_translations',
+            tableName: 'mydash_dash_translations',
             entityClass: DashboardTranslation::class
         );
     }//end __construct()

--- a/lib/Listener/TranslationsListener.php
+++ b/lib/Listener/TranslationsListener.php
@@ -3,7 +3,7 @@
 /**
  * TranslationsListener
  *
- * Cleans up `oc_mydash_dashboard_translations` rows when a dashboard
+ * Cleans up `oc_mydash_dash_translations` rows when a dashboard
  * is soft-deleted. Stub registered as part of the cascade-events
  * scaffolding; the live implementation is owned by the
  * dashboard-language-content follow-up. REQ-CSC-003.
@@ -63,7 +63,7 @@ class TranslationsListener implements IEventListener
 
         try {
             // TODO(dashboard-language-content): DELETE FROM
-            // oc_mydash_dashboard_translations WHERE dashboardUuid = ?.
+            // oc_mydash_dash_translations WHERE dashboardUuid = ?.
             // Stub registered for cascade scaffolding — live cleanup
             // owned by the language-content subsystem.
             $this->logger->debug(

--- a/lib/Migration/DashboardLockTableBuilder.php
+++ b/lib/Migration/DashboardLockTableBuilder.php
@@ -50,68 +50,68 @@ class DashboardLockTableBuilder
      */
     public static function create(ISchemaWrapper $schema): void
     {
-        if ($schema->hasTable(tableName: 'mydash_dashboard_locks') === true) {
+        if ($schema->hasTable('mydash_dashboard_locks') === true) {
             return;
         }
 
-        $table = $schema->createTable(tableName: 'mydash_dashboard_locks');
+        $table = $schema->createTable('mydash_dashboard_locks');
 
         $table->addColumn(
-            name: 'id',
-            typeName: Types::BIGINT,
-            options: [
+            'id',
+            Types::BIGINT,
+            [
                 'autoincrement' => true,
                 'notnull'       => true,
                 'unsigned'      => true,
             ]
         );
         $table->addColumn(
-            name: 'dashboard_uuid',
-            typeName: Types::STRING,
-            options: [
+            'dashboard_uuid',
+            Types::STRING,
+            [
                 'notnull' => true,
                 'length'  => 36,
             ]
         );
         $table->addColumn(
-            name: 'user_id',
-            typeName: Types::STRING,
-            options: [
+            'user_id',
+            Types::STRING,
+            [
                 'notnull' => true,
                 'length'  => 64,
             ]
         );
         $table->addColumn(
-            name: 'display_name',
-            typeName: Types::STRING,
-            options: [
+            'display_name',
+            Types::STRING,
+            [
                 'notnull' => true,
                 'length'  => 255,
             ]
         );
         $table->addColumn(
-            name: 'created_at',
-            typeName: Types::DATETIME,
-            options: ['notnull' => true]
+            'created_at',
+            Types::DATETIME,
+            ['notnull' => true]
         );
         $table->addColumn(
-            name: 'updated_at',
-            typeName: Types::DATETIME,
-            options: ['notnull' => true]
+            'updated_at',
+            Types::DATETIME,
+            ['notnull' => true]
         );
 
-        $table->setPrimaryKey(columnNames: ['id']);
+        $table->setPrimaryKey(['id']);
         $table->addUniqueIndex(
-            columnNames: ['dashboard_uuid'],
-            indexName: 'mydash_lock_dash_unique'
+            ['dashboard_uuid'],
+            'mydash_lock_dash_unique'
         );
         $table->addIndex(
-            columnNames: ['user_id'],
-            indexName: 'mydash_lock_user_idx'
+            ['user_id'],
+            'mydash_lock_user_idx'
         );
         $table->addIndex(
-            columnNames: ['updated_at'],
-            indexName: 'mydash_lock_updated_idx'
+            ['updated_at'],
+            'mydash_lock_updated_idx'
         );
     }//end create()
 }//end class

--- a/lib/Migration/DashboardShareTableBuilder.php
+++ b/lib/Migration/DashboardShareTableBuilder.php
@@ -38,77 +38,77 @@ class DashboardShareTableBuilder
      */
     public static function create(ISchemaWrapper $schema): void
     {
-        if ($schema->hasTable(tableName: 'mydash_dashboard_shares') === true) {
+        if ($schema->hasTable('mydash_dashboard_shares') === true) {
             return;
         }
 
-        $table = $schema->createTable(tableName: 'mydash_dashboard_shares');
+        $table = $schema->createTable('mydash_dashboard_shares');
 
         $table->addColumn(
-            name: 'id',
-            typeName: Types::BIGINT,
-            options: [
+            'id',
+            Types::BIGINT,
+            [
                 'autoincrement' => true,
                 'notnull'       => true,
                 'unsigned'      => true,
             ]
         );
         $table->addColumn(
-            name: 'dashboard_id',
-            typeName: Types::BIGINT,
-            options: [
+            'dashboard_id',
+            Types::BIGINT,
+            [
                 'notnull'  => true,
                 'unsigned' => true,
             ]
         );
         $table->addColumn(
-            name: 'share_type',
-            typeName: Types::STRING,
-            options: [
+            'share_type',
+            Types::STRING,
+            [
                 'notnull' => true,
                 'length'  => 8,
             ]
         );
         $table->addColumn(
-            name: 'share_with',
-            typeName: Types::STRING,
-            options: [
+            'share_with',
+            Types::STRING,
+            [
                 'notnull' => true,
                 'length'  => 64,
             ]
         );
         $table->addColumn(
-            name: 'permission_level',
-            typeName: Types::STRING,
-            options: [
+            'permission_level',
+            Types::STRING,
+            [
                 'notnull' => true,
                 'length'  => 16,
                 'default' => 'view_only',
             ]
         );
         $table->addColumn(
-            name: 'created_at',
-            typeName: Types::DATETIME,
-            options: ['notnull' => true]
+            'created_at',
+            Types::DATETIME,
+            ['notnull' => true]
         );
         $table->addColumn(
-            name: 'updated_at',
-            typeName: Types::DATETIME,
-            options: ['notnull' => false]
+            'updated_at',
+            Types::DATETIME,
+            ['notnull' => false]
         );
 
-        $table->setPrimaryKey(columnNames: ['id']);
+        $table->setPrimaryKey(['id']);
         $table->addIndex(
-            columnNames: ['dashboard_id'],
-            indexName: 'mydash_share_dash_idx'
+            ['dashboard_id'],
+            'mydash_share_dash_idx'
         );
         $table->addIndex(
-            columnNames: ['share_type', 'share_with'],
-            indexName: 'mydash_share_recip_idx'
+            ['share_type', 'share_with'],
+            'mydash_share_recip_idx'
         );
         $table->addUniqueIndex(
-            columnNames: ['dashboard_id', 'share_type', 'share_with'],
-            indexName: 'mydash_share_unique_idx'
+            ['dashboard_id', 'share_type', 'share_with'],
+            'mydash_share_unique_idx'
         );
     }//end create()
 }//end class

--- a/lib/Migration/DashboardTableBuilder.php
+++ b/lib/Migration/DashboardTableBuilder.php
@@ -35,11 +35,11 @@ class DashboardTableBuilder
      */
     public static function create(ISchemaWrapper $schema): void
     {
-        if ($schema->hasTable(tableName: 'mydash_dashboards') === true) {
+        if ($schema->hasTable('mydash_dashboards') === true) {
             return;
         }
 
-        $table = $schema->createTable(tableName: 'mydash_dashboards');
+        $table = $schema->createTable('mydash_dashboards');
 
         self::addColumns(table: $table);
         self::addIndexes(table: $table);
@@ -56,118 +56,118 @@ class DashboardTableBuilder
     private static function addColumns($table): void
     {
         $table->addColumn(
-            name: 'id',
-            typeName: Types::BIGINT,
-            options: [
+            'id',
+            Types::BIGINT,
+            [
                 'autoincrement' => true,
                 'notnull'       => true,
                 'unsigned'      => true,
             ]
         );
         $table->addColumn(
-            name: 'uuid',
-            typeName: Types::STRING,
-            options: [
+            'uuid',
+            Types::STRING,
+            [
                 'notnull' => true,
                 'length'  => 36,
             ]
         );
         $table->addColumn(
-            name: 'name',
-            typeName: Types::STRING,
-            options: [
+            'name',
+            Types::STRING,
+            [
                 'notnull' => true,
                 'length'  => 255,
             ]
         );
         $table->addColumn(
-            name: 'description',
-            typeName: Types::TEXT,
-            options: [
+            'description',
+            Types::TEXT,
+            [
                 'notnull' => false,
             ]
         );
         // Owned by the frontend `dashboard-icons` capability — see
         // `lib/Db/Dashboard.php::$icon` for the legal value classes.
         $table->addColumn(
-            name: 'icon',
-            typeName: Types::STRING,
-            options: [
+            'icon',
+            Types::STRING,
+            [
                 'notnull' => false,
                 'length'  => 2000,
                 'comment' => 'Dashboard icon: registry key (dashboard-icons) or upload URL; NULL = default.',
             ]
         );
         $table->addColumn(
-            name: 'type',
-            typeName: Types::STRING,
-            options: [
+            'type',
+            Types::STRING,
+            [
                 'notnull' => true,
                 'length'  => 20,
                 'default' => 'user',
             ]
         );
         $table->addColumn(
-            name: 'user_id',
-            typeName: Types::STRING,
-            options: [
+            'user_id',
+            Types::STRING,
+            [
                 'notnull' => false,
                 'length'  => 64,
             ]
         );
         $table->addColumn(
-            name: 'group_id',
-            typeName: Types::STRING,
-            options: [
+            'group_id',
+            Types::STRING,
+            [
                 'notnull' => false,
                 'length'  => 64,
             ]
         );
         $table->addColumn(
-            name: 'based_on_template',
-            typeName: Types::BIGINT,
-            options: [
+            'based_on_template',
+            Types::BIGINT,
+            [
                 'notnull'  => false,
                 'unsigned' => true,
             ]
         );
         $table->addColumn(
-            name: 'grid_columns',
-            typeName: Types::INTEGER,
-            options: [
+            'grid_columns',
+            Types::INTEGER,
+            [
                 'notnull' => true,
                 'default' => 12,
             ]
         );
         $table->addColumn(
-            name: 'permission_level',
-            typeName: Types::STRING,
-            options: [
+            'permission_level',
+            Types::STRING,
+            [
                 'notnull' => true,
                 'length'  => 20,
                 'default' => 'full',
             ]
         );
         $table->addColumn(
-            name: 'target_groups',
-            typeName: Types::TEXT,
-            options: [
+            'target_groups',
+            Types::TEXT,
+            [
                 'notnull' => false,
             ]
         );
         $table->addColumn(
-            name: 'is_default',
-            typeName: Types::SMALLINT,
-            options: [
+            'is_default',
+            Types::SMALLINT,
+            [
                 'notnull'  => true,
                 'default'  => 0,
                 'unsigned' => true,
             ]
         );
         $table->addColumn(
-            name: 'is_active',
-            typeName: Types::SMALLINT,
-            options: [
+            'is_active',
+            Types::SMALLINT,
+            [
                 'notnull'  => true,
                 'default'  => 0,
                 'unsigned' => true,
@@ -176,9 +176,9 @@ class DashboardTableBuilder
         // Per-dashboard comments toggle (REQ-CMNT-007). NULL = inherit
         // global setting; 1 = force on; 0 = force off.
         $table->addColumn(
-            name: 'comments_enabled',
-            typeName: Types::SMALLINT,
-            options: [
+            'comments_enabled',
+            Types::SMALLINT,
+            [
                 'notnull'  => false,
                 'default'  => null,
                 'unsigned' => true,
@@ -186,16 +186,16 @@ class DashboardTableBuilder
             ]
         );
         $table->addColumn(
-            name: 'created_at',
-            typeName: Types::DATETIME,
-            options: [
+            'created_at',
+            Types::DATETIME,
+            [
                 'notnull' => true,
             ]
         );
         $table->addColumn(
-            name: 'updated_at',
-            typeName: Types::DATETIME,
-            options: [
+            'updated_at',
+            Types::DATETIME,
+            [
                 'notnull' => true,
             ]
         );
@@ -210,26 +210,26 @@ class DashboardTableBuilder
      */
     private static function addIndexes($table): void
     {
-        $table->setPrimaryKey(columnNames: ['id']);
+        $table->setPrimaryKey(['id']);
         $table->addUniqueIndex(
-            columnNames: ['uuid'],
-            indexName: 'mydash_dashboard_uuid'
+            ['uuid'],
+            'mydash_dashboard_uuid'
         );
         $table->addIndex(
-            columnNames: ['user_id'],
-            indexName: 'mydash_dashboard_user'
+            ['user_id'],
+            'mydash_dashboard_user'
         );
         $table->addIndex(
-            columnNames: ['type'],
-            indexName: 'mydash_dashboard_type'
+            ['type'],
+            'mydash_dashboard_type'
         );
         $table->addIndex(
-            columnNames: ['user_id', 'is_active'],
-            indexName: 'mydash_dashboard_active'
+            ['user_id', 'is_active'],
+            'mydash_dashboard_active'
         );
         $table->addIndex(
-            columnNames: ['type', 'group_id'],
-            indexName: 'mydash_dash_type_group'
+            ['type', 'group_id'],
+            'mydash_dash_type_group'
         );
     }//end addIndexes()
 
@@ -249,47 +249,47 @@ class DashboardTableBuilder
      */
     public static function addTreeColumns($table): void
     {
-        if ($table->hasColumn(name: 'parent_uuid') === false) {
+        if ($table->hasColumn('parent_uuid') === false) {
             $table->addColumn(
-                name: 'parent_uuid',
-                typeName: Types::STRING,
-                options: [
+                'parent_uuid',
+                Types::STRING,
+                [
                     'notnull' => false,
                     'length'  => 36,
                 ]
             );
         }
 
-        if ($table->hasColumn(name: 'slug') === false) {
+        if ($table->hasColumn('slug') === false) {
             $table->addColumn(
-                name: 'slug',
-                typeName: Types::STRING,
-                options: [
+                'slug',
+                Types::STRING,
+                [
                     'notnull' => false,
                     'length'  => 128,
                 ]
             );
         }
 
-        if ($table->hasColumn(name: 'sort_order') === false) {
+        if ($table->hasColumn('sort_order') === false) {
             $table->addColumn(
-                name: 'sort_order',
-                typeName: Types::INTEGER,
-                options: [
+                'sort_order',
+                Types::INTEGER,
+                [
                     'notnull' => true,
                     'default' => 0,
                 ]
             );
         }
 
-        if ($table->hasIndex(name: 'mydash_dash_parent') === false) {
+        if ($table->hasIndex('mydash_dash_parent') === false) {
             $table->addIndex(
-                columnNames: ['parent_uuid'],
-                indexName: 'mydash_dash_parent'
+                ['parent_uuid'],
+                'mydash_dash_parent'
             );
         }
 
-        if ($table->hasIndex(name: 'mydash_dash_parent_slug') === false) {
+        if ($table->hasIndex('mydash_dash_parent_slug') === false) {
             // Composite (parent_uuid, slug) supports per-parent slug
             // uniqueness lookups (REQ-DASH-024) and child-by-slug lookups
             // during path resolution (REQ-DASH-027). NULL parent_uuid is
@@ -298,15 +298,15 @@ class DashboardTableBuilder
             // service layer because composite NULL semantics differ
             // between drivers (sqlite ⇢ NULL = NULL, postgres ⇢ NULL ≠ NULL).
             $table->addIndex(
-                columnNames: ['parent_uuid', 'slug'],
-                indexName: 'mydash_dash_parent_slug'
+                ['parent_uuid', 'slug'],
+                'mydash_dash_parent_slug'
             );
         }
 
-        if ($table->hasIndex(name: 'mydash_dash_sort') === false) {
+        if ($table->hasIndex('mydash_dash_sort') === false) {
             $table->addIndex(
-                columnNames: ['parent_uuid', 'sort_order'],
-                indexName: 'mydash_dash_sort'
+                ['parent_uuid', 'sort_order'],
+                'mydash_dash_sort'
             );
         }
     }//end addTreeColumns()
@@ -333,11 +333,11 @@ class DashboardTableBuilder
      */
     public static function addPublicationColumns($table): void
     {
-        if ($table->hasColumn(name: 'publication_status') === false) {
+        if ($table->hasColumn('publication_status') === false) {
             $table->addColumn(
-                name: 'publication_status',
-                typeName: Types::STRING,
-                options: [
+                'publication_status',
+                Types::STRING,
+                [
                     'notnull' => true,
                     'length'  => 20,
                     'default' => 'published',
@@ -346,32 +346,32 @@ class DashboardTableBuilder
             );
         }
 
-        if ($table->hasColumn(name: 'publish_at') === false) {
+        if ($table->hasColumn('publish_at') === false) {
             $table->addColumn(
-                name: 'publish_at',
-                typeName: Types::DATETIME,
-                options: [
+                'publish_at',
+                Types::DATETIME,
+                [
                     'notnull' => false,
                     'comment' => 'Scheduled publication timestamp; used when publication_status = scheduled.',
                 ]
             );
         }
 
-        if ($table->hasColumn(name: 'published_at') === false) {
+        if ($table->hasColumn('published_at') === false) {
             $table->addColumn(
-                name: 'published_at',
-                typeName: Types::DATETIME,
-                options: [
+                'published_at',
+                Types::DATETIME,
+                [
                     'notnull' => false,
                     'comment' => 'First-publication timestamp; preserved across unpublish. REQ-DASH-032.',
                 ]
             );
         }
 
-        if ($table->hasIndex(name: 'mydash_dash_user_pubstatus') === false) {
+        if ($table->hasIndex('mydash_dash_user_pubstatus') === false) {
             $table->addIndex(
-                columnNames: ['user_id', 'publication_status'],
-                indexName: 'mydash_dash_user_pubstatus'
+                ['user_id', 'publication_status'],
+                'mydash_dash_user_pubstatus'
             );
         }
     }//end addPublicationColumns()
@@ -394,11 +394,11 @@ class DashboardTableBuilder
      */
     public static function addFooterColumns($table): void
     {
-        if ($table->hasColumn(name: 'dashboard_footer_mode') === false) {
+        if ($table->hasColumn('dashboard_footer_mode') === false) {
             $table->addColumn(
-                name: 'dashboard_footer_mode',
-                typeName: Types::STRING,
-                options: [
+                'dashboard_footer_mode',
+                Types::STRING,
+                [
                     'notnull' => true,
                     'length'  => 16,
                     'default' => 'inherit',
@@ -407,11 +407,11 @@ class DashboardTableBuilder
             );
         }
 
-        if ($table->hasColumn(name: 'dashboard_footer_html') === false) {
+        if ($table->hasColumn('dashboard_footer_html') === false) {
             $table->addColumn(
-                name: 'dashboard_footer_html',
-                typeName: Types::TEXT,
-                options: [
+                'dashboard_footer_html',
+                Types::TEXT,
+                [
                     'notnull' => false,
                     'comment' => 'Sanitised dashboard-specific footer HTML; only used when dashboard_footer_mode=custom.',
                 ]
@@ -437,11 +437,11 @@ class DashboardTableBuilder
      */
     public static function addTemplateDiscoveryColumns($table): void
     {
-        if ($table->hasColumn(name: 'template_category') === false) {
+        if ($table->hasColumn('template_category') === false) {
             $table->addColumn(
-                name: 'template_category',
-                typeName: Types::STRING,
-                options: [
+                'template_category',
+                Types::STRING,
+                [
                     'notnull' => false,
                     'length'  => 64,
                     'comment' => 'Free-form gallery category for admin templates. REQ-TMPL-016.',
@@ -449,32 +449,32 @@ class DashboardTableBuilder
             );
         }
 
-        if ($table->hasColumn(name: 'template_description') === false) {
+        if ($table->hasColumn('template_description') === false) {
             $table->addColumn(
-                name: 'template_description',
-                typeName: Types::TEXT,
-                options: [
+                'template_description',
+                Types::TEXT,
+                [
                     'notnull' => false,
                     'comment' => 'Long-form gallery description for admin templates. REQ-TMPL-016.',
                 ]
             );
         }
 
-        if ($table->hasColumn(name: 'template_preview_image') === false) {
+        if ($table->hasColumn('template_preview_image') === false) {
             $table->addColumn(
-                name: 'template_preview_image',
-                typeName: Types::TEXT,
-                options: [
+                'template_preview_image',
+                Types::TEXT,
+                [
                     'notnull' => false,
                     'comment' => 'Preview image URL stored via the resource-uploads pattern. REQ-TMPL-017.',
                 ]
             );
         }
 
-        if ($table->hasIndex(name: 'mydash_tpl_type_cat') === false) {
+        if ($table->hasIndex('mydash_tpl_type_cat') === false) {
             $table->addIndex(
-                columnNames: ['type', 'template_category'],
-                indexName: 'mydash_tpl_type_cat'
+                ['type', 'template_category'],
+                'mydash_tpl_type_cat'
             );
         }
     }//end addTemplateDiscoveryColumns()

--- a/lib/Migration/DashboardTranslationTableBuilder.php
+++ b/lib/Migration/DashboardTranslationTableBuilder.php
@@ -3,7 +3,7 @@
 /**
  * DashboardTranslationTableBuilder
  *
- * Builder for the oc_mydash_dashboard_translations database table schema
+ * Builder for the oc_mydash_dash_translations database table schema
  * — per-language content variants for dashboards. REQ-DASH-038.
  *
  * @category  Migration
@@ -31,7 +31,7 @@ use OCP\DB\Types;
 class DashboardTranslationTableBuilder
 {
     /**
-     * Create the mydash_dashboard_translations table.
+     * Create the mydash_dash_translations table.
      *
      * Idempotent — returns immediately when the table already exists.
      *
@@ -41,65 +41,65 @@ class DashboardTranslationTableBuilder
      */
     public static function create(ISchemaWrapper $schema): void
     {
-        if ($schema->hasTable(tableName: 'mydash_dashboard_translations') === true) {
+        if ($schema->hasTable('mydash_dash_translations') === true) {
             return;
         }
 
         $table = $schema->createTable(
-            tableName: 'mydash_dashboard_translations'
+            'mydash_dash_translations'
         );
 
         $table->addColumn(
-            name: 'id',
-            typeName: Types::BIGINT,
-            options: [
+            'id',
+            Types::BIGINT,
+            [
                 'autoincrement' => true,
                 'notnull'       => true,
                 'unsigned'      => true,
             ]
         );
         $table->addColumn(
-            name: 'dashboard_uuid',
-            typeName: Types::STRING,
-            options: [
+            'dashboard_uuid',
+            Types::STRING,
+            [
                 'notnull' => true,
                 'length'  => 36,
             ]
         );
         $table->addColumn(
-            name: 'language_code',
-            typeName: Types::STRING,
-            options: [
+            'language_code',
+            Types::STRING,
+            [
                 'notnull' => true,
                 'length'  => 16,
                 'comment' => 'ISO 639-1 base code (nl, en, de, fr); normalised by mapper.',
             ]
         );
         $table->addColumn(
-            name: 'name',
-            typeName: Types::STRING,
-            options: [
+            'name',
+            Types::STRING,
+            [
                 'notnull' => false,
                 'length'  => 255,
             ]
         );
         $table->addColumn(
-            name: 'description',
-            typeName: Types::TEXT,
-            options: ['notnull' => false]
+            'description',
+            Types::TEXT,
+            ['notnull' => false]
         );
         $table->addColumn(
-            name: 'widget_tree_json',
-            typeName: Types::TEXT,
-            options: [
+            'widget_tree_json',
+            Types::TEXT,
+            [
                 'notnull' => false,
                 'comment' => 'Localised widget tree JSON — mirrors oc_mydash_dashboards shape.',
             ]
         );
         $table->addColumn(
-            name: 'is_primary',
-            typeName: Types::SMALLINT,
-            options: [
+            'is_primary',
+            Types::SMALLINT,
+            [
                 'notnull'  => true,
                 'default'  => 0,
                 'unsigned' => true,
@@ -107,28 +107,28 @@ class DashboardTranslationTableBuilder
             ]
         );
         $table->addColumn(
-            name: 'created_at',
-            typeName: Types::DATETIME,
-            options: ['notnull' => true]
+            'created_at',
+            Types::DATETIME,
+            ['notnull' => true]
         );
         $table->addColumn(
-            name: 'updated_at',
-            typeName: Types::DATETIME,
-            options: ['notnull' => false]
+            'updated_at',
+            Types::DATETIME,
+            ['notnull' => false]
         );
 
-        $table->setPrimaryKey(columnNames: ['id']);
+        $table->setPrimaryKey(['id']);
         $table->addIndex(
-            columnNames: ['dashboard_uuid'],
-            indexName: 'mydash_trans_dash_idx'
+            ['dashboard_uuid'],
+            'mydash_trans_dash_idx'
         );
         $table->addUniqueIndex(
-            columnNames: ['dashboard_uuid', 'language_code'],
-            indexName: 'mydash_trans_unique_idx'
+            ['dashboard_uuid', 'language_code'],
+            'mydash_trans_unique_idx'
         );
         $table->addIndex(
-            columnNames: ['dashboard_uuid', 'is_primary'],
-            indexName: 'mydash_trans_primary_idx'
+            ['dashboard_uuid', 'is_primary'],
+            'mydash_trans_primary_idx'
         );
     }//end create()
 }//end class

--- a/lib/Migration/DashboardVersionTableBuilder.php
+++ b/lib/Migration/DashboardVersionTableBuilder.php
@@ -53,74 +53,74 @@ class DashboardVersionTableBuilder
      */
     public static function create(ISchemaWrapper $schema): void
     {
-        if ($schema->hasTable(tableName: 'mydash_dashboard_versions') === true) {
+        if ($schema->hasTable('mydash_dashboard_versions') === true) {
             return;
         }
 
         $table = $schema->createTable(
-            tableName: 'mydash_dashboard_versions'
+            'mydash_dashboard_versions'
         );
 
         $table->addColumn(
-            name: 'id',
-            typeName: Types::BIGINT,
-            options: [
+            'id',
+            Types::BIGINT,
+            [
                 'autoincrement' => true,
                 'notnull'       => true,
                 'unsigned'      => true,
             ]
         );
         $table->addColumn(
-            name: 'dashboard_uuid',
-            typeName: Types::STRING,
-            options: [
+            'dashboard_uuid',
+            Types::STRING,
+            [
                 'notnull' => true,
                 'length'  => 36,
             ]
         );
         $table->addColumn(
-            name: 'version_number',
-            typeName: Types::BIGINT,
-            options: [
+            'version_number',
+            Types::BIGINT,
+            [
                 'notnull'  => true,
                 'unsigned' => true,
             ]
         );
         $table->addColumn(
-            name: 'snapshot_json',
-            typeName: Types::TEXT,
-            options: ['notnull' => true]
+            'snapshot_json',
+            Types::TEXT,
+            ['notnull' => true]
         );
         $table->addColumn(
-            name: 'created_by',
-            typeName: Types::STRING,
-            options: [
+            'created_by',
+            Types::STRING,
+            [
                 'notnull' => true,
                 'length'  => 64,
             ]
         );
         $table->addColumn(
-            name: 'created_at',
-            typeName: Types::DATETIME,
-            options: ['notnull' => true]
+            'created_at',
+            Types::DATETIME,
+            ['notnull' => true]
         );
         $table->addColumn(
-            name: 'note',
-            typeName: Types::STRING,
-            options: [
+            'note',
+            Types::STRING,
+            [
                 'notnull' => false,
                 'length'  => 500,
             ]
         );
 
-        $table->setPrimaryKey(columnNames: ['id']);
+        $table->setPrimaryKey(['id']);
         $table->addUniqueIndex(
-            columnNames: ['dashboard_uuid', 'version_number'],
-            indexName: 'mydash_dvers_uuid_num'
+            ['dashboard_uuid', 'version_number'],
+            'mydash_dvers_uuid_num'
         );
         $table->addIndex(
-            columnNames: ['dashboard_uuid', 'created_at'],
-            indexName: 'mydash_dvers_uuid_ts'
+            ['dashboard_uuid', 'created_at'],
+            'mydash_dvers_uuid_ts'
         );
     }//end create()
 }//end class

--- a/lib/Migration/DashboardViewsTableBuilder.php
+++ b/lib/Migration/DashboardViewsTableBuilder.php
@@ -50,11 +50,11 @@ class DashboardViewsTableBuilder
      */
     public static function create(ISchemaWrapper $schema): void
     {
-        if ($schema->hasTable(tableName: 'mydash_dashboard_views') === true) {
+        if ($schema->hasTable('mydash_dashboard_views') === true) {
             return;
         }
 
-        $table = $schema->createTable(tableName: 'mydash_dashboard_views');
+        $table = $schema->createTable('mydash_dashboard_views');
 
         self::addColumns(table: $table);
         self::addIndexes(table: $table);
@@ -70,35 +70,35 @@ class DashboardViewsTableBuilder
     private static function addColumns($table): void
     {
         $table->addColumn(
-            name: 'id',
-            typeName: Types::BIGINT,
-            options: [
+            'id',
+            Types::BIGINT,
+            [
                 'autoincrement' => true,
                 'notnull'       => true,
                 'unsigned'      => true,
             ]
         );
         $table->addColumn(
-            name: 'dashboard_uuid',
-            typeName: Types::STRING,
-            options: [
+            'dashboard_uuid',
+            Types::STRING,
+            [
                 'notnull' => true,
                 'length'  => 36,
                 'comment' => 'The dashboard UUID this aggregate row belongs to (REQ-ANLT-001).',
             ]
         );
         $table->addColumn(
-            name: 'view_bucket',
-            typeName: Types::DATE,
-            options: [
+            'view_bucket',
+            Types::DATE,
+            [
                 'notnull' => true,
                 'comment' => 'Calendar date in UTC; one row per (dashboard, day).',
             ]
         );
         $table->addColumn(
-            name: 'view_count',
-            typeName: Types::INTEGER,
-            options: [
+            'view_count',
+            Types::INTEGER,
+            [
                 'notnull'  => true,
                 'default'  => 0,
                 'unsigned' => true,
@@ -106,9 +106,9 @@ class DashboardViewsTableBuilder
             ]
         );
         $table->addColumn(
-            name: 'unique_viewer_count',
-            typeName: Types::INTEGER,
-            options: [
+            'unique_viewer_count',
+            Types::INTEGER,
+            [
                 'notnull'  => true,
                 'default'  => 0,
                 'unsigned' => true,
@@ -132,14 +132,14 @@ class DashboardViewsTableBuilder
      */
     private static function addIndexes($table): void
     {
-        $table->setPrimaryKey(columnNames: ['id']);
+        $table->setPrimaryKey(['id']);
         $table->addUniqueIndex(
-            columnNames: ['dashboard_uuid', 'view_bucket'],
-            indexName: 'mydash_anlt_uniq'
+            ['dashboard_uuid', 'view_bucket'],
+            'mydash_anlt_uniq'
         );
         $table->addIndex(
-            columnNames: ['view_bucket'],
-            indexName: 'mydash_anlt_bucket'
+            ['view_bucket'],
+            'mydash_anlt_bucket'
         );
     }//end addIndexes()
 }//end class

--- a/lib/Migration/FeedCacheTableBuilder.php
+++ b/lib/Migration/FeedCacheTableBuilder.php
@@ -61,71 +61,71 @@ class FeedCacheTableBuilder
      */
     public static function create(ISchemaWrapper $schema): void
     {
-        if ($schema->hasTable(tableName: 'mydash_feed_cache') === true) {
+        if ($schema->hasTable('mydash_feed_cache') === true) {
             return;
         }
 
-        $table = $schema->createTable(tableName: 'mydash_feed_cache');
+        $table = $schema->createTable('mydash_feed_cache');
 
         $table->addColumn(
-            name: 'id',
-            typeName: Types::BIGINT,
-            options: [
+            'id',
+            Types::BIGINT,
+            [
                 'autoincrement' => true,
                 'notnull'       => true,
                 'unsigned'      => true,
             ]
         );
         $table->addColumn(
-            name: 'feed_url',
-            typeName: Types::STRING,
-            options: [
+            'feed_url',
+            Types::STRING,
+            [
                 'notnull' => true,
                 'length'  => 2048,
             ]
         );
         $table->addColumn(
-            name: 'last_fetched_at',
-            typeName: Types::DATETIME,
-            options: ['notnull' => false]
+            'last_fetched_at',
+            Types::DATETIME,
+            ['notnull' => false]
         );
         $table->addColumn(
-            name: 'last_success_at',
-            typeName: Types::DATETIME,
-            options: ['notnull' => false]
+            'last_success_at',
+            Types::DATETIME,
+            ['notnull' => false]
         );
         $table->addColumn(
-            name: 'last_failure_reason',
-            typeName: Types::TEXT,
-            options: ['notnull' => false]
+            'last_failure_reason',
+            Types::TEXT,
+            ['notnull' => false]
         );
         $table->addColumn(
-            name: 'etag',
-            typeName: Types::STRING,
-            options: [
+            'etag',
+            Types::STRING,
+            [
                 'notnull' => false,
                 'length'  => 255,
             ]
         );
         $table->addColumn(
-            name: 'last_modified',
-            typeName: Types::STRING,
-            options: [
+            'last_modified',
+            Types::STRING,
+            [
                 'notnull' => false,
                 'length'  => 255,
             ]
         );
         $table->addColumn(
-            name: 'items_json',
-            typeName: Types::TEXT,
-            options: ['notnull' => false]
+            'items_json',
+            Types::TEXT,
+            ['notnull' => false]
         );
 
-        $table->setPrimaryKey(columnNames: ['id']);
+        $table->setPrimaryKey(['id']);
         $table->addUniqueIndex(
-            columnNames: ['feed_url'],
-            indexName: 'mydash_feed_cache_url_uq',
-            options: ['lengths' => [191]]
+            ['feed_url'],
+            'mydash_feed_cache_url_uq',
+            ['lengths' => [191]]
         );
     }//end create()
 }//end class

--- a/lib/Migration/FeedTokenTableBuilder.php
+++ b/lib/Migration/FeedTokenTableBuilder.php
@@ -50,61 +50,61 @@ class FeedTokenTableBuilder
      */
     public static function create(ISchemaWrapper $schema): void
     {
-        if ($schema->hasTable(tableName: 'mydash_feed_tokens') === true) {
+        if ($schema->hasTable('mydash_feed_tokens') === true) {
             return;
         }
 
-        $table = $schema->createTable(tableName: 'mydash_feed_tokens');
+        $table = $schema->createTable('mydash_feed_tokens');
 
         $table->addColumn(
-            name: 'id',
-            typeName: Types::BIGINT,
-            options: [
+            'id',
+            Types::BIGINT,
+            [
                 'autoincrement' => true,
                 'notnull'       => true,
                 'unsigned'      => true,
             ]
         );
         $table->addColumn(
-            name: 'user_id',
-            typeName: Types::STRING,
-            options: [
+            'user_id',
+            Types::STRING,
+            [
                 'notnull' => true,
                 'length'  => 64,
             ]
         );
         $table->addColumn(
-            name: 'token',
-            typeName: Types::STRING,
-            options: [
+            'token',
+            Types::STRING,
+            [
                 'notnull' => true,
                 'length'  => 64,
             ]
         );
         $table->addColumn(
-            name: 'created_at',
-            typeName: Types::DATETIME,
-            options: ['notnull' => true]
+            'created_at',
+            Types::DATETIME,
+            ['notnull' => true]
         );
         $table->addColumn(
-            name: 'last_used_at',
-            typeName: Types::DATETIME,
-            options: ['notnull' => false]
+            'last_used_at',
+            Types::DATETIME,
+            ['notnull' => false]
         );
         $table->addColumn(
-            name: 'revoked_at',
-            typeName: Types::DATETIME,
-            options: ['notnull' => false]
+            'revoked_at',
+            Types::DATETIME,
+            ['notnull' => false]
         );
 
-        $table->setPrimaryKey(columnNames: ['id']);
+        $table->setPrimaryKey(['id']);
         $table->addUniqueIndex(
-            columnNames: ['user_id'],
-            indexName: 'mydash_feed_tok_user_uq'
+            ['user_id'],
+            'mydash_feed_tok_user_uq'
         );
         $table->addIndex(
-            columnNames: ['token'],
-            indexName: 'mydash_feed_tok_tok_idx'
+            ['token'],
+            'mydash_feed_tok_tok_idx'
         );
     }//end create()
 }//end class

--- a/lib/Migration/MetadataTablesBuilder.php
+++ b/lib/Migration/MetadataTablesBuilder.php
@@ -58,92 +58,92 @@ class MetadataTablesBuilder
      */
     private static function createFieldsTable(ISchemaWrapper $schema): void
     {
-        if ($schema->hasTable(tableName: 'mydash_meta_fields') === true) {
+        if ($schema->hasTable('mydash_meta_fields') === true) {
             return;
         }
 
-        $table = $schema->createTable(tableName: 'mydash_meta_fields');
+        $table = $schema->createTable('mydash_meta_fields');
 
         $table->addColumn(
-            name: 'id',
-            typeName: Types::BIGINT,
-            options: [
+            'id',
+            Types::BIGINT,
+            [
                 'autoincrement' => true,
                 'notnull'       => true,
                 'unsigned'      => true,
             ]
         );
         $table->addColumn(
-            name: 'field_key',
-            typeName: Types::STRING,
-            options: [
+            'field_key',
+            Types::STRING,
+            [
                 'notnull' => true,
                 'length'  => 64,
             ]
         );
         $table->addColumn(
-            name: 'label',
-            typeName: Types::STRING,
-            options: [
+            'label',
+            Types::STRING,
+            [
                 'notnull' => true,
                 'length'  => 255,
             ]
         );
         $table->addColumn(
-            name: 'type',
-            typeName: Types::STRING,
-            options: [
+            'type',
+            Types::STRING,
+            [
                 'notnull' => true,
                 'length'  => 20,
             ]
         );
         $table->addColumn(
-            name: 'options',
-            typeName: Types::TEXT,
-            options: [
+            'options',
+            Types::TEXT,
+            [
                 'notnull' => false,
                 'comment' => 'JSON array of strings; NULL for non-select types.',
             ]
         );
         $table->addColumn(
-            name: 'required',
-            typeName: Types::SMALLINT,
-            options: [
+            'required',
+            Types::SMALLINT,
+            [
                 'notnull' => true,
                 'default' => 0,
             ]
         );
         $table->addColumn(
-            name: 'sort_order',
-            typeName: Types::INTEGER,
-            options: [
+            'sort_order',
+            Types::INTEGER,
+            [
                 'notnull' => true,
                 'default' => 0,
             ]
         );
         $table->addColumn(
-            name: 'created_at',
-            typeName: Types::DATETIME,
-            options: [
+            'created_at',
+            Types::DATETIME,
+            [
                 'notnull' => false,
             ]
         );
         $table->addColumn(
-            name: 'updated_at',
-            typeName: Types::DATETIME,
-            options: [
+            'updated_at',
+            Types::DATETIME,
+            [
                 'notnull' => false,
             ]
         );
 
-        $table->setPrimaryKey(columnNames: ['id']);
+        $table->setPrimaryKey(['id']);
         $table->addUniqueIndex(
-            columnNames: ['field_key'],
-            indexName: 'mydash_meta_fkey'
+            ['field_key'],
+            'mydash_meta_fkey'
         );
         $table->addIndex(
-            columnNames: ['sort_order'],
-            indexName: 'mydash_meta_forder'
+            ['sort_order'],
+            'mydash_meta_forder'
         );
     }//end createFieldsTable()
 
@@ -156,57 +156,57 @@ class MetadataTablesBuilder
      */
     private static function createValuesTable(ISchemaWrapper $schema): void
     {
-        if ($schema->hasTable(tableName: 'mydash_meta_values') === true) {
+        if ($schema->hasTable('mydash_meta_values') === true) {
             return;
         }
 
-        $table = $schema->createTable(tableName: 'mydash_meta_values');
+        $table = $schema->createTable('mydash_meta_values');
 
         $table->addColumn(
-            name: 'id',
-            typeName: Types::BIGINT,
-            options: [
+            'id',
+            Types::BIGINT,
+            [
                 'autoincrement' => true,
                 'notnull'       => true,
                 'unsigned'      => true,
             ]
         );
         $table->addColumn(
-            name: 'dashboard_uuid',
-            typeName: Types::STRING,
-            options: [
+            'dashboard_uuid',
+            Types::STRING,
+            [
                 'notnull' => true,
                 'length'  => 36,
             ]
         );
         $table->addColumn(
-            name: 'field_id',
-            typeName: Types::BIGINT,
-            options: [
+            'field_id',
+            Types::BIGINT,
+            [
                 'notnull'  => true,
                 'unsigned' => true,
             ]
         );
         $table->addColumn(
-            name: 'value',
-            typeName: Types::TEXT,
-            options: [
+            'value',
+            Types::TEXT,
+            [
                 'notnull' => true,
             ]
         );
 
-        $table->setPrimaryKey(columnNames: ['id']);
+        $table->setPrimaryKey(['id']);
         $table->addUniqueIndex(
-            columnNames: ['dashboard_uuid', 'field_id'],
-            indexName: 'mydash_meta_vunique'
+            ['dashboard_uuid', 'field_id'],
+            'mydash_meta_vunique'
         );
         $table->addIndex(
-            columnNames: ['dashboard_uuid'],
-            indexName: 'mydash_meta_vdash'
+            ['dashboard_uuid'],
+            'mydash_meta_vdash'
         );
         $table->addIndex(
-            columnNames: ['field_id'],
-            indexName: 'mydash_meta_vfield'
+            ['field_id'],
+            'mydash_meta_vfield'
         );
     }//end createValuesTable()
 }//end class

--- a/lib/Migration/PlacementTableBuilder.php
+++ b/lib/Migration/PlacementTableBuilder.php
@@ -36,14 +36,14 @@ class PlacementTableBuilder
     public static function create(ISchemaWrapper $schema): void
     {
         if ($schema->hasTable(
-            tableName: 'mydash_widget_placements'
+            'mydash_widget_placements'
         ) === true
         ) {
             return;
         }
 
         $table = $schema->createTable(
-            tableName: 'mydash_widget_placements'
+            'mydash_widget_placements'
         );
 
         self::addColumns(table: $table);
@@ -60,123 +60,123 @@ class PlacementTableBuilder
     private static function addColumns($table): void
     {
         $table->addColumn(
-            name: 'id',
-            typeName: Types::BIGINT,
-            options: [
+            'id',
+            Types::BIGINT,
+            [
                 'autoincrement' => true,
                 'notnull'       => true,
                 'unsigned'      => true,
             ]
         );
         $table->addColumn(
-            name: 'dashboard_id',
-            typeName: Types::BIGINT,
-            options: [
+            'dashboard_id',
+            Types::BIGINT,
+            [
                 'notnull'  => true,
                 'unsigned' => true,
             ]
         );
         $table->addColumn(
-            name: 'widget_id',
-            typeName: Types::STRING,
-            options: [
+            'widget_id',
+            Types::STRING,
+            [
                 'notnull' => true,
                 'length'  => 255,
             ]
         );
         $table->addColumn(
-            name: 'grid_x',
-            typeName: Types::INTEGER,
-            options: [
+            'grid_x',
+            Types::INTEGER,
+            [
                 'notnull' => true,
                 'default' => 0,
             ]
         );
         $table->addColumn(
-            name: 'grid_y',
-            typeName: Types::INTEGER,
-            options: [
+            'grid_y',
+            Types::INTEGER,
+            [
                 'notnull' => true,
                 'default' => 0,
             ]
         );
         $table->addColumn(
-            name: 'grid_width',
-            typeName: Types::INTEGER,
-            options: [
+            'grid_width',
+            Types::INTEGER,
+            [
                 'notnull' => true,
                 'default' => 4,
             ]
         );
         $table->addColumn(
-            name: 'grid_height',
-            typeName: Types::INTEGER,
-            options: [
+            'grid_height',
+            Types::INTEGER,
+            [
                 'notnull' => true,
                 'default' => 4,
             ]
         );
         $table->addColumn(
-            name: 'is_compulsory',
-            typeName: Types::SMALLINT,
-            options: [
+            'is_compulsory',
+            Types::SMALLINT,
+            [
                 'notnull'  => true,
                 'default'  => 0,
                 'unsigned' => true,
             ]
         );
         $table->addColumn(
-            name: 'is_visible',
-            typeName: Types::SMALLINT,
-            options: [
+            'is_visible',
+            Types::SMALLINT,
+            [
                 'notnull'  => true,
                 'default'  => 1,
                 'unsigned' => true,
             ]
         );
         $table->addColumn(
-            name: 'style_config',
-            typeName: Types::TEXT,
-            options: [
+            'style_config',
+            Types::TEXT,
+            [
                 'notnull' => false,
             ]
         );
         $table->addColumn(
-            name: 'custom_title',
-            typeName: Types::STRING,
-            options: [
+            'custom_title',
+            Types::STRING,
+            [
                 'notnull' => false,
                 'length'  => 255,
             ]
         );
         $table->addColumn(
-            name: 'show_title',
-            typeName: Types::SMALLINT,
-            options: [
+            'show_title',
+            Types::SMALLINT,
+            [
                 'notnull'  => true,
                 'default'  => 1,
                 'unsigned' => true,
             ]
         );
         $table->addColumn(
-            name: 'sort_order',
-            typeName: Types::INTEGER,
-            options: [
+            'sort_order',
+            Types::INTEGER,
+            [
                 'notnull' => true,
                 'default' => 0,
             ]
         );
         $table->addColumn(
-            name: 'created_at',
-            typeName: Types::DATETIME,
-            options: [
+            'created_at',
+            Types::DATETIME,
+            [
                 'notnull' => true,
             ]
         );
         $table->addColumn(
-            name: 'updated_at',
-            typeName: Types::DATETIME,
-            options: [
+            'updated_at',
+            Types::DATETIME,
+            [
                 'notnull' => true,
             ]
         );
@@ -191,14 +191,14 @@ class PlacementTableBuilder
      */
     private static function addIndexes($table): void
     {
-        $table->setPrimaryKey(columnNames: ['id']);
+        $table->setPrimaryKey(['id']);
         $table->addIndex(
-            columnNames: ['dashboard_id'],
-            indexName: 'mydash_placement_dashboard'
+            ['dashboard_id'],
+            'mydash_placement_dashboard'
         );
         $table->addIndex(
-            columnNames: ['widget_id'],
-            indexName: 'mydash_placement_widget'
+            ['widget_id'],
+            'mydash_placement_widget'
         );
     }//end addIndexes()
 }//end class

--- a/lib/Migration/RoleAssignmentTableBuilder.php
+++ b/lib/Migration/RoleAssignmentTableBuilder.php
@@ -47,81 +47,81 @@ class RoleAssignmentTableBuilder
      */
     public static function create(ISchemaWrapper $schema): void
     {
-        if ($schema->hasTable(tableName: 'mydash_role_assignments') === true) {
+        if ($schema->hasTable('mydash_role_assignments') === true) {
             return;
         }
 
-        $table = $schema->createTable(tableName: 'mydash_role_assignments');
+        $table = $schema->createTable('mydash_role_assignments');
 
         $table->addColumn(
-            name: 'id',
-            typeName: Types::BIGINT,
-            options: [
+            'id',
+            Types::BIGINT,
+            [
                 'autoincrement' => true,
                 'notnull'       => true,
                 'unsigned'      => true,
             ]
         );
         $table->addColumn(
-            name: 'user_id',
-            typeName: Types::STRING,
-            options: [
+            'user_id',
+            Types::STRING,
+            [
                 'notnull' => false,
                 'length'  => 64,
             ]
         );
         $table->addColumn(
-            name: 'group_id',
-            typeName: Types::STRING,
-            options: [
+            'group_id',
+            Types::STRING,
+            [
                 'notnull' => false,
                 'length'  => 64,
             ]
         );
         $table->addColumn(
-            name: 'role',
-            typeName: Types::STRING,
-            options: [
+            'role',
+            Types::STRING,
+            [
                 'notnull' => true,
                 'length'  => 16,
             ]
         );
         $table->addColumn(
-            name: 'assigned_by',
-            typeName: Types::STRING,
-            options: [
+            'assigned_by',
+            Types::STRING,
+            [
                 'notnull' => true,
                 'length'  => 64,
             ]
         );
         $table->addColumn(
-            name: 'assigned_at',
-            typeName: Types::DATETIME,
-            options: ['notnull' => true]
+            'assigned_at',
+            Types::DATETIME,
+            ['notnull' => true]
         );
 
-        $table->setPrimaryKey(columnNames: ['id']);
+        $table->setPrimaryKey(['id']);
 
         // Lookup indexes for cascade and resolution paths.
         $table->addIndex(
-            columnNames: ['user_id'],
-            indexName: 'mydash_role_user_idx'
+            ['user_id'],
+            'mydash_role_user_idx'
         );
         $table->addIndex(
-            columnNames: ['group_id'],
-            indexName: 'mydash_role_group_idx'
+            ['group_id'],
+            'mydash_role_group_idx'
         );
 
         // Enforce one assignment per (user, role) and per (group, role).
         // Rows are XOR — only one of user_id / group_id is populated —
         // so a single row never participates in both unique indexes.
         $table->addUniqueIndex(
-            columnNames: ['user_id', 'role'],
-            indexName: 'mydash_role_user_uniq'
+            ['user_id', 'role'],
+            'mydash_role_user_uniq'
         );
         $table->addUniqueIndex(
-            columnNames: ['group_id', 'role'],
-            indexName: 'mydash_role_group_uniq'
+            ['group_id', 'role'],
+            'mydash_role_group_uniq'
         );
     }//end create()
 }//end class

--- a/lib/Migration/RulesTableBuilder.php
+++ b/lib/Migration/RulesTableBuilder.php
@@ -36,14 +36,14 @@ class RulesTableBuilder
     public static function create(ISchemaWrapper $schema): void
     {
         if ($schema->hasTable(
-            tableName: 'mydash_conditional_rules'
+            'mydash_conditional_rules'
         ) === true
         ) {
             return;
         }
 
         $table = $schema->createTable(
-            tableName: 'mydash_conditional_rules'
+            'mydash_conditional_rules'
         );
 
         self::addColumns(table: $table);
@@ -60,50 +60,50 @@ class RulesTableBuilder
     private static function addColumns($table): void
     {
         $table->addColumn(
-            name: 'id',
-            typeName: Types::BIGINT,
-            options: [
+            'id',
+            Types::BIGINT,
+            [
                 'autoincrement' => true,
                 'notnull'       => true,
                 'unsigned'      => true,
             ]
         );
         $table->addColumn(
-            name: 'widget_placement_id',
-            typeName: Types::BIGINT,
-            options: [
+            'widget_placement_id',
+            Types::BIGINT,
+            [
                 'notnull'  => true,
                 'unsigned' => true,
             ]
         );
         $table->addColumn(
-            name: 'rule_type',
-            typeName: Types::STRING,
-            options: [
+            'rule_type',
+            Types::STRING,
+            [
                 'notnull' => true,
                 'length'  => 50,
             ]
         );
         $table->addColumn(
-            name: 'rule_config',
-            typeName: Types::TEXT,
-            options: [
+            'rule_config',
+            Types::TEXT,
+            [
                 'notnull' => false,
             ]
         );
         $table->addColumn(
-            name: 'is_include',
-            typeName: Types::SMALLINT,
-            options: [
+            'is_include',
+            Types::SMALLINT,
+            [
                 'notnull'  => true,
                 'default'  => 1,
                 'unsigned' => true,
             ]
         );
         $table->addColumn(
-            name: 'created_at',
-            typeName: Types::DATETIME,
-            options: [
+            'created_at',
+            Types::DATETIME,
+            [
                 'notnull' => true,
             ]
         );
@@ -118,10 +118,10 @@ class RulesTableBuilder
      */
     private static function addIndexes($table): void
     {
-        $table->setPrimaryKey(columnNames: ['id']);
+        $table->setPrimaryKey(['id']);
         $table->addIndex(
-            columnNames: ['widget_placement_id'],
-            indexName: 'mydash_rule_placement'
+            ['widget_placement_id'],
+            'mydash_rule_placement'
         );
     }//end addIndexes()
 }//end class

--- a/lib/Migration/SettingsTableBuilder.php
+++ b/lib/Migration/SettingsTableBuilder.php
@@ -36,14 +36,14 @@ class SettingsTableBuilder
     public static function create(ISchemaWrapper $schema): void
     {
         if ($schema->hasTable(
-            tableName: 'mydash_admin_settings'
+            'mydash_admin_settings'
         ) === true
         ) {
             return;
         }
 
         $table = $schema->createTable(
-            tableName: 'mydash_admin_settings'
+            'mydash_admin_settings'
         );
 
         self::addColumns(table: $table);
@@ -60,33 +60,33 @@ class SettingsTableBuilder
     private static function addColumns($table): void
     {
         $table->addColumn(
-            name: 'id',
-            typeName: Types::BIGINT,
-            options: [
+            'id',
+            Types::BIGINT,
+            [
                 'autoincrement' => true,
                 'notnull'       => true,
                 'unsigned'      => true,
             ]
         );
         $table->addColumn(
-            name: 'setting_key',
-            typeName: Types::STRING,
-            options: [
+            'setting_key',
+            Types::STRING,
+            [
                 'notnull' => true,
                 'length'  => 255,
             ]
         );
         $table->addColumn(
-            name: 'setting_value',
-            typeName: Types::TEXT,
-            options: [
+            'setting_value',
+            Types::TEXT,
+            [
                 'notnull' => false,
             ]
         );
         $table->addColumn(
-            name: 'updated_at',
-            typeName: Types::DATETIME,
-            options: [
+            'updated_at',
+            Types::DATETIME,
+            [
                 'notnull' => true,
             ]
         );
@@ -101,10 +101,10 @@ class SettingsTableBuilder
      */
     private static function addIndexes($table): void
     {
-        $table->setPrimaryKey(columnNames: ['id']);
+        $table->setPrimaryKey(['id']);
         $table->addUniqueIndex(
-            columnNames: ['setting_key'],
-            indexName: 'mydash_setting_key'
+            ['setting_key'],
+            'mydash_setting_key'
         );
     }//end addIndexes()
 }//end class

--- a/lib/Migration/Version001001Date20260203000000.php
+++ b/lib/Migration/Version001001Date20260203000000.php
@@ -44,47 +44,47 @@ class Version001001Date20260203000000 extends SimpleMigrationStep
         $schema = $schemaClosure();
 
         // Create mydash_tiles table.
-        if ($schema->hasTable(tableName: 'mydash_tiles') === false) {
-            $table = $schema->createTable(tableName: 'mydash_tiles');
+        if ($schema->hasTable('mydash_tiles') === false) {
+            $table = $schema->createTable('mydash_tiles');
 
             $table->addColumn(
-                name: 'id',
-                typeName: Types::BIGINT,
-                options: [
+                'id',
+                Types::BIGINT,
+                [
                     'autoincrement' => true,
                     'notnull'       => true,
                     'unsigned'      => true,
                 ]
             );
             $table->addColumn(
-                name: 'user_id',
-                typeName: Types::STRING,
-                options: [
+                'user_id',
+                Types::STRING,
+                [
                     'notnull' => true,
                     'length'  => 64,
                 ]
             );
             $table->addColumn(
-                name: 'title',
-                typeName: Types::STRING,
-                options: [
+                'title',
+                Types::STRING,
+                [
                     'notnull' => true,
                     'length'  => 255,
                 ]
             );
             $table->addColumn(
-                name: 'icon',
-                typeName: Types::STRING,
-                options: [
+                'icon',
+                Types::STRING,
+                [
                     'notnull' => true,
                     'length'  => 2000,
                     'comment' => 'Icon class, URL to icon image, or SVG path data.',
                 ]
             );
             $table->addColumn(
-                name: 'icon_type',
-                typeName: Types::STRING,
-                options: [
+                'icon_type',
+                Types::STRING,
+                [
                     'notnull' => true,
                     'length'  => 20,
                     'default' => 'class',
@@ -92,9 +92,9 @@ class Version001001Date20260203000000 extends SimpleMigrationStep
                 ]
             );
             $table->addColumn(
-                name: 'background_color',
-                typeName: Types::STRING,
-                options: [
+                'background_color',
+                Types::STRING,
+                [
                     'notnull' => true,
                     'length'  => 7,
                     'default' => '#0082c9',
@@ -102,9 +102,9 @@ class Version001001Date20260203000000 extends SimpleMigrationStep
                 ]
             );
             $table->addColumn(
-                name: 'text_color',
-                typeName: Types::STRING,
-                options: [
+                'text_color',
+                Types::STRING,
+                [
                     'notnull' => true,
                     'length'  => 7,
                     'default' => '#ffffff',
@@ -112,42 +112,42 @@ class Version001001Date20260203000000 extends SimpleMigrationStep
                 ]
             );
             $table->addColumn(
-                name: 'link_type',
-                typeName: Types::STRING,
-                options: [
+                'link_type',
+                Types::STRING,
+                [
                     'notnull' => true,
                     'length'  => 20,
                     'comment' => 'Type of link: app or url.',
                 ]
             );
             $table->addColumn(
-                name: 'link_value',
-                typeName: Types::STRING,
-                options: [
+                'link_value',
+                Types::STRING,
+                [
                     'notnull' => true,
                     'length'  => 1000,
                     'comment' => 'App ID or URL.',
                 ]
             );
             $table->addColumn(
-                name: 'created_at',
-                typeName: Types::DATETIME,
-                options: [
+                'created_at',
+                Types::DATETIME,
+                [
                     'notnull' => true,
                 ]
             );
             $table->addColumn(
-                name: 'updated_at',
-                typeName: Types::DATETIME,
-                options: [
+                'updated_at',
+                Types::DATETIME,
+                [
                     'notnull' => true,
                 ]
             );
 
-            $table->setPrimaryKey(columnNames: ['id']);
+            $table->setPrimaryKey(['id']);
             $table->addIndex(
-                columnNames: ['user_id'],
-                indexName: 'mydash_tiles_user'
+                ['user_id'],
+                'mydash_tiles_user'
             );
         }//end if
 

--- a/lib/Migration/Version001002Date20260204000000.php
+++ b/lib/Migration/Version001002Date20260204000000.php
@@ -44,13 +44,13 @@ class Version001002Date20260204000000 extends SimpleMigrationStep
         $schema = $schemaClosure();
 
         // Increase icon column size to support longer SVG paths.
-        if ($schema->hasTable(tableName: 'mydash_tiles') === true) {
-            $table = $schema->getTable(tableName: 'mydash_tiles');
+        if ($schema->hasTable('mydash_tiles') === true) {
+            $table = $schema->getTable('mydash_tiles');
 
-            if ($table->hasColumn(name: 'icon') === true) {
-                $iconColumn = $table->getColumn(name: 'icon');
+            if ($table->hasColumn('icon') === true) {
+                $iconColumn = $table->getColumn('icon');
                 // Increase from 500 to 2000 characters for complex SVG paths.
-                $iconColumn->setLength(length: 2000);
+                $iconColumn->setLength(2000);
             }
         }
 

--- a/lib/Migration/Version001003Date20260204120000.php
+++ b/lib/Migration/Version001003Date20260204120000.php
@@ -45,19 +45,19 @@ class Version001003Date20260204120000 extends SimpleMigrationStep
 
         // Add tile configuration fields to widget_placements table.
         if ($schema->hasTable(
-            tableName: 'mydash_widget_placements'
+            'mydash_widget_placements'
         ) === true
         ) {
             $table = $schema->getTable(
-                tableName: 'mydash_widget_placements'
+                'mydash_widget_placements'
             );
 
             // Add tile_type to distinguish between widgets and tiles.
-            if ($table->hasColumn(name: 'tile_type') === false) {
+            if ($table->hasColumn('tile_type') === false) {
                 $table->addColumn(
-                    name: 'tile_type',
-                    typeName: Types::STRING,
-                    options: [
+                    'tile_type',
+                    Types::STRING,
+                    [
                         'notnull' => false,
                         'length'  => 20,
                         'default' => null,
@@ -67,11 +67,11 @@ class Version001003Date20260204120000 extends SimpleMigrationStep
             }
 
             // Add tile_title for custom tiles.
-            if ($table->hasColumn(name: 'tile_title') === false) {
+            if ($table->hasColumn('tile_title') === false) {
                 $table->addColumn(
-                    name: 'tile_title',
-                    typeName: Types::STRING,
-                    options: [
+                    'tile_title',
+                    Types::STRING,
+                    [
                         'notnull' => false,
                         'length'  => 255,
                         'default' => null,
@@ -81,11 +81,11 @@ class Version001003Date20260204120000 extends SimpleMigrationStep
             }
 
             // Add tile_icon.
-            if ($table->hasColumn(name: 'tile_icon') === false) {
+            if ($table->hasColumn('tile_icon') === false) {
                 $table->addColumn(
-                    name: 'tile_icon',
-                    typeName: Types::STRING,
-                    options: [
+                    'tile_icon',
+                    Types::STRING,
+                    [
                         'notnull' => false,
                         'length'  => 2000,
                         'default' => null,
@@ -95,11 +95,11 @@ class Version001003Date20260204120000 extends SimpleMigrationStep
             }
 
             // Add tile_icon_type.
-            if ($table->hasColumn(name: 'tile_icon_type') === false) {
+            if ($table->hasColumn('tile_icon_type') === false) {
                 $table->addColumn(
-                    name: 'tile_icon_type',
-                    typeName: Types::STRING,
-                    options: [
+                    'tile_icon_type',
+                    Types::STRING,
+                    [
                         'notnull' => false,
                         'length'  => 20,
                         'default' => null,
@@ -110,13 +110,13 @@ class Version001003Date20260204120000 extends SimpleMigrationStep
 
             // Add tile_background_color.
             if ($table->hasColumn(
-                name: 'tile_background_color'
+                'tile_background_color'
             ) === false
             ) {
                 $table->addColumn(
-                    name: 'tile_background_color',
-                    typeName: Types::STRING,
-                    options: [
+                    'tile_background_color',
+                    Types::STRING,
+                    [
                         'notnull' => false,
                         'length'  => 7,
                         'default' => null,
@@ -126,11 +126,11 @@ class Version001003Date20260204120000 extends SimpleMigrationStep
             }
 
             // Add tile_text_color.
-            if ($table->hasColumn(name: 'tile_text_color') === false) {
+            if ($table->hasColumn('tile_text_color') === false) {
                 $table->addColumn(
-                    name: 'tile_text_color',
-                    typeName: Types::STRING,
-                    options: [
+                    'tile_text_color',
+                    Types::STRING,
+                    [
                         'notnull' => false,
                         'length'  => 7,
                         'default' => null,
@@ -140,11 +140,11 @@ class Version001003Date20260204120000 extends SimpleMigrationStep
             }
 
             // Add tile_link_type.
-            if ($table->hasColumn(name: 'tile_link_type') === false) {
+            if ($table->hasColumn('tile_link_type') === false) {
                 $table->addColumn(
-                    name: 'tile_link_type',
-                    typeName: Types::STRING,
-                    options: [
+                    'tile_link_type',
+                    Types::STRING,
+                    [
                         'notnull' => false,
                         'length'  => 20,
                         'default' => null,
@@ -154,11 +154,11 @@ class Version001003Date20260204120000 extends SimpleMigrationStep
             }
 
             // Add tile_link_value.
-            if ($table->hasColumn(name: 'tile_link_value') === false) {
+            if ($table->hasColumn('tile_link_value') === false) {
                 $table->addColumn(
-                    name: 'tile_link_value',
-                    typeName: Types::STRING,
-                    options: [
+                    'tile_link_value',
+                    Types::STRING,
+                    [
                         'notnull' => false,
                         'length'  => 1000,
                         'default' => null,

--- a/lib/Migration/Version001004Date20260204150000.php
+++ b/lib/Migration/Version001004Date20260204150000.php
@@ -44,14 +44,14 @@ class Version001004Date20260204150000 extends SimpleMigrationStep
         $schema = $schemaClosure();
 
         $table = $schema->getTable(
-            tableName: 'mydash_widget_placements'
+            'mydash_widget_placements'
         );
 
-        if ($table->hasColumn(name: 'custom_icon') === false) {
+        if ($table->hasColumn('custom_icon') === false) {
             $table->addColumn(
-                name: 'custom_icon',
-                typeName: Types::TEXT,
-                options: [
+                'custom_icon',
+                Types::TEXT,
+                [
                     'notnull' => false,
                     'length'  => 2000,
                 ]

--- a/lib/Migration/Version001005Date20260430000000.php
+++ b/lib/Migration/Version001005Date20260430000000.php
@@ -51,27 +51,27 @@ class Version001005Date20260430000000 extends SimpleMigrationStep
     ): ?ISchemaWrapper {
         $schema = $schemaClosure();
 
-        if ($schema->hasTable(tableName: 'mydash_dashboards') === false) {
+        if ($schema->hasTable('mydash_dashboards') === false) {
             return $schema;
         }
 
-        $table = $schema->getTable(tableName: 'mydash_dashboards');
+        $table = $schema->getTable('mydash_dashboards');
 
-        if ($table->hasColumn(name: 'group_id') === false) {
+        if ($table->hasColumn('group_id') === false) {
             $table->addColumn(
-                name: 'group_id',
-                typeName: Types::STRING,
-                options: [
+                'group_id',
+                Types::STRING,
+                [
                     'notnull' => false,
                     'length'  => 64,
                 ]
             );
         }
 
-        if ($table->hasIndex(indexName: 'mydash_dash_type_group') === false) {
+        if ($table->hasIndex('mydash_dash_type_group') === false) {
             $table->addIndex(
-                columnNames: ['type', 'group_id'],
-                indexName: 'mydash_dash_type_group'
+                ['type', 'group_id'],
+                'mydash_dash_type_group'
             );
         }
 

--- a/lib/Migration/Version001006Date20260430130000.php
+++ b/lib/Migration/Version001006Date20260430130000.php
@@ -72,83 +72,83 @@ class Version001006Date20260430130000 extends SimpleMigrationStep
     ): ?ISchemaWrapper {
         $schema = $schemaClosure();
 
-        if ($schema->hasTable(tableName: 'mydash_dashboard_shares') === true) {
+        if ($schema->hasTable('mydash_dashboard_shares') === true) {
             return null;
         }
 
-        $table = $schema->createTable(tableName: 'mydash_dashboard_shares');
+        $table = $schema->createTable('mydash_dashboard_shares');
 
         $table->addColumn(
-            name: 'id',
-            typeName: Types::BIGINT,
-            options: [
+            'id',
+            Types::BIGINT,
+            [
                 'autoincrement' => true,
                 'notnull'       => true,
                 'unsigned'      => true,
             ]
         );
         $table->addColumn(
-            name: 'dashboard_id',
-            typeName: Types::BIGINT,
-            options: [
+            'dashboard_id',
+            Types::BIGINT,
+            [
                 'notnull'  => true,
                 'unsigned' => true,
             ]
         );
         $table->addColumn(
-            name: 'share_type',
-            typeName: Types::STRING,
-            options: [
+            'share_type',
+            Types::STRING,
+            [
                 'notnull' => true,
                 'length'  => 16,
             ]
         );
         $table->addColumn(
-            name: 'share_with',
-            typeName: Types::STRING,
-            options: [
+            'share_with',
+            Types::STRING,
+            [
                 'notnull' => true,
                 'length'  => 255,
             ]
         );
         $table->addColumn(
-            name: 'permission_level',
-            typeName: Types::STRING,
-            options: [
+            'permission_level',
+            Types::STRING,
+            [
                 'notnull' => true,
                 'length'  => 32,
                 'default' => 'view_only',
             ]
         );
         $table->addColumn(
-            name: 'created_at',
-            typeName: Types::STRING,
-            options: [
+            'created_at',
+            Types::STRING,
+            [
                 'notnull' => false,
                 'length'  => 32,
             ]
         );
         $table->addColumn(
-            name: 'updated_at',
-            typeName: Types::STRING,
-            options: [
+            'updated_at',
+            Types::STRING,
+            [
                 'notnull' => false,
                 'length'  => 32,
             ]
         );
 
-        $table->setPrimaryKey(columnNames: ['id']);
+        $table->setPrimaryKey(['id']);
         $table->addIndex(
-            columnNames: ['dashboard_id'],
-            indexName: 'mydash_shares_dashboard'
+            ['dashboard_id'],
+            'mydash_shares_dashboard'
         );
         $table->addIndex(
-            columnNames: ['share_type', 'share_with'],
-            indexName: 'mydash_shares_recipient'
+            ['share_type', 'share_with'],
+            'mydash_shares_recipient'
         );
         $table->addUniqueIndex(
-            columnNames: ['dashboard_id', 'share_type', 'share_with'],
-            indexName: 'mydash_shares_unique'
+            ['dashboard_id', 'share_type', 'share_with'],
+            'mydash_shares_unique'
         );
 
         return $schema;

--- a/lib/Migration/Version001006Date20260502000000.php
+++ b/lib/Migration/Version001006Date20260502000000.php
@@ -52,16 +52,16 @@ class Version001006Date20260502000000 extends SimpleMigrationStep
     ): ?ISchemaWrapper {
         $schema = $schemaClosure();
 
-        if ($schema->hasTable(tableName: 'mydash_dashboards') === false) {
+        if ($schema->hasTable('mydash_dashboards') === false) {
             return null;
         }
 
-        $table = $schema->getTable(tableName: 'mydash_dashboards');
-        if ($table->hasColumn(name: 'icon') === false) {
+        $table = $schema->getTable('mydash_dashboards');
+        if ($table->hasColumn('icon') === false) {
             $table->addColumn(
-                name: 'icon',
-                typeName: Types::STRING,
-                options: [
+                'icon',
+                Types::STRING,
+                [
                     'notnull' => false,
                     'length'  => 2000,
                     'comment' => 'Dashboard icon: registry key (dashboard-icons) or upload URL; NULL = default.',

--- a/lib/Migration/Version001008Date20260502000000.php
+++ b/lib/Migration/Version001008Date20260502000000.php
@@ -56,27 +56,27 @@ class Version001008Date20260502000000 extends SimpleMigrationStep
     ): ?ISchemaWrapper {
         $schema = $schemaClosure();
 
-        if ($schema->hasTable(tableName: 'mydash_dashboards') === false) {
+        if ($schema->hasTable('mydash_dashboards') === false) {
             return $schema;
         }
 
-        $table = $schema->getTable(tableName: 'mydash_dashboards');
+        $table = $schema->getTable('mydash_dashboards');
 
-        if ($table->hasColumn(name: 'group_id') === false) {
+        if ($table->hasColumn('group_id') === false) {
             $table->addColumn(
-                name: 'group_id',
-                typeName: Types::STRING,
-                options: [
+                'group_id',
+                Types::STRING,
+                [
                     'notnull' => false,
                     'length'  => 64,
                 ]
             );
         }
 
-        if ($table->hasIndex(name: 'mydash_dash_type_group') === false) {
+        if ($table->hasIndex('mydash_dash_type_group') === false) {
             $table->addIndex(
-                columnNames: ['type', 'group_id'],
-                indexName: 'mydash_dash_type_group'
+                ['type', 'group_id'],
+                'mydash_dash_type_group'
             );
         }
 

--- a/lib/Migration/Version001010Date20260502120000.php
+++ b/lib/Migration/Version001010Date20260502120000.php
@@ -59,11 +59,11 @@ class Version001010Date20260502120000 extends SimpleMigrationStep
     ): ?ISchemaWrapper {
         $schema = $schemaClosure();
 
-        if ($schema->hasTable(tableName: 'mydash_dashboards') === false) {
+        if ($schema->hasTable('mydash_dashboards') === false) {
             return $schema;
         }
 
-        $table = $schema->getTable(tableName: 'mydash_dashboards');
+        $table = $schema->getTable('mydash_dashboards');
 
         DashboardTableBuilder::addTreeColumns(table: $table);
 

--- a/lib/Migration/Version001011Date20260502130000.php
+++ b/lib/Migration/Version001011Date20260502130000.php
@@ -61,11 +61,11 @@ class Version001011Date20260502130000 extends SimpleMigrationStep
     ): ?ISchemaWrapper {
         $schema = $schemaClosure();
 
-        if ($schema->hasTable(tableName: 'mydash_dashboards') === false) {
+        if ($schema->hasTable('mydash_dashboards') === false) {
             return $schema;
         }
 
-        $table = $schema->getTable(tableName: 'mydash_dashboards');
+        $table = $schema->getTable('mydash_dashboards');
 
         DashboardTableBuilder::addPublicationColumns(table: $table);
 

--- a/lib/Migration/Version001012Date20260503000000.php
+++ b/lib/Migration/Version001012Date20260503000000.php
@@ -59,11 +59,11 @@ class Version001012Date20260503000000 extends SimpleMigrationStep
     ): ?ISchemaWrapper {
         $schema = $schemaClosure();
 
-        if ($schema->hasTable(tableName: 'mydash_dashboards') === false) {
+        if ($schema->hasTable('mydash_dashboards') === false) {
             return $schema;
         }
 
-        $table = $schema->getTable(tableName: 'mydash_dashboards');
+        $table = $schema->getTable('mydash_dashboards');
 
         DashboardTableBuilder::addTemplateDiscoveryColumns(table: $table);
 

--- a/lib/Migration/Version001013Date20260502120000.php
+++ b/lib/Migration/Version001013Date20260502120000.php
@@ -54,17 +54,17 @@ class Version001013Date20260502120000 extends SimpleMigrationStep
     ): ?ISchemaWrapper {
         $schema = $schemaClosure();
 
-        if ($schema->hasTable(tableName: 'mydash_dashboards') === false) {
+        if ($schema->hasTable('mydash_dashboards') === false) {
             return $schema;
         }
 
-        $table = $schema->getTable(tableName: 'mydash_dashboards');
+        $table = $schema->getTable('mydash_dashboards');
 
-        if ($table->hasColumn(name: 'comments_enabled') === false) {
+        if ($table->hasColumn('comments_enabled') === false) {
             $table->addColumn(
-                name: 'comments_enabled',
-                typeName: Types::SMALLINT,
-                options: [
+                'comments_enabled',
+                Types::SMALLINT,
+                [
                     'notnull'  => false,
                     'default'  => null,
                     'unsigned' => true,

--- a/lib/Migration/Version001014Date20260502120000.php
+++ b/lib/Migration/Version001014Date20260502120000.php
@@ -57,75 +57,75 @@ class Version001014Date20260502120000 extends SimpleMigrationStep
         $schema = $schemaClosure();
 
         // 1. Create `mydash_dashboard_reactions` table.
-        if ($schema->hasTable(tableName: 'mydash_dashboard_reactions') === false) {
-            $table = $schema->createTable(tableName: 'mydash_dashboard_reactions');
+        if ($schema->hasTable('mydash_dashboard_reactions') === false) {
+            $table = $schema->createTable('mydash_dashboard_reactions');
 
             $table->addColumn(
-                name: 'id',
-                typeName: Types::BIGINT,
-                options: [
+                'id',
+                Types::BIGINT,
+                [
                     'autoincrement' => true,
                     'notnull'       => true,
                     'unsigned'      => true,
                 ]
             );
             $table->addColumn(
-                name: 'dashboard_uuid',
-                typeName: Types::STRING,
-                options: [
+                'dashboard_uuid',
+                Types::STRING,
+                [
                     'notnull' => true,
                     'length'  => 36,
                 ]
             );
             $table->addColumn(
-                name: 'user_id',
-                typeName: Types::STRING,
-                options: [
+                'user_id',
+                Types::STRING,
+                [
                     'notnull' => true,
                     'length'  => 64,
                 ]
             );
             $table->addColumn(
-                name: 'emoji',
-                typeName: Types::STRING,
-                options: [
+                'emoji',
+                Types::STRING,
+                [
                     'notnull' => true,
                     'length'  => 32,
                 ]
             );
             $table->addColumn(
-                name: 'reacted_at',
-                typeName: Types::DATETIME,
-                options: ['notnull' => true]
+                'reacted_at',
+                Types::DATETIME,
+                ['notnull' => true]
             );
 
-            $table->setPrimaryKey(columnNames: ['id']);
+            $table->setPrimaryKey(['id']);
 
             // Composite uniqueness — REQ-RXN-001 idempotency guarantee.
             $table->addUniqueIndex(
-                columnNames: ['dashboard_uuid', 'user_id', 'emoji'],
-                indexName: 'mydash_react_uuid_user_emoji'
+                ['dashboard_uuid', 'user_id', 'emoji'],
+                'mydash_react_uuid_user_emoji'
             );
 
             // Aggregation lookups — REQ-RXN-003 / REQ-RXN-004.
             $table->addIndex(
-                columnNames: ['dashboard_uuid'],
-                indexName: 'mydash_react_uuid'
+                ['dashboard_uuid'],
+                'mydash_react_uuid'
             );
             $table->addIndex(
-                columnNames: ['emoji'],
-                indexName: 'mydash_react_emoji'
+                ['emoji'],
+                'mydash_react_emoji'
             );
         }//end if
 
         // 2. Per-dashboard toggle column on the existing dashboards table.
-        if ($schema->hasTable(tableName: 'mydash_dashboards') === true) {
-            $dashTable = $schema->getTable(tableName: 'mydash_dashboards');
-            if ($dashTable->hasColumn(name: 'reactions_enabled') === false) {
+        if ($schema->hasTable('mydash_dashboards') === true) {
+            $dashTable = $schema->getTable('mydash_dashboards');
+            if ($dashTable->hasColumn('reactions_enabled') === false) {
                 $dashTable->addColumn(
-                    name: 'reactions_enabled',
-                    typeName: Types::SMALLINT,
-                    options: ['notnull' => false]
+                    'reactions_enabled',
+                    Types::SMALLINT,
+                    ['notnull' => false]
                 );
             }
         }

--- a/lib/Migration/Version001017Date20260502130000.php
+++ b/lib/Migration/Version001017Date20260502130000.php
@@ -3,7 +3,7 @@
 /**
  * Version001017Date20260502130000
  *
- * Migration that adds the `oc_mydash_dashboard_translations` table
+ * Migration that adds the `oc_mydash_dash_translations` table
  * holding per-language content variants (widget tree, name, description)
  * for dashboards. REQ-DASH-038..044 (dashboard-language-content).
  *

--- a/lib/Migration/Version001024Date20260503130000.php
+++ b/lib/Migration/Version001024Date20260503130000.php
@@ -58,11 +58,11 @@ class Version001024Date20260503130000 extends SimpleMigrationStep
     ): ?ISchemaWrapper {
         $schema = $schemaClosure();
 
-        if ($schema->hasTable(tableName: 'mydash_dashboards') === false) {
+        if ($schema->hasTable('mydash_dashboards') === false) {
             return $schema;
         }
 
-        $table = $schema->getTable(tableName: 'mydash_dashboards');
+        $table = $schema->getTable('mydash_dashboards');
 
         DashboardTableBuilder::addFooterColumns(table: $table);
 

--- a/openspec/specs/dashboard-language-content/spec.md
+++ b/openspec/specs/dashboard-language-content/spec.md
@@ -10,7 +10,7 @@ Per-language content variants for MyDash dashboards. A single dashboard can carr
 
 ## Data Model
 
-Per-language variants are stored in a dedicated `oc_mydash_dashboard_translations` table that is independent from the parent `oc_mydash_dashboards` row. This keeps existing dashboards working unchanged and isolates the translation lifecycle from the dashboard lifecycle.
+Per-language variants are stored in a dedicated `oc_mydash_dash_translations` table that is independent from the parent `oc_mydash_dashboards` row. This keeps existing dashboards working unchanged and isolates the translation lifecycle from the dashboard lifecycle.
 
 Columns:
 - **id**: BIGINT auto-increment primary key
@@ -35,12 +35,12 @@ Indexes:
 
 ### Requirement: REQ-DASH-038 Translation Schema
 
-The system MUST store per-language content variants for a dashboard in a dedicated `oc_mydash_dashboard_translations` table. Each variant holds a localised widget tree, name, and description, with exactly one row per (dashboard, language) pair.
+The system MUST store per-language content variants for a dashboard in a dedicated `oc_mydash_dash_translations` table. Each variant holds a localised widget tree, name, and description, with exactly one row per (dashboard, language) pair.
 
 #### Scenario: Translation table structure
 
 - GIVEN the schema migration is applied
-- THEN the `oc_mydash_dashboard_translations` table MUST exist with columns: `id` (auto-increment primary key), `dashboardUuid VARCHAR(36)`, `languageCode VARCHAR(16)`, `name VARCHAR(255)`, `description LONGTEXT`, `widgetTreeJson MEDIUMTEXT`, `isPrimary SMALLINT(0/1)`, `createdAt DATETIME`, `updatedAt DATETIME`
+- THEN the `oc_mydash_dash_translations` table MUST exist with columns: `id` (auto-increment primary key), `dashboardUuid VARCHAR(36)`, `languageCode VARCHAR(16)`, `name VARCHAR(255)`, `description LONGTEXT`, `widgetTreeJson MEDIUMTEXT`, `isPrimary SMALLINT(0/1)`, `createdAt DATETIME`, `updatedAt DATETIME`
 - AND a composite unique constraint MUST exist on `(dashboardUuid, languageCode)` to prevent duplicate language variants per dashboard
 
 #### Scenario: Primary variant enforcement
@@ -309,7 +309,7 @@ Existing dashboards without translation rows MUST continue to function as before
 
 - GIVEN the migration has been applied and translation data exists
 - WHEN the migration is rolled back via `postSchemaChange()` in reverse
-- THEN the `oc_mydash_dashboard_translations` table MUST be dropped
+- THEN the `oc_mydash_dash_translations` table MUST be dropped
 - AND existing dashboard records MUST remain unaffected (the widget tree is still in `oc_mydash_dashboards`)
 
 ## Non-Functional Requirements
@@ -321,7 +321,7 @@ Existing dashboards without translation rows MUST continue to function as before
 
 ## Implementation Notes
 
-- REQ-DASH-038 (Translation schema): `lib/Migration/Version001017Date20260502130000.php` + `lib/Migration/DashboardTranslationTableBuilder.php` add the `mydash_dashboard_translations` table with the unique `(dashboard_uuid, language_code)` index. Entity at `lib/Db/DashboardTranslation.php`; mapper at `lib/Db/DashboardTranslationMapper.php`.
+- REQ-DASH-038 (Translation schema): `lib/Migration/Version001017Date20260502130000.php` + `lib/Migration/DashboardTranslationTableBuilder.php` add the `mydash_dash_translations` table with the unique `(dashboard_uuid, language_code)` index. Entity at `lib/Db/DashboardTranslation.php`; mapper at `lib/Db/DashboardTranslationMapper.php`.
 - REQ-DASH-039 (Locale resolution): `DashboardTranslationMapper::normaliseLanguageCode()` collapses any locale string to its 2-character base code; `DashboardTranslationService::resolveForLocale()` returns `{translation, isFallback}` or `null`. Strict `?lang=` semantics live in `DashboardTranslationApiController::resolved()`.
 - REQ-DASH-040..043 (CRUD + promote): `DashboardTranslationService::createVariant()`, `updateVariant()`, `deleteVariant()`, `promoteVariantToPrimary()` — last/primary delete guards raise distinguishable sentinel exceptions mapped to HTTP 400 by the controller.
 - REQ-DASH-044 (Backwards compatibility + cascade): `DashboardService::createDashboard()` calls `DashboardTranslationService::seedPrimaryFor()` after insert; `DashboardService::deleteDashboard()` cascades via `DashboardTranslationService::deleteAllForDashboard()` for both single-row and subtree delete paths. Legacy dashboards without translation rows are materialised in-memory by `DashboardTranslationService::materialiseLegacyVariant()`.

--- a/openspec/specs/orphaned-data-cleanup/spec.md
+++ b/openspec/specs/orphaned-data-cleanup/spec.md
@@ -20,7 +20,7 @@ Orphaned data exists in multiple tables and file locations. This spec defines wh
 - **orphaned_conditional_rules**: rows in `oc_mydash_conditional_rules` whose `widget_placement_id` does NOT exist in `oc_mydash_widget_placements`.
 - **orphaned_feed_tokens**: rows in `oc_mydash_feed_tokens` where `userId` no longer exists in `oc_users`. Optional; available only on installs with the dashboard-rss-feeds feature.
 - **orphaned_role_assignments**: rows in `oc_mydash_role_assignments` where `userId` (or `groupId`) no longer exists in `oc_users` (or `oc_groups`). Optional; available only on installs with the admin-roles feature.
-- **dangling_dashboard_translations**: rows in `oc_mydash_dashboard_translations` where `dashboardUuid` no longer exists in `oc_mydash_dashboards`. Optional; available only on installs with the dashboard-language-content feature.
+- **dangling_dashboard_translations**: rows in `oc_mydash_dash_translations` where `dashboardUuid` no longer exists in `oc_mydash_dashboards`. Optional; available only on installs with the dashboard-language-content feature.
 
 Categories that map to optional features MUST report `isAvailable() === false` on installs where the feature is not present, so the orchestrator can skip them cleanly (REQ-CLN-001 "Scan handles missing tables gracefully") without erroring on a missing-table SQL fault. The shipped four categories (expired_locks, expired_share_tokens, orphaned_widget_placements, orphaned_conditional_rules) are always available because their tables are part of the core schema.
 


### PR DESCRIPTION
## Summary

Critical fix for two pre-existing latent bugs in wave1/2 migrations that block `occ upgrade` against any real database. Both went undetected because the agent test envs had `Doctrine\\DBAL\\ParameterType not found` errors masking real migration execution.

### Bug 1: ~93 named-arg sites on Doctrine schema methods

PHP 8 rejects named args whose names don't match the receiving function's parameter signature. Agent-authored wave1+2 migrations used semantic names like `indexName:`, `tableName:`, `columnNames:` that Doctrine doesn't declare (its signatures use `$name`, `$columns`). Concrete first failure: `Error: Unknown named parameter $indexName in Version001005Date20260430000000.php:71`.

Converted ~120 sites (some multi-line) across 28 migration files in `lib/Migration/` to positional args. Patterns: `hasTable/createTable/getTable`, `hasColumn/getColumn`, `addColumn`, `setPrimaryKey`, `addIndex/addUniqueIndex`, `hasIndex`, `setLength`.

### Bug 2: `oc_mydash_dashboard_translations` table name too long

32 chars — over Oracle's 30-char identifier limit Nextcloud enforces for cross-DB compatibility. Renamed to `oc_mydash_dash_translations` (27 chars) across 6 files (migration + table builder + entity + mapper + listener TODO + 2 active openspec docs). The affected migration (`Version001017`) had not yet been applied successfully before this fix, so no data migration is required.

## Quality gates

- `composer check:strict`: ALL PASSED (PHPCS, PHPMD, Psalm, PHPStan, lint:initial-state, lint:spec-annotations, test:all)
- `npm test`: 847 vitest passing
- `npm run build`: clean
- PHPUnit: 1047 tests, 2660 assertions

## Notable remainder

`FeedTokenServiceTest` has 1 named-arg case on an Entity `setId(value: …)` (same family of bug, out of scope here). PHPUnit warning, not a failure.

## Test plan

- [x] composer check:strict
- [x] npm test
- [x] npm run build
- [ ] CI green
- [ ] occ upgrade succeeds against the docker dev env (manual)