### PR TITLE
feat(default-dashboard): explicit pin via per-row 'Set as default' cog action

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -27,6 +27,10 @@ return [
 		// the group-scoped routes that share the /api/dashboards/ prefix so the
 		// router matches the literal 'active' segment before any {groupId} wildcard.
 		['name' => 'dashboard_api#setActiveDashboard', 'url' => '/api/dashboards/active', 'verb' => 'POST'],
+		// Wave3.7: explicit default-dashboard pin. Distinct from the
+		// `active` pref above which auto-overwrites on every switch.
+		['name' => 'dashboard_api#setDefaultDashboard', 'url' => '/api/dashboards/default', 'verb' => 'POST'],
+		['name' => 'dashboard_api#getDefaultDashboard', 'url' => '/api/dashboards/default', 'verb' => 'GET'],
 		// REQ-DASH-020..022: fork a visible dashboard as a personal copy.
 		// Registered BEFORE the group-scoped {groupId} wildcard routes to
 		// prevent the literal 'fork' suffix being consumed by any wildcard.

--- a/lib/Controller/DashboardApiController.php
+++ b/lib/Controller/DashboardApiController.php
@@ -936,6 +936,60 @@ class DashboardApiController extends Controller
     }//end setActiveDashboard()
 
     /**
+     * Pin (or clear) the user's EXPLICIT default-dashboard choice
+     * (wave3.7).
+     *
+     * Distinct from {@see self::setActiveDashboard()} — this pref is
+     * only ever written when the user explicitly clicks "Set as
+     * default" on a row's cog menu, and is NOT auto-overwritten on
+     * every switch. The resolver checks it before the active pref so
+     * the pin survives across switches.
+     *
+     * Body shape: `{uuid: string}` — empty string clears the pin.
+     *
+     * @param string|null $uuid The dashboard UUID, or empty string to clear.
+     *
+     * @return JSONResponse 200 `{status: 'success'}` on success; 401
+     *                      when the session has no user.
+     */
+    #[NoAdminRequired]
+    public function setDefaultDashboard(?string $uuid=null): JSONResponse
+    {
+        if ($this->userId === null) {
+            return ResponseHelper::unauthorized();
+        }
+
+        $this->dashboardService->setDefaultPreference(
+            userId: $this->userId,
+            uuid: ($uuid ?? '')
+        );
+
+        return ResponseHelper::success(data: ['status' => 'success']);
+    }//end setDefaultDashboard()
+
+    /**
+     * Read the user's EXPLICIT default-dashboard pin (wave3.7).
+     *
+     * @return JSONResponse 200 `{uuid: string}` — empty string when no
+     *                      pin set; 401 when the session has no user.
+     */
+    #[NoAdminRequired]
+    public function getDefaultDashboard(): JSONResponse
+    {
+        if ($this->userId === null) {
+            return ResponseHelper::unauthorized();
+        }
+
+        return ResponseHelper::success(
+            data: [
+                'uuid' => $this->dashboardService->getDefaultPreference(
+                    userId: $this->userId
+                ),
+            ]
+        );
+    }//end getDefaultDashboard()
+
+    /**
      * Fork any visible dashboard into a brand-new personal copy.
      *
      * REQ-DASH-020 / REQ-DASH-021 / REQ-DASH-022. Body shape:

--- a/lib/Service/DashboardService.php
+++ b/lib/Service/DashboardService.php
@@ -97,6 +97,18 @@ class DashboardService
     public const ACTIVE_DASHBOARD_UUID_PREF_KEY = 'active_dashboard_uuid';
 
     /**
+     * User-pref key for the EXPLICIT default dashboard (wave3.7).
+     * Distinct from `active_dashboard_uuid` — this one is only ever
+     * written when the user explicitly pins a dashboard via the
+     * per-row "Set as default" action; it is NOT auto-overwritten on
+     * every switch. The resolver checks it BEFORE the active pref so
+     * an explicit pin survives across switches.
+     *
+     * @var string
+     */
+    public const DEFAULT_DASHBOARD_UUID_PREF_KEY = 'default_dashboard_uuid';
+
+    /**
      * HTTP-like error message for non-owner / non-admin attempting a
      * publication state mutation. REQ-DASH-032..034.
      *
@@ -293,6 +305,27 @@ class DashboardService
      */
     public function getEffectiveDashboard(string $userId): ?array
     {
+        // Wave3.7 Step 0 — explicit default-dashboard pin wins over
+        // the auto-overwriting active flag. Resolves the pinned UUID
+        // through the user's visible set so a stale UUID falls
+        // through to the legacy chain rather than 404'ing.
+        $defaultUuid = $this->getDefaultPreference(userId: $userId);
+        if ($defaultUuid !== '') {
+            $visible = $this->getVisibleToUser(userId: $userId);
+            foreach ($visible as $entry) {
+                $candidate = $entry['dashboard'];
+                if ((string) $candidate->getUuid() === $defaultUuid) {
+                    $placements = $this->placementMapper->findByDashboardId(
+                        dashboardId: $candidate->getId()
+                    );
+                    return $this->dashResolver->buildResult(
+                        dashboard: $candidate,
+                        placements: $placements
+                    );
+                }
+            }
+        }
+
         $result = $this->dashResolver->tryGetActiveDashboard(
             userId: $userId
         );
@@ -1016,6 +1049,35 @@ class DashboardService
             }
         }
 
+        // Step 0 (wave3.7): explicit default — if the user has pinned
+        // a default dashboard via the per-row "Set as default" action,
+        // it always wins over the auto-overwriting `active_dashboard_uuid`
+        // pref so visiting `/apps/mydash/` consistently opens the same
+        // dashboard regardless of where the user navigated last.
+        $defaultUuid = $this->config->getUserValue(
+            userId: $userId,
+            appName: Application::APP_ID,
+            key: self::DEFAULT_DASHBOARD_UUID_PREF_KEY,
+            default: ''
+        );
+
+        if ($defaultUuid !== '') {
+            if (isset($byUuid[$defaultUuid]) === true) {
+                return $byUuid[$defaultUuid];
+            }
+
+            // Stale default: UUID is no longer visible — clear and fall through.
+            $this->config->deleteUserValue(
+                userId: $userId,
+                appName: Application::APP_ID,
+                key: self::DEFAULT_DASHBOARD_UUID_PREF_KEY
+            );
+            $this->logger->warning(
+                message: 'mydash: stale default_dashboard_uuid "{uuid}" cleared for user "{user}"',
+                context: ['uuid' => $defaultUuid, 'user' => $userId]
+            );
+        }
+
         // Step 1: saved preference.
         $savedUuid = $this->config->getUserValue(
             userId: $userId,
@@ -1132,6 +1194,66 @@ class DashboardService
             value: $uuid
         );
     }//end setActivePreference()
+
+    /**
+     * Persist (or clear) the user's EXPLICIT default-dashboard pin
+     * (wave3.7).
+     *
+     * Distinct from {@see self::setActivePreference()} — this pref is
+     * only ever written when the user clicks "Set as default" on a
+     * row's cog menu (it is NOT auto-overwritten on every switch).
+     * The resolver checks it before the active pref so an explicit
+     * pin survives across switches.
+     *
+     * Same write semantics as `setActivePreference`: no existence
+     * check on write, the resolver's stale-pref path handles missing
+     * UUIDs on next read.
+     *
+     * @param string $userId The user ID.
+     * @param string $uuid   The dashboard UUID, or empty string to clear.
+     *
+     * @return void
+     */
+    public function setDefaultPreference(string $userId, string $uuid): void
+    {
+        if ($uuid === '') {
+            $this->config->deleteUserValue(
+                userId: $userId,
+                appName: Application::APP_ID,
+                key: self::DEFAULT_DASHBOARD_UUID_PREF_KEY
+            );
+            return;
+        }
+
+        $this->config->setUserValue(
+            userId: $userId,
+            appName: Application::APP_ID,
+            key: self::DEFAULT_DASHBOARD_UUID_PREF_KEY,
+            value: $uuid
+        );
+    }//end setDefaultPreference()
+
+    /**
+     * Read the user's explicit default-dashboard pin (wave3.7).
+     *
+     * Returns the empty string when no pin is set. No existence
+     * check is performed here — callers should treat the return
+     * value as advisory; the resolver's stale-pref path is the
+     * authoritative source-of-truth.
+     *
+     * @param string $userId The user ID.
+     *
+     * @return string The pinned dashboard UUID, or '' when unset.
+     */
+    public function getDefaultPreference(string $userId): string
+    {
+        return (string) $this->config->getUserValue(
+            userId: $userId,
+            appName: Application::APP_ID,
+            key: self::DEFAULT_DASHBOARD_UUID_PREF_KEY,
+            default: ''
+        );
+    }//end getDefaultPreference()
 
     /**
      * Transition a dashboard to `published` and stamp `publishedAt`

--- a/src/components/Workspace/DashboardRowActions.vue
+++ b/src/components/Workspace/DashboardRowActions.vue
@@ -69,6 +69,15 @@
 			{{ t('mydash', 'Add custom widget…') }}
 		</NcActionButton>
 		<NcActionButton
+			:close-after-click="true"
+			@click="$emit('set-default')">
+			<template #icon>
+				<StarCheck v-if="isDefault" :size="20" />
+				<Star v-else :size="20" />
+			</template>
+			{{ isDefault ? t('mydash', 'Default dashboard') : t('mydash', 'Set as default') }}
+		</NcActionButton>
+		<NcActionButton
 			v-if="isOwner"
 			:close-after-click="true"
 			@click="$emit('delete')">
@@ -88,6 +97,8 @@ import Pencil from 'vue-material-design-icons/Pencil.vue'
 import Tune from 'vue-material-design-icons/Tune.vue'
 import ShapePolygonPlus from 'vue-material-design-icons/ShapePolygonPlus.vue'
 import TrashCanOutline from 'vue-material-design-icons/TrashCanOutline.vue'
+import Star from 'vue-material-design-icons/Star.vue'
+import StarCheck from 'vue-material-design-icons/StarCheck.vue'
 
 export default {
 	name: 'DashboardRowActions',
@@ -100,6 +111,8 @@ export default {
 		Tune,
 		ShapePolygonPlus,
 		TrashCanOutline,
+		Star,
+		StarCheck,
 	},
 
 	props: {
@@ -116,9 +129,21 @@ export default {
 			type: Boolean,
 			default: false,
 		},
+		/*
+		 * Wave3.7 — UUID of the user's pinned default dashboard, or
+		 * empty/null when no pin is set. The host fetches it once on
+		 * mount via `GET /api/dashboards/default` and forwards it here
+		 * so the cog menu can render the "Set as default" entry as
+		 * either a star (this row is NOT default) or a filled star
+		 * (this row IS the default).
+		 */
+		defaultUuid: {
+			type: String,
+			default: '',
+		},
 	},
 
-	emits: ['toggle-edit', 'open-config', 'add-custom-widget', 'delete'],
+	emits: ['toggle-edit', 'open-config', 'add-custom-widget', 'delete', 'set-default'],
 
 	computed: {
 		/*
@@ -136,6 +161,17 @@ export default {
 				return true
 			}
 			return this.dashboard?.isOwner === true
+		},
+
+		/*
+		 * Wave3.7 — true when THIS row's dashboard is the user's
+		 * pinned default. Drives the cog entry's icon (star vs
+		 * StarCheck) and label ("Set as default" vs "Default
+		 * dashboard").
+		 */
+		isDefault() {
+			const uuid = this.dashboard?.uuid
+			return !!uuid && uuid === this.defaultUuid
 		},
 	},
 

--- a/src/components/Workspace/DashboardSwitcherSidebar.vue
+++ b/src/components/Workspace/DashboardSwitcherSidebar.vue
@@ -109,10 +109,12 @@
 							:dashboard="dashboard"
 							source="group"
 							:can-edit="canEdit"
+							:default-uuid="defaultUuid"
 							@toggle-edit="onRowToggleEdit(dashboard, 'group')"
 							@open-config="onRowOpenConfig(dashboard, 'group')"
 							@add-custom-widget="onRowAddCustomWidget(dashboard, 'group')"
-							@delete="onRowDelete(dashboard, 'group')" />
+							@delete="onRowDelete(dashboard, 'group')"
+							@set-default="onRowSetDefault(dashboard, 'group')" />
 					</li>
 				</ul>
 			</section>
@@ -151,10 +153,12 @@
 							:dashboard="dashboard"
 							source="default"
 							:can-edit="canEdit"
+							:default-uuid="defaultUuid"
 							@toggle-edit="onRowToggleEdit(dashboard, 'default')"
 							@open-config="onRowOpenConfig(dashboard, 'default')"
 							@add-custom-widget="onRowAddCustomWidget(dashboard, 'default')"
-							@delete="onRowDelete(dashboard, 'default')" />
+							@delete="onRowDelete(dashboard, 'default')"
+							@set-default="onRowSetDefault(dashboard, 'default')" />
 					</li>
 				</ul>
 			</section>
@@ -193,10 +197,12 @@
 							:dashboard="dashboard"
 							source="user"
 							:can-edit="canEdit"
+							:default-uuid="defaultUuid"
 							@toggle-edit="onRowToggleEdit(dashboard, 'user')"
 							@open-config="onRowOpenConfig(dashboard, 'user')"
 							@add-custom-widget="onRowAddCustomWidget(dashboard, 'user')"
-							@delete="onRowDelete(dashboard, 'user')" />
+							@delete="onRowDelete(dashboard, 'user')"
+							@set-default="onRowSetDefault(dashboard, 'user')" />
 					</li>
 				</ul>
 
@@ -343,6 +349,17 @@ export default {
 			type: Boolean,
 			default: false,
 		},
+
+		/*
+		 * Wave3.7 — UUID of the user's pinned default dashboard, or
+		 * empty string when no pin is set. Forwarded to each
+		 * DashboardRowActions so the cog menu can show "Set as default"
+		 * vs "Default dashboard" with the right icon.
+		 */
+		defaultUuid: {
+			type: String,
+			default: '',
+		},
 	},
 
 	emits: [
@@ -357,6 +374,9 @@ export default {
 		'toggle-edit',
 		'open-config',
 		'add-custom-widget',
+		// wave3.7 — `(dashboard, source)`. The host pins this row as
+		// the user's default via `POST /api/dashboards/default`.
+		'set-default',
 	],
 
 	computed: {
@@ -433,6 +453,9 @@ export default {
 		},
 		onRowDelete(dashboard, source) {
 			this.$emit('delete-dashboard', dashboard.id, source)
+		},
+		onRowSetDefault(dashboard, source) {
+			this.$emit('set-default', dashboard, source)
 		},
 
 		/**

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -53,6 +53,24 @@ export const api = {
 		return axios.post(`${baseUrl}/api/dashboards/active`, { uuid })
 	},
 
+	/*
+	 * Wave3.7 — pin (or clear) the user's EXPLICIT default-dashboard
+	 * choice. Distinct from `setActiveDashboardPreference` above which
+	 * auto-overwrites on every switch — this one is only ever written
+	 * when the user clicks "Set as default" on a row's cog menu, and
+	 * the resolver checks it before the active pref so the pin
+	 * survives across switches.
+	 */
+	setDefaultDashboardPreference(uuid) {
+		return axios.post(`${baseUrl}/api/dashboards/default`, { uuid })
+	},
+	clearDefaultDashboardPreference() {
+		return axios.post(`${baseUrl}/api/dashboards/default`, { uuid: '' })
+	},
+	getDefaultDashboardPreference() {
+		return axios.get(`${baseUrl}/api/dashboards/default`)
+	},
+
 	createDashboard(data) {
 		return axios.post(`${baseUrl}/api/dashboard`, data)
 	},

--- a/src/views/Views.vue
+++ b/src/views/Views.vue
@@ -14,12 +14,14 @@
 			:active-dashboard-id="activeDashboard?.id"
 			:allow-user-dashboards="allowUserDashboards"
 			:can-edit="canEdit"
+			:default-uuid="defaultDashboardUuid"
 			@switch="onSidebarSwitch"
 			@create-dashboard="onSidebarCreateDashboard"
 			@delete-dashboard="onSidebarDeleteDashboard"
 			@toggle-edit="onRowToggleEdit"
 			@open-config="onRowOpenConfig"
-			@add-custom-widget="onRowAddCustomWidget" />
+			@add-custom-widget="onRowAddCustomWidget"
+			@set-default="onRowSetDefault" />
 		<SidebarBackdrop
 			v-if="sidebarOpen"
 			@close="sidebarOpen = false" />
@@ -274,6 +276,12 @@ export default {
 			// Different uuids are tracked independently per spec
 			// scenario "Different dashboards are not debounced".
 			viewEventLastSent: Object.create(null),
+
+			// Wave3.7 — UUID of the user's pinned default dashboard, or
+			// '' when no pin is set. Fetched once on mount via
+			// `GET /api/dashboards/default` and refreshed locally
+			// whenever the user picks a new default via the cog menu.
+			defaultDashboardUuid: '',
 		}
 	},
 	computed: {
@@ -435,6 +443,18 @@ export default {
 			widgetStore.loadAvailableWidgets(),
 			tileStore.loadTiles(),
 		])
+
+		// Wave3.7 — fetch the user's pinned default-dashboard UUID
+		// once on mount so the per-row cog can render the right "Set
+		// as default" / "Default dashboard" state. Failure here is
+		// non-fatal: the cog falls back to "Set as default" for every
+		// row when the pref can't be read.
+		try {
+			const res = await api.getDefaultDashboardPreference()
+			this.defaultDashboardUuid = res?.data?.uuid ?? ''
+		} catch (error) {
+			console.error('[Views] Failed to load default-dashboard preference:', error)
+		}
 	},
 	mounted() {
 		// Attach the document-level click listener (REQ-WDG-016 outside-
@@ -782,6 +802,34 @@ export default {
 		async onRowAddCustomWidget(dashboard, source) {
 			await this.maybeSwitchTo(dashboard.id, source)
 			this.openCustomWidgetModal()
+		},
+
+		/*
+		 * Wave3.7 — pin the row's dashboard as the user's default.
+		 * Toggle semantics: clicking on the already-pinned row clears
+		 * the pin (so the cog shows "Set as default" again on next
+		 * open); clicking on any other row replaces the pin with that
+		 * dashboard's UUID. The new pref takes effect on the next
+		 * page load — visiting `/apps/mydash/` will resolve to this
+		 * dashboard via the resolver's Step 0.
+		 */
+		// eslint-disable-next-line no-unused-vars
+		async onRowSetDefault(dashboard, source) {
+			const uuid = dashboard?.uuid ?? ''
+			if (uuid === '') {
+				return
+			}
+			try {
+				if (this.defaultDashboardUuid === uuid) {
+					await api.clearDefaultDashboardPreference()
+					this.defaultDashboardUuid = ''
+				} else {
+					await api.setDefaultDashboardPreference(uuid)
+					this.defaultDashboardUuid = uuid
+				}
+			} catch (error) {
+				console.error('[Views] Failed to update default-dashboard preference:', error)
+			}
 		},
 
 		/*


### PR DESCRIPTION
## Summary

Adds a separate `default_dashboard_uuid` user preference distinct from the auto-overwriting `active_dashboard_uuid`. Visiting `/apps/mydash/` now resolves to the pinned default first; switching dashboards no longer changes which one opens on next visit.

Closes the user's two requests:
> Going to http://localhost:8080/apps/mydash/ doesn't open the default dashboard, I should be able to set a dashboard as default in dashboard configuration  
> The edit dashboard function should be per dashboard

(The per-row cog landed in PR #116 / wave3.6; this PR completes the picture by adding the 5th "Set as default" entry alongside it.)

## Backend (PHP)
- `DashboardService::DEFAULT_DASHBOARD_UUID_PREF_KEY` constant.
- `DashboardService::setDefaultPreference($uid, $uuid)` + `getDefaultPreference($uid)` — read/write/clear of the new pref.
- `DashboardService::resolveActiveDashboard()` gets a new **Step 0**: if a default pin is set and resolves to a visible dashboard, return it; if stale, clear the pref + warn + fall through to the existing 7-step chain.
- `DashboardService::getEffectiveDashboard()` mirrors the same Step 0 — the legacy `GET /api/dashboard` endpoint (which the Vue store hits via `loadDashboards`) was bypassing the new chain and overriding the server-rendered initial state on boot. **Both code paths now honour the pin.**
- `DashboardApiController::setDefaultDashboard` + `getDefaultDashboard` endpoints, registered as `POST /api/dashboards/default` + `GET /api/dashboards/default`.

## Frontend (Vue)
- `services/api.js`: `setDefaultDashboardPreference(uuid)`, `clearDefaultDashboardPreference()`, `getDefaultDashboardPreference()`.
- `DashboardRowActions.vue`: 5th cog entry "Set as default" / "Default dashboard" with a Star / StarCheck icon driven by the new `defaultUuid` prop + `isDefault` computed.
- `DashboardSwitcherSidebar.vue`: forwards `defaultUuid` to each row, re-emits `set-default(dashboard, source)` to the host.
- `Views.vue`: fetches the pinned UUID once on `created`, stores it on `defaultDashboardUuid`, and `onRowSetDefault` toggles the pin (clear on the same row, replace otherwise).

## UX semantics
- "Set as default" is shown on every row regardless of ownership; the pin only affects the pinning user, so it doesn't need owner-gating.
- Clicking the pinned row again **clears the pin** (toggle).
- Switching dashboards still updates `active_dashboard_uuid` for the "remember where I was" UX, but the explicit default takes precedence on visit.

## Test plan
- [x] `npm test` — 846/846 unit tests pass
- [x] `npm run build` — webpack 5.104.1 compiled with 7 warnings, 0 errors
- [x] `npm run lint` — 0 errors
- [x] Live: pin "wewr" via the cog → revisit `/apps/mydash/` opens "wewr" (`active.uuid === default.uuid`); cog label flips to "Default dashboard"
- [x] Live: 5 cog items render in the per-row menu (Edit / Configure / Add custom widget / Set as default / Delete)
- [ ] Backend coverage of the new service + controller surface in a follow-up PHPUnit suite (existing `DashboardServiceForUserDashboardTest` pattern is the right home)