### PR TITLE
chore(specs): normalize requirement headings to Form A (ADR-037)

### DIFF
--- a/openspec/specs/admin-settings/spec.md
+++ b/openspec/specs/admin-settings/spec.md
@@ -31,7 +31,7 @@ NOTE: The DB stores settings with snake_case keys, but the API response returns 
 
 ## Requirements
 
-### REQ-ASET-001: Retrieve Admin Settings
+### Requirement: Retrieve Admin Settings (REQ-ASET-001)
 
 Administrators MUST be able to retrieve all current admin settings via the API. The endpoint returns a flat JSON object with all four settings using camelCase keys.
 
@@ -81,7 +81,7 @@ Administrators MUST be able to retrieve all current admin settings via the API. 
 - AND no additional keys MUST be present in the response
 - AND the response MUST be a flat JSON object (no nesting)
 
-### REQ-ASET-002: Update Admin Settings
+### Requirement: Update Admin Settings (REQ-ASET-002)
 
 Administrators MUST be able to update individual or multiple admin settings in a single PUT request.
 
@@ -135,7 +135,7 @@ Administrators MUST be able to update individual or multiple admin settings in a
 - THEN the system MUST ignore the unknown key (unrecognized parameters are simply not matched to method arguments)
 - AND known settings MUST NOT be affected
 
-### REQ-ASET-003: Allow User Dashboards Setting (runtime gating + envelope)
+### Requirement: Allow User Dashboards Setting — runtime gating + envelope (REQ-ASET-003)
 
 The setting `allow_user_dashboards` (boolean stored as `'0'` / `'1'`, default `'0'`) MUST gate every endpoint that **creates** a personal (`type='user'`) dashboard. Read endpoints, update endpoints, and existing personal dashboards MUST remain accessible regardless of the flag's value. Toggling the flag MUST NOT mutate any dashboard records.
 
@@ -203,7 +203,7 @@ Admins MAY always create dashboards regardless of the flag (the `PermissionServi
 - AND the empty-state description MUST read "Personal dashboards are not enabled by your administrator"
 - AND if the call is invoked anyway (stale UI, direct API call) the backend MUST still return the 403 `personal_dashboards_disabled` envelope (defense in depth)
 
-### REQ-ASET-004: Allow Multiple Dashboards Setting
+### Requirement: Allow Multiple Dashboards Setting (REQ-ASET-004)
 
 When `allow_multiple_dashboards` is false, users MUST be limited to one dashboard.
 
@@ -244,7 +244,7 @@ When `allow_multiple_dashboards` is false, users MUST be limited to one dashboar
 - THEN the system MUST still create the template copy for alice
 - AND alice MUST have 2 dashboards (the restriction applies to user-initiated creation, not admin-initiated distribution)
 
-### REQ-ASET-005: Default Permission Level Setting
+### Requirement: Default Permission Level Setting (REQ-ASET-005)
 
 The `defaultPermissionLevel` setting MUST be applied as a fallback when resolving effective permission levels. The factory default is `add_only` (Dashboard::PERMISSION_ADD_ONLY).
 
@@ -279,7 +279,7 @@ The `defaultPermissionLevel` setting MUST be applied as a fallback when resolvin
 - THEN the system MUST check in order: (1) source template's `permissionLevel`, (2) dashboard's own `permissionLevel`, (3) admin default setting
 - AND the first non-empty value in the chain MUST be returned
 
-### REQ-ASET-006: Default Grid Columns Setting
+### Requirement: Default Grid Columns Setting (REQ-ASET-006)
 
 The `defaultGridColumns` setting MUST be applied to new dashboards when no explicit gridColumns is specified.
 
@@ -301,7 +301,7 @@ The `defaultGridColumns` setting MUST be applied to new dashboards when no expli
 - THEN the copy MUST have `gridColumns: 12` (from the template)
 - AND the global default MUST NOT override the template's grid configuration
 
-### REQ-ASET-007: Settings Persistence
+### Requirement: Settings Persistence (REQ-ASET-007)
 
 Admin settings MUST be persisted across server restarts and app updates.
 
@@ -331,7 +331,7 @@ Admin settings MUST be persisted across server restarts and app updates.
 - THEN all settings MUST be reset to their factory defaults
 - AND the response MUST confirm the update
 
-### REQ-ASET-008: Admin Settings UI
+### Requirement: Admin Settings UI (REQ-ASET-008)
 
 The admin settings MUST be accessible via a Nextcloud admin panel page.
 
@@ -363,7 +363,7 @@ The admin settings MUST be accessible via a Nextcloud admin panel page.
 - THEN the system MUST display a success notification
 - AND GET /api/admin/settings MUST reflect the change
 
-### REQ-ASET-009: Settings Impact on Existing Data
+### Requirement: Settings Impact on Existing Data (REQ-ASET-009)
 
 Admin settings changes MUST only affect future operations and MUST NOT retroactively modify existing dashboards.
 
@@ -386,7 +386,7 @@ Admin settings changes MUST only affect future operations and MUST NOT retroacti
 - AND users MUST continue to access their existing dashboards
 - AND only new dashboard creation MUST be blocked
 
-### REQ-ASET-010: Settings Concurrency
+### Requirement: Settings Concurrency (REQ-ASET-010)
 
 Concurrent admin settings updates MUST be handled safely.
 
@@ -402,7 +402,7 @@ Concurrent admin settings updates MUST be handled safely.
 - THEN the system MUST process each request independently
 - AND the final state MUST reflect the last request's values
 
-### REQ-ASET-011: Settings API Error Handling
+### Requirement: Settings API Error Handling (REQ-ASET-011)
 
 The settings API MUST return consistent error responses for various failure scenarios.
 
@@ -424,7 +424,7 @@ The settings API MUST return consistent error responses for various failure scen
 - THEN the system MUST return HTTP 200 with `{"status": "ok"}`
 - AND no settings MUST be modified (all parameters are null, so no updates are applied)
 
-### REQ-ASET-012: Group order setting
+### Requirement: Group order setting (REQ-ASET-012)
 
 The system MUST persist an ordered list of Nextcloud group IDs as the global setting `group_order` (JSON `string[]`, default `[]`). The order MUST be preserved exactly as provided. The setting determines which groups are "active" for MyDash workspace routing (REQ-TMPL-012). Corrupt or unparseable JSON in the database MUST resolve to `[]` at read time without throwing — the resolver and admin UI MUST never see a fatal error from a malformed value.
 
@@ -461,7 +461,7 @@ The system MUST persist an ordered list of Nextcloud group IDs as the global set
 - WHEN `AdminSettingsService::getGroupOrder()` is called
 - THEN it MUST return `[]` (factory default)
 
-### REQ-ASET-013: List groups for admin UI
+### Requirement: List groups for admin UI (REQ-ASET-013)
 
 The system MUST expose `GET /api/admin/groups` returning `{active: [id…], inactive: [id…], allKnown: [{id, displayName}…]}`:
 
@@ -502,7 +502,7 @@ Stale IDs (present in `active` but no longer in Nextcloud) MUST remain in `activ
 - AND `inactive` MUST NOT include it
 - NOTE: The UI SHOULD render stale IDs with a "(removed)" affix.
 
-### REQ-ASET-014: Admin guard and payload validation
+### Requirement: Admin guard and payload validation (REQ-ASET-014)
 
 `POST /api/admin/groups` MUST be admin-only (`IGroupManager::isAdmin`). Non-admins MUST receive HTTP 403 with no side effects. `GET /api/admin/groups` MUST also be admin-only because the inactive list reveals every group on the system.
 
@@ -552,7 +552,7 @@ Unknown (not currently in Nextcloud) IDs MUST NOT cause validation failure — t
 - THEN the request MUST succeed (HTTP 200)
 - AND `group_order` MUST be persisted as `["does-not-exist", "engineering"]`
 
-### REQ-ASET-015: Initial-state mirror of the allow-user-dashboards flag
+### Requirement: Initial-state mirror of the allow-user-dashboards flag (REQ-ASET-015)
 
 The current value of `allow_user_dashboards` MUST be pushed as initial state `allowUserDashboards: bool` on every workspace and admin page render so the frontend can hide the "+ New Dashboard" affordance and any "Fork as personal" affordance without an extra round-trip. The push MUST happen via `InitialStateBuilder::setAllowUserDashboards()` (REQ-INIT-002) — direct calls to `IInitialState::provideInitialState()` are forbidden by the `lint:initial-state` CI guard.
 

--- a/openspec/specs/admin-templates/spec.md
+++ b/openspec/specs/admin-templates/spec.md
@@ -21,7 +21,7 @@ Templates own their widget placements (in `oc_mydash_widget_placements`) which s
 
 ## Requirements
 
-### REQ-TMPL-001: Create Admin Template
+### Requirement: Create Admin Template (REQ-TMPL-001)
 
 Nextcloud administrators MUST be able to create dashboard templates for distribution to users.
 
@@ -76,7 +76,7 @@ Nextcloud administrators MUST be able to create dashboard templates for distribu
 - THEN the system MUST assign a UUID v4 via `Ramsey\Uuid\Uuid::uuid4()` (unlike user dashboards which use a custom UUID generator in `DashboardFactory`)
 - AND the UUID MUST be unique across all dashboards
 
-### REQ-TMPL-002: List Admin Templates
+### Requirement: List Admin Templates (REQ-TMPL-002)
 
 Administrators MUST be able to view all existing templates with their configuration.
 
@@ -109,7 +109,7 @@ Administrators MUST be able to view all existing templates with their configurat
 - THEN the response MUST contain only her user dashboards
 - AND admin templates MUST NOT appear in the user's dashboard list
 
-### REQ-TMPL-003: Update Admin Template
+### Requirement: Update Admin Template (REQ-TMPL-003)
 
 Administrators MUST be able to modify template configuration including name, description, target groups, permission level, and grid columns.
 
@@ -144,7 +144,7 @@ Administrators MUST be able to modify template configuration including name, des
 - WHEN regular user "alice" sends PUT /api/admin/templates/1
 - THEN the system MUST return HTTP 403
 
-### REQ-TMPL-004: Delete Admin Template
+### Requirement: Delete Admin Template (REQ-TMPL-004)
 
 Administrators MUST be able to delete templates, with proper cleanup of associated widget placements.
 
@@ -180,7 +180,7 @@ Administrators MUST be able to delete templates, with proper cleanup of associat
 - AND no template MUST be the default afterward (this is allowed)
 - AND new users without a group-targeted template will get no template on first access
 
-### REQ-TMPL-005: Template Distribution on First Access
+### Requirement: Template Distribution on First Access (REQ-TMPL-005)
 
 When a user accesses MyDash for the first time, the system MUST create personal copies of matching templates via the `DashboardResolver` chain.
 
@@ -224,7 +224,7 @@ When a user accesses MyDash for the first time, the system MUST create personal 
 - THEN alice MUST receive a copy of "Marketing Dashboard" (group-targeted template takes priority over default)
 - NOTE: Only ONE template per first-access. Group-targeted templates are evaluated first; the default template is the fallback.
 
-### REQ-TMPL-006: Template Copy Independence
+### Requirement: Template Copy Independence (REQ-TMPL-006)
 
 User copies of templates MUST be fully independent from the source template after creation, with the exception of permission level resolution.
 
@@ -247,7 +247,7 @@ User copies of templates MUST be fully independent from the source template afte
 - AND alice's dashboard MUST retain all placements
 - AND permission resolution MUST fall back to the dashboard's own `permissionLevel` (template lookup caught by `DoesNotExistException`)
 
-### REQ-TMPL-007: Template Widget Management
+### Requirement: Template Widget Management (REQ-TMPL-007)
 
 Administrators MUST be able to manage widget placements on templates using the same API as regular dashboards.
 
@@ -275,7 +275,7 @@ Administrators MUST be able to manage widget placements on templates using the s
 - THEN the tile placement MUST be cloned with all inline tile data via `clonePlacement()`
 - AND the user copy MUST render the tile identically to the template
 
-### REQ-TMPL-008: Only One Default Template
+### Requirement: Only One Default Template (REQ-TMPL-008)
 
 The system MUST enforce that at most one template is marked as the default at any time.
 
@@ -298,7 +298,7 @@ The system MUST enforce that at most one template is marked as the default at an
 - THEN the template MUST have `isDefault` set to 0 (false)
 - AND no template MUST be the default (this is allowed)
 
-### REQ-TMPL-009: Get Template with Placements
+### Requirement: Get Template with Placements (REQ-TMPL-009)
 
 Administrators MUST be able to retrieve a specific template along with all its widget placements for editing.
 
@@ -318,7 +318,7 @@ Administrators MUST be able to retrieve a specific template along with all its w
 - WHEN the admin sends GET /api/admin/templates/2
 - THEN the system MUST return the template object with an empty placements array
 
-### REQ-TMPL-010: Template Group Resolution
+### Requirement: Template Group Resolution (REQ-TMPL-010)
 
 Template distribution MUST use Nextcloud's `IGroupManager` API to resolve user group memberships accurately.
 
@@ -343,7 +343,7 @@ Template distribution MUST use Nextcloud's `IGroupManager` API to resolve user g
 - THEN the template MUST NOT match any user (no user is in a non-existent group)
 - AND the system MUST NOT throw errors during group resolution
 
-### REQ-TMPL-011: Template Administration UI
+### Requirement: Template Administration UI (REQ-TMPL-011)
 
 The admin settings page MUST provide a UI for managing templates.
 
@@ -362,7 +362,7 @@ The admin settings page MUST provide a UI for managing templates.
 - THEN a group selector MUST allow selecting from available Nextcloud groups
 - NOTE: The current implementation uses `NcSelectTags` but `availableGroups` is hardcoded to an empty array. Groups are NOT fetched from the server.
 
-### REQ-TMPL-012: Primary-group resolution for workspace routing
+### Requirement: Primary-group resolution for workspace routing (REQ-TMPL-012)
 
 The system MUST expose a pure function `resolvePrimaryGroup(string $userId): string` that returns the Nextcloud group ID whose `group_shared` dashboards the user should see, OR the literal string `'default'` when no match is found. The algorithm MUST be:
 
@@ -410,7 +410,7 @@ The function MUST be deterministic and idempotent (no writes).
 - AND MUST NOT raise an error
 - NOTE: Cleanup of stale group IDs in `group_order` is the admin UI's responsibility; the resolver MUST be tolerant.
 
-### REQ-TMPL-013: Resolver is the single routing authority
+### Requirement: Resolver is the single routing authority (REQ-TMPL-013)
 
 All workspace-rendering and dashboard-resolution code paths (REQ-DASH-013, REQ-DASH-018) MUST consult `resolvePrimaryGroup` for the user's primary group. There MUST NOT be parallel implementations of this lookup.
 
@@ -421,7 +421,7 @@ All workspace-rendering and dashboard-resolution code paths (REQ-DASH-013, REQ-D
 - THEN it MUST go through `AdminTemplateService::resolvePrimaryGroup` (or its declared service interface)
 - AND duplicating the algorithm inline is forbidden by code review
 
-### REQ-TMPL-014: Template Gallery Endpoint
+### Requirement: Template Gallery Endpoint (REQ-TMPL-014)
 
 The system MUST expose a read-only gallery endpoint that lists all `admin_template` dashboards with metadata suitable for discovery and instantiation.
 
@@ -463,7 +463,7 @@ The system MUST expose a read-only gallery endpoint that lists all `admin_templa
 - THEN the template MUST be included
 - AND when calling `GET /api/templates/gallery?category=marketing`, the template with `null` category MUST NOT be included
 
-### REQ-TMPL-015: Save-as-template Action
+### Requirement: Save-as-template Action (REQ-TMPL-015)
 
 Any dashboard owner MUST be able to convert their current dashboard into a reusable admin template, creating a snapshot with a fresh UUID and a deep-copied widget tree.
 
@@ -517,7 +517,7 @@ Any dashboard owner MUST be able to convert their current dashboard into a reusa
   - `templatePreviewImage: null`
 - AND HTTP 201 MUST be returned with the new template
 
-### REQ-TMPL-016: Template Metadata Fields
+### Requirement: Template Metadata Fields (REQ-TMPL-016)
 
 Admin templates MUST support three new metadata fields for categorization and discovery: `templateCategory` (VARCHAR 64, nullable), `templateDescription` (TEXT, nullable), and `templatePreviewImage` (TEXT, nullable). The fields are stored as nullable columns on `oc_mydash_dashboards` and only meaningful for rows with `type = 'admin_template'`.
 
@@ -551,7 +551,7 @@ Admin templates MUST support three new metadata fields for categorization and di
 - THEN the response MUST include the fields with null values
 - AND no error MUST be thrown
 
-### REQ-TMPL-017: Preview Image Upload Endpoint
+### Requirement: Preview Image Upload Endpoint (REQ-TMPL-017)
 
 Administrators MUST be able to upload a preview image for a template, persisted using the existing resource-uploads ("custom-icon-upload") pipeline. The endpoint accepts a base64 data URL body so it shares MIME validation, SVG sanitisation, and the 5 MB size cap with `POST /api/resources`.
 

--- a/openspec/specs/conditional-visibility/spec.md
+++ b/openspec/specs/conditional-visibility/spec.md
@@ -46,7 +46,7 @@ NOTE: Date rules use camelCase keys (`startDate`, `endDate`). Both fields are op
 
 ## Requirements
 
-### REQ-VIS-001: Create Conditional Rule
+### Requirement: Create Conditional Rule (REQ-VIS-001)
 
 Users MUST be able to add conditional visibility rules to widget placements on dashboards they own.
 
@@ -114,7 +114,7 @@ Users MUST be able to add conditional visibility rules to widget placements on d
 - WHEN user "bob" sends POST /api/widgets/10/rules
 - THEN the system MUST return HTTP 403 (via `PermissionService::verifyPlacementOwnership()`)
 
-### REQ-VIS-002: List Conditional Rules
+### Requirement: List Conditional Rules (REQ-VIS-002)
 
 Users MUST be able to retrieve all conditional rules for a widget placement they own.
 
@@ -137,7 +137,7 @@ Users MUST be able to retrieve all conditional rules for a widget placement they
 - WHEN user "bob" sends GET /api/widgets/10/rules
 - THEN the system MUST return HTTP 403 (via `verifyPlacementOwnership()`)
 
-### REQ-VIS-003: Update Conditional Rule
+### Requirement: Update Conditional Rule (REQ-VIS-003)
 
 Users MUST be able to modify existing conditional rules on placements they own.
 
@@ -177,7 +177,7 @@ Users MUST be able to modify existing conditional rules on placements they own.
 - THEN only `isInclude` MUST be updated to `false`
 - AND `ruleType` and `ruleConfig` MUST remain unchanged
 
-### REQ-VIS-004: Delete Conditional Rule
+### Requirement: Delete Conditional Rule (REQ-VIS-004)
 
 Users MUST be able to remove conditional rules from their widget placements.
 
@@ -203,7 +203,7 @@ Users MUST be able to remove conditional rules from their widget placements.
 - THEN the system MUST return HTTP 403
 - NOTE: Ownership verification for delete is NOT currently implemented in `RuleApiController`.
 
-### REQ-VIS-005: Group-Based Rule Evaluation
+### Requirement: Group-Based Rule Evaluation (REQ-VIS-005)
 
 Group-based rules MUST show or hide widgets based on the current user's Nextcloud group memberships, resolved via `IGroupManager::getUserGroupIds()`.
 
@@ -237,7 +237,7 @@ Group-based rules MUST show or hide widgets based on the current user's Nextclou
 - THEN the rule MUST evaluate as not matching (empty target groups returns false)
 - AND the widget MUST be hidden (no include rule matches)
 
-### REQ-VIS-006: Time-Based Rule Evaluation
+### Requirement: Time-Based Rule Evaluation (REQ-VIS-006)
 
 Time-based rules MUST show or hide widgets based on the current time of day using the server's local time via `new DateTime()`.
 
@@ -287,7 +287,7 @@ Time-based rules MUST show or hide widgets based on the current time of day usin
 - THEN `startTime` MUST default to `"00:00"` and `endTime` MUST default to `"23:59"`
 - AND the rule MUST match at any time of day
 
-### REQ-VIS-007: Date-Based Rule Evaluation
+### Requirement: Date-Based Rule Evaluation (REQ-VIS-007)
 
 Date-based rules MUST show or hide widgets based on the current date, with optional open-ended ranges.
 
@@ -321,7 +321,7 @@ Date-based rules MUST show or hide widgets based on the current date, with optio
 - WHEN the dashboard is rendered
 - THEN the widget MUST be visible (both start and end dates are inclusive -- uses `<` and `>` comparisons for exclusion)
 
-### REQ-VIS-008: Attribute-Based Rule Evaluation
+### Requirement: Attribute-Based Rule Evaluation (REQ-VIS-008)
 
 Attribute-based rules MUST show or hide widgets based on user profile attributes, resolved by `UserAttributeResolver`.
 
@@ -357,7 +357,7 @@ Attribute-based rules MUST show or hide widgets based on user profile attributes
 - AND for inclusion rules, the widget MUST be hidden
 - AND for exclusion rules, the widget MUST be visible
 
-### REQ-VIS-009: Multiple Rule Combination
+### Requirement: Multiple Rule Combination (REQ-VIS-009)
 
 When a widget placement has multiple conditional rules, they MUST be combined using the VisibilityChecker logic: include rules use OR (at least one must match), exclude rules use AND (any match hides).
 
@@ -394,7 +394,7 @@ When a widget placement has multiple conditional rules, they MUST be combined us
 - WHEN the dashboard is rendered
 - THEN the widget MUST be visible (passesIncludeRules returns true when no include rules exist, passesExcludeRules returns true when no exclude rule matches)
 
-### REQ-VIS-010: Visibility Evaluation Pipeline
+### Requirement: Visibility Evaluation Pipeline (REQ-VIS-010)
 
 The ConditionalService MUST evaluate visibility through a defined pipeline: isVisible flag check, then rule loading, then VisibilityChecker evaluation.
 
@@ -416,7 +416,7 @@ The ConditionalService MUST evaluate visibility through a defined pipeline: isVi
 - THEN the system MUST return true without calling VisibilityChecker
 - AND the widget MUST always be displayed
 
-### REQ-VIS-011: Rule Cascade Deletion
+### Requirement: Rule Cascade Deletion (REQ-VIS-011)
 
 When a widget placement is deleted, all its associated conditional rules MUST also be deleted.
 

--- a/openspec/specs/dashboard-metadata-fields/spec.md
+++ b/openspec/specs/dashboard-metadata-fields/spec.md
@@ -55,7 +55,7 @@ If a field definition is deleted without cascade, the corresponding value rows r
 
 ## Requirements
 
-### REQ-MDFL-001: Field Definition CRUD
+### Requirement: Field Definition CRUD (REQ-MDFL-001)
 
 Administrators MUST be able to create, read, update, and delete field definitions via a dedicated admin API endpoint. Field definitions form the global schema against which all dashboard values are validated.
 
@@ -109,7 +109,7 @@ Administrators MUST be able to create, read, update, and delete field definition
 - THEN the system MUST return HTTP 200 with an envelope `{"fields": [...], "count": 3}`
 - AND fields MUST be sorted by `sort_order` ascending (0, 5, 10)
 
-### REQ-MDFL-002: Field Definition Updates
+### Requirement: Field Definition Updates (REQ-MDFL-002)
 
 Administrators MUST be able to update a field definition's metadata (label, sort order, required flag, options), but renaming the field's `key` MUST be forbidden — the key is the stable identifier and renaming it breaks existing values.
 
@@ -128,7 +128,7 @@ Administrators MUST be able to update a field definition's metadata (label, sort
 - THEN the system MUST return HTTP 400 with error `"Field key cannot be renamed"`
 - AND the key MUST remain "department"
 
-### REQ-MDFL-003: Field Definition Deletion
+### Requirement: Field Definition Deletion (REQ-MDFL-003)
 
 Administrators MUST be able to delete field definitions. Deletion has two modes: soft (reject if orphans would be created) or cascade (delete all values).
 
@@ -154,7 +154,7 @@ Administrators MUST be able to delete field definitions. Deletion has two modes:
 - THEN the system MUST return HTTP 409 with body containing `error: "metadata_field_has_values"` and `valueCount: 3`
 - AND the field and its values MUST remain unchanged
 
-### REQ-MDFL-004: Dashboard Metadata Read
+### Requirement: Dashboard Metadata Read (REQ-MDFL-004)
 
 Users MUST be able to read all metadata values for a given dashboard as a flat key-value object.
 
@@ -185,7 +185,7 @@ Users MUST be able to read all metadata values for a given dashboard as a flat k
 - AND MUST log a warning describing the orphan
 - AND MUST NOT crash
 
-### REQ-MDFL-005: Dashboard Metadata Write
+### Requirement: Dashboard Metadata Write (REQ-MDFL-005)
 
 Users MUST be able to set or update metadata values for a dashboard via a flat key-value object. Omitted keys are NOT deleted; only keys in the request body are upserted. Explicit empty values on optional fields delete the slot so it disappears from the read payload.
 
@@ -210,7 +210,7 @@ Users MUST be able to set or update metadata values for a dashboard via a flat k
 - WHEN user sends `PUT /api/dashboards/abc-123/metadata` with body `{"metadata": {"department": null}}`
 - THEN the system MUST return HTTP 400 with error `"Field 'Department' is required"`
 
-### REQ-MDFL-006: Type Validation at Write
+### Requirement: Type Validation at Write (REQ-MDFL-006)
 
 The system MUST validate each value against its field's type definition before persisting. Invalid values are rejected with a 400 error.
 
@@ -238,7 +238,7 @@ The system MUST validate each value against its field's type definition before p
 - WHEN user sends `PUT /api/dashboards/{uuid}/metadata` with body `{"metadata": {"status": "rejected"}}`
 - THEN the system MUST return HTTP 400 with error `"Field 'Status' value 'rejected' not in allowed options"`
 
-### REQ-MDFL-007: Dashboard Filtering by Metadata
+### Requirement: Dashboard Filtering by Metadata (REQ-MDFL-007)
 
 The system MUST expose a query filter mechanism on the dashboard list endpoint to filter dashboards by metadata values using `?metadata.<key>=<value>` syntax. The filter resolver is implemented in `MetadataService::filterDashboards($dashboards, $filters)` and is consumed by every dashboard-list endpoint that accepts metadata filters; unknown filter keys are silently dropped so a stale URL never empties the list when a field is deleted.
 
@@ -266,7 +266,7 @@ The system MUST expose a query filter mechanism on the dashboard list endpoint t
 - WHEN a user sends `GET /api/dashboards?metadata.status=open`
 - THEN the system MUST return only dashboards with status="open"
 
-### REQ-MDFL-008: Permission and Ownership
+### Requirement: Permission and Ownership (REQ-MDFL-008)
 
 Reading and writing metadata MUST be scoped to the dashboard's owner (for personal dashboards) or to users with access to the dashboard. Admin templates are world-readable; group-shared dashboards are readable + writable by every member of the owning group.
 

--- a/openspec/specs/dashboard-sharing/spec.md
+++ b/openspec/specs/dashboard-sharing/spec.md
@@ -24,7 +24,7 @@ The unique tuple `(dashboardId, shareType, shareWith)` enforces that a recipient
 
 ## Requirements
 
-### REQ-SHARE-001: Owner-only share management
+### Requirement: Owner-only share management (REQ-SHARE-001)
 
 Only the owner of a dashboard MUST be allowed to list, create, update, or delete shares on that dashboard. All share-management endpoints MUST return HTTP 403 for any caller that is not the dashboard owner, including users who themselves have a `full`-level share on the dashboard.
 
@@ -49,7 +49,7 @@ Only the owner of a dashboard MUST be allowed to list, create, update, or delete
 - THEN the system MUST update the existing share row, not create a second one
 - AND only one share row MUST exist for `(dashboardId=5, shareType=user, shareWith=bob)`
 
-### REQ-SHARE-002: Listing dashboards visible to a user
+### Requirement: Listing dashboards visible to a user (REQ-SHARE-002)
 
 `GET /api/dashboards` MUST return both dashboards owned by the caller AND dashboards the caller has access to via a direct or group share. Each entry MUST be decorated with `isOwner: bool`, `sharedBy: string|null` (the owner's userId when not the caller's own dashboard), and `effectivePermissionLevel: 'view_only'|'add_only'|'full'`.
 
@@ -74,7 +74,7 @@ Only the owner of a dashboard MUST be allowed to list, create, update, or delete
 - WHEN carol fetches `GET /api/dashboards`
 - THEN the entry for dashboard `5` MUST report `effectivePermissionLevel: "full"`
 
-### REQ-SHARE-003: Loading a shared dashboard with placements
+### Requirement: Loading a shared dashboard with placements (REQ-SHARE-003)
 
 `GET /api/dashboard/{id}` MUST return the dashboard, its widget placements, and the caller's effective permission level for any dashboard the caller can view (owned or shared). Callers without ownership AND without any matching share MUST receive HTTP 403.
 
@@ -90,7 +90,7 @@ Only the owner of a dashboard MUST be allowed to list, create, update, or delete
 - WHEN carol fetches `GET /api/dashboard/5`
 - THEN the system MUST return HTTP 403
 
-### REQ-SHARE-004: Per-share permission resolution overrides admin defaults
+### Requirement: Per-share permission resolution overrides admin defaults (REQ-SHARE-004)
 
 When a user accesses a dashboard via a share, the system MUST evaluate widget/tile/layout permission checks against **the share's** `permissionLevel` rather than the dashboard's globally-set `permissionLevel` field. The dashboard's own `permissionLevel` continues to apply only to the owner.
 
@@ -102,7 +102,7 @@ When a user accesses a dashboard via a share, the system MUST evaluate widget/ti
 - THEN the system MUST allow the operation (HTTP 201)
 - AND when alice attempts the same call, the system MUST return HTTP 403
 
-### REQ-SHARE-005: Owner-only metadata and lifecycle operations
+### Requirement: Owner-only metadata and lifecycle operations (REQ-SHARE-005)
 
 Even with a `full`-level share, recipients MUST NOT be able to:
 
@@ -130,7 +130,7 @@ Even with a `full`-level share, recipients MUST NOT be able to:
 - THEN the system MUST return HTTP 200 with the dashboard payload
 - AND no row's `is_active` flag MUST change as a result
 
-### REQ-SHARE-006: Sharee autocomplete
+### Requirement: Sharee autocomplete (REQ-SHARE-006)
 
 `GET /api/sharees?query={q}` MUST return up to 10 matching users and 10 matching groups whose name (display name or id) contains `q`. The endpoint MUST exclude the caller from the user results to prevent self-shares. Recipients are matched server-side via `IUserManager::search` and `IGroupManager::search`.
 
@@ -141,7 +141,7 @@ Even with a `full`-level share, recipients MUST NOT be able to:
 - THEN the response MUST include the matching users in the `users` array and any matching groups in the `groups` array
 - AND alice MUST NOT appear in the `users` array
 
-### REQ-SHARE-007: Cascade on dashboard delete
+### Requirement: Cascade on dashboard delete (REQ-SHARE-007)
 
 When a dashboard is deleted (by its owner), every share row referencing that dashboard MUST be deleted in the same transaction. No orphan share rows MAY remain.
 
@@ -153,7 +153,7 @@ When a dashboard is deleted (by its owner), every share row referencing that das
 - AND all 3 share rows in `oc_mydash_dashboard_shares` referencing `dashboard_id = 5` MUST also be deleted
 - AND a query for shares on dashboard `5` MUST return 0 rows
 
-### REQ-SHARE-008: Notify recipient on share add and on level upgrade
+### Requirement: Notify recipient on share add and on level upgrade (REQ-SHARE-008)
 
 When a share is created OR its `permission_level` is **upgraded** (`view_only → add_only|full`, or `add_only → full`), the system MUST publish a Nextcloud notification to each affected recipient via `OCP\Notification\IManager`. The notification MUST use:
 
@@ -208,7 +208,7 @@ The system MUST NOT publish notifications when:
 - THEN the share row MUST be deleted
 - AND no `INotification` MUST be published
 
-### REQ-SHARE-009: Bulk replace shares
+### Requirement: Bulk replace shares (REQ-SHARE-009)
 
 The system MUST support `PUT /api/dashboard/{id}/shares` accepting a JSON body `{"shares": Share[]}` that replaces the entire share list for the dashboard atomically. Only the dashboard owner MUST be allowed to call this endpoint. The operation MUST run in a single DB transaction.
 
@@ -236,7 +236,7 @@ After the transaction commits, the system MUST publish notifications per REQ-SHA
 - THEN the system MUST return HTTP 403
 - AND no rows MUST be modified
 
-### REQ-SHARE-010: Revoke all shares granted to a recipient
+### Requirement: Revoke all shares granted to a recipient (REQ-SHARE-010)
 
 The system MUST support `DELETE /api/sharees/{shareType}/{shareWith}` for an authenticated user. The operation MUST delete every share row where:
 
@@ -257,7 +257,7 @@ The response MUST include the count of removed share rows. No notifications MUST
 - AND any share row on dashboard `9` MUST remain unchanged (alice is not the owner of `9`)
 - AND the response MUST report the number of rows actually deleted (2 in this scenario)
 
-### REQ-SHARE-011: Notifier renders share and ownership-transfer subjects
+### Requirement: Notifier renders share and ownership-transfer subjects (REQ-SHARE-011)
 
 The app MUST register an `OCP\Notification\INotifier` implementation with `id = 'mydash'` that handles two subjects: `dashboard_shared` and `dashboard_ownership_transferred`. For any other subject the notifier MUST throw `\OCP\Notification\UnknownNotificationException` so that other notifiers may handle it.
 
@@ -287,7 +287,7 @@ Localisation MUST be performed via `IFactory::get('mydash')` so the existing Dut
 - WHEN the notifier prepares it
 - THEN `\OCP\Notification\UnknownNotificationException` MUST be thrown
 
-### REQ-SHARE-012: Cascade and admin retention on user deletion
+### Requirement: Cascade and admin retention on user deletion (REQ-SHARE-012)
 
 The app MUST listen to `OCP\User\Events\UserDeletedEvent`. On every event for user `X`, in a single DB transaction per affected dashboard, the system MUST:
 
@@ -343,7 +343,7 @@ The app MUST listen to `OCP\User\Events\UserDeletedEvent`. On every event for us
 - WHEN the system processes `UserDeletedEvent` for alice
 - THEN dashboard `5` MUST be deleted (admin pool is empty after filtering)
 
-### REQ-SHARE-013: Deterministic new-owner selection
+### Requirement: Deterministic new-owner selection (REQ-SHARE-013)
 
 When REQ-SHARE-012 calls for picking a new owner from the admin pool, the system MUST apply this ordering rule:
 

--- a/openspec/specs/dashboards/spec.md
+++ b/openspec/specs/dashboards/spec.md
@@ -28,7 +28,7 @@ Each dashboard record is stored in the `oc_mydash_dashboards` table with the fol
 
 ## Requirements
 
-### REQ-DASH-001: Create Personal Dashboard
+### Requirement: Create Personal Dashboard (REQ-DASH-001)
 
 Users MUST be able to create new personal dashboards with a name, optional description, and default grid configuration.
 
@@ -71,7 +71,7 @@ Users MUST be able to create new personal dashboards with a name, optional descr
   - "activity" widget at (6, 0) with size 6x5
 - AND both placements MUST have `showTitle: 1`, `isVisible: 1`, and appropriate sortOrder values
 
-### REQ-DASH-002: List User Dashboards
+### Requirement: List User Dashboards (REQ-DASH-002)
 
 Users MUST be able to retrieve a list of all their dashboards, scoped to their user ID.
 
@@ -94,7 +94,7 @@ Users MUST be able to retrieve a list of all their dashboards, scoped to their u
 - AND bob's dashboard MUST NOT be included
 - AND admin templates (type: "admin_template") MUST NOT be included
 
-### REQ-DASH-003: Get Active Dashboard
+### Requirement: Get Active Dashboard (REQ-DASH-003)
 
 Users MUST be able to retrieve their currently active dashboard along with its placements and effective permission level in a single request.
 
@@ -136,7 +136,7 @@ Users MUST be able to retrieve their currently active dashboard along with its p
 - THEN the system MUST return null (no dashboard available)
 - AND the response MUST return HTTP 404 or an empty result
 
-### REQ-DASH-004: Update Dashboard
+### Requirement: Update Dashboard (REQ-DASH-004)
 
 Users MUST be able to update the name, description, and grid configuration of their dashboards.
 
@@ -173,7 +173,7 @@ Users MUST be able to update the name, description, and grid configuration of th
 - THEN the system MUST update all placement positions via `placementMapper->updatePositions()`
 - AND this enables efficient grid saves after drag-and-drop rearrangement
 
-### REQ-DASH-005: Delete Dashboard
+### Requirement: Delete Dashboard (REQ-DASH-005)
 
 Users MUST be able to delete their own dashboards with proper cascade deletion of associated data.
 
@@ -209,7 +209,7 @@ Users MUST be able to delete their own dashboards with proper cascade deletion o
 - THEN the system MUST allow the deletion
 - AND users MUST always have the right to remove dashboards from their account regardless of permission level
 
-### REQ-DASH-006: Activate Dashboard
+### Requirement: Activate Dashboard (REQ-DASH-006)
 
 Users MUST be able to set one of their dashboards as the active dashboard, ensuring only one is active at a time.
 
@@ -237,7 +237,7 @@ Users MUST be able to set one of their dashboards as the active dashboard, ensur
 - THEN exactly one dashboard (id 8) MUST have `isActive: 1`
 - AND all other 4 dashboards MUST have `isActive: 0`
 
-### REQ-DASH-007: Dashboard Name Validation
+### Requirement: Dashboard Name Validation (REQ-DASH-007)
 
 Dashboard names MUST be validated for length and content.
 
@@ -260,7 +260,7 @@ Dashboard names MUST be validated for length and content.
 - THEN the system MUST use the default name "My Dashboard"
 - AND the dashboard MUST be created successfully
 
-### REQ-DASH-008: Dashboard Type Enforcement
+### Requirement: Dashboard Type Enforcement (REQ-DASH-008)
 
 The `type` field MUST distinguish between user-created dashboards and admin templates, with appropriate access controls.
 
@@ -282,7 +282,7 @@ The `type` field MUST distinguish between user-created dashboards and admin temp
 - THEN the copy MUST have `type: "user"` (NOT "admin_template")
 - AND `basedOnTemplate` MUST reference the source template's ID
 
-### REQ-DASH-009: Dashboard Resolution Chain
+### Requirement: Dashboard Resolution Chain (REQ-DASH-009)
 
 The system MUST resolve the effective dashboard through a defined chain when GET /api/dashboard is called.
 
@@ -305,7 +305,7 @@ The system MUST resolve the effective dashboard through a defined chain when GET
 - THEN `DashboardService::tryCreateFromTemplate()` MUST be called
 - AND a template copy MUST be created and set as active
 
-### REQ-DASH-010: Dashboard Serialization
+### Requirement: Dashboard Serialization (REQ-DASH-010)
 
 Dashboard objects MUST be consistently serialized across all API responses.
 

--- a/openspec/specs/grid-layout/spec.md
+++ b/openspec/specs/grid-layout/spec.md
@@ -21,7 +21,7 @@ The grid layout system powers the drag-and-drop dashboard experience in MyDash. 
 
 ## Requirements
 
-### REQ-GRID-001: Grid Initialization
+### Requirement: Grid Initialization (REQ-GRID-001)
 
 The grid MUST initialize with the correct configuration when a dashboard is loaded.
 
@@ -64,7 +64,7 @@ The grid MUST initialize with the correct configuration when a dashboard is load
 - THEN GridStack.init MUST be called with `disableDrag: !this.editMode` and `disableResize: !this.editMode`
 - AND `removable: false` MUST prevent accidental widget removal via drag-out
 
-### REQ-GRID-002: Drag to Reposition
+### Requirement: Drag to Reposition (REQ-GRID-002)
 
 Users MUST be able to drag widgets to new positions on the grid in edit mode.
 
@@ -103,7 +103,7 @@ Users MUST be able to drag widgets to new positions on the grid in edit mode.
 - THEN the GridStack `change` event MUST fire
 - AND `handleGridChange()` MUST emit `update:placements` with all current placement positions
 
-### REQ-GRID-003: Resize by Edge Dragging
+### Requirement: Resize by Edge Dragging (REQ-GRID-003)
 
 Users MUST be able to resize widgets by dragging their edges or corners in edit mode.
 
@@ -140,7 +140,7 @@ Users MUST be able to resize widgets by dragging their edges or corners in edit 
 - AND the cursor MUST NOT change to a resize cursor
 - NOTE: `disableResize: !this.editMode` on initialization.
 
-### REQ-GRID-004: View Mode vs Edit Mode
+### Requirement: View Mode vs Edit Mode (REQ-GRID-004)
 
 The grid MUST support two distinct interaction modes controlled by the `editMode` prop.
 
@@ -177,7 +177,7 @@ The grid MUST support two distinct interaction modes controlled by the `editMode
 - THEN the watcher MUST call `grid.enable()`
 - AND when it changes from true to false, the watcher MUST call `grid.disable()`
 
-### REQ-GRID-005: Position Persistence
+### Requirement: Position Persistence (REQ-GRID-005)
 
 Grid position changes MUST be communicated to the parent component for API persistence.
 
@@ -214,7 +214,7 @@ Grid position changes MUST be communicated to the parent component for API persi
 - THEN each grid item's `id` MUST be matched to a placement's `id` via string comparison
 - AND the placement's gridX, gridY, gridWidth, gridHeight MUST be updated from the grid item's x, y, w, h values
 
-### REQ-GRID-006: Widget Auto-Layout (collision placement algorithm)
+### Requirement: Widget Auto-Layout — collision placement algorithm (REQ-GRID-006)
 
 When a new widget is added to an existing dashboard, the system MUST place it without overlapping any existing widget and without leaving it outside the visible grid region. The algorithm MUST be:
 
@@ -272,7 +272,7 @@ Default size when the caller omits `w`/`h` MUST be `w=4, h=4`. Position writes M
 - THEN `syncGridItems()` MUST find the orphaned grid node and call `grid.removeWidget()` with `removeDOM: false`
 - AND the grid MUST update its layout accordingly
 
-### REQ-GRID-007: Grid Responsiveness (concrete breakpoints)
+### Requirement: Grid Responsiveness — concrete breakpoints (REQ-GRID-007)
 
 The GridStack instance MUST be initialised with `columnOpts.breakpoints` containing exactly four entries, each `{w: <viewportWidthPx>, c: <columnCount>}`, applied in descending viewport order:
 
@@ -326,7 +326,7 @@ The grid MUST also adapt to the container width while maintaining the active col
 - WHEN the grid renders
 - THEN the grid container MUST maintain a minimum height of 400px (`.mydash-grid { min-height: 400px }`)
 
-### REQ-GRID-008: Grid Accessibility
+### Requirement: Grid Accessibility (REQ-GRID-008)
 
 The grid MUST support keyboard navigation and screen reader compatibility.
 
@@ -350,7 +350,7 @@ The grid MUST support keyboard navigation and screen reader compatibility.
 - THEN the screen reader MUST announce: the widget title, its grid position, and its size
 - NOTE: ARIA attributes for grid positions are NOT currently implemented.
 
-### REQ-GRID-009: Tile vs Widget Rendering
+### Requirement: Tile vs Widget Rendering (REQ-GRID-009)
 
 The grid MUST distinguish between tile placements and widget placements for rendering.
 
@@ -381,7 +381,7 @@ The grid MUST distinguish between tile placements and widget placements for rend
 - THEN `WidgetWrapper` MUST receive both the `placement` object and the resolved `widget` object
 - AND if no matching widget is found, `widget` MUST be null (graceful degradation)
 
-### REQ-GRID-010: Grid Styling
+### Requirement: Grid Styling (REQ-GRID-010)
 
 The grid MUST apply consistent visual styling to all grid items.
 
@@ -400,7 +400,7 @@ The grid MUST apply consistent visual styling to all grid items.
 - WHEN the grid re-renders
 - THEN the placement key MUST include the `updatedAt` timestamp and `styleConfig` hash to force re-rendering via `getPlacementKey()`
 
-### REQ-GRID-011: Grid Synchronization
+### Requirement: Grid Synchronization (REQ-GRID-011)
 
 The grid MUST stay synchronized with the placements prop when items are added or removed externally.
 
@@ -420,7 +420,7 @@ The grid MUST stay synchronized with the placements prop when items are added or
 - WHEN `beforeDestroy` lifecycle hook fires
 - THEN `grid.destroy(false)` MUST be called (false = do not remove DOM elements)
 
-### REQ-GRID-012: Cell geometry constants
+### Requirement: Cell geometry constants (REQ-GRID-012)
 
 The grid MUST be initialised with `cellHeight: 60` (px) and `margin: 8` (px). These constants MUST live in a single shared module exported from the grid composable, not duplicated in component templates.
 
@@ -437,7 +437,7 @@ The grid MUST be initialised with `cellHeight: 60` (px) and `margin: 8` (px). Th
 - WHEN it renders at the 12-column breakpoint
 - THEN its DOM height MUST be `(4 * 60) + (3 * 8) = 264 px` (4 rows + 3 inter-row margins)
 
-### REQ-GRID-013: GridStack version pin
+### Requirement: GridStack version pin (REQ-GRID-013)
 
 The system MUST pin `gridstack` to a major version that supports `columnOpts.breakpoints` and the `moveScale` layout (currently v10 or later, target v12+). Bumping the major version MUST be a deliberate change with a regression-test pass on this capability.
 
@@ -448,7 +448,7 @@ The system MUST pin `gridstack` to a major version that supports `columnOpts.bre
 - THEN the resolved version MUST be `>= 10.0.0`
 - AND `package.json` MUST declare a constrained range like `"gridstack": "^12.2.1"` (or whichever major is current at apply time)
 
-### REQ-GRID-014: Placement helper is the single placement authority
+### Requirement: Placement helper is the single placement authority (REQ-GRID-014)
 
 All "add widget" code paths (toolbar dropdown, keyboard shortcut, drag-from-picker) MUST go through a single `placeNewWidget(spec)` helper exported from the grid composable. Inline calls to `grid.addWidget` outside this helper are forbidden.
 

--- a/openspec/specs/legacy-widget-bridge/spec.md
+++ b/openspec/specs/legacy-widget-bridge/spec.md
@@ -22,7 +22,7 @@ Both maps persist for the lifetime of the page. Registration is additive — re-
 
 ## Requirements
 
-### REQ-LWB-001: Intercept legacy widget registration at bootstrap
+### Requirement: Intercept legacy widget registration at bootstrap (REQ-LWB-001)
 
 The system MUST intercept calls to `window.OCA.Dashboard.register` and `window.OCA.Dashboard.registerStatus` made by legacy Nextcloud widgets so that their render callbacks can be captured for later mounting by MyDash. Interception is installed once when the bridge singleton is constructed. The system MUST preserve any previously installed `register` / `registerStatus` implementation so that Nextcloud code that depends on the original registrar continues to work.
 
@@ -47,7 +47,7 @@ The system MUST intercept calls to `window.OCA.Dashboard.register` and `window.O
 - THEN the system MUST create the `OCA` and `OCA.Dashboard` objects before installing the `register` / `registerStatus` overrides
 - AND subsequent legacy registrations MUST still be captured correctly
 
-### REQ-LWB-002: Mount a captured legacy widget into a DOM container
+### Requirement: Mount a captured legacy widget into a DOM container (REQ-LWB-002)
 
 The system MUST provide a way for MyDash to render a legacy widget by invoking its captured callback against a DOM container element. Widgets that did not register a callback MUST NOT silently mount; a diagnostic warning MUST be emitted so missing registrations surface during development. Errors raised by a widget's callback MUST NOT propagate — a single broken legacy widget MUST NOT prevent the rest of the dashboard from rendering.
 
@@ -73,7 +73,7 @@ The system MUST provide a way for MyDash to render a legacy widget by invoking i
 - THEN the system MUST catch the error and log it together with the widgetId
 - AND the error MUST NOT propagate to the caller
 
-### REQ-LWB-003: Mount a captured legacy status widget
+### Requirement: Mount a captured legacy status widget (REQ-LWB-003)
 
 The system MUST provide a way to render a legacy status widget. Status widgets differ from regular widgets in their callback signature: they receive only the container element, with no metadata argument.
 
@@ -100,7 +100,7 @@ The system MUST provide a way to render a legacy status widget. Status widgets d
 
 **Notes**: The missing-callback behaviour differs between `mountWidget` (warn) and `mountStatusWidget` (silent). This is observed, not obviously intentional — status widgets may legitimately be absent on dashboards that do not request them, while regular widgets are usually explicit. Flagged for future REQ tightening once a call-site audit confirms the rationale.
 
-### REQ-LWB-004: Query widget-bridge registration state
+### Requirement: Query widget-bridge registration state (REQ-LWB-004)
 
 The system MUST expose a way for MyDash render logic to query which widget callbacks have been captured so that it can choose between the legacy mounting path and the modern v2 rendering path without attempting a mount first.
 
@@ -121,7 +121,7 @@ The system MUST expose a way for MyDash render logic to query which widget callb
 
 **Notes**: `hasWidgetCallback` and `getRegisteredWidgetIds` are combined into a single REQ because they expose the same read-only inspection capability over the widget-callback map. Status callbacks are not exposed via either query — the bridge does not currently need introspection on the status map. Noted for future REQ extension if that need arises.
 
-### REQ-LWB-005: Polling helper for late callback registration
+### Requirement: Polling helper for late callback registration (REQ-LWB-005)
 
 The bridge singleton MUST expose `pollForCallback(widgetId: string, options?: {intervalMs?: number, maxRetries?: number, signal?: AbortSignal}): Promise<boolean>` that periodically checks whether a callback has been registered for the given `widgetId`. Defaults: `intervalMs = 200`, `maxRetries = 15` (~3 s total). The promise MUST resolve to `true` as soon as a callback is detected, OR to `false` after the max retries are exhausted. Each call MUST be cancellable via the AbortSignal of an `AbortController` passed in `options.signal` (so callers can abort polling on unmount).
 
@@ -156,7 +156,7 @@ This helper exists to support the `nc-widget` renderer (REQ-WDG-019), which need
 - THEN the promise MUST resolve `true` synchronously (or on the very next microtask)
 - AND no `setInterval` MUST be scheduled
 
-### REQ-LWB-006: hasWidgetCallback consistency
+### Requirement: hasWidgetCallback consistency (REQ-LWB-006)
 
 `hasWidgetCallback(widgetId)` (already declared in REQ-LWB-004) MUST return `true` if and only if `pollForCallback` would resolve `true` immediately. The polling helper MUST use `hasWidgetCallback` internally as its check function — there MUST NOT be two parallel "is registered" code paths.
 

--- a/openspec/specs/permissions/spec.md
+++ b/openspec/specs/permissions/spec.md
@@ -18,7 +18,7 @@ Permission levels control what users can do with their dashboards. When an admin
 
 ## Requirements
 
-### REQ-PERM-001: View-Only Permission Level
+### Requirement: View-Only Permission Level (REQ-PERM-001)
 
 Dashboards with `permissionLevel: "view_only"` MUST restrict users to viewing only, with no widget or layout editing capabilities.
 
@@ -67,7 +67,7 @@ Dashboards with `permissionLevel: "view_only"` MUST restrict users to viewing on
   - Grid drag handles and resize handles
 - NOTE: Frontend permission-based UI hiding is NOT currently implemented.
 
-### REQ-PERM-002: Add-Only Permission Level
+### Requirement: Add-Only Permission Level (REQ-PERM-002)
 
 Dashboards with `permissionLevel: "add_only"` MUST allow users to add and modify widgets but prevent removal of compulsory widgets.
 
@@ -115,7 +115,7 @@ Dashboards with `permissionLevel: "add_only"` MUST allow users to add and modify
 - THEN the system MUST create the rule
 - AND the response MUST return HTTP 201
 
-### REQ-PERM-003: Full Permission Level
+### Requirement: Full Permission Level (REQ-PERM-003)
 
 Dashboards with `permissionLevel: "full"` MUST allow users complete control over all aspects of the dashboard.
 
@@ -138,7 +138,7 @@ Dashboards with `permissionLevel: "full"` MUST allow users complete control over
 - AND all widget context menus MUST include all options (edit, delete, configure visibility)
 - AND all widgets (including compulsory) MUST show delete options in edit mode
 
-### REQ-PERM-004: Compulsory Widget Marking
+### Requirement: Compulsory Widget Marking (REQ-PERM-004)
 
 Admin templates MUST be able to mark specific widget placements as compulsory, and this flag MUST be inherited by user copies.
 
@@ -176,7 +176,7 @@ Admin templates MUST be able to mark specific widget placements as compulsory, a
 - THEN the new placement MUST have `isCompulsory: 0` (default via `PlacementService::addWidget()`)
 - AND alice MUST be able to remove this widget even on an add-only dashboard
 
-### REQ-PERM-005: Permission Level Immutability for Users
+### Requirement: Permission Level Immutability for Users (REQ-PERM-005)
 
 Users MUST NOT be able to change the permission level on their own dashboards.
 
@@ -193,7 +193,7 @@ Users MUST NOT be able to change the permission level on their own dashboards.
 - THEN the system MUST ignore the `permissionLevel` field
 - AND the permissionLevel MUST remain "full"
 
-### REQ-PERM-006: Permission Enforcement on API Level
+### Requirement: Permission Enforcement on API Level (REQ-PERM-006)
 
 Permission checks MUST be enforced at the API/service level, not just in the frontend UI.
 
@@ -219,7 +219,7 @@ Permission checks MUST be enforced at the API/service level, not just in the fro
 - THEN permission checks (`canAddWidget`, `canStyleWidget`, `canRemoveWidget`) MUST be called before any service method that modifies data
 - AND rejected requests MUST NOT cause any state changes
 
-### REQ-PERM-007: Dashboard Metadata Editing
+### Requirement: Dashboard Metadata Editing (REQ-PERM-007)
 
 Permission levels MUST NOT restrict editing of dashboard metadata (name, description) for users who own the dashboard.
 
@@ -241,7 +241,7 @@ Permission levels MUST NOT restrict editing of dashboard metadata (name, descrip
 - THEN `canEditDashboardMetadata()` (ownership only) MUST be used for name/description changes
 - AND `canEditDashboard()` (ownership + permission level) MUST be used for widget/layout changes
 
-### REQ-PERM-008: Effective Permission Level Resolution
+### Requirement: Effective Permission Level Resolution (REQ-PERM-008)
 
 The system MUST resolve effective permission levels through a defined chain: source template, dashboard's own level, admin default.
 
@@ -271,7 +271,7 @@ The system MUST resolve effective permission levels through a defined chain: sou
 - THEN all 10 users' effective permission level MUST immediately resolve to "full"
 - AND no migration or re-copying is needed (resolution is dynamic at runtime)
 
-### REQ-PERM-009: Permission-Based Widget Styling
+### Requirement: Permission-Based Widget Styling (REQ-PERM-009)
 
 Widget styling (custom title, style config, visibility) MUST respect permission levels via `canStyleWidget()`.
 
@@ -292,7 +292,7 @@ Widget styling (custom title, style config, visibility) MUST respect permission 
 - WHEN she sends PUT /api/widgets/10 with style changes
 - THEN the system MUST allow the update
 
-### REQ-PERM-010: Ownership Verification
+### Requirement: Ownership Verification (REQ-PERM-010)
 
 All permission checks MUST verify that the requesting user owns the dashboard or placement before checking permission levels.
 
@@ -314,7 +314,7 @@ All permission checks MUST verify that the requesting user owns the dashboard or
 - THEN the method MUST look up the placement, find its dashboardId, verify dashboard ownership
 - AND throw "Access denied" since "bob" does not own dashboard 5
 
-### REQ-PERM-011: Admin Template Permission Restrictions
+### Requirement: Admin Template Permission Restrictions (REQ-PERM-011)
 
 Admin templates MUST only be editable by Nextcloud admin users, not by regular users.
 

--- a/openspec/specs/prometheus-metrics/spec.md
+++ b/openspec/specs/prometheus-metrics/spec.md
@@ -20,7 +20,7 @@ Metrics are collected at request time from database queries and system informati
 
 ## Requirements
 
-### REQ-PROM-001: Metrics Endpoint
+### Requirement: Metrics Endpoint (REQ-PROM-001)
 
 The system MUST expose a Prometheus-compatible metrics endpoint accessible to admin users.
 
@@ -49,7 +49,7 @@ The system MUST expose a Prometheus-compatible metrics endpoint accessible to ad
 - THEN the body MUST end with a newline character (Prometheus exposition format requirement)
 - AND each metric MUST be on its own line separated by `\n`
 
-### REQ-PROM-002: Application Info Metric
+### Requirement: Application Info Metric (REQ-PROM-002)
 
 The system MUST expose an info metric with version labels.
 
@@ -76,7 +76,7 @@ The system MUST expose an info metric with version labels.
 - WHEN the info metric is collected
 - THEN the version MUST default to "0.0.0"
 
-### REQ-PROM-003: Application Up Metric
+### Requirement: Application Up Metric (REQ-PROM-003)
 
 The system MUST expose an up metric indicating application health.
 
@@ -96,7 +96,7 @@ The system MUST expose an up metric indicating application health.
 - THEN `mydash_up` MUST be 1 (if the endpoint can respond, the app is up)
 - NOTE: The current implementation always returns 1. A degraded state (0) would only occur if the endpoint itself cannot respond.
 
-### REQ-PROM-004: Dashboard Count Metrics
+### Requirement: Dashboard Count Metrics (REQ-PROM-004)
 
 The system MUST expose dashboard count metrics grouped by type.
 
@@ -132,7 +132,7 @@ The system MUST expose dashboard count metrics grouped by type.
   ```
 - AND the error MUST NOT cause the entire metrics response to fail
 
-### REQ-PROM-005: Widget Placement Count Metric
+### Requirement: Widget Placement Count Metric (REQ-PROM-005)
 
 The system MUST expose the total number of widget placements.
 
@@ -152,7 +152,7 @@ The system MUST expose the total number of widget placements.
 - THEN the system MUST return 0 for the widget count
 - AND log a warning
 
-### REQ-PROM-006: Tile Count Metric
+### Requirement: Tile Count Metric (REQ-PROM-006)
 
 The system MUST expose the total number of tile definitions.
 
@@ -172,7 +172,7 @@ The system MUST expose the total number of tile definitions.
 - THEN the system MUST return 0 for the tile count
 - AND log a warning
 
-### REQ-PROM-007: Health Check Endpoint
+### Requirement: Health Check Endpoint (REQ-PROM-007)
 
 The system MUST expose a health check endpoint for monitoring and container orchestration.
 
@@ -215,7 +215,7 @@ The system MUST expose a health check endpoint for monitoring and container orch
 - AND if the query succeeds, the database check MUST be "ok"
 - AND if the query throws an exception, the database check MUST be "error"
 
-### REQ-PROM-008: Metrics Collection Architecture
+### Requirement: Metrics Collection Architecture (REQ-PROM-008)
 
 The metrics collection MUST follow a clean architecture with separate concerns.
 
@@ -239,7 +239,7 @@ The metrics collection MUST follow a clean architecture with separate concerns.
 - AND tile metrics MUST show the actual count
 - AND the overall response MUST still be returned (partial failure is acceptable)
 
-### REQ-PROM-009: Active Users Metric
+### Requirement: Active Users Metric (REQ-PROM-009)
 
 The system SHALL expose the number of active users (users with at least one dashboard).
 
@@ -254,7 +254,7 @@ The system SHALL expose the number of active users (users with at least one dash
   ```
 - NOTE: This metric is NOT currently implemented.
 
-### REQ-PROM-010: Metrics Endpoint Performance
+### Requirement: Metrics Endpoint Performance (REQ-PROM-010)
 
 The metrics endpoint MUST respond quickly to avoid blocking Prometheus scrape intervals.
 

--- a/openspec/specs/runtime-shell/spec.md
+++ b/openspec/specs/runtime-shell/spec.md
@@ -12,7 +12,7 @@ The shell deliberately holds NO source-of-truth data of its own — every key it
 
 ## Requirements
 
-### REQ-SHELL-001: Single mount point
+### Requirement: Single mount point (REQ-SHELL-001)
 
 The system MUST render the workspace Vue app into exactly one DOM element (id `mydash-app`), located inside a `<div id="app-workspace" class="mydash-workspace">` provided by `templates/index.php`. Nextcloud's chrome MUST treat `#app-workspace` as the main content slot (`'id-app-content' => '#app-workspace'`). No left navigation slot MUST be allocated by the chrome (`'id-app-navigation' => null`) — the shell renders its own slide-in sidebar instead.
 
@@ -86,7 +86,7 @@ The shell MUST NOT render a standalone "Active dashboard" select dropdown anywhe
 - THEN the label MUST be empty
 - AND the empty-state component MUST render in the grid area instead
 
-### REQ-SHELL-005: Empty state
+### Requirement: Empty state (REQ-SHELL-005)
 
 When the resolver returned no active dashboard, the shell MUST render an empty-state UI inside the grid container with: a friendly message ("No dashboards available"), an explanation, and — if `allowUserDashboards` is `true` — a primary "Create your first dashboard" button that calls the create-personal flow. When `allowUserDashboards` is `false` no Create button MUST be shown and the message MUST direct the user to contact their administrator.
 
@@ -106,7 +106,7 @@ When the resolver returned no active dashboard, the shell MUST render an empty-s
 - THEN the empty-state MUST render with a message explaining personal dashboards are disabled
 - AND no "Create" button MUST be present
 
-### REQ-SHELL-006: Sidebar backdrop
+### Requirement: Sidebar backdrop (REQ-SHELL-006)
 
 When `sidebarOpen` is `true`, the shell MUST render a fixed-position backdrop that intercepts clicks and closes the sidebar. The backdrop MUST start at the same `top` offset as the Nextcloud header (50 px) and span the rest of the viewport. Clicks on the sidebar itself MUST NOT close the sidebar.
 
@@ -122,7 +122,7 @@ When `sidebarOpen` is `true`, the shell MUST render a fixed-position backdrop th
 - WHEN the user clicks on a non-actionable area of the sidebar panel
 - THEN `sidebarOpen` MUST remain `true`
 
-### REQ-SHELL-007: Lifecycle hooks
+### Requirement: Lifecycle hooks (REQ-SHELL-007)
 
 The shell MUST register a global `document.click` listener on mount (delegated to the grid composable's `handleClickOutside`) and remove it on unmount. The GridStack instance MUST be initialised after `nextTick()` (so the grid container ref is non-null) and destroyed on unmount.
 

--- a/openspec/specs/tiles/spec.md
+++ b/openspec/specs/tiles/spec.md
@@ -68,7 +68,7 @@ The following behaviour MUST hold during the deprecation window:
 - **THEN** the tile MUST display with title + icon + colours + click-through correctly
 - **AND** no console errors MUST occur
 
-### REQ-TILE-002: List User Tiles
+### Requirement: List User Tiles (REQ-TILE-002)
 
 Users MUST be able to retrieve all their custom tile definitions, scoped to their user ID.
 
@@ -89,7 +89,7 @@ Users MUST be able to retrieve all their custom tile definitions, scoped to thei
 - WHEN she sends GET /api/tiles
 - THEN the system MUST return HTTP 200 with an empty array
 
-### REQ-TILE-003: Update Custom Tile
+### Requirement: Update Custom Tile (REQ-TILE-003)
 
 Users MUST be able to update the properties of their custom tiles with ownership verification.
 
@@ -126,7 +126,7 @@ Users MUST be able to update the properties of their custom tiles with ownership
 - THEN only `title` MUST be updated
 - AND all other fields (icon, iconType, backgroundColor, textColor, linkType, linkValue) MUST remain unchanged
 
-### REQ-TILE-004: Delete Custom Tile
+### Requirement: Delete Custom Tile (REQ-TILE-004)
 
 Users MUST be able to delete their custom tile definitions with ownership verification.
 
@@ -149,7 +149,7 @@ Users MUST be able to delete their custom tile definitions with ownership verifi
 - THEN the system MUST return HTTP 403 (via `findByIdAndUser()`)
 - AND the tile MUST NOT be deleted
 
-### REQ-TILE-005: Place Tile on Dashboard
+### Requirement: Place Tile on Dashboard (REQ-TILE-005)
 
 Users MUST be able to place tile data onto a dashboard, creating a widget placement with inline tile data.
 
@@ -189,7 +189,7 @@ Users MUST be able to place tile data onto a dashboard, creating a widget placem
 - THEN the system MUST return HTTP 403
 - AND `canAddWidget()` MUST block tile additions on view-only dashboards
 
-### REQ-TILE-006: Tile Icon Rendering
+### Requirement: Tile Icon Rendering (REQ-TILE-006)
 
 The frontend MUST support four icon formats: emoji, CSS class, URL, and SVG path.
 
@@ -217,7 +217,7 @@ The frontend MUST support four icon formats: emoji, CSS class, URL, and SVG path
 - THEN the system MUST render the path inside an `<svg viewBox="0 0 24 24">` element
 - AND the SVG fill MUST use the tile's textColor
 
-### REQ-TILE-007: Tile Color Validation
+### Requirement: Tile Color Validation (REQ-TILE-007)
 
 Tile colors MUST be validated to ensure proper display and accessibility.
 
@@ -237,7 +237,7 @@ Tile colors MUST be validated to ensure proper display and accessibility.
 - WHEN the tile is created
 - THEN `backgroundColor` MUST default to `'#0082c9'` (Nextcloud primary) and `textColor` MUST default to `'#ffffff'` (white)
 
-### REQ-TILE-008: Tile Link Navigation
+### Requirement: Tile Link Navigation (REQ-TILE-008)
 
 Tiles MUST navigate correctly based on their linkType.
 
@@ -257,7 +257,7 @@ Tiles MUST navigate correctly based on their linkType.
 - WHEN the user hovers over it
 - THEN the tile MUST scale slightly (transform: scale(1.02)) with reduced opacity (0.95)
 
-### REQ-TILE-009: Tile Styling
+### Requirement: Tile Styling (REQ-TILE-009)
 
 Tiles MUST apply their configured colors as CSS custom properties for consistent rendering.
 
@@ -280,7 +280,7 @@ Tiles MUST apply their configured colors as CSS custom properties for consistent
 - THEN the tile MUST fill the entire grid cell (`position: absolute; top: 0; left: 0; width: 100%; height: 100%`)
 - AND the tile MUST have no border radius and no border (overriding grid item defaults)
 
-### REQ-TILE-010: Tile Edit Mode
+### Requirement: Tile Edit Mode (REQ-TILE-010)
 
 Tiles MUST support an edit mode that allows configuration changes.
 
@@ -301,7 +301,7 @@ Tiles MUST support an edit mode that allows configuration changes.
 - THEN the `TileWidget` component MUST emit an `edit` event
 - AND `click.prevent` MUST prevent link navigation when clicking the edit button
 
-### REQ-TILE-011: Tile Management UI
+### Requirement: Tile Management UI (REQ-TILE-011)
 
 Users MUST be able to manage their tile definitions through a dedicated UI.
 

--- a/openspec/specs/widgets/spec.md
+++ b/openspec/specs/widgets/spec.md
@@ -40,7 +40,7 @@ Widgets are discovered at runtime from Nextcloud's `IManager::getWidgets()`. Eac
 
 ## Requirements
 
-### REQ-WDG-001: Discover Available Widgets
+### Requirement: Discover Available Widgets (REQ-WDG-001)
 
 The system MUST provide an API to list all Nextcloud dashboard widgets available for placement.
 
@@ -69,7 +69,7 @@ The system MUST provide an API to list all Nextcloud dashboard widgets available
 - THEN the output MUST include standardized fields for the frontend
 - AND widgets MUST be sorted by their order property
 
-### REQ-WDG-002: Fetch Widget Items
+### Requirement: Fetch Widget Items (REQ-WDG-002)
 
 The system MUST provide an API to fetch the content items for widgets that support item loading via the Nextcloud Widget API.
 
@@ -96,7 +96,7 @@ The system MUST provide an API to fetch the content items for widgets that suppo
 - WHEN widget items are fetched
 - THEN the endpoint MUST have `#[NoCSRFRequired]` to support async loading from the frontend
 
-### REQ-WDG-003: Add Widget to Dashboard
+### Requirement: Add Widget to Dashboard (REQ-WDG-003)
 
 Users MUST be able to place a discovered widget onto their dashboard with grid coordinates.
 
@@ -139,7 +139,7 @@ Users MUST be able to place a discovered widget onto their dashboard with grid c
 - THEN the system MUST accept the request (for forward compatibility if apps are temporarily disabled)
 - NOTE: Widget ID validation against registered widgets is NOT currently implemented.
 
-### REQ-WDG-004: Update Widget Placement
+### Requirement: Update Widget Placement (REQ-WDG-004)
 
 Users MUST be able to update a widget placement's position, size, title, visibility, and styling via `PlacementUpdater`.
 
@@ -180,7 +180,7 @@ Users MUST be able to update a widget placement's position, size, title, visibil
 - THEN `TileUpdater::applyTileUpdates()` MUST update the tile-specific fields
 - AND both grid and tile updates can be applied in a single request
 
-### REQ-WDG-005: Remove Widget from Dashboard
+### Requirement: Remove Widget from Dashboard (REQ-WDG-005)
 
 Users MUST be able to remove widget placements from their dashboards, subject to permission level and compulsory widget checks.
 
@@ -213,7 +213,7 @@ Users MUST be able to remove widget placements from their dashboards, subject to
 - THEN all 3 conditional rules MUST also be deleted
 - NOTE: `PlacementService::removePlacement()` does NOT explicitly cascade-delete conditional rules. This depends on database-level cascade constraints.
 
-### REQ-WDG-006: Widget Placement Visibility
+### Requirement: Widget Placement Visibility (REQ-WDG-006)
 
 The system MUST support widget placement visibility via an `isVisible` SMALLINT (0/1) flag plus optional ConditionalRule records to control rendering.
 
@@ -240,7 +240,7 @@ The system MUST support widget placement visibility via an `isVisible` SMALLINT 
 - THEN the system MUST update `isVisible` to 0
 - AND the widget MUST be hidden on next render regardless of conditional rules
 
-### REQ-WDG-007: Widget Sort Order
+### Requirement: Widget Sort Order (REQ-WDG-007)
 
 Widget placements MUST maintain a sort order for consistent rendering and tab navigation.
 
@@ -260,7 +260,7 @@ Widget placements MUST maintain a sort order for consistent rendering and tab na
 - WHEN the user presses Tab in view mode
 - THEN focus MUST move through widgets in sortOrder sequence
 
-### REQ-WDG-008: Batch Update Placements
+### Requirement: Batch Update Placements (REQ-WDG-008)
 
 The system MUST support updating multiple widget placements via the dashboard update endpoint for efficient grid saves.
 
@@ -282,7 +282,7 @@ The system MUST support updating multiple widget placements via the dashboard up
 - WHEN DashboardGrid emits `update:placements` with updated positions
 - THEN the parent component MUST send PUT /api/dashboard/{id} with `{"placements": [{"id": 10, "gridX": 0, "gridY": 0, "gridWidth": 4, "gridHeight": 4}, ...]}`
 
-### REQ-WDG-009: Widget Rendering Architecture
+### Requirement: Widget Rendering Architecture (REQ-WDG-009)
 
 The frontend MUST use a layered rendering architecture: `DashboardGrid` -> `WidgetWrapper` -> `WidgetRenderer`.
 
@@ -315,7 +315,7 @@ The frontend MUST use a layered rendering architecture: `DashboardGrid` -> `Widg
 - AND render `TileWidget` directly instead of `WidgetWrapper`
 - AND WidgetWrapper applies transparent background and no padding for tile-type widgetIds
 
-### REQ-WDG-010: Widget Picker
+### Requirement: Widget Picker (REQ-WDG-010)
 
 The widget picker MUST be implemented as a single modal that handles both creation and editing flows. The modal MUST present a type selector at the top (unless a type was preselected by the caller) followed by the per-type configuration sub-form for the currently selected type. Submit MUST emit `{type, content}` where `content` carries only the fields relevant to the selected type — fields belonging to other types MUST NOT be included.
 
@@ -377,7 +377,7 @@ The widget picker MUST be implemented as a single modal that handles both creati
 - THEN POST /api/dashboard/{id}/widgets MUST be sent with the selected widgetId
 - AND GridStack MUST auto-place the new widget at the next available position
 
-### REQ-WDG-011: Widget Style Editor
+### Requirement: Widget Style Editor (REQ-WDG-011)
 
 Users MUST be able to customize widget appearance through a style editor.
 
@@ -404,7 +404,7 @@ Users MUST be able to customize widget appearance through a style editor.
 - THEN PUT /api/widgets/{placementId} MUST be sent with updated `styleConfig`
 - AND the widget MUST immediately reflect the new style
 
-### REQ-WDG-012: Per-type validation contract
+### Requirement: Per-type validation contract (REQ-WDG-012)
 
 Each per-type sub-form component MUST expose a `validate(): string[]` method that returns an array of human-readable error messages (empty array = valid). The modal MUST disable its primary action button when the active sub-form's `validate()` returns a non-empty array. The button MUST re-enable as soon as `validate()` returns empty (reactive on form input).
 
@@ -422,7 +422,7 @@ Each per-type sub-form component MUST expose a `validate(): string[]` method tha
 - WHEN the user types `Hello`
 - THEN the button MUST become enabled within the next render cycle
 
-### REQ-WDG-013: Modal close discipline
+### Requirement: Modal close discipline (REQ-WDG-013)
 
 The modal MUST close on three triggers:
 
@@ -453,7 +453,7 @@ Closing the modal MUST NOT submit. Reopening after a close MUST reset all form s
 - THEN the modal MUST emit `close` only
 - AND MUST NOT emit `submit`
 
-### REQ-WDG-014: Sub-form registry
+### Requirement: Sub-form registry (REQ-WDG-014)
 
 The set of supported widget types MUST come from a single in-frontend registry that maps `type → { component, label, defaults }`. The toolbar dropdown, the modal type selector, and the grid renderer MUST all consult the same registry.
 
@@ -473,7 +473,7 @@ The set of supported widget types MUST come from a single in-frontend registry t
 - THEN it MUST list those 5 types
 - AND MUST NOT hard-code any type name elsewhere in the codebase
 
-### REQ-WDG-015: Right-click context menu in edit mode
+### Requirement: Right-click context menu in edit mode (REQ-WDG-015)
 
 When the user is in edit mode (per REQ-SHELL-002 `canEdit === true`), right-clicking any widget placement on the grid MUST open a small popover at the cursor position offering at least these three actions: **Edit**, **Remove**, **Cancel**. The popover MUST suppress the browser's native context menu via `event.preventDefault()`. In view mode the right-click MUST fall through to native behaviour (no popover).
 
@@ -515,7 +515,7 @@ When the user is in edit mode (per REQ-SHELL-002 `canEdit === true`), right-clic
 - AND no API call MUST fire
 - AND no widget state MUST change
 
-### REQ-WDG-016: Auto-close on outside interaction
+### Requirement: Auto-close on outside interaction (REQ-WDG-016)
 
 The popover MUST close when the user clicks anywhere outside its bounding box (including on another widget). Right-clicking a different widget while the popover is open MUST close the current popover and open a new one at the new cursor position. Closing on outside click MUST be wired via a single document-level listener that the grid composable manages on mount/unmount.
 
@@ -539,7 +539,7 @@ The popover MUST close when the user clicks anywhere outside its bounding box (i
 - THEN the document-level `click` listener MUST be removed
 - AND no popover state MUST leak into a subsequent mount
 
-### REQ-WDG-017: Position constraints
+### Requirement: Position constraints (REQ-WDG-017)
 
 The popover MUST be absolutely positioned at the click coordinates with `min-width: 150px`. If the popover would overflow the viewport on the right or bottom edge, the system SHOULD shift it left/up so it remains fully visible. Z-index MUST be `10000` (above grid, level with modals — popover-then-modal interaction is acceptable since clicking a popover item closes it before the modal opens).
 
@@ -565,7 +565,7 @@ The popover MUST be absolutely positioned at the click coordinates with `min-wid
 - THEN the popover element MUST have `z-index: 10000`
 - AND MUST have `min-width: 150px`
 
-### REQ-WDG-018: nc-widget placement type
+### Requirement: nc-widget placement type (REQ-WDG-018)
 
 The widget registry MUST include the type `nc-widget` representing a Nextcloud Dashboard widget rendered inside MyDash. Its persisted content shape MUST be:
 
@@ -588,7 +588,7 @@ The renderer MUST be `NcDashboardWidget.vue`. The form MUST present (a) a `<sele
 - THEN the picker `<select>` MUST list both options
 - AND validation MUST require a widgetId before Add is enabled
 
-### REQ-WDG-019: Two-mode rendering with bridge polling
+### Requirement: Two-mode rendering with bridge polling (REQ-WDG-019)
 
 The renderer MUST attempt native-callback rendering (REQ-LWB-002 mountWidget) immediately on mount. If no callback is registered for the `widgetId`, the renderer MUST fall back to the API list path (REQ-WDG-002 widget items) AND start a polling watcher that re-checks for the callback every 200 ms for up to 15 retries (~3 s total). If the callback registers within the polling window, the renderer MUST switch to native-callback mode (cancelling the in-flight or completed API render).
 
@@ -619,7 +619,7 @@ The renderer MUST attempt native-callback rendering (REQ-LWB-002 mountWidget) im
 - AND the API list MUST remain rendered as the final state
 - AND no further callback checks MUST occur
 
-### REQ-WDG-020: Display modes
+### Requirement: Display modes (REQ-WDG-020)
 
 The API list MUST render in one of two display modes:
 
@@ -643,7 +643,7 @@ The header (above the list area) MUST always render the widget's title + iconUrl
 - THEN the list MUST be a flex-row wrap with 4 cards of approximately 120 px width
 - AND each card MUST show a 44 px icon top + centred text below
 
-### REQ-WDG-021: API call shape
+### Requirement: API call shape (REQ-WDG-021)
 
 When falling back to the API path, the renderer MUST issue exactly:
 
@@ -664,7 +664,7 @@ The response MUST be parsed as `{items: {[widgetId]: WidgetItem[]}, meta: {[widg
 - THEN the cell MUST display `t('No items available')` centred
 - AND no `<a>` items MUST render
 
-### REQ-WDG-022: Tile widget type registered
+### Requirement: Tile widget type registered (REQ-WDG-022)
 
 The widget registry (`src/constants/widgetRegistry.js`) MUST include a `tile` widget type that:
 


### PR DESCRIPTION
## Summary

Normalize **151 Form B `### REQ-XX-NNN: <title>`** requirement headings across **13 spec files** to canonical **Form A `### Requirement: <title> (REQ-XX-NNN)`** per ADR-037.

Part of the fleet-wide Phase 1c canonicalization sweep (8 parallel sub-agents; mydash is the heaviest with 54 specs).

## What changed

| Spec | Reqs migrated |
|---|---:|
| admin-settings | 15 |
| admin-templates | 17 |
| conditional-visibility | 11 |
| dashboard-metadata-fields | 8 |
| dashboard-sharing | 13 |
| dashboards | 10 |
| grid-layout | 14 |
| legacy-widget-bridge | 6 |
| permissions | 11 |
| prometheus-metrics | 10 |
| runtime-shell | 4 |
| tiles | 10 |
| widgets | 22 |
| **Total** | **151** |

The remaining **40 Form A entries** on other specs (e.g. `initial-state-contract`, `people-widget`, `resource-uploads`, `text-display-widget`) were already canonical and left untouched.

## What does NOT land here

- The **26 `@spec dashboards:...` shorthand annotations** in `lib/` PHP files are deferred to **Phase 2** per ADR-037 (depends on `/opsx-annotate` ghost change running first).
- **3 pre-existing validator failures** (`dashboard-deeplinking`, `default-widget-bundle`, `effective-default-marker`) have body/scenario format issues unrelated to heading form — out of scope for this PR (touching them would violate the guardrail "Don't change body, scenarios, section ordering, or frontmatter").

## Verification

- `openspec validate --specs --strict`: **54 passed, 3 failed** (same 3 pre-existing failures as baseline — no new failures introduced).
- `git diff --shortstat`: **13 files changed, 151 insertions(+), 151 deletions(-)** (1-for-1 line swap).
- All changes confined to `openspec/specs/**/spec.md`; **no `lib/` or `src/` files touched**.
- Body, scenarios, frontmatter, and section ordering preserved.

## References

- Refs #292 (mydash Phase 0/1c umbrella)
- Refs ConductionNL/hydra#326 (ADR-037)