### PR TITLE
docs(openspec): IA alignment refactor (7 drifts: catalog + admin tabs)

### DIFF
--- a/openspec/changes/refactor-mydash-ia-alignment/design.md
+++ b/openspec/changes/refactor-mydash-ia-alignment/design.md
@@ -1,0 +1,129 @@
+# Design: MyDash IA Alignment
+
+## Current Topology (as found by audit)
+
+```
+NC navigation: "MyDash" → /index.php/apps/mydash/
+└── #workspace-vue (WorkspaceApp.vue)
+    ├── OrgNavigationPanel (when configured)
+    ├── Strip: hamburger + active-dashboard title
+    ├── Views.vue
+    │   ├── DashboardGrid (gridstack canvas)
+    │   ├── WidgetPicker (modal, opened from action menu)
+    │   ├── DashboardConfigModal (per-dashboard, opened from cog)
+    │   │   ├── inline sharing field set
+    │   │   └── icon / name / description fields
+    │   ├── TileEditor (modal)
+    │   ├── WidgetRenderer / WidgetWrapper / WidgetContextMenu
+    │   │   └── (no visibility-rule UI today)
+    │   └── DashboardSwitcherSidebar
+    └── DashboardFooter
+
+NC Settings ▸ Administration ▸ MyDash
+└── #mydash-admin-settings (AdminSettings.vue)  ← ONE PAGE, 11 sections:
+    ├── Setup wizard banner
+    ├── Default settings
+    ├── GroupPriorityOrder
+    ├── Dashboard templates (inline list + modal)
+    ├── Group-shared dashboards
+    ├── OrgNavigationEditor
+    ├── DashboardExportImport
+    ├── DashboardBulkOperations
+    ├── ConfluenceImport
+    ├── AdminAnalytics
+    ├── AdminDemoData
+    └── RolePermissionsSection
+```
+
+There is **no router** in mydash; navigation between IA "pages" is currently
+all-or-nothing (workspace vs. admin settings).
+
+## Proposed Topology
+
+```
+NC navigation: "MyDash" → workspace
+└── #workspace-vue (WorkspaceApp.vue)
+    ├── OrgNavigationPanel
+    ├── Strip: hamburger + title + SHARE ACTION (new top-bar button)
+    ├── Sidebar tabs:
+    │   ├── "Dashboards" (current switcher + DashboardConfigModal)
+    │   │   └── DashboardConfigModal — TABBED
+    │   │       ├── Tab: General (name/desc/icon)
+    │   │       ├── Tab: Sharing (relocated from inline field set)
+    │   │       └── Tab: Default (per-user pin)
+    │   └── "Catalog" (NEW SUB_PAGE)
+    │       └── CatalogView.vue
+    │           ├── Widget categories (registry-driven)
+    │           ├── Custom Tiles category (existing TileWidget)
+    │           └── Bridge category (legacy-widget-bridge surface)
+    └── Canvas (Views.vue + DashboardGrid)
+        └── WidgetContextMenu — adds "Visibility rules…"
+            └── VisibilityRulesModal.vue (NEW — wraps existing
+                /api/widgets/{id}/rules API)
+
+NC Settings ▸ Administration ▸ MyDash
+└── #mydash-admin-settings (AdminSettings.vue → orchestrator only)
+    ├── Top strip: Setup wizard banner + Default settings (always visible)
+    └── BeheerTabs.vue (NEW)
+        ├── Tab: "Templates" (admin-templates SUB_PAGE)
+        │   └── TemplatesPage.vue (extracted template list + modal)
+        ├── Tab: "Operations" (Beheer / Operations)
+        │   ├── PrometheusMetricsPanel (new surface, reads /api/metrics)
+        │   ├── HealthPanel (reads /api/health)
+        │   ├── LegacyWidgetBridge admin toggle
+        │   ├── DashboardExportImport
+        │   ├── DashboardBulkOperations
+        │   └── ConfluenceImport
+        ├── Tab: "Roles & Permissions" (Beheer / Roles & Permissions)
+        │   └── RolePermissionsSection (relocated)
+        ├── Tab: "Versioning & Audit" (Beheer / Versioning & Audit)
+        │   ├── ConditionalVisibilityOverview (new — lists per-widget rules)
+        │   └── AdminAnalytics (relocated — already audit-like)
+        └── Tab: "Sharing" (Beheer / Sharing)
+            ├── DashboardSharingPolicy (NEW — defaults / forced share groups)
+            └── GroupPriorityOrder (relocated — related to share resolution)
+        ├── Tab: "Org navigation" (existing OrgNavigationEditor)
+        └── Tab: "Demo data" (existing AdminDemoData)
+```
+
+## Routing Model
+
+mydash has no Vue Router today. Adding one for the workspace adds risk for an
+SPA that auto-saves to backend state per dashboard. Instead:
+
+- **Sidebar mode switch** (Dashboards / Catalog) in the existing sidebar
+  uses local component state and lazy-loads `CatalogView.vue`. No URL change.
+- **Beheer tabs** use a `<NcAppNavigationCaption>`-style tab strip inside the
+  admin form. Tab selection is stored in `localStorage` so a deep-link
+  (`?tab=operations`) round-trips on reload.
+- **Dashboard config drawer** uses an internal `currentTab` ref with
+  `NcAppSidebarTab`-style switching.
+
+This keeps the contract with `manifest.json` (`pages: []` because mydash is a
+single-shell app) intact — no manifest changes required.
+
+## Affected Initial-State Keys
+
+No new initial-state keys are added. The relocated sections consume the
+existing keys they already inject (`allowUserDashboards`, `configuredGroups`,
+`allGroups`, etc.). The new VisibilityRulesModal reads
+`/api/widgets/{id}/rules` lazily on open.
+
+## Backward Compatibility
+
+- `AdminSettings.vue` keeps its current mount id `#mydash-admin-settings` and
+  its position under NC Settings ▸ Administration; the visual change is the
+  introduction of tabs. Admins relying on `data-test=` selectors get
+  unchanged hooks for the wizard banner and group default badge; new tab
+  panels get fresh `data-test` ids.
+- All backend routes are untouched.
+- The inline sharing field in `DashboardConfigModal` becomes a tab; the
+  underlying `localShares` reactive state and emit contract are preserved.
+
+## Out of Scope
+
+- A real Vue Router. If the app ever grows to need URLs per area, that's a
+  separate `add-mydash-router` change.
+- Reworking the activity log; analytics relocates to Versioning & Audit but
+  keeps its current data model.
+- Manifest v2 page entries — the runtime manifest stays `pages: []`.

--- a/openspec/changes/refactor-mydash-ia-alignment/proposal.md
+++ b/openspec/changes/refactor-mydash-ia-alignment/proposal.md
@@ -1,0 +1,86 @@
+# Refactor MyDash IA to align with the proposed information architecture
+
+## Why
+
+The mydash app today is a **two-mount-point** Vue 2 single-page app:
+
+1. **Workspace page** (`#workspace-vue` / `WorkspaceApp.vue`) — a single dashboard canvas
+   with a sidebar, action menu, and a modal-driven widget picker. No router; no
+   `/catalog/`, `/templates/`, or `/admin/` pages exist on the user side.
+2. **Admin settings page** (`#mydash-admin-settings` / `AdminSettings.vue`) — one
+   long form mounted under NC Settings ▸ Administration that stacks **11 unrelated
+   sections** as cards in a single scroll: default settings, group priorities,
+   templates, group-shared dashboards, org-nav editor, export/import,
+   bulk operations, Confluence import, analytics, demo data, role permissions,
+   and a setup-wizard banner. Everything an admin can do lives here.
+
+The proposed IA (see `ia-implemented-mydash.tsv`) instead places admin features
+in a **dedicated "Beheer" area with tabs** (Operations, Roles & Permissions,
+Versioning & Audit, Sharing), promotes **Templates** to its own SUB_PAGE,
+and groups **Widgets / Tiles** under a new **Catalog** SUB_PAGE. It also places
+**Conditional Visibility** as a per-widget micro-UI (currently API-only) and
+elevates **Dashboard Sharing** from an inline form field to a top-bar action
+plus per-dashboard tab.
+
+The audit found **7 specs drift, 4 specs aligned, 0 uncertain** out of 11
+implemented specs surveyed. Without this refactor admins continue to scroll one
+monolithic form to find role permissions or operations, conditional-visibility
+remains invisible to end users despite its backend support, and the legacy-widget
+bridge has no surface at all in the catalog/operations IA.
+
+## What Changes
+
+- **Promote `admin-templates`** from a section inside `AdminSettings.vue` to its
+  own SUB_PAGE (Templates) rendered as a tab inside the admin settings page or
+  a top-level route in a future mydash router shell.
+- **Add per-widget Conditional Visibility UI** to `WidgetContextMenu` /
+  `AddWidgetModal` (a "Visibility rules" action that opens a rule editor),
+  AND add the matching admin overview tab under **Beheer ▸ Versioning & Audit**.
+- **Restructure Dashboard Sharing** from the inline `DashboardConfigModal` field
+  set into (a) a top-bar share action button on the dashboard canvas, and
+  (b) a "Sharing" tab inside the dashboard config drawer. The admin org-wide
+  sharing policy moves to a **Beheer** tab.
+- **Split `AdminSettings.vue` into tabbed sub-views** with the four-tab
+  Beheer layout:
+  - **Beheer ▸ Operations** — `prometheus-metrics` health/metrics + ops actions.
+  - **Beheer ▸ Roles & Permissions** — current `RolePermissionsSection`.
+  - **Beheer ▸ Versioning & Audit** — `conditional-visibility` overview + audit log.
+  - **Beheer ▸ Sharing** — org-wide `dashboard-sharing` policy + share defaults.
+- **Promote Widgets/Tiles into a `Catalog` SUB_PAGE** as a navigable browse view
+  (in addition to the existing modal `WidgetPicker`), with the legacy-widget
+  bridge surfacing as a **Bridge category** filter inside the catalog AND a
+  matching toggle inside **Beheer ▸ Operations**.
+- **Keep `dashboards` and `grid-layout` in their current canvas location** —
+  these already match the IA (WIDGET under Dashboards root / Canvas).
+
+## Impact
+
+- **Affected specs**:
+  - `admin-settings` — split capability surface into Beheer tabs.
+  - `admin-templates` — relocated to SUB_PAGE root.
+  - `conditional-visibility` — adds UI capabilities (per-widget editor + admin tab).
+  - `dashboard-sharing` — adds top-bar action + admin tab; removes inline modal field.
+  - `legacy-widget-bridge` — adds Bridge catalog category + admin Operations toggle.
+  - `permissions` — relocated from inline section to Beheer tab.
+  - `prometheus-metrics` — adds admin Operations tab surface.
+  - `widgets` — adds Catalog SUB_PAGE browse view alongside the modal picker.
+- **Unaffected specs**: `dashboards`, `grid-layout`, `tiles` (already aligned —
+  tiles is a widget type in the picker; dashboards/grid-layout live on the canvas).
+- **Affected code**:
+  - `src/components/admin/AdminSettings.vue` — decomposed into tabs.
+  - `src/components/admin/*` — sections become tab panel children.
+  - `src/components/Widgets/WidgetContextMenu.vue` — adds "Visibility rules" item.
+  - `src/components/DashboardConfigModal.vue` — sharing extracted into its own tab.
+  - `src/views/WorkspaceApp.vue` — adds top-bar share action wiring.
+  - `src/views/Views.vue` and `src/components/WidgetPicker.vue` — new Catalog
+    browse mode reusing the registry.
+  - **New files**: `src/components/admin/BeheerTabs.vue`,
+    `src/components/admin/tabs/OperationsTab.vue`,
+    `src/components/admin/tabs/RolesPermissionsTab.vue`,
+    `src/components/admin/tabs/VersioningAuditTab.vue`,
+    `src/components/admin/tabs/SharingTab.vue`,
+    `src/components/admin/tabs/TemplatesPage.vue`,
+    `src/components/Widgets/VisibilityRulesModal.vue`,
+    `src/views/CatalogView.vue`.
+- **No backend changes**: conditional-visibility, metrics, sharing, and
+  permissions APIs already exist; this refactor is UI relocation only.

--- a/openspec/changes/refactor-mydash-ia-alignment/specs.md
+++ b/openspec/changes/refactor-mydash-ia-alignment/specs.md
@@ -1,0 +1,288 @@
+# Per-Spec Relocation
+
+Format: each capability lists ADDED / REMOVED requirements describing the IA
+relocation. Backend-only requirements (data model, API contracts) are
+intentionally untouched — this change is UI placement only.
+
+## admin-settings
+
+### REMOVED Requirement: Monolithic Settings Form
+
+The single-page `AdminSettings.vue` form that stacks every admin capability
+as flat sections MUST be removed and replaced with the tabbed Beheer layout.
+
+#### Scenario: Admin opens MyDash settings
+
+- **GIVEN** an admin lands on NC Settings ▸ Administration ▸ MyDash
+- **WHEN** the page renders
+- **THEN** the legacy "stacked sections" layout MUST NOT be visible
+- **AND** a tab strip with at least Templates / Operations / Roles & Permissions /
+  Versioning & Audit / Sharing tabs MUST be visible
+
+### ADDED Requirement: Tabbed Beheer Layout
+
+The admin settings page MUST organise its sections into discrete tabs
+matching the IA's Beheer area: Operations, Roles & Permissions,
+Versioning & Audit, Sharing — plus a Templates SUB_PAGE and existing
+Org-Navigation and Demo-Data tabs.
+
+#### Scenario: Switch to Operations tab
+
+- **GIVEN** the admin settings page is open
+- **WHEN** the admin clicks the "Operations" tab
+- **THEN** the Operations panel MUST render Prometheus metrics, health,
+  bulk operations, export/import, Confluence import, and the legacy-widget
+  bridge toggle
+- **AND** no other tab's content MUST be in the DOM
+
+#### Scenario: Deep-link to a tab via query string
+
+- **GIVEN** the admin opens `…/settings/admin/mydash?tab=roles-permissions`
+- **WHEN** the page hydrates
+- **THEN** the Roles & Permissions tab MUST be the active tab on first paint
+
+#### Scenario: Default tab on first visit
+
+- **GIVEN** an admin who has never opened the settings page before
+- **WHEN** the page renders without a `?tab=` query string
+- **THEN** the Templates tab MUST be the active tab (matches the IA's
+  Templates SUB_PAGE as the canonical admin landing surface)
+
+## admin-templates
+
+### ADDED Requirement: Templates SUB_PAGE
+
+Template management MUST live in its own SUB_PAGE under the admin area
+(rendered as the "Templates" tab inside Beheer), not as an inline section
+of the global settings form.
+
+#### Scenario: Templates tab is the landing surface
+
+- **GIVEN** an admin opens NC Settings ▸ Administration ▸ MyDash for the
+  first time
+- **WHEN** the page renders
+- **THEN** the Templates tab MUST be the default active tab
+- **AND** the template list + "Create template" CTA MUST be visible
+  without scrolling past unrelated sections
+
+#### Scenario: Templates page is the only place to manage templates
+
+- **GIVEN** the admin is on any non-Templates tab
+- **WHEN** the admin looks for template controls
+- **THEN** the legacy inline "Dashboard templates" card under "Default
+  settings" MUST NOT be present anywhere outside the Templates tab
+
+## conditional-visibility
+
+### ADDED Requirement: Per-Widget Visibility Rules Editor
+
+End users with `canEdit` on a dashboard MUST be able to open a visibility-rules
+editor for any widget placement from the widget context menu, and add / edit /
+delete rules without leaving the canvas.
+
+#### Scenario: Open the editor from the widget context menu
+
+- **GIVEN** alice owns dashboard D with widget placement P (id 10)
+- **WHEN** she right-clicks placement P and selects "Visibility rules…"
+- **THEN** a `VisibilityRulesModal` MUST open
+- **AND** the modal MUST fetch `GET /api/widgets/10/rules` on open
+- **AND** existing rules MUST be listed with their type, scope, and
+  include / exclude flag
+
+#### Scenario: Add a group rule from the editor
+
+- **GIVEN** the visibility rules modal is open for placement 10
+- **WHEN** alice picks "Group", selects the "marketing" group, sets
+  "Include", and saves
+- **THEN** the modal MUST POST to `/api/widgets/10/rules`
+- **AND** the new rule MUST appear in the modal's list on success
+
+### ADDED Requirement: Admin Versioning & Audit Tab
+
+The Beheer ▸ Versioning & Audit tab MUST surface a per-widget overview
+listing every placement that has at least one visibility rule, with
+links to the owning dashboard.
+
+#### Scenario: Versioning & Audit lists rule-bearing widgets
+
+- **GIVEN** dashboards in the system contain 12 widget placements with at
+  least one conditional rule
+- **WHEN** an admin opens Beheer ▸ Versioning & Audit
+- **THEN** all 12 placements MUST be listed with dashboard name, widget
+  type, rule count, and include / exclude breakdown
+
+## dashboard-sharing
+
+### REMOVED Requirement: Inline Sharing Field Set
+
+The current `DashboardConfigModal.vue` MUST NOT render the sharing
+sharee picker and per-share permission rows as a free-floating field
+set in the modal body.
+
+#### Scenario: Open the dashboard config modal
+
+- **GIVEN** alice clicks the cog on her dashboard
+- **WHEN** the modal opens
+- **THEN** the sharee picker MUST NOT appear in the General tab
+- **AND** sharing MUST be reachable only from the Sharing tab (per the
+  ADDED requirement below)
+
+### ADDED Requirement: Top-Bar Share Action + Per-Dashboard Sharing Tab
+
+The dashboard canvas MUST expose a top-bar share button next to the
+hamburger / title strip; the per-dashboard config drawer MUST organise
+sharing into its own tab.
+
+#### Scenario: Share button on the canvas strip
+
+- **GIVEN** alice is viewing a dashboard she owns
+- **WHEN** the workspace shell renders
+- **THEN** a share icon button MUST appear in the strip, labelled "Share"
+- **AND** clicking it MUST open the config drawer with the Sharing tab
+  pre-selected
+
+#### Scenario: Sharing tab inside the config drawer
+
+- **GIVEN** the dashboard config drawer is open
+- **WHEN** the user clicks the Sharing tab
+- **THEN** the sharee picker, the current share rows, and the per-share
+  permission controls MUST be visible inside that tab panel only
+
+### ADDED Requirement: Admin Sharing Tab for Org Policy
+
+The Beheer ▸ Sharing tab MUST host the org-wide share defaults
+(forced share groups, default permission level for shares) and the
+relocated `GroupPriorityOrder` editor (group resolution order is a
+sharing concern).
+
+#### Scenario: Org sharing defaults are admin-only
+
+- **GIVEN** an admin opens Beheer ▸ Sharing
+- **WHEN** the page renders
+- **THEN** the default share permission selector and the forced-share-group
+  picker MUST be visible
+- **AND** GroupPriorityOrder MUST be visible on the same tab
+
+## dashboards
+
+(No requirement changes — current placement matches the IA: WIDGET under
+Dashboards root / canvas.)
+
+## grid-layout
+
+(No requirement changes — current placement matches the IA: WIDGET on the
+dashboards canvas.)
+
+## legacy-widget-bridge
+
+### ADDED Requirement: Bridge Category in Catalog
+
+The catalog browse view MUST expose a "Bridge" filter / category that
+lists every widget surfaced by the `widgetBridge.js` runtime adapter,
+so end users can discover non-native widgets without reading the registry.
+
+#### Scenario: Filter the catalog by Bridge
+
+- **GIVEN** the workspace sidebar has the Catalog SUB_PAGE active
+- **WHEN** the user clicks the "Bridge" category
+- **THEN** every widget whose registry entry has `source: 'bridge'` (or
+  equivalent) MUST appear in the grid
+- **AND** native MyDash widgets MUST NOT appear in that filter
+
+### ADDED Requirement: Bridge Toggle in Beheer / Operations
+
+The Beheer ▸ Operations tab MUST host an enable / disable toggle for the
+legacy widget bridge, with a hint explaining the impact on existing
+dashboards that already embed bridged widgets.
+
+#### Scenario: Admin disables the bridge
+
+- **GIVEN** an admin opens Beheer ▸ Operations
+- **WHEN** the admin flips the "Legacy widget bridge" switch off
+- **THEN** the change MUST be persisted via the admin settings API
+- **AND** a hint MUST warn that existing bridged widget placements will
+  render an "Unavailable" state until the bridge is re-enabled
+
+## permissions
+
+### REMOVED Requirement: Inline RolePermissionsSection Card
+
+The current placement of `RolePermissionsSection` as one of the 11
+stacked sections inside `AdminSettings.vue` MUST be removed.
+
+#### Scenario: Roles section is no longer inline
+
+- **GIVEN** an admin opens the MyDash settings page
+- **WHEN** the page renders
+- **THEN** the Roles & Permissions controls MUST NOT appear in the
+  scrollable section list below "Default settings"
+
+### ADDED Requirement: Roles & Permissions Tab
+
+`RolePermissionsSection` MUST be relocated to its own Beheer ▸ Roles &
+Permissions tab.
+
+#### Scenario: Roles tab hosts the section
+
+- **GIVEN** the admin clicks the Roles & Permissions tab
+- **WHEN** the tab panel renders
+- **THEN** the role permissions matrix and CRUD controls MUST be the
+  only content visible in the panel body
+
+## prometheus-metrics
+
+### ADDED Requirement: Operations Tab Surface
+
+The Beheer ▸ Operations tab MUST present a Prometheus metrics panel
+that fetches `/api/metrics` and renders the parsed output in a
+read-only code block, plus a health panel reading `/api/health`.
+
+#### Scenario: Operations tab shows current metrics
+
+- **GIVEN** an admin opens Beheer ▸ Operations
+- **WHEN** the tab panel mounts
+- **THEN** a fetch to `/api/metrics` MUST fire
+- **AND** the response body MUST render inside a `<pre>` block with a
+  copy-to-clipboard button
+
+#### Scenario: Health badge reflects /api/health
+
+- **GIVEN** the Operations tab is open
+- **WHEN** the `/api/health` endpoint returns `{ "status": "ok" }`
+- **THEN** a green "Healthy" badge MUST render next to the metrics panel
+- **AND** when the endpoint returns a non-200 response or no `status: ok`,
+  a red "Degraded" badge MUST render instead
+
+## tiles
+
+(No requirement changes — tiles is already a widget type in the registry
+and surfaces via the existing `WidgetPicker` modal; the ADDED catalog
+SUB_PAGE for `widgets` will simply also list it under a "Custom Tiles"
+category. No `tiles`-specific spec changes are required.)
+
+## widgets
+
+### ADDED Requirement: Catalog SUB_PAGE Browse View
+
+The workspace sidebar MUST gain a "Catalog" entry that opens a full-page
+browse view (`CatalogView.vue`) listing every registered widget grouped
+by category — separate from the existing modal `WidgetPicker` that
+opens from the canvas action menu.
+
+#### Scenario: Sidebar opens the Catalog SUB_PAGE
+
+- **GIVEN** alice is on her dashboard
+- **WHEN** she opens the sidebar and clicks the "Catalog" entry
+- **THEN** the canvas region MUST be replaced by `CatalogView.vue`
+- **AND** the existing dashboard state (active dashboard, layout) MUST
+  be preserved so returning to the canvas restores it without a reload
+
+#### Scenario: Catalog groups widgets by category
+
+- **GIVEN** the catalog page is open
+- **WHEN** widgets are listed
+- **THEN** they MUST be grouped under at least: Built-in, Custom Tiles,
+  Bridge (legacy NC widgets), and any user-defined categories from the
+  registry
+- **AND** each group MUST be collapsible and remember its open / closed
+  state across reloads via `localStorage`

--- a/openspec/changes/refactor-mydash-ia-alignment/tasks.md
+++ b/openspec/changes/refactor-mydash-ia-alignment/tasks.md
@@ -1,0 +1,175 @@
+# Tasks
+
+Atomic, numbered, file-by-file. Sequential within each section unless noted.
+
+## 1. Beheer tab shell
+
+- [ ] 1.1 Create `src/components/admin/BeheerTabs.vue` — `NcAppNavigationCaption`-style
+      tab strip with named slots per tab; reads `?tab=` query string and
+      writes selection to `localStorage` (key `mydash.admin.activeTab`).
+- [ ] 1.2 Add `src/components/admin/tabs/` directory and create stub files:
+      `TemplatesPage.vue`, `OperationsTab.vue`, `RolesPermissionsTab.vue`,
+      `VersioningAuditTab.vue`, `SharingTab.vue`, `OrgNavigationTab.vue`,
+      `DemoDataTab.vue` (each renders an `<NcEmptyContent>` placeholder for now).
+- [ ] 1.3 Update `src/components/admin/AdminSettings.vue` to render the
+      Setup-wizard banner + Default-settings card at the top, then mount
+      `<BeheerTabs />` with the seven tab components as slots.
+- [ ] 1.4 Add `data-test="beheer-tabs"` and one `data-test="tab-{slug}"` per
+      tab button.
+
+## 2. Templates relocation
+
+- [ ] 2.1 Move the template CRUD block (lines 95-143 + the Template Editor
+      Modal at lines 250-303 in `AdminSettings.vue`) into
+      `src/components/admin/tabs/TemplatesPage.vue`.
+- [ ] 2.2 Move the `editingTemplate`, `templates`, `permissionOptions` data,
+      and `createTemplate` / `editTemplate` / `saveTemplate` /
+      `deleteTemplate` / `closeTemplateEditor` methods from
+      `AdminSettings.vue` to `TemplatesPage.vue`.
+- [ ] 2.3 Delete the dead inline template markup + script from
+      `AdminSettings.vue`.
+- [ ] 2.4 Set `TemplatesPage` as the default `localStorage` value for the
+      Beheer active-tab when no value is set.
+
+## 3. Operations tab
+
+- [ ] 3.1 In `src/components/admin/tabs/OperationsTab.vue`, add a
+      `PrometheusMetricsPanel` sub-component that fetches `/api/metrics`
+      via `axios.get` on mount and renders the body in `<pre>` with a
+      copy button.
+- [ ] 3.2 Add a `HealthPanel` sub-component that fetches `/api/health` and
+      renders a green / red badge based on `status === 'ok'`.
+- [ ] 3.3 Move the `DashboardExportImport`, `DashboardBulkOperations`, and
+      `ConfluenceImport` imports + mount points from `AdminSettings.vue`
+      into `OperationsTab.vue`.
+- [ ] 3.4 Add a `LegacyWidgetBridgeToggle` sub-component using the
+      `NcCheckboxRadioSwitch` pattern from `AdminSettings.vue`; wire it to
+      `PUT /api/admin/settings` with a `legacyWidgetBridgeEnabled` field
+      (add the field to the backend `MyDashAdmin` form payload — covered
+      by the legacy-widget-bridge spec backend addition).
+- [ ] 3.5 Delete the moved imports + mount points from `AdminSettings.vue`.
+
+## 4. Roles & Permissions tab
+
+- [ ] 4.1 Move the `RolePermissionsSection` import + `<RolePermissionsSection />`
+      mount from `AdminSettings.vue` into
+      `src/components/admin/tabs/RolesPermissionsTab.vue`.
+- [ ] 4.2 Delete the dead import + section from `AdminSettings.vue`.
+
+## 5. Versioning & Audit tab
+
+- [ ] 5.1 Create `src/components/admin/ConditionalVisibilityOverview.vue`
+      that fetches a new admin endpoint
+      `GET /api/admin/widgets/with-rules` (returns `[{ placementId,
+      dashboardId, dashboardName, widgetType, ruleCount, includeCount,
+      excludeCount }, ...]`) and renders the table per the spec scenario.
+- [ ] 5.2 Add the backend `WithRulesController::index` action + route in
+      `appinfo/routes.php` (admin auth required). Service method:
+      `ConditionalService::listAllRules()` — already exists or
+      add as `SELECT * FROM oc_mydash_conditional_rules JOIN
+      oc_mydash_widget_placements`.
+- [ ] 5.3 Mount `ConditionalVisibilityOverview` and the moved
+      `AdminAnalytics` inside
+      `src/components/admin/tabs/VersioningAuditTab.vue`.
+- [ ] 5.4 Delete the `AdminAnalytics` import + mount from
+      `AdminSettings.vue`.
+
+## 6. Sharing tab (admin org policy)
+
+- [ ] 6.1 Create `src/components/admin/DashboardSharingPolicy.vue` —
+      reads / writes `defaultSharePermissionLevel` and `forcedShareGroups`
+      via `PUT /api/admin/settings` (add fields to the backend
+      `MyDashAdmin` form payload — covered by dashboard-sharing spec
+      backend addition).
+- [ ] 6.2 Mount it in `src/components/admin/tabs/SharingTab.vue`.
+- [ ] 6.3 Move the `GroupPriorityOrder` import + mount from
+      `AdminSettings.vue` into `SharingTab.vue`.
+- [ ] 6.4 Delete the moved import + mount from `AdminSettings.vue`.
+
+## 7. Org navigation + Demo data tabs
+
+- [ ] 7.1 Move `OrgNavigationEditor` import + mount into
+      `src/components/admin/tabs/OrgNavigationTab.vue`.
+- [ ] 7.2 Move `AdminDemoData` import + mount into
+      `src/components/admin/tabs/DemoDataTab.vue`.
+- [ ] 7.3 Delete the two imports + mounts from `AdminSettings.vue`.
+
+## 8. Per-widget Conditional Visibility editor
+
+- [ ] 8.1 Create `src/components/Widgets/VisibilityRulesModal.vue` — props:
+      `placementId`, `open`; emits `close`, `rule-added`, `rule-removed`.
+      Mounts an `NcModal`, fetches `GET /api/widgets/{placementId}/rules`
+      on open, renders a list + a "Add rule" form supporting the four
+      rule types from the conditional-visibility spec.
+- [ ] 8.2 Add `Visibility rules…` button to
+      `src/components/Widgets/WidgetContextMenu.vue` between Edit and
+      Remove; emit a new `visibility-rules` event.
+- [ ] 8.3 In `src/views/Views.vue` (or the parent that wires the context
+      menu), listen for `visibility-rules`, store the target placement id,
+      and render `<VisibilityRulesModal :placement-id="..." />`.
+- [ ] 8.4 Gate the button on `canEdit` (REQ-SHELL-002 rule already
+      computed by `WorkspaceApp.vue`).
+
+## 9. Dashboard Sharing relocation
+
+- [ ] 9.1 Refactor `src/components/DashboardConfigModal.vue` to use a tab
+      strip (`NcAppSidebarTab` or local component) with at least: General,
+      Sharing, Default. Keep all current refs (`form`, `localShares`,
+      `permissionOptions`, `shareeOptions`, `onShareeSearch`,
+      `onShareeSelected`, `permissionOptionFor`) and just move the
+      template fragments into the matching tabs.
+- [ ] 9.2 Add a top-bar share button to
+      `src/views/WorkspaceApp.vue` strip (between hamburger and title),
+      `NcButton type="tertiary"` with `ShareVariant` icon; emit a new
+      event up to `Views.vue` or call a `dashboardStore` action to open
+      the config drawer with `initialTab: 'sharing'`.
+- [ ] 9.3 Add the `initialTab` prop / data flow to
+      `DashboardConfigModal.vue` so the share button lands directly on the
+      Sharing tab.
+
+## 10. Catalog SUB_PAGE + Bridge category
+
+- [ ] 10.1 Create `src/views/CatalogView.vue` — full-region browse view
+      that imports the widget registry (`src/constants/widgetRegistry.js`),
+      groups widgets by category (`built-in`, `custom-tile`, `bridge`,
+      user-defined), and renders a sticky filter strip + grid of cards.
+- [ ] 10.2 Add a `mode` ref to the sidebar
+      (`src/components/Workspace/DashboardSwitcherSidebar.vue`) toggling
+      between `'dashboards'` and `'catalog'`; emit a `mode-change` event.
+- [ ] 10.3 In `src/views/WorkspaceApp.vue`, switch the Region 3 render
+      between `<Views />` and `<CatalogView />` based on the sidebar
+      mode (preserve the dashboard store; do not unmount Views' store).
+- [ ] 10.4 Tag bridge widgets in `src/constants/widgetRegistry.js` with
+      `source: 'bridge'` (or derive from `widgetBridge.js` runtime
+      registrations) so the catalog filter has a stable key.
+- [ ] 10.5 Persist the open / closed state of each category group in
+      `localStorage` under `mydash.catalog.openGroups`.
+
+## 11. Documentation + tests
+
+- [ ] 11.1 Update `docs/architecture.md` IA section with the new tab
+      topology + sidebar mode switch.
+- [ ] 11.2 Add Jest specs for `BeheerTabs.vue` (tab switching,
+      localStorage persistence, `?tab=` deep-link).
+- [ ] 11.3 Add Jest spec for `VisibilityRulesModal.vue` (open-fetches,
+      add-rule POST happy path, delete-rule, error rollback).
+- [ ] 11.4 Add Jest spec for `CatalogView.vue` (grouping, filter,
+      localStorage open state).
+- [ ] 11.5 Add Jest spec for `DashboardConfigModal.vue` covering the new
+      tab strip and `initialTab` prop.
+- [ ] 11.6 Add a Playwright integration test
+      (`tests/integration/ia-tabs.spec.js`) that loads the admin page,
+      clicks each Beheer tab, and asserts the expected `data-test` ids
+      appear / disappear.
+
+## 12. Cleanup
+
+- [ ] 12.1 After all sections are moved, `AdminSettings.vue` should be
+      ≤200 lines (orchestrator only). Verify no dead imports remain.
+- [ ] 12.2 Verify the `data-test="setup-wizard-banner"`,
+      `data-test="setup-wizard-rerun"`, `data-test="set-group-default"`,
+      and `data-test="group-default-badge"` selectors still resolve in
+      the new layout (banner stays at top of AdminSettings; group-default
+      moves to TemplatesPage if linked, otherwise stays under
+      group-shared dashboards — confirm during 2.1).
+- [ ] 12.3 Run `composer check:strict` and `npm run lint` clean.


### PR DESCRIPTION
## Information Architecture audit

Generated from the 2026-05-22 IA pass. Compares 11 implemented mydash specs against the proposed IA topology.

**Result: 4 aligned · 7 drift · 0 uncertain**

### Root cause

MyDash today is a **two-mount-point** Vue 2 SPA: a workspace canvas + a monolithic `AdminSettings.vue` form that stacks **11 unrelated sections** as scrollable cards. No router; no `/catalog/`, `/templates/`, or `/admin/` pages exist. The proposed IA places admin features in a **dedicated Beheer area with tabs** (Operations, Roles & Permissions, Versioning & Audit, Sharing), promotes Templates to its own SUB_PAGE, and groups Widgets/Tiles under a Catalog SUB_PAGE.

### Drifts (7)

- `admin-templates` — inline section in `AdminSettings.vue`, not a SUB_PAGE.
- `conditional-visibility` — backend API only (`/api/widgets/{id}/rules`), no UI in `WidgetContextMenu`.
- `dashboard-sharing` — inline field set in `DashboardConfigModal`, no top-bar action.
- `legacy-widget-bridge` — runtime adapter only (`widgetBridge.js`); no catalog category, no admin toggle.
- `permissions` — `RolePermissionsSection` is one of 11 stacked cards, not a tab.
- `prometheus-metrics` — exposes `/api/metrics` but no admin Operations UI.
- `widgets` — only a modal `WidgetPicker`, no Catalog browse SUB_PAGE.

### What's in this change

- `proposal.md` — drift rationale per spec
- `design.md` — new IA topology with tabbed Beheer + Catalog SUB_PAGE
- `specs.md` — per-spec ADDED/REMOVED requirements
- `tasks.md` — atomic UI-only tasks (tabbed `AdminSettings.vue`, sidebar Catalog mode, `VisibilityRulesModal`, top-bar Share action)

No backend route changes — additive UI restructuring only.

To execute: label with `ready-to-build` + `yolo` once approved.