### PR TITLE
fix(ux): wave3.3 — restore dashboard switching, move per-dashboard menu into sidebar header, fix Conduction logo

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -120,6 +120,7 @@ return [
 		// specific routes above to avoid wildcard hijack).
 		['name' => 'dashboard_api#getActive', 'url' => '/api/dashboard', 'verb' => 'GET'],
 		['name' => 'dashboard_api#create', 'url' => '/api/dashboard', 'verb' => 'POST'],
+		['name' => 'dashboard_api#show', 'url' => '/api/dashboard/{id}', 'verb' => 'GET'],
 		['name' => 'dashboard_api#update', 'url' => '/api/dashboard/{id}', 'verb' => 'PUT'],
 		['name' => 'dashboard_api#delete', 'url' => '/api/dashboard/{id}', 'verb' => 'DELETE'],
 		['name' => 'dashboard_api#activate', 'url' => '/api/dashboard/{id}/activate', 'verb' => 'POST'],

--- a/lib/Controller/DashboardApiController.php
+++ b/lib/Controller/DashboardApiController.php
@@ -202,6 +202,62 @@ class DashboardApiController extends Controller
     }//end getActive()
 
     /**
+     * Get a single dashboard by id with its placements + permission level.
+     *
+     * Powers the front-end's `switchDashboard` flow: clicking a row in the
+     * sidebar issues `GET /api/dashboard/{id}` and the response is the
+     * same envelope shape as {@see self::getActive()}, so the store can
+     * write `activeDashboard`, `widgetPlacements`, and `permissionLevel`
+     * with no per-source branching.
+     *
+     * Returns 404 (not 403) when the dashboard exists but is not visible
+     * to the caller — this matches the `getVisibleToUser` policy and
+     * intentionally does not leak existence (REQ-DASH-020 scenario
+     * "Cannot see what you cannot read").
+     *
+     * @param int $id The dashboard ID.
+     *
+     * @return JSONResponse The dashboard envelope (200) or
+     *                      `{'error': 'Not found'}` (404).
+     *
+     * @spec dashboards:REQ-SWITCH-002
+     */
+    #[NoAdminRequired]
+    public function show(int $id): JSONResponse
+    {
+        if ($this->userId === null) {
+            return ResponseHelper::unauthorized();
+        }
+
+        $result = $this->dashboardService->getDashboardForUser(
+            dashboardId: $id,
+            userId: $this->userId
+        );
+
+        if ($result === null) {
+            return ResponseHelper::success(
+                data: ['error' => 'Not found'],
+                statusCode: Http::STATUS_NOT_FOUND
+            );
+        }
+
+        $dashboard = $result['dashboard'];
+        $isOwner = ($dashboard->getUserId() === $this->userId);
+
+        return ResponseHelper::success(
+            data: [
+                'dashboard'       => $dashboard->jsonSerialize(),
+                'placements'      => ResponseHelper::serializeList(
+                    entities: $result['placements']
+                ),
+                'permissionLevel' => $result['permissionLevel'],
+                'isOwner'         => $isOwner,
+                'sharedBy'        => ($isOwner === false ? $dashboard->getUserId() : null),
+            ]
+        );
+    }//end show()
+
+    /**
      * Create a new dashboard.
      *
      * @param mixed       $name        The dashboard name.

--- a/lib/Controller/DashboardApiController.php
+++ b/lib/Controller/DashboardApiController.php
@@ -242,7 +242,11 @@ class DashboardApiController extends Controller
         }
 
         $dashboard = $result['dashboard'];
-        $isOwner = ($dashboard->getUserId() === $this->userId);
+        $isOwner   = ($dashboard->getUserId() === $this->userId);
+        $sharedBy  = null;
+        if ($isOwner === false) {
+            $sharedBy = $dashboard->getUserId();
+        }
 
         return ResponseHelper::success(
             data: [
@@ -252,7 +256,7 @@ class DashboardApiController extends Controller
                 ),
                 'permissionLevel' => $result['permissionLevel'],
                 'isOwner'         => $isOwner,
-                'sharedBy'        => ($isOwner === false ? $dashboard->getUserId() : null),
+                'sharedBy'        => $sharedBy,
             ]
         );
     }//end show()

--- a/lib/Service/DashboardService.php
+++ b/lib/Service/DashboardService.php
@@ -259,11 +259,11 @@ class DashboardService
         // entity — calling `getId()` on the wrapper triggers the
         // "member function on array" fatal that broke the switch flow
         // when this method first shipped.
-        $visible = $this->getVisibleToUser(userId: $userId);
+        $visible   = $this->getVisibleToUser(userId: $userId);
         $dashboard = null;
         foreach ($visible as $entry) {
-            $candidate = $entry['dashboard'] ?? null;
-            if ($candidate !== null && $candidate->getId() === $dashboardId) {
+            $candidate = $entry['dashboard'];
+            if ($candidate->getId() === $dashboardId) {
                 $dashboard = $candidate;
                 break;
             }

--- a/lib/Service/DashboardService.php
+++ b/lib/Service/DashboardService.php
@@ -233,6 +233,57 @@ class DashboardService
     }//end getUserDashboards()
 
     /**
+     * Get a single dashboard with its placements + permission level when
+     * the user is allowed to read it.
+     *
+     * Visibility is delegated to {@see self::getVisibleToUser()} so
+     * ownership, group-share, and publication-state filters all share one
+     * implementation. The returned shape mirrors {@see DashboardResolver::buildResult()}
+     * so the front-end's switch flow consumes the same envelope it gets
+     * from `GET /api/dashboard` (active dashboard).
+     *
+     * @param int    $dashboardId The dashboard ID to load.
+     * @param string $userId      The caller's user ID.
+     *
+     * @return array|null `{dashboard, placements, permissionLevel}` when
+     *                    visible; null when the user has no read access.
+     */
+    public function getDashboardForUser(
+        int $dashboardId,
+        string $userId
+    ): ?array {
+        // `getVisibleToUser` returns entries shaped as
+        // `{dashboard: Dashboard, source: string}` (per
+        // {@see self::filterByPublicationState()} contract). Match on
+        // `dashboard.id` rather than treating the entry itself as an
+        // entity — calling `getId()` on the wrapper triggers the
+        // "member function on array" fatal that broke the switch flow
+        // when this method first shipped.
+        $visible = $this->getVisibleToUser(userId: $userId);
+        $dashboard = null;
+        foreach ($visible as $entry) {
+            $candidate = $entry['dashboard'] ?? null;
+            if ($candidate !== null && $candidate->getId() === $dashboardId) {
+                $dashboard = $candidate;
+                break;
+            }
+        }
+
+        if ($dashboard === null) {
+            return null;
+        }
+
+        $placements = $this->placementMapper->findByDashboardId(
+            dashboardId: $dashboard->getId()
+        );
+
+        return $this->dashResolver->buildResult(
+            dashboard: $dashboard,
+            placements: $placements
+        );
+    }//end getDashboardForUser()
+
+    /**
      * Get the effective dashboard for a user.
      * Returns user's active dashboard or applicable admin template.
      *

--- a/src/components/Workspace/DashboardSwitcherSidebar.vue
+++ b/src/components/Workspace/DashboardSwitcherSidebar.vue
@@ -62,6 +62,63 @@
 			<h2 class="dashboard-switcher-sidebar__title">
 				{{ t('mydash', 'Dashboards') }}
 			</h2>
+			<!--
+				Per-active-dashboard action menu (cog). Hosts the actions
+				that previously lived in the top-right floating
+				`DashboardConfigMenu` (Edit / Configure / Add widget) plus
+				the per-active-dashboard Delete (trashcan) — the per-row
+				X delete buttons were removed in favour of this single
+				menu so the destructive action lives where the rest of
+				the per-dashboard actions sit.
+			-->
+			<NcActions
+				v-if="activeDashboardId"
+				:aria-label="t('mydash', 'Dashboard menu')"
+				:force-menu="true"
+				placement="bottom-end"
+				type="tertiary"
+				class="dashboard-switcher-sidebar__menu">
+				<template #icon>
+					<Cog :size="20" />
+				</template>
+				<NcActionButton
+					v-if="canEdit"
+					:close-after-click="true"
+					@click="onToggleEdit">
+					<template #icon>
+						<ContentSave v-if="isEditMode" :size="20" />
+						<Pencil v-else :size="20" />
+					</template>
+					{{ isEditMode ? t('mydash', 'Save dashboard') : t('mydash', 'Edit dashboard') }}
+				</NcActionButton>
+				<NcActionButton
+					v-if="isActiveOwner"
+					:close-after-click="true"
+					@click="onOpenConfig">
+					<template #icon>
+						<Tune :size="20" />
+					</template>
+					{{ t('mydash', 'Dashboard configuration…') }}
+				</NcActionButton>
+				<NcActionButton
+					v-if="canEdit"
+					:close-after-click="true"
+					@click="onAddCustomWidget">
+					<template #icon>
+						<ShapePolygonPlus :size="20" />
+					</template>
+					{{ t('mydash', 'Add custom widget…') }}
+				</NcActionButton>
+				<NcActionButton
+					v-if="isActiveOwner"
+					:close-after-click="true"
+					@click="onDeleteActive">
+					<template #icon>
+						<TrashCanOutline :size="20" />
+					</template>
+					{{ t('mydash', 'Delete dashboard') }}
+				</NcActionButton>
+			</NcActions>
 			<button
 				type="button"
 				class="dashboard-switcher-sidebar__close"
@@ -165,13 +222,6 @@
 							<IconRenderer :name="dashboard.icon" :size="20" />
 						</span>
 						<span class="dashboard-switcher-sidebar__label">{{ dashboard.name }}</span>
-						<button
-							type="button"
-							class="dashboard-switcher-sidebar__delete"
-							:aria-label="t('mydash', 'Delete dashboard')"
-							@click.stop="onDelete(dashboard.id)">
-							<Close :size="16" />
-						</button>
 					</li>
 				</ul>
 
@@ -211,9 +261,16 @@
 <script>
 import { t } from '@nextcloud/l10n'
 import { NcButton } from '@conduction/nextcloud-vue'
+import { NcActions, NcActionButton } from '@nextcloud/vue'
 
 import Close from 'vue-material-design-icons/Close.vue'
 import Plus from 'vue-material-design-icons/Plus.vue'
+import Cog from 'vue-material-design-icons/Cog.vue'
+import Pencil from 'vue-material-design-icons/Pencil.vue'
+import ContentSave from 'vue-material-design-icons/ContentSave.vue'
+import Tune from 'vue-material-design-icons/Tune.vue'
+import ShapePolygonPlus from 'vue-material-design-icons/ShapePolygonPlus.vue'
+import TrashCanOutline from 'vue-material-design-icons/TrashCanOutline.vue'
 
 import IconRenderer from '../Dashboard/IconRenderer.vue'
 import SidebarFooter from './SidebarFooter.vue'
@@ -224,8 +281,16 @@ export default {
 	components: {
 		Close,
 		Plus,
+		Cog,
+		Pencil,
+		ContentSave,
+		Tune,
+		ShapePolygonPlus,
+		TrashCanOutline,
 		IconRenderer,
 		NcButton,
+		NcActions,
+		NcActionButton,
 		SidebarFooter,
 	},
 
@@ -301,9 +366,38 @@ export default {
 			type: Boolean,
 			default: false,
 		},
+
+		/*
+		 * Per-active-dashboard menu state. Hosted in the sidebar header
+		 * (cog NcActions) since wave3.3 — replaces the floating top-right
+		 * `DashboardConfigMenu`. Each prop mirrors the prop of the same
+		 * name on the old menu so the host wiring stays one-to-one.
+		 */
+		isEditMode: {
+			type: Boolean,
+			default: false,
+		},
+		canEdit: {
+			type: Boolean,
+			default: false,
+		},
+		isActiveOwner: {
+			type: Boolean,
+			default: false,
+		},
 	},
 
-	emits: ['switch', 'create-dashboard', 'delete-dashboard', 'update:open'],
+	emits: [
+		'switch',
+		'create-dashboard',
+		'delete-dashboard',
+		'update:open',
+		// wave3.3 — emitted by the new in-sidebar cog menu, mirroring the
+		// retired floating `DashboardConfigMenu` events one-to-one.
+		'toggle-edit',
+		'open-config',
+		'add-custom-widget',
+	],
 
 	computed: {
 		primaryGroupDashboards() {
@@ -361,15 +455,32 @@ export default {
 		},
 
 		/**
-		 * Click handler for the personal-row delete button. MUST emit
-		 * `delete-dashboard(id)` only — never `switch` or `update:open`
-		 * (REQ-SWITCH-004). The template uses `@click.stop` to prevent
-		 * the parent row's switch handler from firing.
-		 *
-		 * @param {string|number} id Personal dashboard id to delete.
+		 * Click handler for the cog menu's Delete entry. Emits
+		 * `delete-dashboard(activeDashboardId)`. Wave3.3 replaced the
+		 * per-row X delete buttons with this single header-menu action
+		 * so the destructive path lives next to Edit / Configure / Add
+		 * widget instead of being scattered along the rows.
 		 */
-		onDelete(id) {
-			this.$emit('delete-dashboard', id)
+		onDeleteActive() {
+			if (this.activeDashboardId != null) {
+				this.$emit('delete-dashboard', this.activeDashboardId)
+			}
+		},
+
+		/**
+		 * Cog-menu pass-throughs — these mirror the old floating
+		 * `DashboardConfigMenu` events one-to-one so the host (Views.vue
+		 * / WorkspaceApp.vue) can keep using the same handler bodies it
+		 * already has.
+		 */
+		onToggleEdit() {
+			this.$emit('toggle-edit')
+		},
+		onOpenConfig() {
+			this.$emit('open-config')
+		},
+		onAddCustomWidget() {
+			this.$emit('add-custom-widget')
 		},
 
 		/**

--- a/src/components/Workspace/SidebarFooter.vue
+++ b/src/components/Workspace/SidebarFooter.vue
@@ -192,9 +192,17 @@ export default {
 	display: block;
 }
 
-/* Conduction wordmark renders dark on dark NC themes — invert so it
-   reads on either background. */
+/*
+ * The Conduction logo is shipped as a WHITE wordmark on transparent —
+ * designed for dark backgrounds. The Nextcloud `--background-invert-if-bright`
+ * CSS variable resolves to `invert(100%)` on light themes and `no` (i.e.
+ * the fallback `none`) on dark themes. Using it directly inverts on
+ * light (white → black, visible on the white footer) and leaves the
+ * logo untouched on dark themes (white → still white, visible on the
+ * dark footer). No fallback `invert(1)` is needed — and adding one
+ * causes a double-invert that cancels out on light themes.
+ */
 .dashboard-switcher-sidebar-footer__brand-image--invert {
-	filter: var(--background-invert-if-dark, none);
+	filter: var(--background-invert-if-bright, none);
 }
 </style>

--- a/src/components/Workspace/__tests__/DashboardSwitcherSidebar.spec.js
+++ b/src/components/Workspace/__tests__/DashboardSwitcherSidebar.spec.js
@@ -242,29 +242,15 @@ describe('DashboardSwitcherSidebar', () => {
 		})
 	})
 
-	describe('REQ-SWITCH-004 personal-row delete affordance', () => {
-		it('emits delete-dashboard(id) on delete button click', async () => {
+	describe('wave3.3: per-row delete affordance is REMOVED', () => {
+		it('user rows no longer render an inline `__delete` button', () => {
 			const wrapper = mountSidebar({
 				userDashboards: [userRow, userRow2],
 			})
-			const deleteBtn = wrapper.findAll('.dashboard-switcher-sidebar__delete').at(0)
-			await deleteBtn.trigger('click')
-			expect(wrapper.emitted('delete-dashboard')).toBeTruthy()
-			expect(wrapper.emitted('delete-dashboard')[0]).toEqual(['p1'])
+			expect(wrapper.findAll('.dashboard-switcher-sidebar__delete').length).toBe(0)
 		})
 
-		it('delete click does not also emit switch or update:open (@click.stop)', async () => {
-			const wrapper = mountSidebar({
-				userDashboards: [userRow],
-			})
-			const deleteBtn = wrapper.find('.dashboard-switcher-sidebar__delete')
-			await deleteBtn.trigger('click')
-			expect(wrapper.emitted('delete-dashboard')).toBeTruthy()
-			expect(wrapper.emitted('switch')).toBeFalsy()
-			expect(wrapper.emitted('update:open')).toBeFalsy()
-		})
-
-		it('group / default rows have NO delete button', () => {
+		it('group / default rows still have NO delete button', () => {
 			const wrapper = mountSidebar({
 				groupDashboards: [groupRow, defaultRow],
 				userDashboards: [],

--- a/src/views/Views.vue
+++ b/src/views/Views.vue
@@ -13,14 +13,26 @@
 			:user-dashboards="sidebarUserDashboards"
 			:active-dashboard-id="activeDashboard?.id"
 			:allow-user-dashboards="allowUserDashboards"
+			:is-edit-mode="isEditMode"
+			:can-edit="canEdit"
+			:is-active-owner="activeDashboard?.isOwner !== false"
 			@switch="onSidebarSwitch"
 			@create-dashboard="onSidebarCreateDashboard"
-			@delete-dashboard="onSidebarDeleteDashboard" />
+			@delete-dashboard="onSidebarDeleteDashboard"
+			@toggle-edit="toggleEditMode"
+			@open-config="openConfigModal"
+			@add-custom-widget="openCustomWidgetModal()" />
 		<SidebarBackdrop
 			v-if="sidebarOpen"
 			@close="sidebarOpen = false" />
 
-		<!-- Floating controls in top right -->
+		<!-- Floating controls in top right.
+		     Wave3.3 removed the floating `DashboardConfigMenu` (cog) — its
+		     entries (Edit / Configure / Add widget / Delete) now live in
+		     the left sidebar's header NcActions menu so the per-dashboard
+		     destructive + edit actions sit alongside switching. The
+		     hamburger keeps its place (top-right entry point when the
+		     sidebar is closed). -->
 		<div class="mydash-floating-controls">
 			<NcButton
 				type="secondary"
@@ -43,20 +55,6 @@
 				:title="t('mydash', 'Your primary group for shared dashboards')">
 				{{ primaryGroupLabel }}
 			</div>
-			<!--
-				`runtime-shell-trim` removed the standalone "Active dashboard"
-				`<NcSelect>` switcher (`DashboardSwitcher`). The left sidebar
-				(`dashboard-switcher` capability) is now the only surface for
-				switching between dashboards (REQ-SHELL-004, REQ-SWITCH-002).
-			-->
-			<DashboardConfigMenu
-				:active-dashboard-id="activeDashboard?.id"
-				:is-edit-mode="isEditMode"
-				:can-edit="canEdit"
-				:is-active-owner="activeDashboard?.isOwner !== false"
-				@toggle-edit="toggleEditMode"
-				@open-config="openConfigModal"
-				@add-custom-widget="openCustomWidgetModal()" />
 		</div>
 
 		<!-- Main dashboard grid -->
@@ -169,7 +167,6 @@ import DashboardGrid from '../components/DashboardGrid.vue'
 import WidgetPickerModal from '../components/WidgetPickerModal.vue'
 import WidgetStyleEditor from '../components/WidgetStyleEditor.vue'
 import TileEditor from '../components/TileEditor.vue'
-import DashboardConfigMenu from '../components/DashboardConfigMenu.vue'
 import DashboardConfigModal from '../components/DashboardConfigModal.vue'
 import AddWidgetModal from '../components/Widgets/AddWidgetModal.vue'
 import WidgetContextMenu from '../components/Widgets/WidgetContextMenu.vue'
@@ -196,7 +193,6 @@ export default {
 		WidgetPickerModal,
 		WidgetStyleEditor,
 		TileEditor,
-		DashboardConfigMenu,
 		DashboardConfigModal,
 		AddWidgetModal,
 		WidgetContextMenu,


### PR DESCRIPTION
## Summary

Five user-spotted issues in one PR:

### 1. Dashboard switching broken
The store's `switchDashboard(id)` calls `GET /api/dashboard/{id}` — but no such route existed (only PUT/DELETE/POST(activate) were wired). Browser got back 405, the catch logged silently, and the active dashboard never changed.

Added:
- `DashboardService::getDashboardForUser(int \$id, string \$userId): ?array` — reuses `getVisibleToUser` for the visibility filter (so ownership / group-share / publication-state policies stay in one implementation) and `DashboardResolver::buildResult` for the envelope shape so the response matches `GET /api/dashboard` byte-for-byte.
- `DashboardApiController::show(int \$id)` — 200 + envelope when visible, 404 when not (do not leak existence per REQ-DASH-020).
- Route `dashboard_api#show` on `/api/dashboard/{id}` GET, placed before update/delete so the verb dispatch is unambiguous.

### 2. Per-dashboard cog menu moved into sidebar header
Floating `DashboardConfigMenu` (top-right) replaced by an `NcActions` cog in the sidebar header — same entries (Edit dashboard / Dashboard configuration… / Add custom widget…) plus the new Delete entry below. Hamburger toggle stays in the floating row as the only entry point when the sidebar is closed.

### 3. Per-row X delete buttons removed
Replaced by the cog-menu Delete entry which deletes the active dashboard. To delete a different dashboard the user switches first then deletes — destructive action sits next to edit/configure now instead of being scattered along the rows.

### 4. Conduction logo invisible in "Powered by"
Logo ships as a WHITE wordmark on transparent (designed for dark backgrounds); on Nextcloud's default light footer it disappeared. Switched the filter to use NC's \`--background-invert-if-bright\` token directly (resolves to \`invert(100%)\` on light themes, untouched on dark) — no fallback \`invert(1)\` needed (a fallback caused a double-invert that cancelled out).

### 5. Sidebar component contract
Added new props on `DashboardSwitcherSidebar`: `isEditMode`, `canEdit`, `isActiveOwner`. Added new emits: `toggle-edit`, `open-config`, `add-custom-widget`. Mirrors the retired `DashboardConfigMenu` one-to-one so the host wiring is plug-compatible.

## Test plan
- [x] `npm test` — 846/846 pass; sidebar spec rewritten to assert the per-row delete is removed
- [x] `npm run build` — webpack 5.104.1 compiled with 7 warnings, 0 errors
- [x] `npm run lint` — 0 errors
- [x] Live: switch from My Dashboard (id 1) → wewr (id 16) — active id and placements update correctly
- [x] Live: cog menu in sidebar header renders Edit / Configure / Add widget / Delete
- [x] Live: floating cog removed; hamburger remains
- [x] Live: Conduction logo visible side-by-side with Sendent in the footer

## Follow-ups (not in this PR)
- WorkspaceApp.sidebarOpen is decoupled from Views.sidebarOpen (duplicate-sidebar architecture). The user's interactions go through Views' sidebar, so the WorkspaceApp duplicate is dead code — separate cleanup PR.
- Playwright + Newman as hard CI gates.