### PR TITLE
fix(docs): bump preset to 1.4.2 (navbar.clientHeight docs crash)

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -8,7 +8,7 @@
       "name": "mydash-docs",
       "version": "0.0.0",
       "dependencies": {
-        "@conduction/docusaurus-preset": "^1.4.1",
+        "@conduction/docusaurus-preset": "^1.4.2",
         "@docusaurus/core": "^3.10.0",
         "@docusaurus/preset-classic": "^3.10.0",
         "@docusaurus/theme-mermaid": "^3.10.0",
@@ -2045,9 +2045,9 @@
       }
     },
     "node_modules/@conduction/docusaurus-preset": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@conduction/docusaurus-preset/-/docusaurus-preset-1.4.1.tgz",
-      "integrity": "sha512-oORbrZVXlW3eXIHCLK0Xyxvyd4XIkD3uOmbwlFXtunnYYWkZ+CfNnNITkmqikVWK19DTIQhW+wQYoisH7MQdVQ==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@conduction/docusaurus-preset/-/docusaurus-preset-1.4.2.tgz",
+      "integrity": "sha512-JDdz3Dpl2rQ1ORspwwAkunosaS1LMViW0zeduSmorgG7R4Ih8nmifsGHsi/Reu6/IpxFLSkUTTc/2kyUBDNPDQ==",
       "license": "EUPL-1.2",
       "peerDependencies": {
         "@docusaurus/core": "^3.0.0",

--- a/docs/package.json
+++ b/docs/package.json
@@ -15,7 +15,7 @@
     "ci": "npm ci --legacy-peer-deps && npm run build"
   },
   "dependencies": {
-    "@conduction/docusaurus-preset": "^1.4.1",
+    "@conduction/docusaurus-preset": "^1.4.2",
     "@docusaurus/core": "^3.10.0",
     "@docusaurus/preset-classic": "^3.10.0",
     "@docusaurus/theme-mermaid": "^3.10.0",


### PR DESCRIPTION
## Summary

Bumps \`@conduction/docusaurus-preset\` from 1.4.1 → **1.4.2**.

## What 1.4.2 fixes

The brand Navbar swizzle rendered \`<nav class={styles.nav}>\` (a CSS-module class). Docusaurus's framework code reads navbar height via \`document.querySelector('.navbar').clientHeight\` for in-page scroll-anchor offsets, and on the swizzled markup that selector returned \`null\` and crashed the React tree on the first heading scroll:

\`\`\`
TypeError: Cannot read properties of null (reading 'clientHeight')
\`\`\`

Result: every docs page rendered "This page crashed. Try again." once a heading scrolled into view. https://mydash.conduction.nl/docs/intro/ caught it first.

Preset 1.4.2 stamps the framework \`navbar\` class alongside the brand styles.nav so the selector resolves. Brand visuals are unaffected.

## Verified locally

\`npm run build\` in \`docs/\` passes (Server + Client compiled successfully, static files generated).

## Test plan

- [ ] Approve + admin-merge to \`development\`
- [ ] Watch the [Documentation deploy](https://github.com/ConductionNL/mydash/actions/workflows/documentation.yml)
- [ ] After cache flip, https://mydash.conduction.nl/docs/intro/ should render the doc body and scroll smoothly without the React error boundary