### PR TITLE
feat(sidebar): per-row cog menu — actions act on the row, not on whichever dashboard is active

### DIFF
--- a/src/components/Workspace/DashboardRowActions.vue
+++ b/src/components/Workspace/DashboardRowActions.vue
@@ -1,0 +1,153 @@
+<!--
+  - SPDX-FileCopyrightText: 2026 MyDash Contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<!--
+	DashboardRowActions — wave3.6 per-row cog menu
+
+	Lives at the right edge of every dashboard `<li>` in the sidebar.
+	The 4 actions (Edit / Configure / Add custom widget / Delete) act on
+	the row's own dashboard, not on whichever dashboard happens to be
+	"active" — so the user can edit, configure, or delete any dashboard
+	they have access to without having to switch first.
+
+	Action gating:
+	  - Edit dashboard         → only when `canEdit` is true (parent
+	    flag derived from the active dashboard's permission level; for
+	    other rows it remains advisory — clicking still emits the
+	    event so the host can decide whether to switch + enter edit
+	    mode or no-op).
+	  - Dashboard configuration → only when the row's `dashboard.isOwner !== false`.
+	  - Add custom widget       → only when `canEdit` is true.
+	  - Delete dashboard        → only when the row's `dashboard.isOwner !== false`.
+
+	Emits raw events; the host (`DashboardSwitcherSidebar.vue`) maps
+	them to its `toggle-edit` / `open-config` / `add-custom-widget` /
+	`delete-dashboard` outputs with the per-row dashboard payload.
+
+	`@click.stop` is set on the cog trigger so opening the menu never
+	fires the row's `@click` switch handler.
+-->
+
+<template>
+	<NcActions
+		:aria-label="t('mydash', 'Dashboard menu')"
+		:force-menu="true"
+		placement="bottom-end"
+		type="tertiary-no-background"
+		class="dashboard-row-actions"
+		@click.native.stop>
+		<template #icon>
+			<Cog :size="18" />
+		</template>
+		<NcActionButton
+			v-if="canEdit"
+			:close-after-click="true"
+			@click="$emit('toggle-edit')">
+			<template #icon>
+				<Pencil :size="20" />
+			</template>
+			{{ t('mydash', 'Edit dashboard') }}
+		</NcActionButton>
+		<NcActionButton
+			v-if="isOwner"
+			:close-after-click="true"
+			@click="$emit('open-config')">
+			<template #icon>
+				<Tune :size="20" />
+			</template>
+			{{ t('mydash', 'Dashboard configuration…') }}
+		</NcActionButton>
+		<NcActionButton
+			v-if="canEdit"
+			:close-after-click="true"
+			@click="$emit('add-custom-widget')">
+			<template #icon>
+				<ShapePolygonPlus :size="20" />
+			</template>
+			{{ t('mydash', 'Add custom widget…') }}
+		</NcActionButton>
+		<NcActionButton
+			v-if="isOwner"
+			:close-after-click="true"
+			@click="$emit('delete')">
+			<template #icon>
+				<TrashCanOutline :size="20" />
+			</template>
+			{{ t('mydash', 'Delete dashboard') }}
+		</NcActionButton>
+	</NcActions>
+</template>
+
+<script>
+import { t } from '@nextcloud/l10n'
+import { NcActions, NcActionButton } from '@nextcloud/vue'
+import Cog from 'vue-material-design-icons/Cog.vue'
+import Pencil from 'vue-material-design-icons/Pencil.vue'
+import Tune from 'vue-material-design-icons/Tune.vue'
+import ShapePolygonPlus from 'vue-material-design-icons/ShapePolygonPlus.vue'
+import TrashCanOutline from 'vue-material-design-icons/TrashCanOutline.vue'
+
+export default {
+	name: 'DashboardRowActions',
+
+	components: {
+		NcActions,
+		NcActionButton,
+		Cog,
+		Pencil,
+		Tune,
+		ShapePolygonPlus,
+		TrashCanOutline,
+	},
+
+	props: {
+		dashboard: {
+			type: Object,
+			required: true,
+		},
+		source: {
+			type: String,
+			required: true,
+			validator: v => ['group', 'default', 'user'].includes(v),
+		},
+		canEdit: {
+			type: Boolean,
+			default: false,
+		},
+	},
+
+	emits: ['toggle-edit', 'open-config', 'add-custom-widget', 'delete'],
+
+	computed: {
+		/*
+		 * Owner-gated actions (Configure, Delete) require the user to
+		 * own this dashboard. The visibility API doesn't always set
+		 * `isOwner` on every row, so we infer ownership from the
+		 * `source` discriminator: rows under "MY DASHBOARDS" (user
+		 * source) are inherently owned by the caller; group / default
+		 * rows are owned by whoever created them, so we honour the
+		 * explicit `dashboard.isOwner` flag when present and otherwise
+		 * conservatively hide the destructive actions.
+		 */
+		isOwner() {
+			if (this.source === 'user') {
+				return true
+			}
+			return this.dashboard?.isOwner === true
+		},
+	},
+
+	methods: {
+		t,
+	},
+}
+</script>
+
+<style scoped>
+.dashboard-row-actions {
+	margin-inline-start: auto;
+	flex: 0 0 auto;
+}
+</style>

--- a/src/components/Workspace/DashboardSwitcherSidebar.vue
+++ b/src/components/Workspace/DashboardSwitcherSidebar.vue
@@ -63,62 +63,13 @@
 				{{ t('mydash', 'Dashboards') }}
 			</h2>
 			<!--
-				Per-active-dashboard action menu (cog). Hosts the actions
-				that previously lived in the top-right floating
-				`DashboardConfigMenu` (Edit / Configure / Add widget) plus
-				the per-active-dashboard Delete (trashcan) — the per-row
-				X delete buttons were removed in favour of this single
-				menu so the destructive action lives where the rest of
-				the per-dashboard actions sit.
+				Wave3.6 moved the per-dashboard actions out of the header
+				cog and into a per-row cog (rendered next to each <li>),
+				so each dashboard's Edit / Configure / Add widget / Delete
+				operate on that specific row regardless of which dashboard
+				is currently active. The header keeps only the X close
+				now.
 			-->
-			<NcActions
-				v-if="activeDashboardId"
-				:aria-label="t('mydash', 'Dashboard menu')"
-				:force-menu="true"
-				placement="bottom-end"
-				type="tertiary"
-				class="dashboard-switcher-sidebar__menu">
-				<template #icon>
-					<Cog :size="20" />
-				</template>
-				<NcActionButton
-					v-if="canEdit"
-					:close-after-click="true"
-					@click="onToggleEdit">
-					<template #icon>
-						<ContentSave v-if="isEditMode" :size="20" />
-						<Pencil v-else :size="20" />
-					</template>
-					{{ isEditMode ? t('mydash', 'Save dashboard') : t('mydash', 'Edit dashboard') }}
-				</NcActionButton>
-				<NcActionButton
-					v-if="isActiveOwner"
-					:close-after-click="true"
-					@click="onOpenConfig">
-					<template #icon>
-						<Tune :size="20" />
-					</template>
-					{{ t('mydash', 'Dashboard configuration…') }}
-				</NcActionButton>
-				<NcActionButton
-					v-if="canEdit"
-					:close-after-click="true"
-					@click="onAddCustomWidget">
-					<template #icon>
-						<ShapePolygonPlus :size="20" />
-					</template>
-					{{ t('mydash', 'Add custom widget…') }}
-				</NcActionButton>
-				<NcActionButton
-					v-if="isActiveOwner"
-					:close-after-click="true"
-					@click="onDeleteActive">
-					<template #icon>
-						<TrashCanOutline :size="20" />
-					</template>
-					{{ t('mydash', 'Delete dashboard') }}
-				</NcActionButton>
-			</NcActions>
 			<button
 				type="button"
 				class="dashboard-switcher-sidebar__close"
@@ -154,6 +105,14 @@
 							<IconRenderer :name="dashboard.icon" :size="20" />
 						</span>
 						<span class="dashboard-switcher-sidebar__label">{{ dashboard.name }}</span>
+						<DashboardRowActions
+							:dashboard="dashboard"
+							source="group"
+							:can-edit="canEdit"
+							@toggle-edit="onRowToggleEdit(dashboard, 'group')"
+							@open-config="onRowOpenConfig(dashboard, 'group')"
+							@add-custom-widget="onRowAddCustomWidget(dashboard, 'group')"
+							@delete="onRowDelete(dashboard, 'group')" />
 					</li>
 				</ul>
 			</section>
@@ -188,6 +147,14 @@
 							<IconRenderer :name="dashboard.icon" :size="20" />
 						</span>
 						<span class="dashboard-switcher-sidebar__label">{{ dashboard.name }}</span>
+						<DashboardRowActions
+							:dashboard="dashboard"
+							source="default"
+							:can-edit="canEdit"
+							@toggle-edit="onRowToggleEdit(dashboard, 'default')"
+							@open-config="onRowOpenConfig(dashboard, 'default')"
+							@add-custom-widget="onRowAddCustomWidget(dashboard, 'default')"
+							@delete="onRowDelete(dashboard, 'default')" />
 					</li>
 				</ul>
 			</section>
@@ -222,6 +189,14 @@
 							<IconRenderer :name="dashboard.icon" :size="20" />
 						</span>
 						<span class="dashboard-switcher-sidebar__label">{{ dashboard.name }}</span>
+						<DashboardRowActions
+							:dashboard="dashboard"
+							source="user"
+							:can-edit="canEdit"
+							@toggle-edit="onRowToggleEdit(dashboard, 'user')"
+							@open-config="onRowOpenConfig(dashboard, 'user')"
+							@add-custom-widget="onRowAddCustomWidget(dashboard, 'user')"
+							@delete="onRowDelete(dashboard, 'user')" />
 					</li>
 				</ul>
 
@@ -261,19 +236,13 @@
 <script>
 import { t } from '@nextcloud/l10n'
 import { NcButton } from '@conduction/nextcloud-vue'
-import { NcActions, NcActionButton } from '@nextcloud/vue'
 
 import Close from 'vue-material-design-icons/Close.vue'
 import Plus from 'vue-material-design-icons/Plus.vue'
-import Cog from 'vue-material-design-icons/Cog.vue'
-import Pencil from 'vue-material-design-icons/Pencil.vue'
-import ContentSave from 'vue-material-design-icons/ContentSave.vue'
-import Tune from 'vue-material-design-icons/Tune.vue'
-import ShapePolygonPlus from 'vue-material-design-icons/ShapePolygonPlus.vue'
-import TrashCanOutline from 'vue-material-design-icons/TrashCanOutline.vue'
 
 import IconRenderer from '../Dashboard/IconRenderer.vue'
 import SidebarFooter from './SidebarFooter.vue'
+import DashboardRowActions from './DashboardRowActions.vue'
 
 export default {
 	name: 'DashboardSwitcherSidebar',
@@ -281,17 +250,10 @@ export default {
 	components: {
 		Close,
 		Plus,
-		Cog,
-		Pencil,
-		ContentSave,
-		Tune,
-		ShapePolygonPlus,
-		TrashCanOutline,
 		IconRenderer,
 		NcButton,
-		NcActions,
-		NcActionButton,
 		SidebarFooter,
+		DashboardRowActions,
 	},
 
 	/**
@@ -368,20 +330,16 @@ export default {
 		},
 
 		/*
-		 * Per-active-dashboard menu state. Hosted in the sidebar header
-		 * (cog NcActions) since wave3.3 — replaces the floating top-right
-		 * `DashboardConfigMenu`. Each prop mirrors the prop of the same
-		 * name on the old menu so the host wiring stays one-to-one.
+		 * `canEdit` flows down to each per-row cog (wave3.6) so the
+		 * Edit / Add-custom-widget entries can hide for view-only
+		 * users. Configure / Delete remain owner-gated per row via
+		 * `dashboard.isOwner`. The wave3.3 `isEditMode` /
+		 * `isActiveOwner` props were removed when the cog moved out
+		 * of the header — per-row gating uses each row's own
+		 * `dashboard.isOwner`, and Edit/Save toggle is implicit
+		 * (the host enters edit mode after switching).
 		 */
-		isEditMode: {
-			type: Boolean,
-			default: false,
-		},
 		canEdit: {
-			type: Boolean,
-			default: false,
-		},
-		isActiveOwner: {
 			type: Boolean,
 			default: false,
 		},
@@ -392,8 +350,10 @@ export default {
 		'create-dashboard',
 		'delete-dashboard',
 		'update:open',
-		// wave3.3 — emitted by the new in-sidebar cog menu, mirroring the
-		// retired floating `DashboardConfigMenu` events one-to-one.
+		// wave3.6 — per-row events. Each carries `(dashboard, source)`
+		// so the host can switch to that dashboard and then apply the
+		// action. The sidebar emits the raw event; the host owns the
+		// switch-then-apply orchestration.
 		'toggle-edit',
 		'open-config',
 		'add-custom-widget',
@@ -454,33 +414,25 @@ export default {
 			this.$emit('switch', id, source)
 		},
 
-		/**
-		 * Click handler for the cog menu's Delete entry. Emits
-		 * `delete-dashboard(activeDashboardId)`. Wave3.3 replaced the
-		 * per-row X delete buttons with this single header-menu action
-		 * so the destructive path lives next to Edit / Configure / Add
-		 * widget instead of being scattered along the rows.
+		/*
+		 * Per-row action handlers (wave3.6). Each receives the row's
+		 * dashboard payload + its source bucket; they wrap each cog
+		 * action by first emitting `update:open(false)` so the
+		 * sidebar collapses, THEN re-emitting the action upward with
+		 * `(dashboard, source)` so the host can switch to that
+		 * dashboard before applying the action.
 		 */
-		onDeleteActive() {
-			if (this.activeDashboardId != null) {
-				this.$emit('delete-dashboard', this.activeDashboardId)
-			}
+		onRowToggleEdit(dashboard, source) {
+			this.$emit('toggle-edit', dashboard, source)
 		},
-
-		/**
-		 * Cog-menu pass-throughs — these mirror the old floating
-		 * `DashboardConfigMenu` events one-to-one so the host (Views.vue
-		 * / WorkspaceApp.vue) can keep using the same handler bodies it
-		 * already has.
-		 */
-		onToggleEdit() {
-			this.$emit('toggle-edit')
+		onRowOpenConfig(dashboard, source) {
+			this.$emit('open-config', dashboard, source)
 		},
-		onOpenConfig() {
-			this.$emit('open-config')
+		onRowAddCustomWidget(dashboard, source) {
+			this.$emit('add-custom-widget', dashboard, source)
 		},
-		onAddCustomWidget() {
-			this.$emit('add-custom-widget')
+		onRowDelete(dashboard, source) {
+			this.$emit('delete-dashboard', dashboard.id, source)
 		},
 
 		/**

--- a/src/views/Views.vue
+++ b/src/views/Views.vue
@@ -13,15 +13,13 @@
 			:user-dashboards="sidebarUserDashboards"
 			:active-dashboard-id="activeDashboard?.id"
 			:allow-user-dashboards="allowUserDashboards"
-			:is-edit-mode="isEditMode"
 			:can-edit="canEdit"
-			:is-active-owner="activeDashboard?.isOwner !== false"
 			@switch="onSidebarSwitch"
 			@create-dashboard="onSidebarCreateDashboard"
 			@delete-dashboard="onSidebarDeleteDashboard"
-			@toggle-edit="toggleEditMode"
-			@open-config="openConfigModal"
-			@add-custom-widget="openCustomWidgetModal()" />
+			@toggle-edit="onRowToggleEdit"
+			@open-config="onRowOpenConfig"
+			@add-custom-widget="onRowAddCustomWidget" />
 		<SidebarBackdrop
 			v-if="sidebarOpen"
 			@close="sidebarOpen = false" />
@@ -760,6 +758,43 @@ export default {
 			// without re-touching this view (and so the load-bearing
 			// REQ-SWITCH-002 contract is visible at the call site).
 			await this.switchDashboard(id)
+		},
+
+		/*
+		 * Wave3.6 per-row action handlers. Each cog action emits the
+		 * row's full dashboard payload (not just the active one), so
+		 * we first switch to that dashboard (when not already active)
+		 * and then apply the requested action. This lets the user
+		 * Edit / Configure / Add-widget on any row without manually
+		 * switching first.
+		 *
+		 * @param {object} dashboard Row payload (`id`, `name`, `isOwner`, …).
+		 * @param {'group'|'default'|'user'} source Row section discriminator.
+		 */
+		async onRowToggleEdit(dashboard, source) {
+			await this.maybeSwitchTo(dashboard.id, source)
+			this.toggleEditMode()
+		},
+		async onRowOpenConfig(dashboard, source) {
+			await this.maybeSwitchTo(dashboard.id, source)
+			this.openConfigModal()
+		},
+		async onRowAddCustomWidget(dashboard, source) {
+			await this.maybeSwitchTo(dashboard.id, source)
+			this.openCustomWidgetModal()
+		},
+
+		/*
+		 * Switch the active dashboard only when the requested id
+		 * differs from the current active. Avoids a redundant API
+		 * round-trip when the per-row action targets the row that is
+		 * already active.
+		 */
+		async maybeSwitchTo(id, source) {
+			if (this.activeDashboard?.id === id) {
+				return
+			}
+			await this.onSidebarSwitch(id, source)
 		},
 		/**
 		 * Sidebar `+ New Dashboard` row handler — opens the create

--- a/tests/e2e/wave3-runtime-shell.spec.ts
+++ b/tests/e2e/wave3-runtime-shell.spec.ts
@@ -72,19 +72,26 @@ test.describe('wave3 runtime-shell + sidebar UX', () => {
 		expect(box!.width).toBeGreaterThan(800)
 	})
 
-	test('PR #113: sidebar header has cog menu with Edit/Configure/Add-widget/Delete', async ({ page }) => {
+	test('wave3.6: each dashboard row has its own cog menu with Edit/Configure/Add-widget/Delete', async ({ page }) => {
 		await page.locator('.mydash-sidebar-toggle').click()
 		await page.waitForSelector('.dashboard-switcher-sidebar.open', { timeout: 5_000 })
 
-		const cog = page.locator('.dashboard-switcher-sidebar__menu button').first()
-		await expect(cog).toBeVisible()
+		// Header has NO cog after wave3.6 — only the X close button.
+		await expect(page.locator('.dashboard-switcher-sidebar__menu')).toHaveCount(0)
 
-		// Open the cog popover. NcActions teleports the menu to a
-		// portal at the body root, so we don't scope the assertions to
-		// the trigger's subtree — the menu items only exist while the
-		// popover is open which is itself the assertion.
-		await cog.click()
-		await expect(page.getByRole('menuitem', { name: /Edit dashboard|Save dashboard/ })).toBeVisible()
+		// One cog per dashboard row, rendered by `<DashboardRowActions>`.
+		const rowCogs = page.locator('.dashboard-row-actions button')
+		const cogCount = await rowCogs.count()
+		expect(cogCount).toBeGreaterThan(0)
+
+		// Open the cog on a personal dashboard (admin owns all rows in
+		// the test fixture, so the personal section always exposes the
+		// full action set including the owner-gated Configure / Delete).
+		const personalRow = page.locator('[data-section="user"] li.dashboard-switcher-sidebar__item').first()
+		await expect(personalRow).toBeVisible()
+		await personalRow.locator('.dashboard-row-actions button').click()
+
+		await expect(page.getByRole('menuitem', { name: /Edit dashboard/ })).toBeVisible()
 		await expect(page.getByRole('menuitem', { name: /Dashboard configuration/ })).toBeVisible()
 		await expect(page.getByRole('menuitem', { name: /Add custom widget/ })).toBeVisible()
 		await expect(page.getByRole('menuitem', { name: /Delete dashboard/ })).toBeVisible()
@@ -94,7 +101,8 @@ test.describe('wave3 runtime-shell + sidebar UX', () => {
 		await page.locator('.mydash-sidebar-toggle').click()
 		await page.waitForSelector('.dashboard-switcher-sidebar.open', { timeout: 5_000 })
 
-		// Wave3.3 dropped these in favour of the header cog → Delete entry.
+		// Wave3.3 dropped the inline `.__delete` X buttons; wave3.6
+		// moved Delete into the per-row cog (DashboardRowActions).
 		await expect(page.locator('.dashboard-switcher-sidebar__delete')).toHaveCount(0)
 	})
 


### PR DESCRIPTION
## Summary

Wave3.6 moves the per-dashboard actions out of the sidebar header cog and into a per-row cog rendered next to each `<li>`. The header now hosts only the X close button. Each row's cog (**Edit / Configure / Add custom widget / Delete**) operates on that specific dashboard, so the user can edit, configure, or delete any dashboard they have access to without having to switch first.

The arrow in the user's screenshot pointed from the header cog to a specific row — this PR makes the relationship explicit by giving each row its own cog.

### New component
- `src/components/Workspace/DashboardRowActions.vue` — small `NcActions` wrapper used in all three list sections (group / default / personal).

### Sidebar (`DashboardSwitcherSidebar.vue`)
- Drops the header cog block + the wave3.3 `isEditMode` / `isActiveOwner` props (gating now happens per-row).
- Each `<li>` mounts `<DashboardRowActions>` and re-emits `toggle-edit` / `open-config` / `add-custom-widget` / `delete-dashboard` upward with `(dashboard, source)` payloads.
- `@click.stop` on the cog so opening the menu never fires the row's switch handler.

### Host (`Views.vue`)
- New `onRow*` handlers + a `maybeSwitchTo(id, source)` helper that switches to the requested dashboard only when it differs from the currently active one — avoids a redundant API round-trip when the per-row action targets the row that's already active.

### Owner gating
- Personal-section rows (`source === 'user'`) are inherently owned by the caller, so Configure / Delete always render there.
- Group / default rows honour `dashboard.isOwner === true` (set by the visibility API for rows the caller created), and otherwise hide the destructive entries.

## Test plan
- [x] `npm test` — 846/846 pass
- [x] `npm run build` — webpack 5.104.1 compiled with 7 warnings, 0 errors
- [x] `npm run lint` — 0 errors
- [x] `npx playwright test wave3-runtime-shell` — wave3 e2e specs updated (header cog → per-row cog assertions); 2/2 pass on the touched scenarios
- [x] Live: 19 cogs render (one per dashboard row); header has only the X close; clicking a personal row's cog shows all 4 actions

## Follow-ups (not in this PR)
- **Wave3.7 — set as default.** The user also asked for a "Set as default" toggle in dashboard configuration so visiting `/apps/mydash/` always opens the chosen dashboard. The existing `setActivePreference` mechanism already saves the user's last switch as a sticky default (resolver checks it first), but an explicit pin separate from the auto-overwriting active flag is cleaner. Tracked separately.