### PR TITLE
fix(sidebar): per-row cog flips Edit→Save on the active row when editing

### DIFF
--- a/src/components/Workspace/DashboardRowActions.vue
+++ b/src/components/Workspace/DashboardRowActions.vue
@@ -46,9 +46,10 @@
 			:close-after-click="true"
 			@click="$emit('toggle-edit')">
 			<template #icon>
-				<Pencil :size="20" />
+				<ContentSave v-if="showSave" :size="20" />
+				<Pencil v-else :size="20" />
 			</template>
-			{{ t('mydash', 'Edit dashboard') }}
+			{{ showSave ? t('mydash', 'Save dashboard') : t('mydash', 'Edit dashboard') }}
 		</NcActionButton>
 		<NcActionButton
 			v-if="isOwner"
@@ -94,6 +95,7 @@ import { t } from '@nextcloud/l10n'
 import { NcActions, NcActionButton } from '@nextcloud/vue'
 import Cog from 'vue-material-design-icons/Cog.vue'
 import Pencil from 'vue-material-design-icons/Pencil.vue'
+import ContentSave from 'vue-material-design-icons/ContentSave.vue'
 import Tune from 'vue-material-design-icons/Tune.vue'
 import ShapePolygonPlus from 'vue-material-design-icons/ShapePolygonPlus.vue'
 import TrashCanOutline from 'vue-material-design-icons/TrashCanOutline.vue'
@@ -108,6 +110,7 @@ export default {
 		NcActionButton,
 		Cog,
 		Pencil,
+		ContentSave,
 		Tune,
 		ShapePolygonPlus,
 		TrashCanOutline,
@@ -141,6 +144,23 @@ export default {
 			type: String,
 			default: '',
 		},
+
+		/*
+		 * Wave3.9 — when this row matches the currently active
+		 * dashboard AND the host is in edit mode, the cog's
+		 * Edit / Save toggle button flips to "Save dashboard" with
+		 * the ContentSave icon. The host owns the edit-mode boolean
+		 * (lives on Views.vue's `isEditMode` data field) and the
+		 * active id (`activeDashboard.id`) and forwards both down.
+		 */
+		isEditMode: {
+			type: Boolean,
+			default: false,
+		},
+		activeDashboardId: {
+			type: [String, Number],
+			default: null,
+		},
 	},
 
 	emits: ['toggle-edit', 'open-config', 'add-custom-widget', 'delete', 'set-default'],
@@ -172,6 +192,20 @@ export default {
 		isDefault() {
 			const uuid = this.dashboard?.uuid
 			return !!uuid && uuid === this.defaultUuid
+		},
+
+		/*
+		 * Wave3.9 — true when the cog button should show the Save
+		 * variant (icon + label). Only true on the row whose
+		 * dashboard is currently active AND the host is in edit
+		 * mode. Other rows keep showing "Edit dashboard" so the
+		 * user can still enter edit mode on them by switching first
+		 * (the host's `maybeSwitchTo` helper handles that).
+		 */
+		showSave() {
+			return this.isEditMode
+				&& this.activeDashboardId != null
+				&& this.dashboard?.id === this.activeDashboardId
 		},
 	},
 

--- a/src/components/Workspace/DashboardSwitcherSidebar.vue
+++ b/src/components/Workspace/DashboardSwitcherSidebar.vue
@@ -110,6 +110,8 @@
 							source="group"
 							:can-edit="canEdit"
 							:default-uuid="defaultUuid"
+							:is-edit-mode="isEditMode"
+							:active-dashboard-id="activeDashboardId"
 							@toggle-edit="onRowToggleEdit(dashboard, 'group')"
 							@open-config="onRowOpenConfig(dashboard, 'group')"
 							@add-custom-widget="onRowAddCustomWidget(dashboard, 'group')"
@@ -154,6 +156,8 @@
 							source="default"
 							:can-edit="canEdit"
 							:default-uuid="defaultUuid"
+							:is-edit-mode="isEditMode"
+							:active-dashboard-id="activeDashboardId"
 							@toggle-edit="onRowToggleEdit(dashboard, 'default')"
 							@open-config="onRowOpenConfig(dashboard, 'default')"
 							@add-custom-widget="onRowAddCustomWidget(dashboard, 'default')"
@@ -198,6 +202,8 @@
 							source="user"
 							:can-edit="canEdit"
 							:default-uuid="defaultUuid"
+							:is-edit-mode="isEditMode"
+							:active-dashboard-id="activeDashboardId"
 							@toggle-edit="onRowToggleEdit(dashboard, 'user')"
 							@open-config="onRowOpenConfig(dashboard, 'user')"
 							@add-custom-widget="onRowAddCustomWidget(dashboard, 'user')"
@@ -359,6 +365,16 @@ export default {
 		defaultUuid: {
 			type: String,
 			default: '',
+		},
+
+		/*
+		 * Wave3.9 — host's edit-mode boolean. Forwarded down so the
+		 * cog button on the active row flips to "Save dashboard" +
+		 * ContentSave icon while editing.
+		 */
+		isEditMode: {
+			type: Boolean,
+			default: false,
 		},
 	},
 

--- a/src/views/Views.vue
+++ b/src/views/Views.vue
@@ -15,6 +15,7 @@
 			:allow-user-dashboards="allowUserDashboards"
 			:can-edit="canEdit"
 			:default-uuid="defaultDashboardUuid"
+			:is-edit-mode="isEditMode"
 			@switch="onSidebarSwitch"
 			@create-dashboard="onSidebarCreateDashboard"
 			@delete-dashboard="onSidebarDeleteDashboard"


### PR DESCRIPTION
## Summary

Wave3.6 dropped the wave3.3 header-cog `isEditMode` awareness when the per-dashboard actions moved into per-row cogs. The button always showed "Edit dashboard" + pencil icon, even after entering edit mode — so the user had no visual cue that clicking again saves (their report: *"When editing the dashboard I don't get a save option"*).

## Changes

**DashboardRowActions**
- New `isEditMode: Boolean` + `activeDashboardId: [String, Number]` props.
- New `showSave` computed — true only when this row's dashboard matches the active id **AND** the host is in edit mode.
- Edit button shows `ContentSave` icon + "Save dashboard" label when `showSave`; pencil + "Edit dashboard" otherwise.

**DashboardSwitcherSidebar**
- New `isEditMode: Boolean` prop, forwarded to all three per-row `<DashboardRowActions>` instances (group / default / personal) along with the existing `activeDashboardId`.

**Views.vue**
- Forwards `:is-edit-mode="isEditMode"` to the sidebar so the label flips reactively when `toggleEditMode()` runs.

Other rows still show "Edit dashboard" — clicking on a non-active row's "Edit dashboard" switches to that dashboard via the existing `maybeSwitchTo` helper, then enters edit mode (same flow as wave3.6).

## Test plan
- [x] `npm test` — 846/846 pass
- [x] `npm run build` — webpack 5.104.1 compiled with 7 warnings, 0 errors
- [x] `npm run lint` — 0 errors
- [x] Live verified end-to-end:
  - Open active row's cog → "Edit dashboard"
  - Click → `isEditMode = true`
  - Re-open same cog → "Save dashboard" with ContentSave icon
  - Click → `isEditMode = false`, dashboard saved, label flips back