### PR TITLE
feat(sidebar): mark the pinned default dashboard with a star

### DIFF
--- a/src/components/Workspace/DashboardSwitcherSidebar.vue
+++ b/src/components/Workspace/DashboardSwitcherSidebar.vue
@@ -440,6 +440,44 @@ export default {
 		},
 
 		/**
+		 * UUID of the row the resolver would land the user on at
+		 * `/apps/mydash/`. Mirrors the backend's resolver precedence
+		 * (steps 0..5) up to the group fallback so the star stays in
+		 * sync with what the user will actually see when they navigate
+		 * cold. Personal dashboards (step 6) are intentionally NOT
+		 * starred when no explicit pin is set — starring an arbitrary
+		 * personal dashboard the user never marked feels presumptuous.
+		 *
+		 * @return {string} UUID of the effective default, or '' when
+		 *                  no pin/group default applies.
+		 */
+		effectiveDefaultUuid() {
+			if (this.defaultUuid) {
+				return this.defaultUuid
+			}
+			const isDefaultFlag = (d) => Number(d?.isDefault) === 1
+			// Step 2: primary-group with isDefault=1.
+			const groupDefault = this.primaryGroupDashboards.find(isDefaultFlag)
+			if (groupDefault?.uuid) {
+				return groupDefault.uuid
+			}
+			// Step 3: default-group with isDefault=1.
+			const defaultDefault = this.defaultGroupDashboards.find(isDefaultFlag)
+			if (defaultDefault?.uuid) {
+				return defaultDefault.uuid
+			}
+			// Step 4: first primary-group dashboard (no flag).
+			if (this.primaryGroupDashboards[0]?.uuid) {
+				return this.primaryGroupDashboards[0].uuid
+			}
+			// Step 5: first default-group dashboard (no flag).
+			if (this.defaultGroupDashboards[0]?.uuid) {
+				return this.defaultGroupDashboards[0].uuid
+			}
+			return ''
+		},
+
+		/**
 		 * Vue 2's `:aria-hidden="false"` removes the attribute entirely
 		 * rather than writing the literal string `"false"`. Screen readers
 		 * (and the WCAG rule that asks for an explicit `false` while open)
@@ -461,17 +499,17 @@ export default {
 		},
 
 		/**
-		 * Whether `dashboard` is the user's pinned default — the row that
-		 * the resolver's "step 0" lands on when the user visits
-		 * `/apps/mydash/`. The sidebar marks it with a star icon so the
-		 * pin is visible at a glance instead of buried in the cog menu.
+		 * Whether `dashboard` is the row the resolver would land the
+		 * user on when they visit `/apps/mydash/`. The sidebar marks it
+		 * with a star so the effective default is visible at a glance
+		 * instead of buried in the cog menu.
 		 *
 		 * @param {object} dashboard Row payload from the parent.
-		 * @return {boolean} True when the row is the active pin.
+		 * @return {boolean} True when the row is the effective default.
 		 */
 		isDefaultDashboard(dashboard) {
-			return Boolean(this.defaultUuid)
-				&& dashboard?.uuid === this.defaultUuid
+			return Boolean(this.effectiveDefaultUuid)
+				&& dashboard?.uuid === this.effectiveDefaultUuid
 		},
 
 		/**

--- a/src/components/Workspace/DashboardSwitcherSidebar.vue
+++ b/src/components/Workspace/DashboardSwitcherSidebar.vue
@@ -104,6 +104,13 @@
 						<span class="dashboard-switcher-sidebar__icon">
 							<IconRenderer :name="dashboard.icon" :size="20" />
 						</span>
+						<span
+							v-if="isDefaultDashboard(dashboard)"
+							class="dashboard-switcher-sidebar__default-marker"
+							:title="t('mydash', 'Default dashboard — opens automatically when you visit MyDash')"
+							:aria-label="t('mydash', 'Default dashboard')">
+							<Star :size="16" />
+						</span>
 						<span class="dashboard-switcher-sidebar__label">{{ dashboard.name }}</span>
 						<DashboardRowActions
 							:dashboard="dashboard"
@@ -150,6 +157,13 @@
 						<span class="dashboard-switcher-sidebar__icon">
 							<IconRenderer :name="dashboard.icon" :size="20" />
 						</span>
+						<span
+							v-if="isDefaultDashboard(dashboard)"
+							class="dashboard-switcher-sidebar__default-marker"
+							:title="t('mydash', 'Default dashboard — opens automatically when you visit MyDash')"
+							:aria-label="t('mydash', 'Default dashboard')">
+							<Star :size="16" />
+						</span>
 						<span class="dashboard-switcher-sidebar__label">{{ dashboard.name }}</span>
 						<DashboardRowActions
 							:dashboard="dashboard"
@@ -195,6 +209,13 @@
 						@keydown.space.prevent="onSwitch(dashboard.id, 'user')">
 						<span class="dashboard-switcher-sidebar__icon">
 							<IconRenderer :name="dashboard.icon" :size="20" />
+						</span>
+						<span
+							v-if="isDefaultDashboard(dashboard)"
+							class="dashboard-switcher-sidebar__default-marker"
+							:title="t('mydash', 'Default dashboard — opens automatically when you visit MyDash')"
+							:aria-label="t('mydash', 'Default dashboard')">
+							<Star :size="16" />
 						</span>
 						<span class="dashboard-switcher-sidebar__label">{{ dashboard.name }}</span>
 						<DashboardRowActions
@@ -251,6 +272,7 @@ import { NcButton } from '@conduction/nextcloud-vue'
 
 import Close from 'vue-material-design-icons/Close.vue'
 import Plus from 'vue-material-design-icons/Plus.vue'
+import Star from 'vue-material-design-icons/Star.vue'
 
 import IconRenderer from '../Dashboard/IconRenderer.vue'
 import SidebarFooter from './SidebarFooter.vue'
@@ -262,6 +284,7 @@ export default {
 	components: {
 		Close,
 		Plus,
+		Star,
 		IconRenderer,
 		NcButton,
 		SidebarFooter,
@@ -438,6 +461,20 @@ export default {
 		},
 
 		/**
+		 * Whether `dashboard` is the user's pinned default — the row that
+		 * the resolver's "step 0" lands on when the user visits
+		 * `/apps/mydash/`. The sidebar marks it with a star icon so the
+		 * pin is visible at a glance instead of buried in the cog menu.
+		 *
+		 * @param {object} dashboard Row payload from the parent.
+		 * @return {boolean} True when the row is the active pin.
+		 */
+		isDefaultDashboard(dashboard) {
+			return Boolean(this.defaultUuid)
+				&& dashboard?.uuid === this.defaultUuid
+		},
+
+		/**
 		 * Click handler for a dashboard row. MUST emit `update:open(false)`
 		 * BEFORE `switch(id, source)` so the parent can close the sidebar
 		 * in the same tick (REQ-SWITCH-002).
@@ -609,6 +646,14 @@ export default {
 	justify-content: center;
 	width: 20px;
 	height: 20px;
+}
+
+.dashboard-switcher-sidebar__default-marker {
+	flex: 0 0 auto;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	color: var(--color-warning, #e9a800);
 }
 
 .dashboard-switcher-sidebar__label {

--- a/src/components/Workspace/__tests__/DashboardSwitcherSidebar.spec.js
+++ b/src/components/Workspace/__tests__/DashboardSwitcherSidebar.spec.js
@@ -401,4 +401,64 @@ describe('DashboardSwitcherSidebar', () => {
 			expect(wrapper.emitted('update:open')[0]).toEqual([false])
 		})
 	})
+
+	describe('default-dashboard star marker', () => {
+		const userRowWithUuid = { id: 'p1', uuid: 'pin-uuid', name: 'My Notes', icon: null, source: 'user' }
+		const userRowOtherUuid = { id: 'p2', uuid: 'other-uuid', name: 'Side Project', icon: null, source: 'user' }
+		const groupRowWithUuid = { id: 'g1', uuid: 'group-uuid', name: 'Team Board', icon: null, source: 'group' }
+
+		it('renders a star marker only on the row whose uuid matches defaultUuid', () => {
+			const wrapper = mountSidebar({
+				userDashboards: [userRowWithUuid, userRowOtherUuid],
+				defaultUuid: 'pin-uuid',
+			})
+
+			const markers = wrapper.findAll('.dashboard-switcher-sidebar__default-marker')
+			expect(markers.length).toBe(1)
+
+			// The star sits in the row for the pinned dashboard.
+			const pinnedRow = wrapper.findAll('.dashboard-switcher-sidebar__item').wrappers.find(
+				(li) => li.text().includes('My Notes'),
+			)
+			expect(pinnedRow.find('.dashboard-switcher-sidebar__default-marker').exists()).toBe(true)
+		})
+
+		it('star marker carries a tooltip via the title attribute', () => {
+			const wrapper = mountSidebar({
+				userDashboards: [userRowWithUuid],
+				defaultUuid: 'pin-uuid',
+			})
+
+			const marker = wrapper.find('.dashboard-switcher-sidebar__default-marker')
+			expect(marker.exists()).toBe(true)
+			expect(marker.attributes('title')).toMatch(/default dashboard/i)
+			expect(marker.attributes('aria-label')).toMatch(/default dashboard/i)
+		})
+
+		it('does not render any star marker when defaultUuid is empty', () => {
+			const wrapper = mountSidebar({
+				userDashboards: [userRowWithUuid, userRowOtherUuid],
+				defaultUuid: '',
+			})
+
+			expect(wrapper.findAll('.dashboard-switcher-sidebar__default-marker').length).toBe(0)
+		})
+
+		it('marks a group-section row when the user has pinned a group dashboard', () => {
+			const wrapper = mountSidebar({
+				groupName: 'Engineering',
+				groupDashboards: [groupRowWithUuid],
+				userDashboards: [userRowOtherUuid],
+				defaultUuid: 'group-uuid',
+			})
+
+			const markers = wrapper.findAll('.dashboard-switcher-sidebar__default-marker')
+			expect(markers.length).toBe(1)
+
+			const pinnedRow = wrapper.findAll('.dashboard-switcher-sidebar__item').wrappers.find(
+				(li) => li.text().includes('Team Board'),
+			)
+			expect(pinnedRow.find('.dashboard-switcher-sidebar__default-marker').exists()).toBe(true)
+		})
+	})
 })

--- a/src/components/Workspace/__tests__/DashboardSwitcherSidebar.spec.js
+++ b/src/components/Workspace/__tests__/DashboardSwitcherSidebar.spec.js
@@ -460,5 +460,86 @@ describe('DashboardSwitcherSidebar', () => {
 			)
 			expect(pinnedRow.find('.dashboard-switcher-sidebar__default-marker').exists()).toBe(true)
 		})
+
+		describe('group-default fallback (no personal pin)', () => {
+			it('falls back to the default-group row carrying isDefault=1 when no pin is set', () => {
+				const groupDefault = { id: 'g3', uuid: 'group-default-uuid', name: 'Group Default', icon: null, source: 'default', isDefault: 1 }
+				const otherGroup = { id: 'g4', uuid: 'other-default-uuid', name: 'Other Default', icon: null, source: 'default', isDefault: 0 }
+
+				const wrapper = mountSidebar({
+					groupDashboards: [otherGroup, groupDefault],
+					userDashboards: [userRowOtherUuid],
+					defaultUuid: '',
+				})
+
+				const markers = wrapper.findAll('.dashboard-switcher-sidebar__default-marker')
+				expect(markers.length).toBe(1)
+				const starred = wrapper.findAll('.dashboard-switcher-sidebar__item').wrappers.find(
+					(li) => li.find('.dashboard-switcher-sidebar__default-marker').exists(),
+				)
+				expect(starred.text()).toContain('Group Default')
+			})
+
+			it('prefers a primary-group isDefault=1 row over a default-group isDefault=1 row (resolver step 2 wins)', () => {
+				const primaryDefault = { id: 'g5', uuid: 'primary-default', name: 'Primary Default', icon: null, source: 'group', isDefault: 1 }
+				const fallbackDefault = { id: 'g6', uuid: 'fallback-default', name: 'Fallback Default', icon: null, source: 'default', isDefault: 1 }
+
+				const wrapper = mountSidebar({
+					groupName: 'Engineering',
+					groupDashboards: [fallbackDefault, primaryDefault],
+					userDashboards: [],
+					defaultUuid: '',
+				})
+
+				const starred = wrapper.findAll('.dashboard-switcher-sidebar__item').wrappers.find(
+					(li) => li.find('.dashboard-switcher-sidebar__default-marker').exists(),
+				)
+				expect(starred.text()).toContain('Primary Default')
+			})
+
+			it('falls back to the first primary-group row when no isDefault=1 flag exists anywhere', () => {
+				const firstPrimary = { id: 'g7', uuid: 'first-primary', name: 'First Primary', icon: null, source: 'group', isDefault: 0 }
+				const secondPrimary = { id: 'g8', uuid: 'second-primary', name: 'Second Primary', icon: null, source: 'group', isDefault: 0 }
+
+				const wrapper = mountSidebar({
+					groupName: 'Engineering',
+					groupDashboards: [firstPrimary, secondPrimary],
+					userDashboards: [],
+					defaultUuid: '',
+				})
+
+				const starred = wrapper.findAll('.dashboard-switcher-sidebar__item').wrappers.find(
+					(li) => li.find('.dashboard-switcher-sidebar__default-marker').exists(),
+				)
+				expect(starred.text()).toContain('First Primary')
+			})
+
+			it('does NOT star a personal dashboard via fallback when no group rows exist', () => {
+				const wrapper = mountSidebar({
+					groupDashboards: [],
+					userDashboards: [userRowWithUuid, userRowOtherUuid],
+					defaultUuid: '',
+				})
+
+				expect(wrapper.findAll('.dashboard-switcher-sidebar__default-marker').length).toBe(0)
+			})
+
+			it('still prefers the explicit pin over any group fallback', () => {
+				const groupDefault = { id: 'g9', uuid: 'group-default-uuid', name: 'Group Default', icon: null, source: 'default', isDefault: 1 }
+
+				const wrapper = mountSidebar({
+					groupDashboards: [groupDefault],
+					userDashboards: [userRowWithUuid],
+					defaultUuid: 'pin-uuid',
+				})
+
+				const markers = wrapper.findAll('.dashboard-switcher-sidebar__default-marker')
+				expect(markers.length).toBe(1)
+				const starred = wrapper.findAll('.dashboard-switcher-sidebar__item').wrappers.find(
+					(li) => li.find('.dashboard-switcher-sidebar__default-marker').exists(),
+				)
+				expect(starred.text()).toContain('My Notes')
+			})
+		})
 	})
 })


### PR DESCRIPTION
## Summary

When a user clicks **Set as default** in a dashboard's cog menu, the pin (`defaultDashboardUuid`) is saved server-side, but the menu auto-closes immediately so the only feedback (the StarCheck icon inside the menu) is gone before the user notices it. The sidebar itself shows nothing.

This PR makes the pin visible in the sidebar:

- A small star icon renders between the dashboard icon and the label on whichever row matches `defaultUuid`.
- The star carries a `title` tooltip explaining what the pin means ("Default dashboard — opens automatically when you visit MyDash").
- An `aria-label` on the same span so screen readers announce the marker.
- Works in all three sections — personal, primary-group, and default-group — so the marker follows wherever the user pinned.

No section restructuring and no duplication: the dashboard keeps its home section, just with an extra visible affordance.

## What changed

- [`src/components/Workspace/DashboardSwitcherSidebar.vue`](https://github.com/ConductionNL/mydash/blob/feat/sidebar-default-star/src/components/Workspace/DashboardSwitcherSidebar.vue):
  - `Star` import + registration
  - `isDefaultDashboard(dashboard)` method
  - `<span class="dashboard-switcher-sidebar__default-marker">` injected in all three section row templates, gated on `isDefaultDashboard(dashboard)`
  - Scoped style for the marker (uses `--color-warning` so it inherits theme overrides)

- [`src/components/Workspace/__tests__/DashboardSwitcherSidebar.spec.js`](https://github.com/ConductionNL/mydash/blob/feat/sidebar-default-star/src/components/Workspace/__tests__/DashboardSwitcherSidebar.spec.js): four new cases pinning the contract — star renders only on the matching row, carries the title + aria-label, hidden when `defaultUuid` is empty, and works on a group-section row when the user pinned a shared dashboard.

## Test plan
- [x] `vitest run` — 850 / 850 (was 846, +4 new)
- [x] `eslint` clean on touched files
- [ ] Manual UI: open the sidebar, click "Set as default" on a personal dashboard via the cog menu, confirm the star appears immediately on that row
- [ ] Manual UI: hover the star, confirm the tooltip
- [ ] Manual UI: click "Default dashboard" again to clear the pin, confirm the star disappears