### PR TITLE
ci(playwright): future-prep `ensureBundleBuilt()` helper (gate stays disabled)

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -18,19 +18,23 @@ jobs:
       enable-phpmetrics: true
       enable-frontend: true
       enable-eslint: true
-      # Hard gate added wave3.10: PHPUnit. The shared workflow runs
-      # `./vendor/bin/phpunit -c phpunit.xml`; mydash historically
-      # used `phpunit-unit.xml` so the validation step accepted the
-      # name but the run step failed with "Could not read XML from
-      # file `phpunit.xml`". This branch renames the file to
-      # `phpunit.xml` so the run step works without a cross-repo
-      # input change to `ConductionNL/.github/quality.yml`. The
-      # composer scripts that drive local runs (`test`, `test:unit`,
-      # `test:all`, `test:coverage`) were updated in the same commit.
+      # Hard gates wired in wave3.10..3.11:
+      #   - PHPUnit (3.10) — `phpunit.xml` rename (was phpunit-unit.xml)
+      #     plus a `$roleFeaturePerm` nullable shim so existing PHPUnit
+      #     fixtures keep building. 4-way matrix (PHP 8.3/8.4 × NC
+      #     stable31/stable32) all green.
+      #   - Playwright (3.11) — the shared job runs `npm ci` +
+      #     `playwright install` but never `npm run build`. The bundle
+      #     `js/mydash-main.js` therefore wouldn't exist on a fresh CI
+      #     runner, the page would 404 the script tag, and every spec
+      #     would time out on `.mydash-sidebar-toggle`. The Playwright
+      #     `globalSetup` (tests/e2e/global-setup.ts) now detects the
+      #     missing bundle and runs `npm run build` once before specs
+      #     start. Local runs short-circuit when the bundle is already
+      #     on disk (no rebuild penalty).
       #
-      # Newman + Playwright are still disabled — the postman
-      # collection has pre-existing assertion drift, and the shared
-      # Playwright job needs an `occ app:enable mydash` + fixture
-      # seed step before specs run on a fresh CI VM. Tracked
-      # separately as their own follow-up commits.
+      # Newman is still disabled — the postman collection has
+      # pre-existing assertion drift (e.g. an endpoint returns 204
+      # where the test expects [400, 403, 404]). Tracked separately.
       enable-phpunit: true
+      enable-playwright: true

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -18,23 +18,23 @@ jobs:
       enable-phpmetrics: true
       enable-frontend: true
       enable-eslint: true
-      # Hard gates wired in wave3.10..3.11:
-      #   - PHPUnit (3.10) — `phpunit.xml` rename (was phpunit-unit.xml)
-      #     plus a `$roleFeaturePerm` nullable shim so existing PHPUnit
+      # Hard gate wired in wave3.10:
+      #   - PHPUnit — `phpunit.xml` rename (was phpunit-unit.xml) plus
+      #     a `$roleFeaturePerm` nullable shim so existing PHPUnit
       #     fixtures keep building. 4-way matrix (PHP 8.3/8.4 × NC
       #     stable31/stable32) all green.
-      #   - Playwright (3.11) — the shared job runs `npm ci` +
-      #     `playwright install` but never `npm run build`. The bundle
-      #     `js/mydash-main.js` therefore wouldn't exist on a fresh CI
-      #     runner, the page would 404 the script tag, and every spec
-      #     would time out on `.mydash-sidebar-toggle`. The Playwright
-      #     `globalSetup` (tests/e2e/global-setup.ts) now detects the
-      #     missing bundle and runs `npm run build` once before specs
-      #     start. Local runs short-circuit when the bundle is already
-      #     on disk (no rebuild penalty).
       #
-      # Newman is still disabled — the postman collection has
-      # pre-existing assertion drift (e.g. an endpoint returns 204
-      # where the test expects [400, 403, 404]). Tracked separately.
+      # Playwright + Newman remain disabled:
+      #   - Playwright: this branch ALSO landed the
+      #     `tests/e2e/global-setup.ts` `ensureBundleBuilt()` helper —
+      #     a future-prep change so when the shared workflow's
+      #     PHP-built-in-server lifetime is fixed (cross-repo PR to
+      #     `ConductionNL/.github`), flipping the gate Just Works.
+      #     Today the server appears to die between the build step and
+      #     the spec phase — every spec times out on
+      #     `.mydash-sidebar-toggle` even though the bundle compiles
+      #     successfully. Locally `npx playwright test` still passes
+      #     against the dev container.
+      #   - Newman: postman collection has pre-existing assertion
+      #     drift; needs its own sweep.
       enable-phpunit: true
-      enable-playwright: true

--- a/tests/e2e/global-setup.ts
+++ b/tests/e2e/global-setup.ts
@@ -17,11 +17,40 @@
  */
 
 import { chromium, request, type FullConfig } from '@playwright/test'
+import { execSync } from 'child_process'
 import * as path from 'path'
 import * as fs from 'fs'
 
 const AUTH_DIR = path.resolve(__dirname, '.auth')
 const STORAGE_STATE = path.join(AUTH_DIR, 'admin.json')
+const APP_ROOT = path.resolve(__dirname, '..', '..')
+const BUNDLE_PATH = path.join(APP_ROOT, 'js', 'mydash-main.js')
+
+/**
+ * Ensure the webpack bundle exists before specs hit `/apps/mydash/`.
+ *
+ * The shared `ConductionNL/.github/quality.yml` Playwright job runs
+ * `npm ci` + `npx playwright install` before the spec run, but never
+ * `npm run build`. On a fresh CI VM the `js/mydash-main.js` artefact
+ * doesn't exist, so the rendered page loads a 404 script tag and the
+ * Vue app never mounts — every selector wait then times out.
+ *
+ * This helper detects the missing bundle and invokes the build once
+ * before specs run. Local dev usually has the bundle present (latest
+ * webpack output is cached on disk) so the build is a no-op there.
+ *
+ * Skipping the build entirely on CI would require a cross-repo PR to
+ * `ConductionNL/.github` adding a `npm run build` step to the shared
+ * workflow; doing it here keeps the fix self-contained.
+ */
+function ensureBundleBuilt(): void {
+	if (fs.existsSync(BUNDLE_PATH)) {
+		return
+	}
+	// eslint-disable-next-line no-console
+	console.log(`[playwright globalSetup] bundle missing at ${BUNDLE_PATH}; running 'npm run build' once…`)
+	execSync('npm run build', { cwd: APP_ROOT, stdio: 'inherit' })
+}
 
 async function ensureNextcloudReachable(baseURL: string): Promise<void> {
 	const ctx = await request.newContext()
@@ -51,6 +80,7 @@ export default async function globalSetup(config: FullConfig): Promise<void> {
 	const username = process.env.NC_ADMIN_USER ?? 'admin'
 	const password = process.env.NC_ADMIN_PASS ?? 'admin'
 
+	ensureBundleBuilt()
 	await ensureNextcloudReachable(baseURL)
 	fs.mkdirSync(AUTH_DIR, { recursive: true })
 


### PR DESCRIPTION
## Summary

Lands future-prep for the Playwright hard-gate without flipping it. The first attempt (commit c3ba10a, see history) flipped \`enable-playwright: true\` end-to-end; the matrix run revealed a separate blocker: the shared workflow's backgrounded \`php -S 0.0.0.0:8080 &\` server appears to die between the start step and the spec phase. The only HTTP request the server's access log records is the initial \`GET /status.php\`; every Playwright navigation thereafter times out.

Fix needs to be in the shared workflow — either restart the server before specs run, or do the build before the server start. That's a cross-repo PR to \`ConductionNL/.github\` and tracked separately.

## What lands

\`tests/e2e/global-setup.ts\` — new \`ensureBundleBuilt()\` helper. Detects \`js/mydash-main.js\` and runs \`npm run build\` once when missing. Local dev short-circuits (bundle already on disk → no-op). When the shared workflow is eventually fixed, flipping \`enable-playwright: true\` Just Works without further mydash changes.

The wave3.5 e2e spec file (\`tests/e2e/wave3-runtime-shell.spec.ts\`) is already in dev (PR #115) and locally passes 7/7.

## Diagnosis (for future cleanup)

CI run \`25307...\` for commit c3ba10a:
- \`occ app:enable mydash\` ✓ (line 1049 of shared workflow)
- \`php -S 0.0.0.0:8080 &\` started, status.php returns 200 (line 1054)
- composer install + npm ci + playwright install + 50 s npm run build (now via globalSetup)
- Run Playwright tests → 21/22 specs time out on \`.mydash-sidebar-toggle\`
- Server access log shows only the original \`GET /status.php\` — no spec-phase requests reached it

Most likely root cause: the backgrounded server process is owned by the start step's shell, gets disowned when that step ends, and either dies on reap or remains alive but with stale state. Either way, the spec phase doesn't reach a working server.

## Test plan
- [x] PHPUnit gate (PR #121) still green: 4/4 matrix slots pass
- [x] All other quality jobs pass (phpcs, phpstan, psalm, eslint, …)
- [x] Local: \`npx playwright test wave3-runtime-shell -g 'default state'\` passes against dev container; helper short-circuits

## Follow-ups
- Cross-repo PR to \`ConductionNL/.github\` to fix the PHP-server lifetime in the Playwright job
- Newman gate: postman collection assertion drift sweep