### PR TITLE
retrofit: reverse-spec dashboards helpers (4 REQs / 9 methods)

### DIFF
--- a/lib/Controller/DashboardRequestValidator.php
+++ b/lib/Controller/DashboardRequestValidator.php
@@ -12,6 +12,9 @@
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @version   GIT:auto
  * @link      https://conduction.nl
+ *
+ * @spec openspec/changes/archive/2026-05-24-retrofit-dashboards/tasks.md#task-1
+ * @spec openspec/changes/archive/2026-05-24-retrofit-dashboards/tasks.md#task-2
  */
 
 declare(strict_types=1);
@@ -56,6 +59,8 @@ class DashboardRequestValidator
      * @return JSONResponse|null Error response or null if allowed.
      *
      * @SuppressWarnings(PHPMD.StaticAccess) — ResponseHelper uses static methods by design
+     *
+     * @spec openspec/changes/archive/2026-05-24-retrofit-dashboards/tasks.md#task-1
      */
     public function checkUpdatePermissions(string $userId, int $dashboardId, ?array $placements): ?JSONResponse
     {
@@ -84,6 +89,8 @@ class DashboardRequestValidator
      * @param string|null $description The description parameter.
      *
      * @return array The resolved name and description.
+     *
+     * @spec openspec/changes/archive/2026-05-24-retrofit-dashboards/tasks.md#task-2
      */
     public function resolveCreateParams(
         $name,
@@ -110,6 +117,8 @@ class DashboardRequestValidator
      * @return JSONResponse|null Error response or null if allowed.
      *
      * @SuppressWarnings(PHPMD.StaticAccess) — ResponseHelper uses static methods by design
+     *
+     * @spec openspec/changes/archive/2026-05-24-retrofit-dashboards/tasks.md#task-1
      */
     public function checkCreatePermissions(string $userId): ?JSONResponse
     {
@@ -146,6 +155,8 @@ class DashboardRequestValidator
      * @param array|null  $placements  The placements.
      *
      * @return array The non-null update data.
+     *
+     * @spec openspec/changes/archive/2026-05-24-retrofit-dashboards/tasks.md#task-2
      */
     public function buildUpdateData(
         ?string $name,

--- a/lib/Controller/ResponseHelper.php
+++ b/lib/Controller/ResponseHelper.php
@@ -12,6 +12,9 @@
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @version   GIT:auto
  * @link      https://conduction.nl
+ *
+ * @spec openspec/changes/archive/2026-05-24-retrofit-dashboards/tasks.md#task-3
+ * @spec openspec/changes/archive/2026-05-24-retrofit-dashboards/tasks.md#task-4
  */
 
 declare(strict_types=1);
@@ -31,6 +34,8 @@ class ResponseHelper
      * Create an unauthorized response.
      *
      * @return JSONResponse The unauthorized response.
+     *
+     * @spec openspec/changes/archive/2026-05-24-retrofit-dashboards/tasks.md#task-3
      */
     public static function unauthorized(): JSONResponse
     {
@@ -46,6 +51,8 @@ class ResponseHelper
      * @param string $message The error message.
      *
      * @return JSONResponse The forbidden response.
+     *
+     * @spec openspec/changes/archive/2026-05-24-retrofit-dashboards/tasks.md#task-3
      */
     public static function forbidden(
         string $message='Access denied'
@@ -72,6 +79,8 @@ class ResponseHelper
      * @param string               $message    Generic client-facing message.
      *
      * @return JSONResponse The error response.
+     *
+     * @spec openspec/changes/archive/2026-05-24-retrofit-dashboards/tasks.md#task-4
      */
     public static function error(
         \Exception $exception,
@@ -99,6 +108,8 @@ class ResponseHelper
      * @param int   $statusCode The HTTP status code.
      *
      * @return JSONResponse The success response.
+     *
+     * @spec openspec/changes/archive/2026-05-24-retrofit-dashboards/tasks.md#task-3
      */
     public static function success(
         array $data,
@@ -116,6 +127,8 @@ class ResponseHelper
      * @param array $entities The entities to serialize.
      *
      * @return array The serialized entities.
+     *
+     * @spec openspec/changes/archive/2026-05-24-retrofit-dashboards/tasks.md#task-3
      */
     public static function serializeList(array $entities): array
     {

--- a/openspec/changes/archive/2026-05-24-retrofit-dashboards/design.md
+++ b/openspec/changes/archive/2026-05-24-retrofit-dashboards/design.md
@@ -1,0 +1,49 @@
+# Design — retrofit-2026-05-24-dashboards
+
+**Retrofit change. Tasks describe retroactive annotation, not new implementation work.**
+
+## Context
+
+The `dashboards` capability has been live in production for many months and is well-specced at the user-facing level (REQ-DASH-001 .. REQ-DASH-037). During the 2026-05-24 coverage scan, two helper classes were flagged as Bucket 2a (capability-owned but no covering REQ):
+
+- `lib/Controller/DashboardRequestValidator.php` — 4 methods extracted from `DashboardApiController` for testability and re-use
+- `lib/Controller/ResponseHelper.php` — 5 static helpers that define the JSON envelope shape used across every dashboard endpoint
+
+The methods are not aspirational — they ship today and are exercised by every dashboard create/update/list request. This retrofit captures the existing contract as 4 new REQs so future changes (e.g. tightening the nullable-logger path in `ResponseHelper::error()`) have a written contract to amend.
+
+## Approach
+
+For each of the 9 methods in the cluster:
+
+1. Read inputs (parameters, class state)
+2. Read outputs (return type, side effects — log writes, response shape)
+3. Read preconditions (caller assumptions, type contracts)
+4. Read postconditions (what the method guarantees)
+5. Read failure modes (return-nulls, throws, silent-drops)
+
+The 9 methods cluster into 4 distinct observable behaviours:
+
+| REQ | Methods | Behaviour |
+|---|---|---|
+| REQ-DASH-038 | `checkCreatePermissions`, `checkUpdatePermissions` | Permission-gate that returns `JSONResponse` on deny or `null` on allow |
+| REQ-DASH-039 | `resolveCreateParams`, `buildUpdateData` | Parameter resolution from heterogeneous request shapes; partial-update null-filtering |
+| REQ-DASH-040 | `unauthorized`, `forbidden`, `success`, `serializeList` | Response envelope shape + HTTP status code contract |
+| REQ-DASH-041 | `error` | Exception-to-response translation with no message leak (ADR-005) |
+
+Granularity rationale: `checkCreatePermissions` + `checkUpdatePermissions` share the same observable behaviour (return 403 JSON on deny, null on allow). Collapsing them into REQ-DASH-038 keeps the REQ count honest. Similarly, the four envelope helpers (`unauthorized`/`forbidden`/`success`/`serializeList`) share one envelope contract. The error helper has a distinct security-relevant contract (no message leak) and gets its own REQ.
+
+## Annotation strategy
+
+Each method gets a single-line `@spec openspec/changes/retrofit-2026-05-24-dashboards/tasks.md#task-N` tag in its docblock, alongside any existing tags. The 2 files were not previously annotated.
+
+## Notes — observed-but-suspicious
+
+- `ResponseHelper::error()` accepts a nullable `LoggerInterface`. When omitted, the exception is silently swallowed. REQ-DASH-041 documents the observed behaviour and the spec's Notes section surfaces the future-tightening TODO.
+- `serializeList()` has no defensive check — passing plain arrays fatals. Documented as a precondition.
+- `DashboardRequestValidator` references `REQ-PERM-007` inline (in code comments) but no formal `@spec` tag — the new REQ owns the validator's contract; the permission rules themselves stay with `permissions` / `admin-settings`.
+
+## Source
+
+- Coverage report: `openspec/coverage-report.json` generated 2026-05-24
+- Umbrella issue: ConductionNL/mydash#292
+- Bucket: 2a (capability-owned, missing REQ)

--- a/openspec/changes/archive/2026-05-24-retrofit-dashboards/proposal.md
+++ b/openspec/changes/archive/2026-05-24-retrofit-dashboards/proposal.md
@@ -1,0 +1,40 @@
+# Retrofit — dashboards (Bucket 2a)
+
+Describes observed behavior of 9 methods across 2 controller-helper files under the `dashboards` capability as 4 new REQs. Code already exists — this change retroactively specifies it.
+
+## Affected code units
+
+- `lib/Controller/DashboardRequestValidator.php::checkCreatePermissions()`
+- `lib/Controller/DashboardRequestValidator.php::checkUpdatePermissions()`
+- `lib/Controller/DashboardRequestValidator.php::resolveCreateParams()`
+- `lib/Controller/DashboardRequestValidator.php::buildUpdateData()`
+- `lib/Controller/ResponseHelper.php::unauthorized()`
+- `lib/Controller/ResponseHelper.php::forbidden()`
+- `lib/Controller/ResponseHelper.php::error()`
+- `lib/Controller/ResponseHelper.php::success()`
+- `lib/Controller/ResponseHelper.php::serializeList()`
+
+## Approach
+
+- For each method: describe observed inputs, outputs, pre/postconditions, failure modes
+- Draft REQs that match behavior (not aspirational)
+- Notes section surfaces any observed-but-suspicious behavior
+
+The existing `dashboards` spec covers end-user dashboard behaviour (REQ-DASH-001 .. REQ-DASH-037) but does not describe two helper classes that were extracted from controllers for testability and re-use:
+
+1. **`DashboardRequestValidator`** centralises permission checks and parameter resolution for the create/update endpoints. The existing CRUD requirements (REQ-DASH-001/004) describe the *user-facing* outcome but not the validator's contract (e.g. "metadata-only updates require `canEditDashboardMetadata`, layout updates require `canEditDashboard`").
+2. **`ResponseHelper`** is the canonical JSON-envelope shape used across every dashboard endpoint. The existing spec describes payloads but not the envelope/status-code contract or the rule that exception messages are never returned to the client (ADR-005).
+
+This retrofit adds:
+- REQ-DASH-038 — Dashboard request validator: permission gating for create + update
+- REQ-DASH-039 — Dashboard request parameter resolution (JSON body or scalar params)
+- REQ-DASH-040 — Dashboard response envelope shape and status codes
+- REQ-DASH-041 — Exception-to-error response (no exception message leak)
+
+## Notes
+
+- `DashboardRequestValidator::checkCreatePermissions()` references `REQ-PERM-007` and `REQ-ASET-002`-style behaviours (multiple-dashboards setting) in code comments but no formal `@spec` tag exists. The new REQ-DASH-038 owns the validator contract; the underlying permission rules stay with `permissions` / `admin-settings`.
+- `ResponseHelper::error()` `$logger` parameter is nullable — when omitted, the exception is silently swallowed and the client only sees the generic message. The REQ documents the observed behaviour and surfaces this as a TODO (callers SHOULD always pass a logger).
+- `ResponseHelper::serializeList()` assumes every element implements `jsonSerialize()` and will fatal otherwise — the REQ documents the precondition.
+
+Source: `openspec/coverage-report.md` generated 2026-05-24. See [retrofit playbook](../../../.github/docs/claude/retrofit.md).

--- a/openspec/changes/archive/2026-05-24-retrofit-dashboards/specs/dashboards/spec.md
+++ b/openspec/changes/archive/2026-05-24-retrofit-dashboards/specs/dashboards/spec.md
@@ -1,0 +1,110 @@
+---
+retrofit_extensions:
+  - REQ-DASH-038
+  - REQ-DASH-039
+  - REQ-DASH-040
+  - REQ-DASH-041
+---
+
+## ADDED Requirements
+
+### REQ-DASH-038: Dashboard request validator permission gating
+
+The system MUST centralise dashboard create + update permission checks in `DashboardRequestValidator`, returning a `JSONResponse` (with status 403 and a localised error message) when a request is denied and `null` when it is allowed. Update requests with `placements === null` are treated as metadata-only and require only `canEditDashboardMetadata`; requests carrying placements require the stricter `canEditDashboard`. Create requests additionally MUST fail with 403 when the user already owns at least one dashboard and `canHaveMultipleDashboards()` is false.
+
+#### Scenario: Metadata-only update allowed for users with metadata-edit permission
+
+- GIVEN a user with `canEditDashboardMetadata = true` but `canEditDashboard = false` on a dashboard
+- WHEN `checkUpdatePermissions(userId, dashboardId, placements: null)` is called
+- THEN it returns `null` (allowed) and the caller proceeds with the update
+
+#### Scenario: Layout update blocked for users without full edit permission
+
+- GIVEN a user with `canEditDashboardMetadata = true` but `canEditDashboard = false`
+- WHEN `checkUpdatePermissions(userId, dashboardId, placements: [...])` is called with a non-null placements array
+- THEN it returns a `JSONResponse` with status 403 and body `{ "error": "Access denied" }`
+
+#### Scenario: Multiple-dashboard creation blocked when admin setting is off
+
+- GIVEN a user who already owns at least one dashboard
+- AND the admin setting `canHaveMultipleDashboards(userId)` is false
+- WHEN `checkCreatePermissions(userId)` is called
+- THEN it returns a `JSONResponse` with status 403 and body `{ "error": "Multiple dashboards not allowed" }` (localised)
+
+### REQ-DASH-039: Dashboard create-request parameter resolution
+
+The system MUST accept dashboard creation parameters from EITHER a structured JSON body (a single `$name` parameter that is an array containing `name` and `description` keys) OR individual scalar parameters (`$name: string|null`, `$description: string|null`). When the structured-body form is used, missing `name` defaults to `'My Dashboard'` (untranslated) and missing `description` defaults to `null`. When the scalar form is used, a null name defaults to `$l10n->t('My Dashboard')` (translated). The update form MUST filter out null fields before persistence so that PATCH-style partial updates do not overwrite existing values.
+
+#### Scenario: Resolve create params from JSON body
+
+- GIVEN the request body parses to `['name' => 'Sales', 'description' => 'Q1 dashboard']`
+- WHEN `resolveCreateParams($body, null)` is called
+- THEN it returns `['name' => 'Sales', 'description' => 'Q1 dashboard']`
+
+#### Scenario: Resolve create params from scalar inputs
+
+- GIVEN `$name = null` and `$description = null`
+- WHEN `resolveCreateParams(null, null)` is called
+- THEN it returns `['name' => $l10n->t('My Dashboard'), 'description' => null]`
+
+#### Scenario: Partial update preserves untouched fields
+
+- GIVEN an existing dashboard with name `'A'`, description `'B'`, placements `[…]`
+- WHEN `buildUpdateData(name: 'Renamed', description: null, placements: null)` is called
+- THEN it returns `['name' => 'Renamed']` (description and placements are filtered out as nulls)
+
+### REQ-DASH-040: Dashboard response envelope shape and status codes
+
+The system MUST return every dashboard API response as a `JSONResponse` built through `ResponseHelper`. The envelope contract is:
+
+- Success responses use `{...payload...}` with status 200 (default) or a caller-specified 2xx code
+- Unauthorized responses use `{ "error": "Not logged in" }` with status 401
+- Forbidden responses use `{ "error": <message> }` with status 403 (default message: `"Access denied"`)
+- Error responses use `{ "error": <generic-message> }` with status 400 (or caller-specified)
+- List responses MUST be serialized via `ResponseHelper::serializeList()` which calls `jsonSerialize()` on each element
+
+#### Scenario: Unauthorized helper returns canonical 401
+
+- GIVEN no authenticated user
+- WHEN a controller calls `ResponseHelper::unauthorized()`
+- THEN the response body is `{ "error": "Not logged in" }` with HTTP status 401
+
+#### Scenario: Forbidden helper accepts custom message
+
+- WHEN a controller calls `ResponseHelper::forbidden('Dashboard creation not allowed')`
+- THEN the response body is `{ "error": "Dashboard creation not allowed" }` with HTTP status 403
+
+#### Scenario: Success helper accepts custom status
+
+- WHEN a controller calls `ResponseHelper::success(['id' => 1], 201)`
+- THEN the response body is `{ "id": 1 }` with HTTP status 201
+
+#### Scenario: Serialize list of dashboards
+
+- GIVEN an array of three `Dashboard` entities (each implementing `JsonSerializable`)
+- WHEN a controller calls `ResponseHelper::serializeList($dashboards)`
+- THEN it returns an array of three associative arrays, each the result of calling `jsonSerialize()` on the corresponding entity
+
+### REQ-DASH-041: Exception-to-error response without message leak
+
+The system MUST translate caught exceptions into JSON error responses via `ResponseHelper::error()` without ever exposing the raw exception message to the client (ADR-005). Callers SHOULD pass a `LoggerInterface` so the real exception (message + stack) is recorded at ERROR level on the server; the client always receives a generic `$message` (default `"Operation failed"`) and the caller-specified HTTP status (default 400).
+
+#### Scenario: Caught exception is logged and a generic error is returned
+
+- GIVEN a controller catches `\RuntimeException('Database constraint X violated')`
+- AND the controller has an injected `LoggerInterface`
+- WHEN the controller calls `ResponseHelper::error($e, 500, $logger, 'Could not save dashboard')`
+- THEN the logger records the raw `'Database constraint X violated'` message at ERROR level with the exception in the context
+- AND the response body is `{ "error": "Could not save dashboard" }` with HTTP status 500
+
+#### Scenario: Logger omitted — exception is silently swallowed
+
+- GIVEN a controller catches `\RuntimeException('secret')`
+- WHEN the controller calls `ResponseHelper::error($e, 400, null, 'Operation failed')`
+- THEN the response body is `{ "error": "Operation failed" }` with HTTP status 400
+- AND no log entry is written (observed behaviour — see Notes)
+
+#### Notes
+
+- The "logger optional" path in `ResponseHelper::error()` is a latent risk: a caller that forgets to wire the logger gets silently dropped exceptions with no audit trail. Future-tightening TODO: make `LoggerInterface` non-nullable in a follow-up change once every call site is converted.
+- `serializeList()` assumes every element implements `jsonSerialize()` — passing plain arrays results in a fatal `Error: Call to a member function jsonSerialize() on array`. This is a precondition, not a defensive check.

--- a/openspec/changes/archive/2026-05-24-retrofit-dashboards/tasks.md
+++ b/openspec/changes/archive/2026-05-24-retrofit-dashboards/tasks.md
@@ -1,0 +1,6 @@
+# Tasks
+
+- [x] task-1: dashboards#REQ-DASH-038 — Dashboard request validator permission gating (retroactive annotation)
+- [x] task-2: dashboards#REQ-DASH-039 — Dashboard create-request parameter resolution (retroactive annotation)
+- [x] task-3: dashboards#REQ-DASH-040 — Dashboard response envelope shape and status codes (retroactive annotation)
+- [x] task-4: dashboards#REQ-DASH-041 — Exception-to-error response without message leak (retroactive annotation)

--- a/openspec/specs/dashboards/spec.md
+++ b/openspec/specs/dashboards/spec.md
@@ -1,5 +1,10 @@
 ---
 status: implemented
+retrofit_extensions:
+  - REQ-DASH-038
+  - REQ-DASH-039
+  - REQ-DASH-040
+  - REQ-DASH-041
 ---
 
 # Dashboards Specification
@@ -1297,3 +1302,104 @@ The Pinia dashboard store MUST track `publicationStatus`, `publishAt`, and `publ
 - Nextcloud Controller patterns: `OCP\AppFramework\Controller`, `#[NoAdminRequired]` attribute
 - UUID generation: Custom UUID v4 implementation in `DashboardFactory::generateUuid()`
 - WCAG 2.1 AA: Dashboard management UI elements should be keyboard-operable
+
+### REQ-DASH-038: Dashboard request validator permission gating
+
+The system MUST centralise dashboard create + update permission checks in `DashboardRequestValidator`, returning a `JSONResponse` (with status 403 and a localised error message) when a request is denied and `null` when it is allowed. Update requests with `placements === null` are treated as metadata-only and require only `canEditDashboardMetadata`; requests carrying placements require the stricter `canEditDashboard`. Create requests additionally MUST fail with 403 when the user already owns at least one dashboard and `canHaveMultipleDashboards()` is false.
+
+#### Scenario: Metadata-only update allowed for users with metadata-edit permission
+
+- GIVEN a user with `canEditDashboardMetadata = true` but `canEditDashboard = false` on a dashboard
+- WHEN `checkUpdatePermissions(userId, dashboardId, placements: null)` is called
+- THEN it returns `null` (allowed) and the caller proceeds with the update
+
+#### Scenario: Layout update blocked for users without full edit permission
+
+- GIVEN a user with `canEditDashboardMetadata = true` but `canEditDashboard = false`
+- WHEN `checkUpdatePermissions(userId, dashboardId, placements: [...])` is called with a non-null placements array
+- THEN it returns a `JSONResponse` with status 403 and body `{ "error": "Access denied" }`
+
+#### Scenario: Multiple-dashboard creation blocked when admin setting is off
+
+- GIVEN a user who already owns at least one dashboard
+- AND the admin setting `canHaveMultipleDashboards(userId)` is false
+- WHEN `checkCreatePermissions(userId)` is called
+- THEN it returns a `JSONResponse` with status 403 and body `{ "error": "Multiple dashboards not allowed" }` (localised)
+
+### REQ-DASH-039: Dashboard create-request parameter resolution
+
+The system MUST accept dashboard creation parameters from EITHER a structured JSON body (a single `$name` parameter that is an array containing `name` and `description` keys) OR individual scalar parameters (`$name: string|null`, `$description: string|null`). When the structured-body form is used, missing `name` defaults to `'My Dashboard'` (untranslated) and missing `description` defaults to `null`. When the scalar form is used, a null name defaults to `$l10n->t('My Dashboard')` (translated). The update form MUST filter out null fields before persistence so that PATCH-style partial updates do not overwrite existing values.
+
+#### Scenario: Resolve create params from JSON body
+
+- GIVEN the request body parses to `['name' => 'Sales', 'description' => 'Q1 dashboard']`
+- WHEN `resolveCreateParams($body, null)` is called
+- THEN it returns `['name' => 'Sales', 'description' => 'Q1 dashboard']`
+
+#### Scenario: Resolve create params from scalar inputs
+
+- GIVEN `$name = null` and `$description = null`
+- WHEN `resolveCreateParams(null, null)` is called
+- THEN it returns `['name' => $l10n->t('My Dashboard'), 'description' => null]`
+
+#### Scenario: Partial update preserves untouched fields
+
+- GIVEN an existing dashboard with name `'A'`, description `'B'`, placements `[…]`
+- WHEN `buildUpdateData(name: 'Renamed', description: null, placements: null)` is called
+- THEN it returns `['name' => 'Renamed']` (description and placements are filtered out as nulls)
+
+### REQ-DASH-040: Dashboard response envelope shape and status codes
+
+The system MUST return every dashboard API response as a `JSONResponse` built through `ResponseHelper`. The envelope contract is:
+
+- Success responses use `{...payload...}` with status 200 (default) or a caller-specified 2xx code
+- Unauthorized responses use `{ "error": "Not logged in" }` with status 401
+- Forbidden responses use `{ "error": <message> }` with status 403 (default message: `"Access denied"`)
+- Error responses use `{ "error": <generic-message> }` with status 400 (or caller-specified)
+- List responses MUST be serialized via `ResponseHelper::serializeList()` which calls `jsonSerialize()` on each element
+
+#### Scenario: Unauthorized helper returns canonical 401
+
+- GIVEN no authenticated user
+- WHEN a controller calls `ResponseHelper::unauthorized()`
+- THEN the response body is `{ "error": "Not logged in" }` with HTTP status 401
+
+#### Scenario: Forbidden helper accepts custom message
+
+- WHEN a controller calls `ResponseHelper::forbidden('Dashboard creation not allowed')`
+- THEN the response body is `{ "error": "Dashboard creation not allowed" }` with HTTP status 403
+
+#### Scenario: Success helper accepts custom status
+
+- WHEN a controller calls `ResponseHelper::success(['id' => 1], 201)`
+- THEN the response body is `{ "id": 1 }` with HTTP status 201
+
+#### Scenario: Serialize list of dashboards
+
+- GIVEN an array of three `Dashboard` entities (each implementing `JsonSerializable`)
+- WHEN a controller calls `ResponseHelper::serializeList($dashboards)`
+- THEN it returns an array of three associative arrays, each the result of calling `jsonSerialize()` on the corresponding entity
+
+### REQ-DASH-041: Exception-to-error response without message leak
+
+The system MUST translate caught exceptions into JSON error responses via `ResponseHelper::error()` without ever exposing the raw exception message to the client (ADR-005). Callers SHOULD pass a `LoggerInterface` so the real exception (message + stack) is recorded at ERROR level on the server; the client always receives a generic `$message` (default `"Operation failed"`) and the caller-specified HTTP status (default 400).
+
+#### Scenario: Caught exception is logged and a generic error is returned
+
+- GIVEN a controller catches `\RuntimeException('Database constraint X violated')`
+- AND the controller has an injected `LoggerInterface`
+- WHEN the controller calls `ResponseHelper::error($e, 500, $logger, 'Could not save dashboard')`
+- THEN the logger records the raw `'Database constraint X violated'` message at ERROR level with the exception in the context
+- AND the response body is `{ "error": "Could not save dashboard" }` with HTTP status 500
+
+#### Scenario: Logger omitted — exception is silently swallowed
+
+- GIVEN a controller catches `\RuntimeException('secret')`
+- WHEN the controller calls `ResponseHelper::error($e, 400, null, 'Operation failed')`
+- THEN the response body is `{ "error": "Operation failed" }` with HTTP status 400
+- AND no log entry is written (observed behaviour — see Notes)
+
+#### Notes (REQ-DASH-038..041)
+
+- The "logger optional" path in `ResponseHelper::error()` is a latent risk: a caller that forgets to wire the logger gets silently dropped exceptions with no audit trail. Future-tightening TODO: make `LoggerInterface` non-nullable in a follow-up change once every call site is converted.
+- `serializeList()` assumes every element implements `jsonSerialize()` — passing plain arrays results in a fatal `Error: Call to a member function jsonSerialize() on array`. This is a precondition, not a defensive check.


### PR DESCRIPTION
## Retrofit — Reverse-Spec

Describes observed behavior of 9 methods under `dashboards` (two controller-helper classes) as 4 new REQs.

Ghost change: `archive/2026-05-24-retrofit-dashboards` (archived in this PR).

### What this PR does

- Drafts 4 REQs as `retrofit_extensions: [REQ-DASH-038..041]` on the dashboards spec frontmatter:
  - **REQ-DASH-038** — Dashboard request validator permission gating
  - **REQ-DASH-039** — Dashboard create-request parameter resolution
  - **REQ-DASH-040** — Dashboard response envelope shape and status codes
  - **REQ-DASH-041** — Exception-to-error response without message leak (ADR-005)
- Creates tasks.md with one task per REQ (all `[x]` — code already exists)
- Annotates 9 methods + 2 files with `@spec openspec/changes/archive/2026-05-24-retrofit-dashboards/tasks.md#task-N`
- Archives the change (merges spec delta into `openspec/specs/dashboards/spec.md`)

### What this PR does NOT do

- No code behaviour changes — pure annotation + spec
- Does not silently fix observed-but-suspicious behaviour:
  - `ResponseHelper::error()` nullable-logger silent-swallow is documented in REQ-DASH-041 Notes (TODO for future tightening)
  - `ResponseHelper::serializeList()` precondition (every element must implement `JsonSerializable`) is documented, not defended-against

### Review focus

- REQ language matches observed behaviour (not aspirational)
- Scenarios are testable
- One REQ per distinct observable behaviour — 4 REQs across 9 methods reflects the actual behaviour clustering (permission-gate, param-resolution, envelope, exception-translation)

Source: `openspec/coverage-report.md` generated 2026-05-24
Cluster: dashboards (Bucket 2a)
Refs #292