### PR TITLE
ci(branch-policy): allow Conventional-Commits prefixes into development

### DIFF
--- a/.github/workflows/branch-policy.yml
+++ b/.github/workflows/branch-policy.yml
@@ -40,11 +40,24 @@ jobs:
               fi
               ;;
             development)
-              if [[ "$SOURCE" == feature/* ]]; then
+              # Allow Conventional-Commits style prefixes plus Dependabot.
+              if [[ "$SOURCE" == feature/* \
+                || "$SOURCE" == feat/* \
+                || "$SOURCE" == fix/* \
+                || "$SOURCE" == chore/* \
+                || "$SOURCE" == refactor/* \
+                || "$SOURCE" == docs/* \
+                || "$SOURCE" == test/* \
+                || "$SOURCE" == perf/* \
+                || "$SOURCE" == build/* \
+                || "$SOURCE" == ci/* \
+                || "$SOURCE" == style/* \
+                || "$SOURCE" == spec/* \
+                || "$SOURCE" == dependabot/* ]]; then
                 echo "✅ Branch '$SOURCE' is allowed to merge into development."
               else
                 echo "❌ Branch '$SOURCE' is not allowed to merge into development."
-                echo "Only 'feature/*' and 'hotfix/*' branches can be merged into development."
+                echo "Allowed prefixes: feature/*, feat/*, fix/*, chore/*, refactor/*, docs/*, test/*, perf/*, build/*, ci/*, style/*, spec/*, hotfix/*, dependabot/*."
                 exit 1
               fi
               ;;


### PR DESCRIPTION
## Summary
- Branch Policy workflow currently only allows `feature/*` and `hotfix/*` heads to target `development`.
- Several open PRs use Conventional-Commits prefixes (`feat/specter-fleet-rollout`, `chore/widget-catalog-docs`, `chore/preset-2.10-derived-status`, `chore/brand-cobalt-21468b`) and are blocked on this one check.
- Dependabot PRs (`dependabot/npm_and_yarn/...`) hit the same wall.

Expanding the allow-list to `feat/`, `fix/`, `chore/`, `refactor/`, `docs/`, `test/`, `perf/`, `build/`, `ci/`, `style/`, `spec/`, and `dependabot/` (in addition to the existing `feature/` + `hotfix/`) brings the policy in line with how the fleet actually names branches and unblocks the queue.

## Test plan
- [x] Branch Policy Check passes for this PR (head `feature/...`, no behaviour change for existing prefix).
- [ ] After merge, re-run Branch Policy on PRs #143, #150, #151, #153, #145 (each should flip green on that check).