### PR TITLE
fix(ux): hide title strip when sidebar closed, restore Conduction logo, drop Default pill

### DIFF
--- a/src/components/Dashboard/DashboardMetadataPanel.vue
+++ b/src/components/Dashboard/DashboardMetadataPanel.vue
@@ -54,7 +54,9 @@
 					:id="`mdfl-${field.id}`"
 					v-model="localValues[field.key]"
 					class="dashboard-metadata-panel__input">
-					<option value="">{{ t('mydash', '— Choose —') }}</option>
+					<option value="">
+						{{ t('mydash', '— Choose —') }}
+					</option>
 					<option
 						v-for="option in (field.options || [])"
 						:key="option"
@@ -68,9 +70,15 @@
 					:id="`mdfl-${field.id}`"
 					v-model="localValues[field.key]"
 					class="dashboard-metadata-panel__input">
-					<option value="">{{ t('mydash', '— Choose —') }}</option>
-					<option value="1">{{ t('mydash', 'Yes') }}</option>
-					<option value="0">{{ t('mydash', 'No') }}</option>
+					<option value="">
+						{{ t('mydash', '— Choose —') }}
+					</option>
+					<option value="1">
+						{{ t('mydash', 'Yes') }}
+					</option>
+					<option value="0">
+						{{ t('mydash', 'No') }}
+					</option>
 				</select>
 
 				<input

--- a/src/components/DashboardFooter.vue
+++ b/src/components/DashboardFooter.vue
@@ -208,6 +208,7 @@ export default {
 		 * empty string. The parent layer is responsible for inserting the
 		 * dashboard primary-language fallback before this component sees
 		 * the map.
+		 * @param map
 		 */
 		pickVariant(map) {
 			if (!map || typeof map !== 'object') {

--- a/src/components/Widgets/Forms/__tests__/ContainerForm.spec.js
+++ b/src/components/Widgets/Forms/__tests__/ContainerForm.spec.js
@@ -10,6 +10,8 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { mount } from '@vue/test-utils'
 
+import ContainerForm from '../ContainerForm.vue'
+
 vi.mock('@conduction/nextcloud-vue', () => ({
 	NcTextField: {
 		name: 'NcTextField',
@@ -22,8 +24,6 @@ vi.mock('@conduction/nextcloud-vue', () => ({
 		template: '<select :value="value" :data-input-label="inputLabel" @change="$emit(\'input\', $event.target.value)"><option v-for="opt in options" :key="opt.value || opt" :value="opt.value || opt">{{ opt.label || opt }}</option></select>',
 	},
 }))
-
-import ContainerForm from '../ContainerForm.vue'
 
 beforeEach(() => {
 	globalThis.t = (_app, key) => key

--- a/src/components/Widgets/Renderers/ContainerWidget.vue
+++ b/src/components/Widgets/Renderers/ContainerWidget.vue
@@ -5,7 +5,9 @@
 
 <template>
 	<div class="container-widget" :style="wrapperStyle">
-		<h4 v-if="hasTitle" class="container-widget__title">{{ titleText }}</h4>
+		<h4 v-if="hasTitle" class="container-widget__title">
+			{{ titleText }}
+		</h4>
 
 		<div ref="innerGrid" class="grid-stack mydash-container-grid">
 			<div

--- a/src/components/Widgets/Renderers/NewsWidget.vue
+++ b/src/components/Widgets/Renderers/NewsWidget.vue
@@ -54,7 +54,9 @@
 						:src="item.thumbnailUrl"
 						:alt="''">
 					<div class="news-widget__body">
-						<h4 class="news-widget__title">{{ item.title }}</h4>
+						<h4 class="news-widget__title">
+							{{ item.title }}
+						</h4>
 						<p
 							v-if="showSummary && item.summary"
 							class="news-widget__summary"

--- a/src/components/Widgets/Renderers/PeopleWidget.vue
+++ b/src/components/Widgets/Renderers/PeopleWidget.vue
@@ -215,10 +215,6 @@ export default {
 		},
 	},
 
-	mounted() {
-		this.fetchPage(0)
-	},
-
 	watch: {
 		queryParams: {
 			handler() {
@@ -231,6 +227,10 @@ export default {
 			},
 			deep: true,
 		},
+	},
+
+	mounted() {
+		this.fetchPage(0)
 	},
 
 	methods: {

--- a/src/components/Widgets/Renderers/TextDisplayWidget.vue
+++ b/src/components/Widgets/Renderers/TextDisplayWidget.vue
@@ -139,10 +139,6 @@ export default {
 		},
 	},
 
-	created() {
-		ensureDomPurifyHook()
-	},
-
 	computed: {
 		text() {
 			return typeof this.content?.text === 'string' ? this.content.text : ''
@@ -284,6 +280,10 @@ export default {
 				width: '100%',
 			}
 		},
+	},
+
+	created() {
+		ensureDomPurifyHook()
 	},
 
 	methods: {

--- a/src/components/Widgets/Renderers/TileWidget.vue
+++ b/src/components/Widgets/Renderers/TileWidget.vue
@@ -223,7 +223,7 @@ export default {
 			if (this.linkType === 'url') {
 				event.preventDefault()
 				window.open(this.linkValue, '_blank', 'noopener,noreferrer')
-				return
+
 			}
 			// `linkType === 'app'` falls through to the anchor's default
 			// behaviour, which navigates to the resolved Nextcloud route.

--- a/src/components/Widgets/Renderers/__tests__/CalendarWidget.spec.js
+++ b/src/components/Widgets/Renderers/__tests__/CalendarWidget.spec.js
@@ -13,6 +13,9 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { mount } from '@vue/test-utils'
 
+import axios from '@nextcloud/axios'
+import CalendarWidget from '../CalendarWidget.vue'
+
 vi.mock('@nextcloud/axios', () => {
 	return {
 		default: {
@@ -32,9 +35,6 @@ vi.mock('@nextcloud/router', () => {
 		},
 	}
 })
-
-import axios from '@nextcloud/axios'
-import CalendarWidget from '../CalendarWidget.vue'
 
 beforeEach(() => {
 	globalThis.t = (_app, key) => key
@@ -62,7 +62,7 @@ describe('CalendarWidget', () => {
 				placementId: 42,
 			},
 		})
-		await new Promise((r) => setTimeout(r, 0))
+		await new Promise((resolve) => setTimeout(resolve, 0))
 		await wrapper.vm.$nextTick()
 		expect(wrapper.text()).toContain('No events in the next 7 days')
 	})
@@ -75,7 +75,7 @@ describe('CalendarWidget', () => {
 				placementId: 42,
 			},
 		})
-		await new Promise((r) => setTimeout(r, 0))
+		await new Promise((resolve) => setTimeout(resolve, 0))
 		await wrapper.vm.$nextTick()
 		expect(wrapper.text()).toContain('Failed to load events')
 		expect(wrapper.text()).toContain('Retry')
@@ -111,7 +111,7 @@ describe('CalendarWidget', () => {
 				placementId: 42,
 			},
 		})
-		await new Promise((r) => setTimeout(r, 0))
+		await new Promise((resolve) => setTimeout(resolve, 0))
 		await wrapper.vm.$nextTick()
 		const txt = wrapper.text()
 		expect(txt).toContain('Meeting one')
@@ -127,7 +127,7 @@ describe('CalendarWidget', () => {
 				placementId: 42,
 			},
 		})
-		await new Promise((r) => setTimeout(r, 0))
+		await new Promise((resolve) => setTimeout(resolve, 0))
 		await wrapper.vm.$nextTick()
 		expect(wrapper.find('.calendar-widget__month').exists()).toBe(true)
 		// 7 weekday headers + at least 28 day cells = >= 35 children
@@ -143,7 +143,7 @@ describe('CalendarWidget', () => {
 				placementId: 42,
 			},
 		})
-		await new Promise((r) => setTimeout(r, 0))
+		await new Promise((resolve) => setTimeout(resolve, 0))
 		await wrapper.vm.$nextTick()
 		const cols = wrapper.findAll('.calendar-widget__week-col')
 		expect(cols.length).toBe(7)
@@ -170,7 +170,7 @@ describe('CalendarWidget', () => {
 				placementId: 42,
 			},
 		})
-		await new Promise((r) => setTimeout(r, 0))
+		await new Promise((resolve) => setTimeout(resolve, 0))
 		await wrapper.vm.$nextTick()
 		expect(wrapper.find('.calendar-widget__failures').exists()).toBe(true)
 		expect(wrapper.text()).toContain('1 calendar source(s) unavailable')

--- a/src/components/Workspace/SidebarFooter.vue
+++ b/src/components/Workspace/SidebarFooter.vue
@@ -160,7 +160,10 @@ export default {
 .dashboard-switcher-sidebar-footer__brand-logos {
 	display: flex;
 	align-items: center;
-	gap: 16px;
+	justify-content: center;
+	flex-wrap: wrap;
+	gap: 8px 16px;
+	width: 100%;
 }
 
 .dashboard-switcher-sidebar-footer__brand-link {
@@ -181,6 +184,8 @@ export default {
 .dashboard-switcher-sidebar-footer__brand-image {
 	height: 18px;
 	width: auto;
+	max-width: 100px;
+	object-fit: contain;
 	display: block;
 }
 

--- a/src/components/admin/AdminAnalytics.vue
+++ b/src/components/admin/AdminAnalytics.vue
@@ -22,9 +22,15 @@
 				v-model="period"
 				class="mydash-analytics__select"
 				@change="reload">
-				<option value="7d">{{ t('mydash', 'Last 7 days') }}</option>
-				<option value="30d">{{ t('mydash', 'Last 30 days') }}</option>
-				<option value="90d">{{ t('mydash', 'Last 90 days') }}</option>
+				<option value="7d">
+					{{ t('mydash', 'Last 7 days') }}
+				</option>
+				<option value="30d">
+					{{ t('mydash', 'Last 30 days') }}
+				</option>
+				<option value="90d">
+					{{ t('mydash', 'Last 90 days') }}
+				</option>
 			</select>
 		</div>
 
@@ -73,15 +79,23 @@
 				<thead>
 					<tr>
 						<th>{{ t('mydash', 'Dashboard') }}</th>
-						<th class="mydash-analytics__num">{{ t('mydash', 'Views') }}</th>
-						<th class="mydash-analytics__num">{{ t('mydash', 'Unique viewers') }}</th>
+						<th class="mydash-analytics__num">
+							{{ t('mydash', 'Views') }}
+						</th>
+						<th class="mydash-analytics__num">
+							{{ t('mydash', 'Unique viewers') }}
+						</th>
 					</tr>
 				</thead>
 				<tbody>
 					<tr v-for="row in topDashboards" :key="row.dashboardUuid">
 						<td>{{ row.name || row.dashboardUuid }}</td>
-						<td class="mydash-analytics__num">{{ row.viewCount }}</td>
-						<td class="mydash-analytics__num">{{ row.uniqueViewerCount }}</td>
+						<td class="mydash-analytics__num">
+							{{ row.viewCount }}
+						</td>
+						<td class="mydash-analytics__num">
+							{{ row.uniqueViewerCount }}
+						</td>
 					</tr>
 				</tbody>
 			</table>

--- a/src/components/admin/AdminDemoData.vue
+++ b/src/components/admin/AdminDemoData.vue
@@ -30,7 +30,7 @@
 						v-if="showcase.thumbnailUrl"
 						:src="showcase.thumbnailUrl"
 						:alt="showcase.name"
-						@error="onThumbError($event)" />
+						@error="onThumbError($event)">
 					<ViewDashboard v-else :size="64" />
 				</div>
 
@@ -40,7 +40,9 @@
 						<span class="mydash-demo-showcases__lang-badge">{{ showcase.language.toUpperCase() }}</span>
 					</div>
 
-					<p class="mydash-demo-showcases__desc">{{ showcase.description }}</p>
+					<p class="mydash-demo-showcases__desc">
+						{{ showcase.description }}
+					</p>
 
 					<div v-if="warnings[showcase.id]" class="mydash-demo-showcases__warning">
 						{{ t('mydash', 'Installed but skipped widgets: {list}', { list: warnings[showcase.id].join(', ') }) }}

--- a/src/components/admin/ConfluenceImport.vue
+++ b/src/components/admin/ConfluenceImport.vue
@@ -21,7 +21,7 @@
 				type="file"
 				accept=".zip,application/zip"
 				data-test="confluence-import-file"
-				@change="onFileSelected" />
+				@change="onFileSelected">
 
 			<label for="mydash-cfli-parent" class="mydash-confluence-import__label">
 				{{ t('mydash', 'Optional parent dashboard UUID (root pages will be slotted under this dashboard)') }}
@@ -31,7 +31,7 @@
 				v-model="parentUuid"
 				type="text"
 				class="mydash-confluence-import__text-input"
-				:placeholder="t('mydash', 'Leave empty to import as root dashboards')" />
+				:placeholder="t('mydash', 'Leave empty to import as root dashboards')">
 
 			<div class="mydash-confluence-import__actions">
 				<NcButton

--- a/src/components/admin/DashboardBulkOperations.vue
+++ b/src/components/admin/DashboardBulkOperations.vue
@@ -32,7 +32,7 @@
 							:checked="allSelected"
 							:indeterminate.prop="someSelected && !allSelected"
 							data-test="bulk-ops-select-all"
-							@change="toggleSelectAll" />
+							@change="toggleSelectAll">
 					</th>
 					<th>{{ t('mydash', 'Name') }}</th>
 					<th>{{ t('mydash', 'Status') }}</th>
@@ -49,7 +49,7 @@
 							:value="dash.uuid"
 							:checked="selectedUuids.includes(dash.uuid)"
 							data-test="bulk-ops-row-select"
-							@change="toggleRow(dash.uuid)" />
+							@change="toggleRow(dash.uuid)">
 					</td>
 					<td>{{ dash.name }}</td>
 					<td>{{ dash.publicationStatus || 'published' }}</td>
@@ -62,11 +62,21 @@
 				v-model="selectedAction"
 				:disabled="selectedUuids.length === 0"
 				data-test="bulk-ops-action-select">
-				<option value="">{{ t('mydash', 'Actions…') }}</option>
-				<option value="delete">{{ t('mydash', 'Delete') }}</option>
-				<option value="move">{{ t('mydash', 'Move to…') }}</option>
-				<option value="status">{{ t('mydash', 'Set status') }}</option>
-				<option value="reindex">{{ t('mydash', 'Reindex') }}</option>
+				<option value="">
+					{{ t('mydash', 'Actions…') }}
+				</option>
+				<option value="delete">
+					{{ t('mydash', 'Delete') }}
+				</option>
+				<option value="move">
+					{{ t('mydash', 'Move to…') }}
+				</option>
+				<option value="status">
+					{{ t('mydash', 'Set status') }}
+				</option>
+				<option value="reindex">
+					{{ t('mydash', 'Reindex') }}
+				</option>
 			</select>
 			<button
 				:disabled="selectedUuids.length === 0 || selectedAction === '' || running"
@@ -86,33 +96,41 @@
 					<input
 						v-model="parentUuidInput"
 						type="text"
-						data-test="bulk-ops-parent-uuid" />
+						data-test="bulk-ops-parent-uuid">
 				</div>
 
 				<div v-if="modal.action === 'status'" class="mydash-bulk-ops__field">
 					<label>{{ t('mydash', 'Publication status') }}</label>
 					<select v-model="statusInput" data-test="bulk-ops-status-select">
-						<option value="draft">{{ t('mydash', 'Draft') }}</option>
-						<option value="published">{{ t('mydash', 'Published') }}</option>
-						<option value="scheduled">{{ t('mydash', 'Scheduled') }}</option>
+						<option value="draft">
+							{{ t('mydash', 'Draft') }}
+						</option>
+						<option value="published">
+							{{ t('mydash', 'Published') }}
+						</option>
+						<option value="scheduled">
+							{{ t('mydash', 'Scheduled') }}
+						</option>
 					</select>
 					<input
 						v-if="statusInput === 'scheduled'"
 						v-model="publishAtInput"
 						type="datetime-local"
-						data-test="bulk-ops-publish-at" />
+						data-test="bulk-ops-publish-at">
 				</div>
 
 				<label class="mydash-bulk-ops__dryrun">
 					<input
 						v-model="dryRun"
 						type="checkbox"
-						data-test="bulk-ops-dryrun" />
+						data-test="bulk-ops-dryrun">
 					{{ t('mydash', 'Dry run (preview only)') }}
 				</label>
 
 				<div class="mydash-bulk-ops__modal-actions">
-					<button @click="cancelModal">{{ t('mydash', 'Cancel') }}</button>
+					<button @click="cancelModal">
+						{{ t('mydash', 'Cancel') }}
+					</button>
 					<button
 						:disabled="running"
 						data-test="bulk-ops-confirm"

--- a/src/components/admin/DashboardExportImport.vue
+++ b/src/components/admin/DashboardExportImport.vue
@@ -28,7 +28,7 @@
 			</span>
 		</div>
 
-		<hr class="mydash-export-import__divider" />
+		<hr class="mydash-export-import__divider">
 
 		<!-- Import controls -->
 		<div class="mydash-export-import__row mydash-export-import__row--column">
@@ -41,7 +41,7 @@
 				type="file"
 				accept=".zip,application/zip"
 				data-test="import-file-input"
-				@change="onFileSelected" />
+				@change="onFileSelected">
 
 			<NcCheckboxRadioSwitch
 				:checked="preserveUuids"

--- a/src/views/Views.vue
+++ b/src/views/Views.vue
@@ -23,7 +23,7 @@
 		<!-- Floating controls in top right -->
 		<div class="mydash-floating-controls">
 			<NcButton
-				type="tertiary"
+				type="secondary"
 				:aria-label="t('mydash', 'Dashboards')"
 				class="mydash-sidebar-toggle"
 				@click="sidebarOpen = !sidebarOpen">
@@ -31,14 +31,14 @@
 					<MenuIcon :size="20" />
 				</template>
 			</NcButton>
-			<!-- Primary-group label (REQ-TMPL-012). Surfaces the resolved
-			     primary group's display name so the user can see which
-			     group's dashboards they are currently viewing. The label
-			     is hidden when the resolver returned the `default`
-			     sentinel AND no friendly name was pushed (avoids a noisy
-			     "Default" badge for one-group installations). -->
+			<!-- Primary-group label (REQ-TMPL-012) is suppressed for the
+			     `default` sentinel — REQ-TMPL-012 documents the literal
+			     'Default' as the absence of a configured primary group, so
+			     surfacing it adds noise without information. The label
+			     remains visible whenever a real Nextcloud group display
+			     name is resolved. -->
 			<div
-				v-if="primaryGroupLabel"
+				v-if="primaryGroupLabel && primaryGroupLabel !== 'Default'"
 				class="mydash-primary-group-label"
 				:title="t('mydash', 'Your primary group for shared dashboards')">
 				{{ primaryGroupLabel }}

--- a/src/views/Views.vue
+++ b/src/views/Views.vue
@@ -204,6 +204,22 @@ export default {
 		DashboardSwitcherSidebar,
 		SidebarBackdrop,
 	},
+	// REQ-INIT-004 / REQ-ASET-003 / REQ-TMPL-012: pull typed initial-state
+	// values down the tree. Defaults keep the UX safe when keys are missing.
+	inject: {
+		allowUserDashboards: {
+			from: 'allowUserDashboards',
+			default: false,
+		},
+		primaryGroup: {
+			from: 'primaryGroup',
+			default: 'default',
+		},
+		primaryGroupName: {
+			from: 'primaryGroupName',
+			default: '',
+		},
+	},
 	// Inject the typed initial-state snapshot pushed from `src/main.js`
 	// (REQ-INIT-003..005). Defaults match the reader contract so the
 	// sidebar still mounts when running under tests that don't set a
@@ -238,22 +254,6 @@ export default {
 		})
 
 		return { canEditRef, grid }
-	},
-	// REQ-INIT-004 / REQ-ASET-003 / REQ-TMPL-012: pull typed initial-state
-	// values down the tree. Defaults keep the UX safe when keys are missing.
-	inject: {
-		allowUserDashboards: {
-			from: 'allowUserDashboards',
-			default: false,
-		},
-		primaryGroup: {
-			from: 'primaryGroup',
-			default: 'default',
-		},
-		primaryGroupName: {
-			from: 'primaryGroupName',
-			default: '',
-		},
 	},
 	data() {
 		return {

--- a/src/views/WorkspaceApp.vue
+++ b/src/views/WorkspaceApp.vue
@@ -42,7 +42,11 @@
 		     persistence path (REQ-GRID-005), and the action menu
 		     (gear) reachable inside Views.vue covers Add Custom
 		     Widget. -->
-		<div class="workspace-shell__strip">
+		<!-- Title strip is only visible when the sidebar is OPEN.
+		     When closed, the floating sidebar-toggle in mydash-floating-controls
+		     (top-right) is the only entry point — keeps the dashboard surface
+		     uncluttered. -->
+		<div v-if="sidebarOpen" class="workspace-shell__strip">
 			<NcButton
 				type="tertiary"
 				:aria-label="t('mydash', 'Open menu')"

--- a/src/views/WorkspaceApp.vue
+++ b/src/views/WorkspaceApp.vue
@@ -275,7 +275,7 @@ export default {
 		 * Falls back to the initial-state injection when the active
 		 * dashboard hasn't been hydrated yet.
 		 *
-		 * @return {Object|null}
+		 * @return {object | null}
 		 */
 		effectiveFooter() {
 			if (!this.injectedActiveDashboardId) {

--- a/src/views/__tests__/WorkspaceApp.spec.js
+++ b/src/views/__tests__/WorkspaceApp.spec.js
@@ -123,31 +123,43 @@ describe('WorkspaceApp', () => {
 		expect(wrapper.vm.saving).toBeUndefined()
 	})
 
-	it('REQ-SHELL-004: hamburger toggles sidebar state', async () => {
+	it('REQ-SHELL-004: title strip is hidden when sidebar is closed', () => {
 		const wrapper = mountShell({ inject: { activeDashboardId: 'd1' } })
+		// Default state: sidebar closed → strip should NOT render.
 		expect(wrapper.vm.sidebarOpen).toBe(false)
-		await wrapper.find('.workspace-shell__hamburger').trigger('click')
-		expect(wrapper.vm.sidebarOpen).toBe(true)
-		await wrapper.find('.workspace-shell__hamburger').trigger('click')
-		expect(wrapper.vm.sidebarOpen).toBe(false)
+		expect(wrapper.find('.workspace-shell__strip').exists()).toBe(false)
+		expect(wrapper.find('.workspace-shell__hamburger').exists()).toBe(false)
+		expect(wrapper.find('.workspace-shell__title').exists()).toBe(false)
 	})
 
-	it('REQ-SHELL-004: hamburger renders as NcButton type="tertiary"', () => {
+	it('REQ-SHELL-004: title strip with hamburger appears when sidebar is open', async () => {
 		const wrapper = mountShell({ inject: { activeDashboardId: 'd1' } })
+		// Open the sidebar via the exposed setter on the component.
+		wrapper.vm.sidebarOpen = true
+		await wrapper.vm.$nextTick()
+		const strip = wrapper.find('.workspace-shell__strip')
+		expect(strip.exists()).toBe(true)
 		const hamburger = wrapper.find('.workspace-shell__hamburger')
 		expect(hamburger.exists()).toBe(true)
-		// The stubbed NcButton mirrors the `type` prop onto a data
-		// attribute so we can assert on the variant the shell selected.
+		// Stubbed NcButton mirrors the `type` prop onto a data attribute
+		// so we can assert on the variant the shell selected.
 		expect(hamburger.attributes('data-nc-button-type')).toBe('tertiary')
+		// Clicking the in-strip hamburger closes the sidebar (it's the only
+		// affordance available while the strip is mounted).
+		await hamburger.trigger('click')
+		expect(wrapper.vm.sidebarOpen).toBe(false)
 	})
 
-	it('REQ-SHELL-004: title strip shows dashboard name as a heading, NOT as a select', () => {
+	it('REQ-SHELL-004: title strip shows dashboard name as a heading, NOT as a select', async () => {
 		const wrapper = mountShell({
 			inject: {
 				activeDashboardId: 'd1',
 				userDashboards: [{ id: 'd1', name: 'Marketing Overview' }],
 			},
 		})
+		// Title only renders when the sidebar is open.
+		wrapper.vm.sidebarOpen = true
+		await wrapper.vm.$nextTick()
 		const title = wrapper.find('.workspace-shell__title')
 		expect(title.exists()).toBe(true)
 		expect(title.element.tagName).toBe('H1')


### PR DESCRIPTION
## Summary

Four UX fixes spotted in screenshot review of the live dev environment, plus an in-PR cleanup of pre-existing eslint errors that were blocking CI on `development`.

### UX fixes (4 user-spotted issues)
1. **Title strip hidden when sidebar closed** — `WorkspaceApp.vue` wraps `.workspace-shell__strip` (header + hamburger) in `v-if="sidebarOpen"`. The floating sidebar-toggle in `mydash-floating-controls` is the sole entry point with the sidebar closed, keeping the dashboard surface uncluttered.
2. **Floating hamburger matches the cog button** — `Views.vue` changes the dashboards-toggle to `type="secondary"` so it visually matches the settings action menu sitting next to it (was `tertiary` / no background, looked detached).
3. **Default group pill suppressed** — `Views.vue` hides the primary-group pill when the resolved label is the sentinel `"Default"`. Real group names still render.
4. **Powered-by logo row centered + Conduction logo visible** — `SidebarFooter.vue` adds `justify-content: center; flex-wrap: wrap` and caps brand-image `max-width: 100px` so both Sendent and Conduction render side-by-side instead of one being squeezed off-screen.

### Eslint cleanup
- `eslint --fix` over 15 files (admin/*, Renderers/*, DashboardMetadataPanel, DashboardFooter, Container/Calendar tests).
- Manual rename `r` → `resolve` in 6 `new Promise((r) => …)` sites in CalendarWidget.spec.js for `promise/param-names`.
- Net: **0 errors**, 22 warnings (all pre-existing JSDoc style — not gated).

## Test plan
- [x] `npm test` — 847/847 tests pass
- [x] `npm run build` — webpack 5.104.1 compiled with 7 warnings, 0 errors
- [x] `npm run lint` — 0 errors locally
- [ ] Manual: open `/apps/mydash/` with sidebar **closed** → no header/hamburger above the dashboard
- [ ] Manual: open sidebar → header strip + hamburger appear, hamburger closes the sidebar
- [ ] Manual: floating sidebar-toggle (top-right) shares the same secondary-button look as the cog
- [ ] Manual: "Default" pill no longer renders for users without a real primary group
- [ ] Manual: footer shows both Sendent and Conduction logos centered under "Powered by"

Supersedes #110 (closed because branch needed `feature/*` prefix to satisfy Branch Policy Check).