### PR TITLE
fix(ux): hide title strip when sidebar closed, restore Conduction logo, drop Default pill

### DIFF
--- a/src/components/Workspace/SidebarFooter.vue
+++ b/src/components/Workspace/SidebarFooter.vue
@@ -160,7 +160,10 @@ export default {
 .dashboard-switcher-sidebar-footer__brand-logos {
 	display: flex;
 	align-items: center;
-	gap: 16px;
+	justify-content: center;
+	flex-wrap: wrap;
+	gap: 8px 16px;
+	width: 100%;
 }
 
 .dashboard-switcher-sidebar-footer__brand-link {
@@ -181,6 +184,8 @@ export default {
 .dashboard-switcher-sidebar-footer__brand-image {
 	height: 18px;
 	width: auto;
+	max-width: 100px;
+	object-fit: contain;
 	display: block;
 }
 

--- a/src/views/Views.vue
+++ b/src/views/Views.vue
@@ -23,7 +23,7 @@
 		<!-- Floating controls in top right -->
 		<div class="mydash-floating-controls">
 			<NcButton
-				type="tertiary"
+				type="secondary"
 				:aria-label="t('mydash', 'Dashboards')"
 				class="mydash-sidebar-toggle"
 				@click="sidebarOpen = !sidebarOpen">
@@ -31,14 +31,14 @@
 					<MenuIcon :size="20" />
 				</template>
 			</NcButton>
-			<!-- Primary-group label (REQ-TMPL-012). Surfaces the resolved
-			     primary group's display name so the user can see which
-			     group's dashboards they are currently viewing. The label
-			     is hidden when the resolver returned the `default`
-			     sentinel AND no friendly name was pushed (avoids a noisy
-			     "Default" badge for one-group installations). -->
+			<!-- Primary-group label (REQ-TMPL-012) is suppressed for the
+			     `default` sentinel — REQ-TMPL-012 documents the literal
+			     'Default' as the absence of a configured primary group, so
+			     surfacing it adds noise without information. The label
+			     remains visible whenever a real Nextcloud group display
+			     name is resolved. -->
 			<div
-				v-if="primaryGroupLabel"
+				v-if="primaryGroupLabel && primaryGroupLabel !== 'Default'"
 				class="mydash-primary-group-label"
 				:title="t('mydash', 'Your primary group for shared dashboards')">
 				{{ primaryGroupLabel }}

--- a/src/views/WorkspaceApp.vue
+++ b/src/views/WorkspaceApp.vue
@@ -42,7 +42,11 @@
 		     persistence path (REQ-GRID-005), and the action menu
 		     (gear) reachable inside Views.vue covers Add Custom
 		     Widget. -->
-		<div class="workspace-shell__strip">
+		<!-- Title strip is only visible when the sidebar is OPEN.
+		     When closed, the floating sidebar-toggle in mydash-floating-controls
+		     (top-right) is the only entry point — keeps the dashboard surface
+		     uncluttered. -->
+		<div v-if="sidebarOpen" class="workspace-shell__strip">
 			<NcButton
 				type="tertiary"
 				:aria-label="t('mydash', 'Open menu')"

--- a/src/views/__tests__/WorkspaceApp.spec.js
+++ b/src/views/__tests__/WorkspaceApp.spec.js
@@ -123,31 +123,43 @@ describe('WorkspaceApp', () => {
 		expect(wrapper.vm.saving).toBeUndefined()
 	})
 
-	it('REQ-SHELL-004: hamburger toggles sidebar state', async () => {
+	it('REQ-SHELL-004: title strip is hidden when sidebar is closed', () => {
 		const wrapper = mountShell({ inject: { activeDashboardId: 'd1' } })
+		// Default state: sidebar closed → strip should NOT render.
 		expect(wrapper.vm.sidebarOpen).toBe(false)
-		await wrapper.find('.workspace-shell__hamburger').trigger('click')
-		expect(wrapper.vm.sidebarOpen).toBe(true)
-		await wrapper.find('.workspace-shell__hamburger').trigger('click')
-		expect(wrapper.vm.sidebarOpen).toBe(false)
+		expect(wrapper.find('.workspace-shell__strip').exists()).toBe(false)
+		expect(wrapper.find('.workspace-shell__hamburger').exists()).toBe(false)
+		expect(wrapper.find('.workspace-shell__title').exists()).toBe(false)
 	})
 
-	it('REQ-SHELL-004: hamburger renders as NcButton type="tertiary"', () => {
+	it('REQ-SHELL-004: title strip with hamburger appears when sidebar is open', async () => {
 		const wrapper = mountShell({ inject: { activeDashboardId: 'd1' } })
+		// Open the sidebar via the exposed setter on the component.
+		wrapper.vm.sidebarOpen = true
+		await wrapper.vm.$nextTick()
+		const strip = wrapper.find('.workspace-shell__strip')
+		expect(strip.exists()).toBe(true)
 		const hamburger = wrapper.find('.workspace-shell__hamburger')
 		expect(hamburger.exists()).toBe(true)
-		// The stubbed NcButton mirrors the `type` prop onto a data
-		// attribute so we can assert on the variant the shell selected.
+		// Stubbed NcButton mirrors the `type` prop onto a data attribute
+		// so we can assert on the variant the shell selected.
 		expect(hamburger.attributes('data-nc-button-type')).toBe('tertiary')
+		// Clicking the in-strip hamburger closes the sidebar (it's the only
+		// affordance available while the strip is mounted).
+		await hamburger.trigger('click')
+		expect(wrapper.vm.sidebarOpen).toBe(false)
 	})
 
-	it('REQ-SHELL-004: title strip shows dashboard name as a heading, NOT as a select', () => {
+	it('REQ-SHELL-004: title strip shows dashboard name as a heading, NOT as a select', async () => {
 		const wrapper = mountShell({
 			inject: {
 				activeDashboardId: 'd1',
 				userDashboards: [{ id: 'd1', name: 'Marketing Overview' }],
 			},
 		})
+		// Title only renders when the sidebar is open.
+		wrapper.vm.sidebarOpen = true
+		await wrapper.vm.$nextTick()
 		const title = wrapper.find('.workspace-shell__title')
 		expect(title.exists()).toBe(true)
 		expect(title.element.tagName).toBe('H1')


### PR DESCRIPTION
## Summary

Four UX fixes spotted in screenshot review of the live dev environment:

1. **Title strip hidden when sidebar closed** — `WorkspaceApp.vue` wraps `.workspace-shell__strip` (header + hamburger) in `v-if="sidebarOpen"`. The floating sidebar-toggle in `mydash-floating-controls` is the sole entry point with the sidebar closed, keeping the dashboard surface uncluttered.
2. **Floating hamburger matches the cog button** — `Views.vue` changes the dashboards-toggle to `type="secondary"` so it visually matches the settings action menu sitting next to it (was `tertiary` / no background, looked detached).
3. **Default group pill suppressed** — `Views.vue` hides the primary-group pill when the resolved label is the sentinel `"Default"`. Real group names still render.
4. **Powered-by logo row centered + Conduction logo visible** — `SidebarFooter.vue` adds `justify-content: center; flex-wrap: wrap` and caps brand-image `max-width: 100px` so both Sendent and Conduction render side-by-side instead of one being squeezed off-screen.

## Test plan
- [x] `npm test` — 11/11 WorkspaceApp tests pass; 1 pre-existing widgetRegistry timeout (REQ-LBL-007) is unrelated and predates this branch
- [x] `npm run build` — webpack 5.104.1 compiled with 7 warnings, 0 errors
- [ ] Manual: open `/apps/mydash/` with sidebar **closed** → no header/hamburger above the dashboard
- [ ] Manual: open sidebar → header strip + hamburger appear, hamburger closes the sidebar
- [ ] Manual: floating sidebar-toggle (top-right) shares the same secondary-button look as the cog
- [ ] Manual: "Default" pill no longer renders for users without a real primary group
- [ ] Manual: footer shows both Sendent and Conduction logos centered under "Powered by"