### PR TITLE
sync: development to documentation (meta descriptions #81)

### DIFF
--- a/docs/intro.md
+++ b/docs/intro.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 1
+description: Get started with MyDash, customizable dashboards for Nextcloud. Compose KPI widgets and live charts on top of your OpenRegister data.
 ---
 
 # MyDash

--- a/docs/src/pages/index.js
+++ b/docs/src/pages/index.js
@@ -252,7 +252,7 @@ export default function Home() {
   return (
     <Layout
       title="MyDash, customizable dashboards for Nextcloud workspaces"
-      description="Personal and team dashboards built directly on your Nextcloud registers. No separate BI tool, no extra login, no ETL."
+      description="Build customizable dashboards on Nextcloud. Widgets, KPIs, and live charts on top of OpenRegister data with no separate BI stack."
     >
       <main className="marketing-page">
         <DetailHero


### PR DESCRIPTION
Sync development to documentation so the meta-description deploy fires.