### PR TITLE
chore: sync canonical root configs + mechanical phpmd cleanup

### DIFF
--- a/lib/Activity/Extension.php
+++ b/lib/Activity/Extension.php
@@ -209,10 +209,9 @@ class Extension implements IProvider
             haystack: self::ALL_EVENTS,
             strict: true
         );
+        $file  = 'activity/mydash.svg';
         if ($known === true) {
             $file = 'activity/'.$eventType.'.svg';
-        } else {
-            $file = 'activity/mydash.svg';
         }
 
         return $this->urlGenerator->getAbsoluteURL(
@@ -303,10 +302,9 @@ class Extension implements IProvider
     private function resolveSubjectTemplate(string $type, bool $isSelf): string
     {
         $templates = $this->getSubjectTemplates();
+        $variant   = 'other';
         if ($isSelf === true) {
             $variant = 'self';
-        } else {
-            $variant = 'other';
         }
 
         return ($templates[$type][$variant] ?? '');

--- a/lib/Command/CleanupPurgeCommand.php
+++ b/lib/Command/CleanupPurgeCommand.php
@@ -165,27 +165,24 @@ class CleanupPurgeCommand extends Command
             $prefix = 'DRY-RUN: Would purge';
         }
 
+        $summaryMessage = sprintf(
+            '<info>%s %d items across %d categories in %dms.</info>',
+            $prefix,
+            $result->getTotalRows(),
+            count(value: $result->getByCategory()),
+            $result->getDurationMs()
+        );
         if (count(value: $categoryNames) === 1) {
-            $output->writeln(
-                messages: sprintf(
-                    '<info>%s %d items from category \'%s\' in %dms.</info>',
-                    $prefix,
-                    $result->getTotalRows(),
-                    $categoryNames[0],
-                    $result->getDurationMs()
-                )
+            $summaryMessage = sprintf(
+                '<info>%s %d items from category \'%s\' in %dms.</info>',
+                $prefix,
+                $result->getTotalRows(),
+                $categoryNames[0],
+                $result->getDurationMs()
             );
-        } else {
-            $output->writeln(
-                messages: sprintf(
-                    '<info>%s %d items across %d categories in %dms.</info>',
-                    $prefix,
-                    $result->getTotalRows(),
-                    count(value: $result->getByCategory()),
-                    $result->getDurationMs()
-                )
-            );
-        }//end if
+        }
+
+        $output->writeln(messages: $summaryMessage);
 
         $skipped = $result->getSkipped();
         if (count(value: $skipped) > 0) {

--- a/lib/Command/CommandBase.php
+++ b/lib/Command/CommandBase.php
@@ -147,7 +147,9 @@ abstract class CommandBase extends Command
             );
             if ($this->isJson(input: $input) === true) {
                 $output->writeln(messages: $this->commandService->encodeEnvelope(envelope: $envelope));
-            } else {
+            }
+
+            if ($this->isJson(input: $input) === false) {
                 $this->writeError(output: $output, message: '<error>'.$e->getMessage().'</error>');
             }
         } finally {
@@ -264,9 +266,11 @@ abstract class CommandBase extends Command
                     )
                 )
             );
-        } else {
-            $this->writeError(output: $output, message: '<error>'.$message.'</error>');
+
+            return $exitCode;
         }
+
+        $this->writeError(output: $output, message: '<error>'.$message.'</error>');
 
         return $exitCode;
     }//end emitError()

--- a/lib/Command/DashboardDeleteCommand.php
+++ b/lib/Command/DashboardDeleteCommand.php
@@ -161,7 +161,9 @@ class DashboardDeleteCommand extends CommandBase
 
         if ($cascade === true) {
             $this->treeService->deleteSubtree(dashboard: $dashboard);
-        } else {
+        }
+
+        if ($cascade === false) {
             $this->placementMapper->deleteByDashboardId(dashboardId: (int) $dashboard->getId());
             $this->dashboardMapper->delete(entity: $dashboard);
         }

--- a/lib/Command/DashboardListCommand.php
+++ b/lib/Command/DashboardListCommand.php
@@ -191,27 +191,27 @@ class DashboardListCommand extends CommandBase
             return CommandService::EXIT_SUCCESS;
         }
 
-        if ($this->isQuiet(input: $input) === false) {
-            if (count(value: $rows) === 0) {
-                $output->writeln(messages: 'No dashboards match the supplied filters.');
-            } else {
+        if ($this->isQuiet(input: $input) === false && count(value: $rows) === 0) {
+            $output->writeln(messages: 'No dashboards match the supplied filters.');
+        }
+
+        if ($this->isQuiet(input: $input) === false && count(value: $rows) > 0) {
+            $output->writeln(
+                messages: sprintf('%-36s  %-20s  %-14s  %-12s  %s', 'UUID', 'NAME', 'TYPE', 'STATUS', 'OWNER')
+            );
+            foreach ($rows as $row) {
                 $output->writeln(
-                    messages: sprintf('%-36s  %-20s  %-14s  %-12s  %s', 'UUID', 'NAME', 'TYPE', 'STATUS', 'OWNER')
+                    messages: sprintf(
+                        '%-36s  %-20s  %-14s  %-12s  %s',
+                        $row['uuid'],
+                        mb_strimwidth(string: $row['name'], start: 0, width: 20, trim_marker: '..'),
+                        $row['type'],
+                        $row['publicationStatus'],
+                        $row['owner']
+                    )
                 );
-                foreach ($rows as $row) {
-                    $output->writeln(
-                        messages: sprintf(
-                            '%-36s  %-20s  %-14s  %-12s  %s',
-                            $row['uuid'],
-                            mb_strimwidth(string: $row['name'], start: 0, width: 20, trim_marker: '..'),
-                            $row['type'],
-                            $row['publicationStatus'],
-                            $row['owner']
-                        )
-                    );
-                }
             }
-        }//end if
+        }
 
         return CommandService::EXIT_SUCCESS;
     }//end handle()
@@ -239,11 +239,15 @@ class DashboardListCommand extends CommandBase
             foreach ($this->dashboardMapper->findByUserId(userId: $user) as $dashboard) {
                 $dashboards[] = $dashboard;
             }
-        } else if ($group !== null) {
+        }
+
+        if ($user === null && $group !== null) {
             foreach ($this->dashboardMapper->findByGroup(groupId: $group) as $dashboard) {
                 $dashboards[] = $dashboard;
             }
-        } else {
+        }
+
+        if ($user === null && $group === null) {
             foreach ($this->dashboardMapper->findAdminTemplates() as $dashboard) {
                 $dashboards[] = $dashboard;
             }
@@ -259,7 +263,7 @@ class DashboardListCommand extends CommandBase
                     $dashboards[] = $child;
                 }
             }
-        }//end if
+        }
 
         if ($status === null) {
             return $dashboards;

--- a/lib/Controller/AdminController.php
+++ b/lib/Controller/AdminController.php
@@ -413,10 +413,9 @@ class AdminController extends Controller
                 haystack: $e->getMessage(),
                 needle: '8 KB limit'
             );
+            $status     = Http::STATUS_BAD_REQUEST;
             if ($isOversize === true) {
                 $status = Http::STATUS_REQUEST_ENTITY_TOO_LARGE;
-            } else {
-                $status = Http::STATUS_BAD_REQUEST;
             }
 
             return new JSONResponse(

--- a/lib/Controller/DashboardApiController.php
+++ b/lib/Controller/DashboardApiController.php
@@ -420,22 +420,22 @@ class DashboardApiController extends Controller
         // allowed for all permission levels. Widget/tile/layout changes
         // require add_only or full permission.
         $isMetadataOnly = $placements === null;
-        if ($isMetadataOnly === true) {
-            if ($this->permissionService->canEditDashboardMetadata(
+        if ($isMetadataOnly === true
+            && $this->permissionService->canEditDashboardMetadata(
                 userId: $this->userId,
                 dashboardId: $id
             ) === false
-            ) {
-                return ResponseHelper::forbidden();
-            }
-        } else {
-            if ($this->permissionService->canEditDashboard(
+        ) {
+            return ResponseHelper::forbidden();
+        }
+
+        if ($isMetadataOnly === false
+            && $this->permissionService->canEditDashboard(
                 userId: $this->userId,
                 dashboardId: $id
             ) === false
-            ) {
-                return ResponseHelper::forbidden();
-            }
+        ) {
+            return ResponseHelper::forbidden();
         }
 
         try {
@@ -1534,10 +1534,9 @@ class DashboardApiController extends Controller
         // else (non-null string) is forwarded verbatim — including the
         // empty string, which the service treats as a NULL parent.
         if ($parentUuid !== null) {
+            $data['parentUuid'] = $parentUuid;
             if ($parentUuid === '__null__' || $parentUuid === '') {
                 $data['parentUuid'] = null;
-            } else {
-                $data['parentUuid'] = $parentUuid;
             }
         }
 

--- a/lib/Controller/RuleApiController.php
+++ b/lib/Controller/RuleApiController.php
@@ -18,6 +18,7 @@ declare(strict_types=1);
 
 namespace OCA\MyDash\Controller;
 
+use InvalidArgumentException;
 use OCA\MyDash\AppInfo\Application;
 use OCA\MyDash\Service\ConditionalService;
 use OCA\MyDash\Service\PermissionService;
@@ -113,7 +114,7 @@ class RuleApiController extends Controller
         // hardening on WidgetApiController::addWidget.
         if ($ruleType === null || $ruleType === '') {
             return ResponseHelper::error(
-                exception: new \InvalidArgumentException(
+                exception: new InvalidArgumentException(
                     'Missing required field: ruleType'
                 ),
                 statusCode: Http::STATUS_BAD_REQUEST
@@ -122,7 +123,7 @@ class RuleApiController extends Controller
 
         if ($ruleConfig === null) {
             return ResponseHelper::error(
-                exception: new \InvalidArgumentException(
+                exception: new InvalidArgumentException(
                     'Missing required field: ruleConfig'
                 ),
                 statusCode: Http::STATUS_BAD_REQUEST

--- a/lib/Controller/WidgetApiController.php
+++ b/lib/Controller/WidgetApiController.php
@@ -19,6 +19,7 @@ declare(strict_types=1);
 namespace OCA\MyDash\Controller;
 
 use DateTimeImmutable;
+use InvalidArgumentException;
 use OCA\MyDash\AppInfo\Application;
 use OCA\MyDash\Service\CalendarWidgetService;
 use OCA\MyDash\Service\NewsWidgetService;
@@ -179,7 +180,7 @@ class WidgetApiController extends Controller
         // without the field and used to crash the dispatcher.
         if ($widgetId === null || $widgetId === '') {
             return ResponseHelper::error(
-                exception: new \InvalidArgumentException(
+                exception: new InvalidArgumentException(
                     'Missing required field: widgetId'
                 ),
                 statusCode: Http::STATUS_BAD_REQUEST

--- a/lib/Service/RoleFeaturePermissionService.php
+++ b/lib/Service/RoleFeaturePermissionService.php
@@ -27,6 +27,7 @@ declare(strict_types=1);
 namespace OCA\MyDash\Service;
 
 use DateTime;
+use InvalidArgumentException;
 use OCA\MyDash\Db\Dashboard;
 use OCA\MyDash\Db\RoleFeaturePermission;
 use OCA\MyDash\Db\RoleFeaturePermissionMapper;
@@ -105,7 +106,7 @@ class RoleFeaturePermissionService
     {
         $groupId = (string) ($data['groupId'] ?? '');
         if ($groupId === '') {
-            throw new \InvalidArgumentException(message: 'groupId is required');
+            throw new InvalidArgumentException(message: 'groupId is required');
         }
 
         try {
@@ -205,7 +206,7 @@ class RoleFeaturePermissionService
         $groupId  = (string) ($data['groupId'] ?? '');
         $widgetId = (string) ($data['widgetId'] ?? '');
         if ($groupId === '' || $widgetId === '') {
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentException(
                 message: 'groupId and widgetId are required'
             );
         }

--- a/phpcs-custom-sniffs/CustomSniffs/Sniffs/Commenting/SpecTagSniff.php
+++ b/phpcs-custom-sniffs/CustomSniffs/Sniffs/Commenting/SpecTagSniff.php
@@ -1,0 +1,377 @@
+<?php
+/**
+ * Warn when a PHP class or public method lacks an @spec PHPDoc tag.
+ *
+ * ConductionNL ADR-003 (Backend rules) mandates that every class and public
+ * method MUST have one or more @spec PHPDoc tags linking back to the OpenSpec
+ * change that caused the code to exist:
+ *
+ *     @spec openspec/changes/{change-name}/tasks.md#task-N
+ *
+ * This sniff emits warnings (not errors) so that CI surfaces the gap without
+ * blocking merges while teams backfill coverage. Tests files and magic
+ * methods are skipped, as are private/protected methods — the ADR only
+ * mandates @spec for classes and public methods.
+ *
+ * @author  Conduction
+ * @package CustomSniffs
+ */
+
+namespace CustomSniffs\Sniffs\Commenting;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+
+/**
+ * SpecTagSniff — warns when @spec PHPDoc tag is missing on classes / public methods.
+ */
+class SpecTagSniff implements Sniff
+{
+
+
+    /**
+     * PHP magic methods that are exempt from the @spec requirement.
+     *
+     * @var array<string>
+     */
+    private const MAGIC_METHODS = [
+        '__construct',
+        '__destruct',
+        '__get',
+        '__set',
+        '__call',
+        '__callstatic',
+        '__isset',
+        '__unset',
+        '__tostring',
+        '__invoke',
+        '__clone',
+        '__sleep',
+        '__wakeup',
+        '__serialize',
+        '__unserialize',
+        '__set_state',
+        '__debuginfo',
+    ];
+
+
+    /**
+     * Returns tokens this sniff listens for.
+     *
+     * @return array<int>
+     */
+    public function register(): array
+    {
+        return [T_CLASS, T_FUNCTION];
+
+    }//end register()
+
+
+    /**
+     * Process a T_CLASS or T_FUNCTION token.
+     *
+     * @param File $phpcsFile The file being scanned.
+     * @param int  $stackPtr  Position of the token.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr): void
+    {
+        // Skip test files.
+        if ($this->isTestFile(phpcsFile: $phpcsFile) === true) {
+            return;
+        }
+
+        $tokens = $phpcsFile->getTokens();
+        $code   = $tokens[$stackPtr]['code'];
+
+        if ($code === T_CLASS) {
+            $this->processClass(phpcsFile: $phpcsFile, stackPtr: $stackPtr);
+            return;
+        }
+
+        if ($code === T_FUNCTION) {
+            $this->processFunction(phpcsFile: $phpcsFile, stackPtr: $stackPtr);
+            return;
+        }
+
+    }//end process()
+
+
+    /**
+     * Check a class declaration for an @spec docblock tag.
+     *
+     * Skips anonymous classes (no name follows the T_CLASS keyword).
+     *
+     * @param File $phpcsFile The file being scanned.
+     * @param int  $stackPtr  Position of the T_CLASS token.
+     *
+     * @return void
+     */
+    private function processClass(File $phpcsFile, int $stackPtr): void
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        // Anonymous classes — $var = new class { ... } — have no name; skip.
+        $namePtr = $phpcsFile->findNext(T_STRING, ($stackPtr + 1), null, false, null, true);
+        if ($namePtr === false) {
+            return;
+        }
+
+        // Sanity: name should be on the same line or within a short window.
+        $openBracePtr = $phpcsFile->findNext(T_OPEN_CURLY_BRACKET, ($stackPtr + 1));
+        if ($openBracePtr !== false && $namePtr > $openBracePtr) {
+            return;
+        }
+
+        $className = $tokens[$namePtr]['content'];
+
+        if ($this->hasSpecTag(phpcsFile: $phpcsFile, stackPtr: $stackPtr) === true) {
+            return;
+        }
+
+        $message = 'Class %s is missing @spec PHPDoc tag — link back to openspec/changes/{name}/tasks.md#task-N';
+        $phpcsFile->addWarning($message, $stackPtr, 'MissingClassSpec', [$className]);
+
+    }//end processClass()
+
+
+    /**
+     * Check a function declaration for an @spec docblock tag.
+     *
+     * Only flags public methods declared inside a class. Global functions,
+     * private/protected methods, and magic methods are skipped.
+     *
+     * @param File $phpcsFile The file being scanned.
+     * @param int  $stackPtr  Position of the T_FUNCTION token.
+     *
+     * @return void
+     */
+    private function processFunction(File $phpcsFile, int $stackPtr): void
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        // Must be inside a class scope.
+        $className = $this->getEnclosingClassName(phpcsFile: $phpcsFile, stackPtr: $stackPtr);
+        if ($className === null) {
+            return;
+        }
+
+        // Get method name.
+        $namePtr = $phpcsFile->findNext(T_STRING, ($stackPtr + 1));
+        if ($namePtr === false) {
+            return;
+        }
+
+        $methodName = $tokens[$namePtr]['content'];
+
+        // Skip magic methods.
+        if (in_array(strtolower($methodName), self::MAGIC_METHODS, true) === true) {
+            return;
+        }
+
+        // Determine visibility: default is public when no modifier present.
+        if ($this->isPublicMethod(phpcsFile: $phpcsFile, stackPtr: $stackPtr) === false) {
+            return;
+        }
+
+        if ($this->hasSpecTag(phpcsFile: $phpcsFile, stackPtr: $stackPtr) === true) {
+            return;
+        }
+
+        $message = 'Public method %s::%s() is missing @spec PHPDoc tag';
+        $phpcsFile->addWarning($message, $stackPtr, 'MissingMethodSpec', [$className, $methodName]);
+
+    }//end processFunction()
+
+
+    /**
+     * Check whether the docblock directly preceding $stackPtr contains an @spec tag.
+     *
+     * Walks backwards from the token skipping whitespace, attribute tokens, and
+     * visibility/abstract/final/static modifiers. If the next non-skipped token
+     * is the close of a doc comment, scan the block for @spec.
+     *
+     * @param File $phpcsFile The file being scanned.
+     * @param int  $stackPtr  Position of the class/function token.
+     *
+     * @return bool True when an @spec tag is present.
+     */
+    private function hasSpecTag(File $phpcsFile, int $stackPtr): bool
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        $skip = [
+            T_WHITESPACE,
+            T_ABSTRACT,
+            T_FINAL,
+            T_STATIC,
+            T_PUBLIC,
+            T_PROTECTED,
+            T_PRIVATE,
+            T_READONLY,
+            T_ATTRIBUTE,
+            T_ATTRIBUTE_END,
+        ];
+
+        $ptr = ($stackPtr - 1);
+        while ($ptr >= 0) {
+            $code = $tokens[$ptr]['code'];
+
+            // Skip over attribute blocks (PHP 8 #[Attribute]) in full.
+            if ($code === T_ATTRIBUTE_END && isset($tokens[$ptr]['attribute_opener']) === true) {
+                $ptr = ($tokens[$ptr]['attribute_opener'] - 1);
+                continue;
+            }
+
+            if (in_array($code, $skip, true) === true) {
+                $ptr--;
+                continue;
+            }
+
+            break;
+        }
+
+        if ($ptr < 0) {
+            return false;
+        }
+
+        if ($tokens[$ptr]['code'] !== T_DOC_COMMENT_CLOSE_TAG) {
+            return false;
+        }
+
+        if (isset($tokens[$ptr]['comment_opener']) === false) {
+            return false;
+        }
+
+        $opener = $tokens[$ptr]['comment_opener'];
+        for ($i = $opener; $i <= $ptr; $i++) {
+            if ($tokens[$i]['code'] === T_DOC_COMMENT_TAG
+                && strtolower($tokens[$i]['content']) === '@spec'
+            ) {
+                return true;
+            }
+        }
+
+        return false;
+
+    }//end hasSpecTag()
+
+
+    /**
+     * Determine if the function at $stackPtr is a public method.
+     *
+     * Methods default to public when no visibility modifier is present.
+     *
+     * @param File $phpcsFile The file being scanned.
+     * @param int  $stackPtr  Position of the T_FUNCTION token.
+     *
+     * @return bool True when the method is public (explicit or default).
+     */
+    private function isPublicMethod(File $phpcsFile, int $stackPtr): bool
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        $ptr = ($stackPtr - 1);
+        while ($ptr >= 0) {
+            $code = $tokens[$ptr]['code'];
+            if ($code === T_PUBLIC) {
+                return true;
+            }
+
+            if ($code === T_PROTECTED || $code === T_PRIVATE) {
+                return false;
+            }
+
+            if ($code === T_WHITESPACE
+                || $code === T_ABSTRACT
+                || $code === T_FINAL
+                || $code === T_STATIC
+                || $code === T_READONLY
+            ) {
+                $ptr--;
+                continue;
+            }
+
+            // Skip attributes in full.
+            if ($code === T_ATTRIBUTE_END && isset($tokens[$ptr]['attribute_opener']) === true) {
+                $ptr = ($tokens[$ptr]['attribute_opener'] - 1);
+                continue;
+            }
+
+            if ($code === T_DOC_COMMENT_CLOSE_TAG
+                || $code === T_COMMENT
+                || $code === T_OPEN_CURLY_BRACKET
+                || $code === T_CLOSE_CURLY_BRACKET
+                || $code === T_SEMICOLON
+            ) {
+                // No visibility modifier found — default public.
+                return true;
+            }
+
+            $ptr--;
+        }
+
+        return true;
+
+    }//end isPublicMethod()
+
+
+    /**
+     * Return the name of the class/interface/trait/enum enclosing $stackPtr, or null.
+     *
+     * @param File $phpcsFile The file being scanned.
+     * @param int  $stackPtr  Position of the token to inspect.
+     *
+     * @return string|null The enclosing class name, or null when at file scope.
+     */
+    private function getEnclosingClassName(File $phpcsFile, int $stackPtr): ?string
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        if (isset($tokens[$stackPtr]['conditions']) === false) {
+            return null;
+        }
+
+        // Walk the conditions chain looking for the innermost class-like scope.
+        $classLike = [T_CLASS, T_INTERFACE, T_TRAIT, T_ENUM, T_ANON_CLASS];
+
+        foreach (array_reverse($tokens[$stackPtr]['conditions'], true) as $scopePtr => $scopeCode) {
+            if (in_array($scopeCode, $classLike, true) === true) {
+                $namePtr = $phpcsFile->findNext(T_STRING, ($scopePtr + 1));
+                if ($namePtr === false) {
+                    return '{anonymous}';
+                }
+
+                // Sanity: ensure the name is before the opening brace for that class.
+                if (isset($tokens[$scopePtr]['scope_opener']) === true
+                    && $namePtr > $tokens[$scopePtr]['scope_opener']
+                ) {
+                    return '{anonymous}';
+                }
+
+                return $tokens[$namePtr]['content'];
+            }
+        }
+
+        return null;
+
+    }//end getEnclosingClassName()
+
+
+    /**
+     * Check whether the currently-scanned file is a test file.
+     *
+     * @param File $phpcsFile The file being scanned.
+     *
+     * @return bool True for files under /tests/ or /Tests/.
+     */
+    private function isTestFile(File $phpcsFile): bool
+    {
+        $path = str_replace('\\', '/', $phpcsFile->getFilename());
+        return (stripos($path, '/tests/') !== false);
+
+    }//end isTestFile()
+
+
+}//end class

--- a/phpcs-custom-sniffs/CustomSniffs/Sniffs/Nextcloud/NoLegacyServerAccessorsSniff.php
+++ b/phpcs-custom-sniffs/CustomSniffs/Sniffs/Nextcloud/NoLegacyServerAccessorsSniff.php
@@ -1,0 +1,180 @@
+<?php
+/**
+ * Forbid the legacy named accessors on \OC::$server that were removed in Nextcloud 34.
+ *
+ * Flags patterns like:
+ *   \OC::$server->getDatabaseConnection()
+ *   \OC::$server->getSystemConfig()
+ *   \OC::$server->getLogger()
+ *
+ * These named accessors were removed in Nextcloud 34. The replacement pattern
+ * is constructor dependency injection of the equivalent OCP interface.
+ *
+ * PSR-11 lookups such as \OC::$server->get(SomeClass::class) are NOT flagged
+ * here; service-locator deprecation is tracked separately (design.md, D4).
+ *
+ * @author  Conduction
+ * @package CustomSniffs
+ */
+
+namespace CustomSniffs\Sniffs\Nextcloud;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+
+/**
+ * NoLegacyServerAccessorsSniff — forbids removed \OC::$server->getX() accessors.
+ */
+class NoLegacyServerAccessorsSniff implements Sniff
+{
+
+
+    /**
+     * Map of known named accessors to their approved OCP replacement interface.
+     *
+     * Covers the accessors that still appeared in this codebase plus the most
+     * frequently used Nextcloud 34 removals. The error message interpolates the
+     * accessor name and the replacement from this table so engineers see the
+     * intended DI target at the violation site.
+     *
+     * @var array<string, string>
+     */
+    private const REPLACEMENTS = [
+        'getSystemConfig'           => '\OCP\IConfig',
+        'getConfig'                 => '\OCP\IConfig',
+        'getDatabaseConnection'     => '\OCP\IDBConnection',
+        'getLogger'                 => '\Psr\Log\LoggerInterface',
+        'getL10NFactory'            => '\OCP\L10N\IFactory',
+        'getL10N'                   => '\OCP\IL10N (via \OCP\L10N\IFactory)',
+        'getUserSession'            => '\OCP\IUserSession',
+        'getUserManager'            => '\OCP\IUserManager',
+        'getGroupManager'           => '\OCP\IGroupManager',
+        'getURLGenerator'           => '\OCP\IURLGenerator',
+        'getRequest'                => '\OCP\IRequest',
+        'getRootFolder'             => '\OCP\Files\IRootFolder',
+        'getAppManager'             => '\OCP\App\IAppManager',
+        'getSession'                => '\OCP\ISession',
+        'getMemCacheFactory'        => '\OCP\ICacheFactory',
+        'getEventDispatcher'        => '\OCP\EventDispatcher\IEventDispatcher',
+        'getNotificationManager'    => '\OCP\Notification\IManager',
+        'getTempManager'            => '\OCP\ITempManager',
+        'getMimeTypeDetector'       => '\OCP\Files\IMimeTypeDetector',
+        'getMimeTypeLoader'         => '\OCP\Files\IMimeTypeLoader',
+        'getActivityManager'        => '\OCP\Activity\IManager',
+        'getDateTimeFormatter'      => '\OCP\IDateTimeFormatter',
+        'getDateTimeZone'           => '\OCP\IDateTimeZone',
+        'getTrustedDomainHelper'    => '\OCP\Security\ITrustedDomainHelper',
+        'getRegisteredAppContainer' => 'explicit constructor injection of the specific service',
+    ];
+
+    /**
+     * Returns tokens this sniff listens for.
+     *
+     * Anchors on T_DOUBLE_COLON so we can reconstruct the full pattern
+     * \OC :: $server -> getX ( in a single process() call.
+     *
+     * @return array<int>
+     */
+    public function register(): array
+    {
+        return [T_DOUBLE_COLON];
+
+    }//end register()
+
+    /**
+     * Process a T_DOUBLE_COLON token — flag if part of \OC::$server->getX().
+     *
+     * @param File $phpcsFile The file being scanned.
+     * @param int  $stackPtr  Position of the T_DOUBLE_COLON token.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr): void
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        // Previous non-whitespace token must be T_STRING "OC".
+        $prev = $phpcsFile->findPrevious(
+            types: [T_WHITESPACE],
+            start: ($stackPtr - 1),
+            end: null,
+            exclude: true
+        );
+        if ($prev === false
+            || $tokens[$prev]['code'] !== T_STRING
+            || $tokens[$prev]['content'] !== 'OC'
+        ) {
+            return;
+        }
+
+        // Next non-whitespace token must be T_VARIABLE "$server".
+        $afterColon = $phpcsFile->findNext(
+            types: [T_WHITESPACE],
+            start: ($stackPtr + 1),
+            end: null,
+            exclude: true
+        );
+        if ($afterColon === false
+            || $tokens[$afterColon]['code'] !== T_VARIABLE
+            || $tokens[$afterColon]['content'] !== '$server'
+        ) {
+            return;
+        }
+
+        // Expect T_OBJECT_OPERATOR '->'.
+        $arrow = $phpcsFile->findNext(
+            types: [T_WHITESPACE],
+            start: ($afterColon + 1),
+            end: null,
+            exclude: true
+        );
+        if ($arrow === false || $tokens[$arrow]['code'] !== T_OBJECT_OPERATOR) {
+            return;
+        }
+
+        // Expect T_STRING method name.
+        $methodPtr = $phpcsFile->findNext(
+            types: [T_WHITESPACE],
+            start: ($arrow + 1),
+            end: null,
+            exclude: true
+        );
+        if ($methodPtr === false || $tokens[$methodPtr]['code'] !== T_STRING) {
+            return;
+        }
+
+        // Must be followed by ( to be a call.
+        $openParen = $phpcsFile->findNext(
+            types: [T_WHITESPACE],
+            start: ($methodPtr + 1),
+            end: null,
+            exclude: true
+        );
+        if ($openParen === false || $tokens[$openParen]['code'] !== T_OPEN_PARENTHESIS) {
+            return;
+        }
+
+        $methodName = $tokens[$methodPtr]['content'];
+
+        // PSR-11 ->get(...) is deferred (D4 in design.md) — not flagged here.
+        if ($methodName === 'get') {
+            return;
+        }
+
+        // Only flag named accessors: getX where X starts with an uppercase letter.
+        if (preg_match(pattern: '/^get[A-Z]/', subject: $methodName) !== 1) {
+            return;
+        }
+
+        $replacement = self::REPLACEMENTS[$methodName] ?? 'the corresponding OCP interface';
+
+        $error = 'Named accessor \\OC::$server->%s() is removed in Nextcloud 34. Inject %s via the constructor instead.';
+        $phpcsFile->addError(
+            $error,
+            $stackPtr,
+            'LegacyNamedAccessor',
+            [$methodName, $replacement]
+        );
+
+    }//end process()
+}//end class

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,13 +1,20 @@
 <?xml version="1.0"?>
 <ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="PHP_CodeSniffer" xsi:noNamespaceSchemaLocation="phpcs.xsd">
-    <description>Coding standard for MyDash, based on the Conduction/OpenRegister standard.</description>
+    <description>Coding standard for Mydash, based on the Conduction/OpenRegister standard.</description>
 
     <file>lib</file>
 
     <!-- Exclude external and vendor files -->
     <exclude-pattern>*/vendor/*</exclude-pattern>
+    <exclude-pattern>*/vendor-bin/*</exclude-pattern>
     <exclude-pattern>*/node_modules/*</exclude-pattern>
     <exclude-pattern>composer-setup.php</exclude-pattern>
+    <!-- Apps that ship a verbatim template snapshot under lib/Resources/template/ (e.g. openbuilt)
+         keep it out of lint scope; no-op for apps without the directory. -->
+    <exclude-pattern>lib/Resources/template/*</exclude-pattern>
+
+    <!-- Surface phpcs warnings (e.g. SpecTagSniff) in CI logs without failing the build. -->
+    <config name="ignore_warnings_on_exit" value="1"/>
 
     <arg name="basepath" value="."/>
     <arg name="colors"/>
@@ -38,23 +45,23 @@
     <rule ref="Squiz.Arrays.ArrayBracketSpacing"/>
     <rule ref="Squiz.ControlStructures.ControlSignature"/>
     <rule ref="Squiz.ControlStructures.ElseIfDeclaration"/>
-    <rule ref="Squiz.PHP.DisallowInlineIf"/>
     <rule ref="Squiz.Commenting.ClosingDeclarationComment"/>
-    <rule ref="Squiz.Commenting.BlockComment">
-        <exclude name="Squiz.Commenting.BlockComment.WrongStart"/>
-    </rule>
+    <rule ref="Squiz.Commenting.BlockComment"/>
     <rule ref="Squiz.Commenting.DocCommentAlignment"/>
     <rule ref="Squiz.Commenting.EmptyCatchComment"/>
-    <rule ref="Squiz.Commenting.InlineComment">
-        <exclude name="Squiz.Commenting.InlineComment.DocBlock"/>
-    </rule>
+    <rule ref="Squiz.Commenting.InlineComment"/>
     <rule ref="Squiz.Commenting.LongConditionClosingComment"/>
     <rule ref="Squiz.Commenting.PostStatementComment"/>
     <rule ref="Squiz.Commenting.VariableComment"/>
     <rule ref="Squiz.Functions.FunctionDeclarationArgumentSpacing"/>
     <rule ref="Squiz.Operators.ComparisonOperatorUsage"/>
+    <rule ref="Squiz.PHP.DisallowInlineIf"/>
     <rule ref="Squiz.Scope.MethodScope"/>
-    <rule ref="Squiz.Strings.ConcatenationSpacing"/>
+    <rule ref="Squiz.Strings.ConcatenationSpacing">
+        <properties>
+            <property name="ignoreNewlines" value="true"/>
+        </properties>
+    </rule>
     <rule ref="Squiz.WhiteSpace.ControlStructureSpacing"/>
     <rule ref="Squiz.WhiteSpace.FunctionSpacing">
         <properties>
@@ -76,14 +83,18 @@
     <rule ref="Generic.Formatting.SpaceAfterCast"/>
     <rule ref="Generic.Files.LineLength">
         <properties>
-            <property name="lineLimit" value="125"/>
+            <property name="lineLimit" value="150"/>
             <property name="absoluteLineLimit" value="150"/>
         </properties>
     </rule>
     <rule ref="Generic.NamingConventions.ConstructorName"/>
     <rule ref="Generic.PHP.DeprecatedFunctions"/>
     <rule ref="Generic.PHP.LowerCaseKeyword"/>
-    <rule ref="Generic.Strings.UnnecessaryStringConcat"/>
+    <rule ref="Generic.Strings.UnnecessaryStringConcat">
+        <properties>
+            <property name="allowMultiline" value="true"/>
+        </properties>
+    </rule>
     <rule ref="Generic.WhiteSpace.IncrementDecrementSpacing"/>
     <rule ref="PSR2.Classes.PropertyDeclaration"/>
     <rule ref="PSR2.Methods.MethodDeclaration"/>
@@ -207,6 +218,17 @@
     <!-- Custom rule to enforce named parameters -->
     <rule ref="./phpcs-custom-sniffs/CustomSniffs/Sniffs/Functions/NamedParametersSniff.php">
         <type>error</type>
+    </rule>
+
+    <!-- Block calls to \OC::$server->getX() / \OC::$server->query() removed in Nextcloud 34. -->
+    <rule ref="./phpcs-custom-sniffs/CustomSniffs/Sniffs/Nextcloud/NoLegacyServerAccessorsSniff.php">
+        <type>error</type>
+    </rule>
+
+    <!-- Warn when a class or public method is missing the @spec PHPDoc tag (hydra ADR-003).
+         Emitted as warnings (not errors) so CI surfaces the gap but doesn't block merges. -->
+    <rule ref="./phpcs-custom-sniffs/CustomSniffs/Sniffs/Commenting/SpecTagSniff.php">
+        <type>warning</type>
     </rule>
 
 </ruleset>

--- a/phpmd.xml
+++ b/phpmd.xml
@@ -1,15 +1,18 @@
 <?xml version="1.0"?>
-<ruleset name="MyDash Nextcloud Rules"
+<ruleset name="Mydash Nextcloud Rules"
     xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0
                         http://pmd.sourceforge.net/ruleset_xml_schema.xsd">
 
     <description>
-        PHPMD ruleset for MyDash, based on the Conduction/OpenRegister standard.
+        This is a custom ruleset for Mydash Nextcloud.
     </description>
 
     <!-- Clean Code Rules -->
+    <rule ref="rulesets/cleancode.xml/BooleanArgumentFlag"/>
+    <rule ref="rulesets/cleancode.xml/ElseExpression"/>
+    <rule ref="rulesets/cleancode.xml/StaticAccess"/>
     <rule ref="rulesets/cleancode.xml/IfStatementAssignment"/>
     <rule ref="rulesets/cleancode.xml/DuplicatedArrayKey"/>
     <rule ref="rulesets/cleancode.xml/MissingImport"/>
@@ -17,26 +20,10 @@
     <rule ref="rulesets/cleancode.xml/ErrorControlOperator"/>
 
     <!-- Code Size Rules -->
-    <rule ref="rulesets/codesize.xml/CyclomaticComplexity">
-        <properties>
-            <property name="reportLevel" value="15" />
-        </properties>
-    </rule>
-    <rule ref="rulesets/codesize.xml/NPathComplexity">
-        <properties>
-            <property name="minimum" value="5000" />
-        </properties>
-    </rule>
-    <rule ref="rulesets/codesize.xml/ExcessiveMethodLength">
-        <properties>
-            <property name="minimum" value="200" />
-        </properties>
-    </rule>
-    <rule ref="rulesets/codesize.xml/ExcessiveClassLength">
-        <properties>
-            <property name="minimum" value="1500" />
-        </properties>
-    </rule>
+    <rule ref="rulesets/codesize.xml/CyclomaticComplexity"/>
+    <rule ref="rulesets/codesize.xml/NPathComplexity"/>
+    <rule ref="rulesets/codesize.xml/ExcessiveMethodLength"/>
+    <rule ref="rulesets/codesize.xml/ExcessiveClassLength"/>
     <rule ref="rulesets/codesize.xml/ExcessiveParameterList"/>
     <rule ref="rulesets/codesize.xml/ExcessivePublicCount"/>
     <rule ref="rulesets/codesize.xml/TooManyFields"/>
@@ -49,6 +36,10 @@
     <rule ref="rulesets/controversial.xml/CamelCaseClassName"/>
     <rule ref="rulesets/controversial.xml/CamelCasePropertyName"/>
     <rule ref="rulesets/controversial.xml/CamelCaseMethodName"/>
+    <!-- CamelCaseParameterName removed - we allow leading underscores on parameters (convention for unused/config params) -->
+    <!-- <rule ref="rulesets/controversial.xml/CamelCaseParameterName"/> -->
+    <!-- CamelCaseVariableName removed - we allow leading underscores on variables (convention for unused loop vars) -->
+    <!-- <rule ref="rulesets/controversial.xml/CamelCaseVariableName"/> -->
 
     <!-- Design Rules -->
     <rule ref="rulesets/design.xml/ExitExpression"/>
@@ -64,6 +55,7 @@
     <!-- Naming Rules -->
     <rule ref="rulesets/naming.xml/LongClassName"/>
     <rule ref="rulesets/naming.xml/ShortClassName"/>
+    <!-- ShortVariable configured with allowlist of idiomatic short names -->
     <rule ref="rulesets/naming.xml/ShortVariable">
         <properties>
             <property name="minimum" value="3" />
@@ -80,4 +72,7 @@
     <rule ref="rulesets/unusedcode.xml/UnusedPrivateField"/>
     <rule ref="rulesets/unusedcode.xml/UnusedLocalVariable"/>
     <rule ref="rulesets/unusedcode.xml/UnusedPrivateMethod"/>
+    <rule ref="rulesets/unusedcode.xml/UnusedFormalParameter">
+        <exclude-pattern>*Migration*</exclude-pattern>
+    </rule>
 </ruleset>

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,81 +1,162 @@
+# Per-app phpstan lint debt baseline.
+#
+# Regenerate with: ./vendor/bin/phpstan analyse --generate-baseline
+# Apps without lint debt ship this file empty.
+#
+# Tracked-debt entries here MUST have an open GitHub issue. The directive for the
+# Conduction fleet is "no per-app validation rules; if we need exceptions then
+# they are for all apps." A baseline entry is acceptable only as a temporary
+# tracked-debt marker with a removal timeline.
+#
+# Tracking issue: https://github.com/ConductionNL/mydash/issues/269
+# Generated: 2026-05-21 by canonical-root-configs sync (Phase 2 fleet rollout).
+# Captures the 50 errors that surfaced when the prior 14 path-scoped JSONResponse
+# / DataResponse suppressions in phpstan.neon were removed, plus pre-existing
+# latent debt. Remove entries incrementally per the strategy in #269.
+
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Parameter \\#1 \\$createdAt of method OCA\\\\MyDash\\\\Db\\\\Dashboard\\:\\:setCreatedAt\\(\\) expects string\\|null, DateTime given\\.$#"
-			count: 1
-			path: lib/Service/AdminTemplateService.php
-
-		-
-			message: "#^Parameter \\#1 \\$isDefault of method OCA\\\\MyDash\\\\Db\\\\Dashboard\\:\\:setIsDefault\\(\\) expects int, bool given\\.$#"
-			count: 1
-			path: lib/Service/AdminTemplateService.php
-
-		-
-			message: "#^Parameter \\#1 \\$updatedAt of method OCA\\\\MyDash\\\\Db\\\\Dashboard\\:\\:setUpdatedAt\\(\\) expects string\\|null, DateTime given\\.$#"
+			message: "#^Parameter \\$data of class OCP\\\\AppFramework\\\\Http\\\\DataResponse constructor expects T of OCP\\\\AppFramework\\\\Http\\\\DataResponseType, array given\\.$#"
 			count: 2
-			path: lib/Service/AdminTemplateService.php
+			path: lib/Controller/DashboardShareApiController.php
 
 		-
-			message: "#^Strict comparison using \\=\\=\\= between int and false will always evaluate to false\\.$#"
-			count: 1
-			path: lib/Service/ConditionalService.php
+			message: "#^Parameter \\$data of class OCP\\\\AppFramework\\\\Http\\\\DataResponse constructor expects T of OCP\\\\AppFramework\\\\Http\\\\DataResponseType, array\\<array\\> given\\.$#"
+			count: 2
+			path: lib/Controller/DashboardShareApiController.php
 
 		-
-			message: "#^Parameter \\#1 \\$isActive of method OCA\\\\MyDash\\\\Db\\\\Dashboard\\:\\:setIsActive\\(\\) expects int, true given\\.$#"
+			message: "#^Parameter \\$data of class OCP\\\\AppFramework\\\\Http\\\\DataResponse constructor expects T of OCP\\\\AppFramework\\\\Http\\\\DataResponseType, array\\<string, array\\<int\\<0, max\\>, array\\<string, string\\>\\>\\> given\\.$#"
 			count: 1
-			path: lib/Service/DashboardResolver.php
+			path: lib/Controller/DashboardShareApiController.php
 
 		-
-			message: "#^Property OCA\\\\MyDash\\\\Service\\\\DashboardResolver\\:\\:\\$settingMapper is never read, only written\\.$#"
+			message: "#^Parameter \\$data of class OCP\\\\AppFramework\\\\Http\\\\DataResponse constructor expects T of OCP\\\\AppFramework\\\\Http\\\\DataResponseType, array\\<string, array\\> given\\.$#"
 			count: 1
-			path: lib/Service/DashboardResolver.php
+			path: lib/Controller/DashboardShareApiController.php
 
 		-
-			message: "#^Unreachable statement \\- code above always terminates\\.$#"
+			message: "#^Parameter \\$data of class OCP\\\\AppFramework\\\\Http\\\\DataResponse constructor expects T of OCP\\\\AppFramework\\\\Http\\\\DataResponseType, array\\<string, int\\> given\\.$#"
 			count: 1
-			path: lib/Service/DashboardResolver.php
+			path: lib/Controller/DashboardShareApiController.php
 
 		-
-			message: "#^Method OCA\\\\MyDash\\\\Service\\\\DashboardService\\:\\:createDefaultPlacements\\(\\) has invalid return type OCA\\\\MyDash\\\\Service\\\\WidgetPlacement\\.$#"
-			count: 1
-			path: lib/Service/DashboardService.php
+			message: "#^Parameter \\$data of class OCP\\\\AppFramework\\\\Http\\\\DataResponse constructor expects T of OCP\\\\AppFramework\\\\Http\\\\DataResponseType, array\\<string, string\\> given\\.$#"
+			count: 17
+			path: lib/Controller/DashboardShareApiController.php
 
 		-
-			message: "#^Method OCA\\\\MyDash\\\\Service\\\\DashboardService\\:\\:createDefaultPlacements\\(\\) should return array\\<OCA\\\\MyDash\\\\Service\\\\WidgetPlacement\\> but returns array\\<int, OCA\\\\MyDash\\\\Db\\\\WidgetPlacement\\>\\.$#"
+			message: "#^Parameter \\$data of class OCP\\\\AppFramework\\\\Http\\\\DataResponse constructor expects T of OCP\\\\AppFramework\\\\Http\\\\DataResponseType, array given\\.$#"
 			count: 1
-			path: lib/Service/DashboardService.php
+			path: lib/Controller/FeedController.php
 
 		-
-			message: "#^Parameter \\#1 \\$isActive of method OCA\\\\MyDash\\\\Db\\\\Dashboard\\:\\:setIsActive\\(\\) expects int, true given\\.$#"
-			count: 1
-			path: lib/Service/DashboardService.php
+			message: "#^Parameter \\$data of class OCP\\\\AppFramework\\\\Http\\\\DataResponse constructor expects T of OCP\\\\AppFramework\\\\Http\\\\DataResponseType, array\\<string, string\\> given\\.$#"
+			count: 4
+			path: lib/Controller/FeedController.php
 
 		-
-			message: "#^Strict comparison using \\=\\=\\= between int and false will always evaluate to false\\.$#"
+			message: "#^Parameter \\$statusCode of class OCP\\\\AppFramework\\\\Http\\\\DataResponse constructor expects S of 100\\|101\\|102\\|200\\|201\\|202\\|203\\|204\\|205\\|206\\|207\\|208\\|226\\|300\\|301\\|302\\|303\\|304\\|305\\|306\\|307\\|400\\|401\\|402\\|403\\|404\\|405\\|406\\|407\\|408\\|409\\|410\\|411\\|412\\|413\\|414\\|415\\|416\\|417\\|418\\|422\\|423\\|424\\|426\\|428\\|429\\|431\\|500\\|501\\|502\\|503\\|504\\|505\\|506\\|507\\|508\\|509\\|510\\|511, int given\\.$#"
 			count: 1
-			path: lib/Service/PermissionService.php
+			path: lib/Controller/FeedController.php
 
 		-
-			message: "#^Parameter \\#1 \\$createdAt of method OCA\\\\MyDash\\\\Db\\\\Dashboard\\:\\:setCreatedAt\\(\\) expects string\\|null, DateTime given\\.$#"
+			message: "#^Comparison operation \"\\<\" between 0\\|1 and 5 is always true\\.$#"
 			count: 1
-			path: lib/Service/TemplateService.php
+			path: lib/Db/DashboardMapper.php
 
 		-
-			message: "#^Parameter \\#1 \\$createdAt of method OCA\\\\MyDash\\\\Db\\\\WidgetPlacement\\:\\:setCreatedAt\\(\\) expects string\\|null, DateTime given\\.$#"
+			message: "#^Parameter \\$table of method OCA\\\\MyDash\\\\Migration\\\\DashboardTableBuilder\\:\\:addColumns\\(\\) has invalid type Doctrine\\\\DBAL\\\\Schema\\\\Table\\.$#"
 			count: 1
-			path: lib/Service/TemplateService.php
+			path: lib/Migration/DashboardTableBuilder.php
 
 		-
-			message: "#^Parameter \\#1 \\$isActive of method OCA\\\\MyDash\\\\Db\\\\Dashboard\\:\\:setIsActive\\(\\) expects int, true given\\.$#"
+			message: "#^Parameter \\$table of method OCA\\\\MyDash\\\\Migration\\\\DashboardTableBuilder\\:\\:addFooterColumns\\(\\) has invalid type Doctrine\\\\DBAL\\\\Schema\\\\Table\\.$#"
 			count: 1
-			path: lib/Service/TemplateService.php
+			path: lib/Migration/DashboardTableBuilder.php
 
 		-
-			message: "#^Parameter \\#1 \\$updatedAt of method OCA\\\\MyDash\\\\Db\\\\Dashboard\\:\\:setUpdatedAt\\(\\) expects string\\|null, DateTime given\\.$#"
+			message: "#^Parameter \\$table of method OCA\\\\MyDash\\\\Migration\\\\DashboardTableBuilder\\:\\:addIndexes\\(\\) has invalid type Doctrine\\\\DBAL\\\\Schema\\\\Table\\.$#"
 			count: 1
-			path: lib/Service/TemplateService.php
+			path: lib/Migration/DashboardTableBuilder.php
 
 		-
-			message: "#^Parameter \\#1 \\$updatedAt of method OCA\\\\MyDash\\\\Db\\\\WidgetPlacement\\:\\:setUpdatedAt\\(\\) expects string\\|null, DateTime given\\.$#"
+			message: "#^Parameter \\$table of method OCA\\\\MyDash\\\\Migration\\\\DashboardTableBuilder\\:\\:addPublicationColumns\\(\\) has invalid type Doctrine\\\\DBAL\\\\Schema\\\\Table\\.$#"
 			count: 1
-			path: lib/Service/TemplateService.php
+			path: lib/Migration/DashboardTableBuilder.php
+
+		-
+			message: "#^Parameter \\$table of method OCA\\\\MyDash\\\\Migration\\\\DashboardTableBuilder\\:\\:addTemplateDiscoveryColumns\\(\\) has invalid type Doctrine\\\\DBAL\\\\Schema\\\\Table\\.$#"
+			count: 1
+			path: lib/Migration/DashboardTableBuilder.php
+
+		-
+			message: "#^Parameter \\$table of method OCA\\\\MyDash\\\\Migration\\\\DashboardTableBuilder\\:\\:addTreeColumns\\(\\) has invalid type Doctrine\\\\DBAL\\\\Schema\\\\Table\\.$#"
+			count: 1
+			path: lib/Migration/DashboardTableBuilder.php
+
+		-
+			message: "#^Parameter \\$table of method OCA\\\\MyDash\\\\Migration\\\\DashboardViewsTableBuilder\\:\\:addColumns\\(\\) has invalid type Doctrine\\\\DBAL\\\\Schema\\\\Table\\.$#"
+			count: 1
+			path: lib/Migration/DashboardViewsTableBuilder.php
+
+		-
+			message: "#^Parameter \\$table of method OCA\\\\MyDash\\\\Migration\\\\DashboardViewsTableBuilder\\:\\:addIndexes\\(\\) has invalid type Doctrine\\\\DBAL\\\\Schema\\\\Table\\.$#"
+			count: 1
+			path: lib/Migration/DashboardViewsTableBuilder.php
+
+		-
+			message: "#^Parameter \\$table of method OCA\\\\MyDash\\\\Migration\\\\PlacementTableBuilder\\:\\:addColumns\\(\\) has invalid type Doctrine\\\\DBAL\\\\Schema\\\\Table\\.$#"
+			count: 1
+			path: lib/Migration/PlacementTableBuilder.php
+
+		-
+			message: "#^Parameter \\$table of method OCA\\\\MyDash\\\\Migration\\\\PlacementTableBuilder\\:\\:addIndexes\\(\\) has invalid type Doctrine\\\\DBAL\\\\Schema\\\\Table\\.$#"
+			count: 1
+			path: lib/Migration/PlacementTableBuilder.php
+
+		-
+			message: "#^Parameter \\$table of method OCA\\\\MyDash\\\\Migration\\\\RoleFeaturePermissionTableBuilder\\:\\:addColumns\\(\\) has invalid type Doctrine\\\\DBAL\\\\Schema\\\\Table\\.$#"
+			count: 1
+			path: lib/Migration/RoleFeaturePermissionTableBuilder.php
+
+		-
+			message: "#^Parameter \\$table of method OCA\\\\MyDash\\\\Migration\\\\RoleFeaturePermissionTableBuilder\\:\\:addIndexes\\(\\) has invalid type Doctrine\\\\DBAL\\\\Schema\\\\Table\\.$#"
+			count: 1
+			path: lib/Migration/RoleFeaturePermissionTableBuilder.php
+
+		-
+			message: "#^Parameter \\$table of method OCA\\\\MyDash\\\\Migration\\\\RoleLayoutDefaultTableBuilder\\:\\:addColumns\\(\\) has invalid type Doctrine\\\\DBAL\\\\Schema\\\\Table\\.$#"
+			count: 1
+			path: lib/Migration/RoleLayoutDefaultTableBuilder.php
+
+		-
+			message: "#^Parameter \\$table of method OCA\\\\MyDash\\\\Migration\\\\RoleLayoutDefaultTableBuilder\\:\\:addIndexes\\(\\) has invalid type Doctrine\\\\DBAL\\\\Schema\\\\Table\\.$#"
+			count: 1
+			path: lib/Migration/RoleLayoutDefaultTableBuilder.php
+
+		-
+			message: "#^Parameter \\$table of method OCA\\\\MyDash\\\\Migration\\\\RulesTableBuilder\\:\\:addColumns\\(\\) has invalid type Doctrine\\\\DBAL\\\\Schema\\\\Table\\.$#"
+			count: 1
+			path: lib/Migration/RulesTableBuilder.php
+
+		-
+			message: "#^Parameter \\$table of method OCA\\\\MyDash\\\\Migration\\\\RulesTableBuilder\\:\\:addIndexes\\(\\) has invalid type Doctrine\\\\DBAL\\\\Schema\\\\Table\\.$#"
+			count: 1
+			path: lib/Migration/RulesTableBuilder.php
+
+		-
+			message: "#^Parameter \\$table of method OCA\\\\MyDash\\\\Migration\\\\SettingsTableBuilder\\:\\:addColumns\\(\\) has invalid type Doctrine\\\\DBAL\\\\Schema\\\\Table\\.$#"
+			count: 1
+			path: lib/Migration/SettingsTableBuilder.php
+
+		-
+			message: "#^Parameter \\$table of method OCA\\\\MyDash\\\\Migration\\\\SettingsTableBuilder\\:\\:addIndexes\\(\\) has invalid type Doctrine\\\\DBAL\\\\Schema\\\\Table\\.$#"
+			count: 1
+			path: lib/Migration/SettingsTableBuilder.php
+
+		-
+			message: "#^Offset 'mime' on array\\{0\\: int\\<0, max\\>, 1\\: int\\<0, max\\>, 2\\: int, 3\\: string, mime\\: string, channels\\?\\: int, bits\\?\\: int\\} on left side of \\?\\? always exists and is not nullable\\.$#"
+			count: 1
+			path: lib/Service/ImageMimeValidator.php

--- a/phpstan-bootstrap.php
+++ b/phpstan-bootstrap.php
@@ -2,10 +2,6 @@
 
 /**
  * PHPStan bootstrap file - registers OCP autoloader for static analysis.
- *
- * The nextcloud/ocp package ships PHP class stubs at vendor/nextcloud/ocp/OCP/
- * but its composer.json does not register a PSR-4 autoload mapping. We add the
- * mappings here so PHPStan can resolve OCP\* and NCU\* class references.
  */
 
 $autoloader = require __DIR__ . '/vendor/autoload.php';

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,4 +1,7 @@
 includes:
+    # Per-app tracked lint debt lives here (auto-generated via `phpstan --generate-baseline`).
+    # Apps without debt ship an empty baseline file; canonical includes are otherwise byte-identical
+    # across the fleet.
     - phpstan-baseline.neon
 
 parameters:
@@ -9,123 +12,48 @@ parameters:
         - phpstan-bootstrap.php
     excludePaths:
         - vendor
-    # nextcloud/ocp ships stubs without an autoload section, so list the
-    # namespace roots explicitly. Keep both OCP (public API) and NCU
-    # (unstable internal API) reachable for symbol resolution.
+        - vendor-bin
+        # Apps that ship a verbatim template snapshot under lib/Resources/template/ (e.g. openbuilt).
+        - lib/Resources/template
     scanDirectories:
-        - vendor/nextcloud/ocp/OCP
-        - vendor/nextcloud/ocp/NCU
+        - vendor/nextcloud/ocp
     reportUnmatchedIgnoredErrors: false
     ignoreErrors:
-        # Nextcloud internal classes that PHPStan might not recognize
+        # Nextcloud server internals (\OC, OC_App, OC\) not stubbed in nextcloud/ocp
         - '#Call to an undefined method OC::#'
         - '#Class OC not found#'
         - '#Access to static property \$server on an unknown class OC#'
-        # Doctrine\DBAL\Schema\Table is provided by Nextcloud server's
-        # 3rdparty bundle, not by our app's vendor/. Migration table
-        # builders type-hint the class but PHPStan cannot resolve it
-        # locally; they are exercised at runtime under Nextcloud.
-        -
-            message: '#unknown class Doctrine\\DBAL\\Schema\\Table#'
-            path: lib/Migration/*
-        -
-            message: '#has invalid type Doctrine\\DBAL\\Schema\\Table#'
-            path: lib/Migration/*
-        # JSONResponse uses a strict status-code union; a plain int parameter
-        # widens that. Both call sites already constrain via Http::STATUS_*
-        # defaults at the public boundary, so the runtime behaviour is sound.
-        -
-            message: '#Parameter \$statusCode of class OCP\\AppFramework\\Http\\JSONResponse constructor#'
-            path: lib/Controller/ResponseHelper.php
-        # Same JSONResponse status-code union widening — ResourceController
-        # builds the int from typed exceptions whose `getHttpStatus()` only
-        # ever returns members of the literal union (verified by tests).
-        -
-            message: '#Parameter \$statusCode of class OCP\\AppFramework\\Http\\JSONResponse constructor#'
-            path: lib/Controller/ResourceController.php
-        # Same JSONResponse status-code union widening — FileController
-        # forwards an HTTP status int from typed createFile exceptions.
-        -
-            message: '#Parameter \$statusCode of class OCP\\AppFramework\\Http\\JSONResponse constructor#'
-            path: lib/Controller/FileController.php
-        # Same JSONResponse status-code union widening — comment exceptions
-        # carry a typed `getHttpStatus()` that only returns 400/403/404 but
-        # PHPStan cannot prove the constraint statically.
-        -
-            message: '#Parameter \$statusCode of class OCP\\AppFramework\\Http\\JSONResponse constructor#'
-            path: lib/Controller/DashboardCommentsApiController.php
-        # DataResponse declares a `T of DataResponseType` template parameter
-        # whose union does not cover plain associative arrays. Every call
-        # site here passes a JSON-serialisable array — runtime is sound;
-        # the type system cannot narrow `array<string, X>` into the
-        # template union without a generic helper. Suppressing here keeps
-        # the controller readable until Nextcloud upstream loosens the
-        # generic bound.
-        -
-            message: '#Parameter \$data of class OCP\\AppFramework\\Http\\DataResponse constructor#'
-            path: lib/Controller/DashboardShareApiController.php
-        # Same DataResponse template-narrowing issue — FeedController's
-        # `{token, url}` envelopes are `array<string, string>` and the
-        # 401 envelope is `array<string, string>`; both are sound at
-        # runtime but trip the upstream generic bound. The 204 path
-        # also widens an int-literal status code that PHPStan refuses
-        # to narrow without a generic helper.
-        -
-            message: '#Parameter \$data of class OCP\\AppFramework\\Http\\DataResponse constructor#'
-            path: lib/Controller/FeedController.php
-        -
-            message: '#Parameter \$statusCode of class OCP\\AppFramework\\Http\\DataResponse constructor#'
-            path: lib/Controller/FeedController.php
-        # `getimagesizefromstring` shape from PHPStan's stubs already
-        # guarantees the `mime` key exists; the `??` is intentional defence
-        # in depth for older runtimes / stubs.
-        -
-            message: "#Offset 'mime' on .* on left side of \\?\\? always exists#"
-            path: lib/Service/ImageMimeValidator.php
-        # Entity types implement JsonSerializable on the concrete subclass;
-        # the OCP stub for Entity does not declare jsonSerialize() so PHPStan
-        # cannot statically prove the call. The only callers wrap entities
-        # that always define it.
-        -
-            message: '#Call to an undefined method OCP\\AppFramework\\Db\\Entity::jsonSerialize\(\)#'
-            path: lib/Db/EntitySerializer.php
-        # registerRepairStep / getLanguage exist on server but not in nextcloud/ocp stub
+        - '#unknown class OC\\#'
+        - '#Caught class OC\\#'
+        - '#unknown class OC_App#'
+        - '#Class OC_App not found#'
+        # OCA\DAV is server-internal and not in nextcloud/ocp stubs
+        - '#unknown class OCA\\DAV\\#'
+        - '#Class OCA\\DAV\\#'
+        # OCA classes from other apps (OpenRegister) not available during static analysis
+        - '#unknown class OCA\\OpenRegister\\#'
+        - '#OCA\\OpenRegister\\[a-zA-Z\\]+.*not found#'
+        - '#on an unknown class OCA\\OpenRegister\\#'
+        - '#has invalid return type OCA\\OpenRegister\\#'
+        - '#has invalid type OCA\\OpenRegister\\#'
+        - '#implements unknown interface OCA\\OpenRegister\\#'
+        # GuzzleHttp is available at runtime via Nextcloud but not in composer require
+        - '#unknown class GuzzleHttp\\#'
+        - '#GuzzleHttp\\[a-zA-Z\\]+.*not found#'
+        - '#on an unknown class GuzzleHttp\\#'
+        - '#invalid type GuzzleHttp\\#'
+        - '#Caught class GuzzleHttp\\#'
+        # Doctrine\DBAL is shipped by Nextcloud server but not stubbed in nextcloud/ocp
+        - '#unknown class Doctrine\\DBAL\\#'
+        - '#Doctrine\\DBAL\\[a-zA-Z\\]+.*not found#'
+        - '#on an unknown class Doctrine\\DBAL\\#'
+        # Dynamic HTTP status codes from business rule validation results
+        # (matches both `Parameter $statusCode` and `Parameter #N $statusCode` forms emitted by phpstan)
+        - '#Parameter (\#\d+ )?\$statusCode of class OCP\\AppFramework\\Http\\JSONResponse constructor expects#'
+        # registerRepairStep exists on server; not yet in nextcloud/ocp stub used for analysis
         - '#Call to an undefined method OCP\\AppFramework\\Bootstrap\\IRegistrationContext::registerRepairStep#'
-        - '#Call to an undefined method OCP\\IUser::getLanguage#'
-        # OCP\AppFramework\Db\Entity implements JsonSerializable at runtime but stub omits it
+        # OCP stub gaps for methods that exist at runtime
+        - '#Call to an undefined method OCP\\IRequest::getContent\(\)#'
+        - '#Call to an undefined method OCP\\IRequest::setParameter\(\)#'
+        - '#Call to an undefined method OCP\\Mail\\IMessage::attachFile\(\)#'
         - '#Call to an undefined method OCP\\AppFramework\\Db\\Entity::jsonSerialize#'
-        # `Dashboard::MAX_DEPTH` is a literal-typed integer constant; PHPStan
-        # collapses depth-bounded loops on it to "always true" comparisons.
-        # The bound exists so future MAX_DEPTH bumps work unchanged — the
-        # comparison is correct at runtime.
-        -
-            message: "#Comparison operation \"<\" between .* and 5 is always true#"
-            path: lib/Db/DashboardMapper.php
-        -
-            message: "#Comparison operation \"<\" between .* and 5 is always true#"
-            path: lib/Service/DashboardTreeService.php
-        # OpenRegister is an optional runtime dependency. ManifestController
-        # and the v2 migration load ObjectService lazily via the DI container
-        # so that mydash degrades gracefully when OpenRegister is absent.
-        # PHPStan cannot resolve the class from our vendor/ — suppress.
-        -
-            message: '#unknown class OCA\\OpenRegister\\Service\\ObjectService#'
-            path: lib/Controller/ManifestController.php
-        -
-            message: '#Call to method .* on an unknown class OCA\\OpenRegister\\Service\\ObjectService#'
-            path: lib/Controller/ManifestController.php
-        -
-            message: '#unknown class OCA\\OpenRegister\\Service\\ObjectService#'
-            path: lib/Migration/Version002000Date20260519000000.php
-        -
-            message: '#Call to method .* on an unknown class OCA\\OpenRegister\\Service\\ObjectService#'
-            path: lib/Migration/Version002000Date20260519000000.php
-        # Doctrine\DBAL\Schema\Schema is provided by Nextcloud server's
-        # 3rdparty bundle, not by our vendor/. The hasTable() call in the
-        # migration is sound at runtime; suppress the unknown-class error.
-        -
-            message: '#unknown class Doctrine\\DBAL\\Schema\\Schema#'
-            path: lib/Migration/Version002000Date20260519000000.php
-        -
-            message: '#Call to method hasTable\(\) on an unknown class Doctrine\\DBAL\\Schema\\Schema#'
-            path: lib/Migration/Version002000Date20260519000000.php

--- a/psalm.xml
+++ b/psalm.xml
@@ -59,6 +59,35 @@
                 <referencedClass name="OCP\Http\Client\IClientService"/>
                 <referencedClass name="OCP\Notification\IManager"/>
                 <referencedClass name="OCP\Share\IManager"/>
+                <!-- OpenRegister cross-app classes (loaded dynamically) -->
+                <referencedClass name="OCA\OpenRegister\Db\ObjectEntity"/>
+                <referencedClass name="OCA\OpenRegister\Db\RegisterMapper"/>
+                <referencedClass name="OCA\OpenRegister\Db\SchemaMapper"/>
+                <referencedClass name="OCA\OpenRegister\Event\DeepLinkRegistrationEvent"/>
+                <referencedClass name="OCA\OpenRegister\Event\ObjectCreatingEvent"/>
+                <referencedClass name="OCA\OpenRegister\Event\ObjectCreatedEvent"/>
+                <referencedClass name="OCA\OpenRegister\Event\ObjectUpdatingEvent"/>
+                <referencedClass name="OCA\OpenRegister\Event\ObjectUpdatedEvent"/>
+                <referencedClass name="OCA\OpenRegister\Event\ObjectDeletedEvent"/>
+                <referencedClass name="OCA\OpenRegister\Service\ObjectService"/>
+                <referencedClass name="OCA\OpenRegister\Service\ConfigurationService"/>
+                <referencedClass name="OCA\OpenRegister\Service\RegisterService"/>
+                <referencedClass name="OCA\OpenRegister\Service\FileService"/>
+                <referencedClass name="OCA\OpenRegister\Service\CalendarEventService"/>
+                <referencedClass name="OCA\OpenRegister\Mcp\IMcpToolProvider"/>
+                <!-- Additional OCP infrastructure types used across the fleet -->
+                <referencedClass name="OCP\AppFramework\Bootstrap\IBootContext"/>
+                <referencedClass name="OCP\AppFramework\Bootstrap\IRegistrationContext"/>
+                <referencedClass name="OCP\AppFramework\Db\DoesNotExistException"/>
+                <referencedClass name="OCP\DB\Exception"/>
+                <referencedClass name="OCP\IGroup"/>
+                <referencedClass name="OCP\IUser"/>
+                <referencedClass name="OCP\Migration\IRepairStep"/>
+                <!-- Nextcloud server internals -->
+                <referencedClass name="OC"/>
+                <!-- GuzzleHttp (loaded via composer at runtime) -->
+                <referencedClass name="GuzzleHttp\Client"/>
+                <referencedClass name="GuzzleHttp\Exception\GuzzleException"/>
             </errorLevel>
         </UndefinedClass>
         <UndefinedMagicMethod errorLevel="suppress"/>
@@ -89,6 +118,8 @@
         <EmptyArrayAccess errorLevel="suppress"/>
         <ImplementedReturnTypeMismatch errorLevel="suppress"/>
         <InvalidMethodCall errorLevel="suppress"/>
+        <UndefinedInterfaceMethod errorLevel="suppress"/>
+        <MissingTemplateParam errorLevel="suppress"/>
     </issueHandlers>
     <extraFiles>
         <directory name="vendor/nextcloud/ocp" />


### PR DESCRIPTION
## Phase 2 fleet rollout — canonical root configs

Adopts the canonical Phase 2 root configs across mydash. Pattern proven on shillinq#300 and decidesk#243.

**Note: mydash carried the largest residual lint debt of the fleet** because the prior `phpmd.xml` shipped with deliberately relaxed architectural thresholds (Cyclomatic 15, MethodLength 200, ClassLength 1500, NPath 5000) and `phpstan.neon` masked 14 path-scoped `JSONResponse`/`DataResponse` errors under `lib/Controller/*`. After this sync the phpmd CI will be very red until the cleanup tracked in #269 lands. That is the expected trajectory.

## What changed

| File | Change |
| --- | --- |
| `phpcs.xml` | Drops Block/Inline comment exclusions; pulls in shared `CustomSniffs` (`SpecTagSniff`, `NoLegacyServerAccessorsSniff`). Ruleset name = `Mydash`. |
| `phpmd.xml` | REVERTS relaxed thresholds to fleet default. Ruleset name = `Mydash Nextcloud Rules`. |
| `phpstan.neon` + `phpstan-bootstrap.php` | Canonical config — removes 14 path-scoped suppressions. |
| `psalm.xml` | Canonical config. |
| `phpstan-baseline.neon` | Regenerated (50 entries) — header links to tracking issue #269. |
| `phpcs-custom-sniffs/CustomSniffs/Sniffs/Commenting/SpecTagSniff.php` | Added (shared sniff). |
| `phpcs-custom-sniffs/CustomSniffs/Sniffs/Nextcloud/NoLegacyServerAccessorsSniff.php` | Added (shared sniff). |
| `lib/...` (10 files) | Mechanical phpmd fixes: 5 `MissingImport` + 6 `ElseExpression`. |

## Quality-gate state

| Gate    | Before sync                 | After sync                 |
| ------- | --------------------------- | -------------------------- |
| phpcs   | (excluded sniffs)           | 19 errors / 1051 warnings  |
| phpmd   | (relaxed thresholds)        | 528 violations             |
| phpstan | 0 errors (14 path suppressions hiding ~50) | 0 errors (50-entry baseline) |
| psalm   | 2 errors                    | 2 errors                   |

## Mechanical fixes already shipped

| Category | Pre | Post |
| --- | --: | --: |
| MissingImport | 5 | 0 |
| ElseExpression | 41 | 30 |

## Follow-up

- **#269** — Lint debt cleanup post-canonical-sync. Tracks all 528 phpmd hits + 50 phpstan baseline entries + 19 phpcs errors with a four-phase strategy. The phpmd CI will be red until Phase A+C complete; this is acknowledged in the issue.

## Test plan

- `./vendor/bin/phpcs --standard=phpcs.xml --report=summary` -> 19 errors / 1051 warnings
- `./vendor/bin/phpstan analyse --memory-limit=1G` -> No errors (baseline covers 50)
- `./vendor/bin/psalm --threads=1 --no-cache --show-info=false` -> 2 errors (unchanged)
- `./vendor/bin/phpmd lib text phpmd.xml | wc -l` -> 528 lines (tracked in #269)