### PR TITLE
feat(in-app-docs): point in-app Documentation links at mydash.conduction.nl

### DIFF
--- a/src/components/Workspace/SidebarFooter.vue
+++ b/src/components/Workspace/SidebarFooter.vue
@@ -16,7 +16,7 @@
 	     (security gate — never omit `noopener noreferrer`).
 	  2. A Documentation link (icon + label) targeting the same URL the
 	     gear-menu Documentation entry used before runtime-shell-trim
-	     removed it (https://mydash.app).
+	     removed it (https://mydash.conduction.nl).
 
 	The footer itself is a stateless block; the parent
 	(`DashboardSwitcherSidebar`) owns the `position: sticky; bottom: 0`
@@ -82,7 +82,7 @@ import BookOpenVariantOutline from 'vue-material-design-icons/BookOpenVariantOut
  * and the new sidebar footer link. Kept in module scope so the test
  * suite can assert exact value parity with the previous gear-menu link.
  */
-export const DOCS_URL = 'https://mydash.app'
+export const DOCS_URL = 'https://mydash.conduction.nl'
 
 export default {
 	name: 'SidebarFooter',

--- a/src/components/Workspace/__tests__/SidebarFooter.spec.js
+++ b/src/components/Workspace/__tests__/SidebarFooter.spec.js
@@ -8,7 +8,7 @@
  *  - Sendent + Conduction logos are wrapped in `<a target="_blank"
  *    rel="noopener noreferrer">` (security gate; never omit the rel)
  *  - Documentation link points at the same URL the gear-menu Documentation
- *    entry used before runtime-shell-trim (https://mydash.app)
+ *    entry used before runtime-shell-trim (https://mydash.conduction.nl)
  */
 
 import { describe, it, expect, beforeEach, vi } from 'vitest'
@@ -83,7 +83,7 @@ describe('SidebarFooter', () => {
 			const link = wrapper.find('a.dashboard-switcher-sidebar-footer__doc-link')
 			expect(link.exists()).toBe(true)
 			expect(link.attributes('href')).toBe(DOCS_URL)
-			expect(link.attributes('href')).toBe('https://mydash.app')
+			expect(link.attributes('href')).toBe('https://mydash.conduction.nl')
 			expect(link.attributes('target')).toBe('_blank')
 			expect(link.attributes('rel')).toBe('noopener noreferrer')
 		})

--- a/src/components/admin/AdminSettings.vue
+++ b/src/components/admin/AdminSettings.vue
@@ -8,7 +8,7 @@
 		<CnSettingsSection
 			:name="t('mydash', 'MyDash settings')"
 			:description="t('mydash', 'Configure dashboard permissions and defaults')"
-			doc-url="https://mydash.app">
+			doc-url="https://mydash.conduction.nl">
 			<!-- Setup wizard banner (REQ-WIZ-001). Stays visible until the
 			     admin clicks Finish in the wizard; after completion a less
 			     prominent re-run link replaces it (REQ-WIZ-011). -->


### PR DESCRIPTION
## Summary

Companion to PR #132 (which moved the Docusaurus deploy domain). The in-app `DOCS_URL` constant in `SidebarFooter.vue` and the `CnSettingsSection` `doc-url` in `AdminSettings.vue` still pointed at `https://mydash.app` — those are the targets of the sidebar footer's Documentation icon and the admin-page documentation link respectively, so users clicking either would have landed on the old domain.

Updated both to `https://mydash.conduction.nl`. The test fixture in `SidebarFooter.spec.js` (which exact-asserts the URL) and the prose comments referencing the URL are updated in lockstep so the spec still passes and the comments don't drift.

## What changed

- `src/components/Workspace/SidebarFooter.vue` — `DOCS_URL` constant + comment block
- `src/components/admin/AdminSettings.vue` — `CnSettingsSection` `doc-url` prop
- `src/components/Workspace/__tests__/SidebarFooter.spec.js` — exact-asserted URL in the test + comment block

3 files, 6 insertions, 5 deletions. No behaviour change beyond the link target.

## Test plan
- [x] `vitest run` — 857 / 857 pass (was already 857 before; SidebarFooter spec exercises the new URL)
- [ ] Manual UI: hover the Documentation icon in the sidebar footer, confirm the tooltip / new-tab opens `mydash.conduction.nl`
- [ ] Manual UI: open admin settings, click the Documentation icon next to "MyDash settings", confirm same destination