### PR TITLE
chore: rename composer vendor mydash/mydash -> conductionnl/mydash

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-	"name": "mydash/mydash",
+	"name": "conductionnl/mydash",
 	"description": "Enhanced dashboard with grid layout and admin controls for Nextcloud",
 	"type": "project",
 	"license": "EUPL-1.2",


### PR DESCRIPTION
## Summary

- Rename composer vendor `mydash/mydash` → `conductionnl/mydash`. Every other Conduction app in the fleet uses the `conductionnl/` vendor prefix; this one was bootstrapped standalone and never realigned.

## Context

Phase 1c of a fleetwide root-config consolidation. This app is an installable, not a library — no internal consumer references it by composer-package name.

## Test plan
- [x] `composer.json` is valid JSON
- [ ] CI green