### PR TITLE
fix(docs): bump preset to 1.4.3 (skyline empty on no-game footer)

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -8,7 +8,7 @@
       "name": "mydash-docs",
       "version": "0.0.0",
       "dependencies": {
-        "@conduction/docusaurus-preset": "^1.4.2",
+        "@conduction/docusaurus-preset": "^1.4.3",
         "@docusaurus/core": "^3.10.0",
         "@docusaurus/preset-classic": "^3.10.0",
         "@docusaurus/theme-mermaid": "^3.10.0",
@@ -2045,9 +2045,9 @@
       }
     },
     "node_modules/@conduction/docusaurus-preset": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@conduction/docusaurus-preset/-/docusaurus-preset-1.4.2.tgz",
-      "integrity": "sha512-JDdz3Dpl2rQ1ORspwwAkunosaS1LMViW0zeduSmorgG7R4Ih8nmifsGHsi/Reu6/IpxFLSkUTTc/2kyUBDNPDQ==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@conduction/docusaurus-preset/-/docusaurus-preset-1.4.3.tgz",
+      "integrity": "sha512-64F8A0qal/EfNYJKqsXMGjsOV2X0WYi72plO6MTC/9h60Fz85cMwzEiRpi58e9lloHAc3UBVMuffrzmDimsfwA==",
       "license": "EUPL-1.2",
       "peerDependencies": {
         "@docusaurus/core": "^3.0.0",

--- a/docs/package.json
+++ b/docs/package.json
@@ -15,7 +15,7 @@
     "ci": "npm ci --legacy-peer-deps && npm run build"
   },
   "dependencies": {
-    "@conduction/docusaurus-preset": "^1.4.2",
+    "@conduction/docusaurus-preset": "^1.4.3",
     "@docusaurus/core": "^3.10.0",
     "@docusaurus/preset-classic": "^3.10.0",
     "@docusaurus/theme-mermaid": "^3.10.0",


### PR DESCRIPTION
Bumps @conduction/docusaurus-preset 1.4.2 → 1.4.3. The brand canal-footer's trapgevel skyline failed to populate when minigames:false because the script's bootstrap calls (buildSkyline, drift speeds, etc.) sat below the null-guard early-return. 1.4.3 reorders so static decoration runs before the game-only bail. Verified locally with npm run build.