### PR TITLE
ci(docs): fix documentation workflow cname to mydash.conduction.nl

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -10,4 +10,4 @@ jobs:
   deploy:
     uses: ConductionNL/.github/.github/workflows/documentation.yml@main
     with:
-      cname: mydash.app
+      cname: mydash.conduction.nl


### PR DESCRIPTION
The main-branch documentation.yml still pointed at mydash.app; development already uses mydash.conduction.nl.