### PR TITLE
fix(docs): bump preset to 1.5.1 (cobalt hero full-bleed)

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -8,7 +8,7 @@
       "name": "mydash-docs",
       "version": "0.0.0",
       "dependencies": {
-        "@conduction/docusaurus-preset": "^1.5.0",
+        "@conduction/docusaurus-preset": "^1.5.1",
         "@docusaurus/core": "^3.10.0",
         "@docusaurus/preset-classic": "^3.10.0",
         "@docusaurus/theme-mermaid": "^3.10.0",
@@ -2045,9 +2045,9 @@
       }
     },
     "node_modules/@conduction/docusaurus-preset": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@conduction/docusaurus-preset/-/docusaurus-preset-1.5.0.tgz",
-      "integrity": "sha512-RvpHhOnZDFQOZ7RLm2QObPvuR2ziHph4SnuuTGMp/GLqKwOePNkXu8W4cCGCK5VQfWkqA1DNb34d1XqkbPiKjA==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@conduction/docusaurus-preset/-/docusaurus-preset-1.5.1.tgz",
+      "integrity": "sha512-xKcq6OHKvKMHopqP7PzOjviyLe5D91Za9qpY2teMiLN9jOOfbhM1lvv/dK+o7N+kK0ATolM7rOZOHNZwfIIaNQ==",
       "license": "EUPL-1.2",
       "peerDependencies": {
         "@docusaurus/core": "^3.0.0",

--- a/docs/package.json
+++ b/docs/package.json
@@ -15,7 +15,7 @@
     "ci": "npm ci --legacy-peer-deps && npm run build"
   },
   "dependencies": {
-    "@conduction/docusaurus-preset": "^1.5.0",
+    "@conduction/docusaurus-preset": "^1.5.1",
     "@docusaurus/core": "^3.10.0",
     "@docusaurus/preset-classic": "^3.10.0",
     "@docusaurus/theme-mermaid": "^3.10.0",


### PR DESCRIPTION
Bumps @conduction/docusaurus-preset 1.5.0 → 1.5.1. Fixes the cobalt panel getting clipped on the right edge at viewports ≥1280px (Docusaurus's <main>/<article> overflow:hidden was trimming the 100vw pseudo-element). Switched to box-shadow + clip-path bleed which is robust against any ancestor overflow.