### PR TITLE
feat(docs): adopt @conduction/docusaurus-preset

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -1,28 +1,39 @@
 // @ts-check
 
-/** @type {import('@docusaurus/types').Config} */
-const config = {
+/**
+ * MyDash documentation site.
+ *
+ * Built on @conduction/docusaurus-preset for brand defaults (tokens,
+ * theme swizzles for Navbar / Footer, four-locale i18n scaffolding,
+ * KvK / BTW copyright). Site-specific overrides — locales, sidebar
+ * path, mermaid theme, custom prism themes, mydash-only navbar items —
+ * are passed through createConfig() opts.
+ */
+
+const { createConfig, baseFooterLinks } = require('@conduction/docusaurus-preset');
+
+/* createConfig replaces themes wholesale when `themes:` is passed, so
+   we re-include the brand theme plugin alongside @docusaurus/theme-mermaid.
+   Without the brand theme entry the Navbar/Footer swizzles and
+   brand.css auto-load would silently drop. */
+const BRAND_THEME = require.resolve('@conduction/docusaurus-preset/theme');
+
+const config = createConfig({
   title: 'MyDash',
   tagline: 'Your customizable dashboard for Nextcloud',
   url: 'https://mydash.conduction.nl',
   baseUrl: '/',
 
-  // GitHub pages deployment config
   organizationName: 'ConductionNL',
   projectName: 'mydash',
-  trailingSlash: false,
 
-  onBrokenLinks: 'warn',
-  onBrokenMarkdownLinks: 'warn',
-  onBrokenAnchors: 'warn',
-
+  /* English-only for now. Dutch was dropped on the previous config
+     because i18n/nl/ carries stale strings without translated markdown
+     and broke Dutch SSR on a handful of recent doc pages. Re-enable by
+     adding 'nl' back once the Dutch translation pass has been completed
+     or the metadata audited for stale references. The brand preset's
+     default i18n block (nl/en/de/fr) is replaced wholesale here. */
   i18n: {
-    // Dutch locale temporarily dropped — `i18n/nl/` carries only stale
-    // translation strings (no actual translated markdown), and recent
-    // docs additions broke Dutch SSR with "Cannot read properties of
-    // undefined (reading 'id')" on a handful of pages. Re-enable by
-    // adding `'nl'` back once the Dutch translation pass has been
-    // completed or the metadata audited for stale references.
     defaultLocale: 'en',
     locales: ['en'],
     localeConfigs: {
@@ -30,98 +41,94 @@ const config = {
     },
   },
 
+  /* The mydash docs source lives at the repo root of `docs/` rather
+     than under a `docs/` subfolder, so we override the preset's default
+     `presets:` block to point `docs.path` at './' and disable the blog
+     plugin. customCss carries mydash-specific CSS only — brand tokens
+     and the theme swizzles are auto-loaded by the brand theme entry in
+     `themes:` below. */
   presets: [
     [
       'classic',
-      /** @type {import('@docusaurus/preset-classic').Options} */
-      ({
+      {
         docs: {
           path: './',
           exclude: ['**/node_modules/**'],
           sidebarPath: require.resolve('./sidebars.js'),
-          editUrl:
-            'https://github.com/ConductionNL/mydash/tree/main/docs/',
+          editUrl: 'https://github.com/ConductionNL/mydash/tree/main/docs/',
         },
         blog: false,
         theme: {
           customCss: require.resolve('./src/css/custom.css'),
         },
-      }),
+      },
     ],
   ],
 
-  themeConfig:
-    /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
-    ({
-      navbar: {
-        title: 'MyDash',
-        logo: {
-          alt: 'MyDash Logo',
-          src: 'img/logo.svg',
-        },
-        items: [
-          {
-            type: 'docSidebar',
-            sidebarId: 'tutorialSidebar',
-            position: 'left',
-            label: 'Documentation',
-          },
-          {
-            href: 'https://github.com/ConductionNL/mydash',
-            label: 'GitHub',
-            position: 'right',
-          },
-          {
-            type: 'localeDropdown',
-            position: 'right',
-          },
-        ],
+  themes: [BRAND_THEME, '@docusaurus/theme-mermaid'],
+
+  /* Brand navbar provides locale dropdown + GitHub by default; we
+     replace items[] with mydash's own (Documentation sidebar link,
+     mydash GitHub link). Object.assign in createConfig is shallow, so
+     items: replaces wholesale — re-include the locale dropdown and
+     add the mydash GitHub repo link explicitly. */
+  navbar: {
+    items: [
+      {
+        type: 'docSidebar',
+        sidebarId: 'tutorialSidebar',
+        position: 'left',
+        label: 'Documentation',
       },
-      footer: {
-        style: 'dark',
-        links: [
-          {
-            title: 'Docs',
-            items: [
-              {
-                label: 'Documentation',
-                to: '/docs/intro',
-              },
-            ],
-          },
-          {
-            title: 'Community',
-            items: [
-              {
-                label: 'GitHub',
-                href: 'https://github.com/ConductionNL/mydash',
-              },
-            ],
-          },
-        ],
-        copyright: `Copyright © ${new Date().getFullYear()} for <a href="https://openwebconcept.nl">Open Webconcept</a> by <a href="https://conduction.nl">Conduction B.V.</a>`,
+      {
+        href: 'https://github.com/ConductionNL/mydash',
+        label: 'GitHub',
+        position: 'right',
       },
-      prism: {
-        theme: require('prism-react-renderer/themes/github'),
-        darkTheme: require('prism-react-renderer/themes/dracula'),
-      },
-      mermaid: {
-        theme: { light: 'default', dark: 'dark' },
-      },
-    }),
-  markdown: {
-    mermaid: true,
-    // Tutorial pages reference screenshots that are populated by
-    // `tests/e2e/docs-screenshots.spec.ts`. The Playwright capture run is
-    // separate from the docs build, so the build needs to succeed even
-    // when a fresh checkout doesn't have every PNG yet. Warn instead of
-    // failing — the absence is visible at preview time and the capture
-    // spec brings everything back on demand.
-    hooks: {
-      onBrokenMarkdownImages: 'warn',
+      { type: 'localeDropdown', position: 'right' },
+    ],
+  },
+
+  /* Per-property footer override (preset 1.2.0+): we pass `links` only,
+     so the brand `style: 'dark'` and the brand KvK/BTW/IBAN/address
+     copyright string both inherit unchanged. Mydash currently ships
+     just the brand "Conduction" column; site-specific Product / Support
+     columns will be added in a follow-up. */
+  footer: {
+    links: baseFooterLinks().filter((column) => column.title === 'Conduction'),
+  },
+
+  /* themeConfig is shallow-merged into the preset's defaults
+     (colorMode + navbar + footer). prism + mermaid land alongside. */
+  themeConfig: {
+    prism: {
+      theme: require('prism-react-renderer/themes/github'),
+      darkTheme: require('prism-react-renderer/themes/dracula'),
+    },
+    mermaid: {
+      theme: { light: 'default', dark: 'dark' },
     },
   },
-  themes: ['@docusaurus/theme-mermaid'],
+});
+
+/* createConfig doesn't pass-through arbitrary top-level fields; assign
+   markdown + onBrokenAnchors + trailingSlash directly so they make it
+   into the final Docusaurus config. trailingSlash is flipped to false
+   because the previous config locked it that way and the GH Pages CNAME
+   target depends on it (true would 301-redirect to /-suffix URLs). */
+config.trailingSlash = false;
+config.onBrokenAnchors = 'warn';
+config.markdown = {
+  mermaid: true,
+  /* Tutorial pages reference screenshots that are populated by
+     `tests/e2e/docs-screenshots.spec.ts`. The Playwright capture run is
+     separate from the docs build, so the build needs to succeed even
+     when a fresh checkout doesn't have every PNG yet. Warn instead of
+     failing — the absence is visible at preview time and the capture
+     spec brings everything back on demand. */
+  hooks: {
+    onBrokenMarkdownImages: 'warn',
+  },
 };
 
 module.exports = config;

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -8,6 +8,7 @@
       "name": "mydash-docs",
       "version": "0.0.0",
       "dependencies": {
+        "@conduction/docusaurus-preset": "^1.2.1",
         "@docusaurus/core": "^3.7.0",
         "@docusaurus/preset-classic": "^3.7.0",
         "@docusaurus/theme-mermaid": "^3.7.0",
@@ -2036,6 +2037,18 @@
       "optional": true,
       "engines": {
         "node": ">=0.1.90"
+      }
+    },
+    "node_modules/@conduction/docusaurus-preset": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@conduction/docusaurus-preset/-/docusaurus-preset-1.2.1.tgz",
+      "integrity": "sha512-NwkcafPoNaBJLiLyDFCYn45GQUfRQILZmiC2Ms9t2ev2j1+lPE+v5ie7uB/3y2Jba+VC0AlfrBf8qMjAf8mI7A==",
+      "license": "EUPL-1.2",
+      "peerDependencies": {
+        "@docusaurus/core": "^3.0.0",
+        "@docusaurus/preset-classic": "^3.0.0",
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
       }
     },
     "node_modules/@csstools/cascade-layer-name-parser": {

--- a/docs/package.json
+++ b/docs/package.json
@@ -15,6 +15,7 @@
     "ci": "npm ci --legacy-peer-deps && npm run build"
   },
   "dependencies": {
+    "@conduction/docusaurus-preset": "^1.2.1",
     "@docusaurus/core": "^3.7.0",
     "@docusaurus/preset-classic": "^3.7.0",
     "@docusaurus/theme-mermaid": "^3.7.0",


### PR DESCRIPTION
## Summary

- Replace the inline \`@docusaurus/preset-classic\` configuration in [docs/docusaurus.config.js](docs/docusaurus.config.js) with \`createConfig()\` from \`@conduction/docusaurus-preset@^1.2.1\`.
- Adds the preset to [docs/package.json](docs/package.json) (package-lock entry mirrors).
- mydash-specific overrides preserved: en-only i18n, docs at \`./\`, blog disabled, prism + mermaid theme config, \`onBrokenAnchors: 'warn'\`, \`trailingSlash: false\`, the \`onBrokenMarkdownImages\` hook for the screenshot-driven tutorial pages.
- Footer uses preset 1.2.0+'s per-property override: passes only \`links\` (filtered to the brand "Conduction" column) and inherits the brand \`style: 'dark'\` and KvK/BTW/IBAN copyright unchanged.
- Re-includes the brand theme plugin in \`themes:\` alongside \`@docusaurus/theme-mermaid\` so the brand swizzles + brand.css auto-load aren't dropped.

## Net effect

Once this merges and the documentation workflow deploys, mydash.conduction.nl picks up the Conduction brand chrome — cobalt navbar, dark footer panel with KvK/BTW anchor, Plex Mono captions, the brand colour palette mapped onto Docusaurus's Infima theme variables.

Mydash-specific Product / Support / etc. footer columns are intentionally **not** added in this PR — those will slot in next to the brand "Conduction" column in a follow-up once the link list is decided. The preset infrastructure is in place to accept them.

## Why bumped to 1.2.1

While wiring this in, the build surfaced a packaging bug in the preset:
\`src/css/tokens.css\` imports the design-system monorepo's canonical
\`tokens.css\` and \`typography.css\` via three-up relative paths, which
only resolve inside the monorepo. Consumers installing via npm hit
\`Can't resolve '../../../tokens.css'\`. Fixed in design-system at
[c8e3de7](https://github.com/ConductionNL/design-system/commit/c8e3de7) by adding a \`prepack\` lifecycle script that bundles the canonical content into the preset before \`npm publish\`. The fix is live as \`@conduction/docusaurus-preset@1.2.1\`.

## Test plan

- [ ] Approve + merge to \`development\`
- [ ] Watch the Documentation workflow run on the merge: https://github.com/ConductionNL/mydash/actions/workflows/documentation.yml
- [ ] Confirm \`https://mydash.conduction.nl/\` reloads with the cobalt navbar + dark footer + Conduction column + KvK/BTW copyright string
- [ ] Confirm the Documentation page (sidebar entry) still renders and \`/intro\` etc. work
- [ ] Confirm prism / mermaid blocks still render with the brand colour scheme

## Verified locally

- \`npm install --legacy-peer-deps\` clean
- \`npm run build\` passes (Server + Client compiled successfully, static files generated)