### PR TITLE
feat(docs): cobalt-background hero on landing (preset 1.5.0)

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -8,7 +8,7 @@
       "name": "mydash-docs",
       "version": "0.0.0",
       "dependencies": {
-        "@conduction/docusaurus-preset": "^1.4.3",
+        "@conduction/docusaurus-preset": "^1.5.0",
         "@docusaurus/core": "^3.10.0",
         "@docusaurus/preset-classic": "^3.10.0",
         "@docusaurus/theme-mermaid": "^3.10.0",
@@ -2045,9 +2045,9 @@
       }
     },
     "node_modules/@conduction/docusaurus-preset": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/@conduction/docusaurus-preset/-/docusaurus-preset-1.4.3.tgz",
-      "integrity": "sha512-64F8A0qal/EfNYJKqsXMGjsOV2X0WYi72plO6MTC/9h60Fz85cMwzEiRpi58e9lloHAc3UBVMuffrzmDimsfwA==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@conduction/docusaurus-preset/-/docusaurus-preset-1.5.0.tgz",
+      "integrity": "sha512-RvpHhOnZDFQOZ7RLm2QObPvuR2ziHph4SnuuTGMp/GLqKwOePNkXu8W4cCGCK5VQfWkqA1DNb34d1XqkbPiKjA==",
       "license": "EUPL-1.2",
       "peerDependencies": {
         "@docusaurus/core": "^3.0.0",

--- a/docs/package.json
+++ b/docs/package.json
@@ -15,7 +15,7 @@
     "ci": "npm ci --legacy-peer-deps && npm run build"
   },
   "dependencies": {
-    "@conduction/docusaurus-preset": "^1.4.3",
+    "@conduction/docusaurus-preset": "^1.5.0",
     "@docusaurus/core": "^3.10.0",
     "@docusaurus/preset-classic": "^3.10.0",
     "@docusaurus/theme-mermaid": "^3.10.0",

--- a/docs/src/pages/index.js
+++ b/docs/src/pages/index.js
@@ -257,6 +257,7 @@ export default function Home() {
       <main className="marketing-page">
         <DetailHero
           appId="mydash"
+          background="cobalt"
           status={{ label: 'Beta', color: 'var(--c-orange-knvb)' }}
           version="v0.9"
           locales="NL · EN"


### PR DESCRIPTION
Bumps @conduction/docusaurus-preset to 1.5.0 (which adds the new `DetailHero background="cobalt"` variant) and applies it to the landing. Renders the hero as a full-bleed cobalt panel with white type + orange icon + orange Install button — matches the prior on-cobalt hero pattern the user expects on a product-page identity. Build verified locally.