### PR TITLE
retrofit: reverse-spec widgets formatter+loader (3 REQs / 9 methods)

### DIFF
--- a/lib/Service/WidgetFormatter.php
+++ b/lib/Service/WidgetFormatter.php
@@ -12,6 +12,8 @@
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @version   GIT:auto
  * @link      https://conduction.nl
+ *
+ * @spec openspec/changes/archive/2026-05-24-retrofit-widgets/tasks.md#task-1
  */
 
 declare(strict_types=1);
@@ -40,6 +42,7 @@ class WidgetFormatter
      * @return array The formatted widget data.
      *
      * @spec openspec/changes/retrofit-2026-05-24-annotate-mydash/tasks.md#task-32
+     * @spec openspec/changes/archive/2026-05-24-retrofit-widgets/tasks.md#task-1
      */
     public function format(IWidget $widget, string $userId): array
     {
@@ -64,6 +67,8 @@ class WidgetFormatter
      * @param IWidget $widget The widget.
      *
      * @return array The base data.
+     *
+     * @spec openspec/changes/archive/2026-05-24-retrofit-widgets/tasks.md#task-1
      */
     private function buildBaseData(IWidget $widget): array
     {
@@ -88,6 +93,8 @@ class WidgetFormatter
      * @param array   $data   The data array (passed by reference).
      *
      * @return void
+     *
+     * @spec openspec/changes/archive/2026-05-24-retrofit-widgets/tasks.md#task-1
      */
     private function applyIconUrl(IWidget $widget, array &$data): void
     {
@@ -103,6 +110,8 @@ class WidgetFormatter
      * @param array   $data   The data array (passed by reference).
      *
      * @return void
+     *
+     * @spec openspec/changes/archive/2026-05-24-retrofit-widgets/tasks.md#task-1
      */
     private function applyApiVersions(
         IWidget $widget,
@@ -125,6 +134,8 @@ class WidgetFormatter
      * @param array   $data   The data array (passed by reference).
      *
      * @return void
+     *
+     * @spec openspec/changes/archive/2026-05-24-retrofit-widgets/tasks.md#task-1
      */
     private function applyButtons(
         IWidget $widget,
@@ -155,6 +166,8 @@ class WidgetFormatter
      * @param array   $data   The data array (passed by reference).
      *
      * @return void
+     *
+     * @spec openspec/changes/archive/2026-05-24-retrofit-widgets/tasks.md#task-1
      */
     private function applyOptions(IWidget $widget, array &$data): void
     {
@@ -171,6 +184,8 @@ class WidgetFormatter
      * @param array   $data   The data array (passed by reference).
      *
      * @return void
+     *
+     * @spec openspec/changes/archive/2026-05-24-retrofit-widgets/tasks.md#task-1
      */
     private function applyReloadInterval(
         IWidget $widget,

--- a/lib/Service/WidgetItemLoader.php
+++ b/lib/Service/WidgetItemLoader.php
@@ -12,6 +12,9 @@
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @version   GIT:auto
  * @link      https://conduction.nl
+ *
+ * @spec openspec/changes/archive/2026-05-24-retrofit-widgets/tasks.md#task-2
+ * @spec openspec/changes/archive/2026-05-24-retrofit-widgets/tasks.md#task-3
  */
 
 declare(strict_types=1);
@@ -38,6 +41,7 @@ class WidgetItemLoader
      * @return array The widget items keyed by widget ID.
      *
      * @spec openspec/changes/retrofit-2026-05-24-annotate-mydash/tasks.md#task-33
+     * @spec openspec/changes/archive/2026-05-24-retrofit-widgets/tasks.md#task-2
      */
     public function loadItems(
         array $widgets,
@@ -70,6 +74,8 @@ class WidgetItemLoader
      * @param int     $limit  Maximum items.
      *
      * @return array The widget items data.
+     *
+     * @spec openspec/changes/archive/2026-05-24-retrofit-widgets/tasks.md#task-2
      */
     private function loadSingleWidget(
         IWidget $widget,
@@ -107,6 +113,8 @@ class WidgetItemLoader
      * @param int          $limit  Maximum items.
      *
      * @return array The serialized items data.
+     *
+     * @spec openspec/changes/archive/2026-05-24-retrofit-widgets/tasks.md#task-3
      */
     private function loadV2Items(
         IAPIWidgetV2 $widget,
@@ -138,6 +146,8 @@ class WidgetItemLoader
      * @param int        $limit  Maximum items.
      *
      * @return array The serialized items data.
+     *
+     * @spec openspec/changes/archive/2026-05-24-retrofit-widgets/tasks.md#task-3
      */
     private function loadV1Items(
         IAPIWidget $widget,

--- a/openspec/changes/archive/2026-05-24-retrofit-widgets/design.md
+++ b/openspec/changes/archive/2026-05-24-retrofit-widgets/design.md
@@ -1,0 +1,37 @@
+# Design — retrofit-2026-05-24-widgets
+
+**Retrofit change. Tasks describe retroactive annotation, not new implementation work.**
+
+## Context
+
+The `widgets` capability is well-specced for end-user behaviour (REQ-WDG-001 .. REQ-WDG-023) and the widget data contract. During the 2026-05-24 coverage scan, two service classes were flagged as Bucket 2a — they exist and are exercised on every dashboard widget fetch, but no covering REQ describes their contract:
+
+- `lib/Service/WidgetFormatter.php` — 7 methods (1 public `format()`, 6 private apply-* helpers). Already partially annotated (`format()` carries `@spec ...annotate-mydash...task-32`) but the underlying contract for the envelope shape + capability-interface fan-out is not in the spec.
+- `lib/Service/WidgetItemLoader.php` — 4 methods (1 public `loadItems()`, 3 private dispatch/load helpers). Already partially annotated (`loadItems()` → task-33). The V2-preferred / V1-fallback dispatch strategy is not in the spec.
+
+## Approach
+
+Read each method, classify by observable behaviour:
+
+| REQ | Methods | Behaviour |
+|---|---|---|
+| REQ-WDG-024 | `WidgetFormatter::format` + 5 `apply*` + `buildBaseData` | Capability-interface fan-out into the envelope shape |
+| REQ-WDG-025 | `WidgetItemLoader::loadItems` + `loadSingleWidget` | Dispatch strategy: V2 preferred, V1 fallback, empty default |
+| REQ-WDG-026 | `WidgetItemLoader::loadV1Items` + `loadV2Items` | Item serialization + empty-content messaging asymmetry |
+
+Granularity rationale: the seven formatter methods all collaborate on one envelope. Splitting per-method would inflate to 7 REQs of low value. Collapsing into one envelope-contract REQ keeps the spec at the right abstraction level. The loader split (strategy REQ + serialization REQ) keeps the dispatch logic separable from the per-version item-shape concerns, which is where future divergence (e.g. V3) would land.
+
+## Annotation strategy
+
+Add `@spec openspec/changes/archive/2026-05-24-retrofit-widgets/tasks.md#task-N` tags. File-level tags on both files. Per-method tags on the 9 methods covered by this retrofit; existing `@spec ...annotate-mydash...` tags on `format()` and `loadItems()` are LEFT IN PLACE (they reference a different annotation cohort) and the new tags are appended.
+
+## Notes — observed-but-suspicious
+
+- `WidgetItemLoader::loadItems()` silent-skip of unknown widget IDs: callers cannot distinguish skipped-widget from no-items. Documented as observed behaviour; future-tightening TODO in spec Notes.
+- V1/V2 empty-content message asymmetry: inherent in the Nextcloud `IAPIWidget` contract, not a bug in our loader. Documented for clarity.
+
+## Source
+
+- Coverage report: `openspec/coverage-report.json` generated 2026-05-24
+- Umbrella issue: ConductionNL/mydash#292
+- Bucket: 2a (capability-owned, missing REQ)

--- a/openspec/changes/archive/2026-05-24-retrofit-widgets/proposal.md
+++ b/openspec/changes/archive/2026-05-24-retrofit-widgets/proposal.md
@@ -1,0 +1,41 @@
+# Retrofit — widgets (Bucket 2a)
+
+Describes observed behavior of 9 methods across 2 widget-service files under the `widgets` capability as 3 new REQs. Code already exists — this change retroactively specifies it.
+
+## Affected code units
+
+- `lib/Service/WidgetFormatter.php::format()` (already partially annotated)
+- `lib/Service/WidgetFormatter.php::buildBaseData()`
+- `lib/Service/WidgetFormatter.php::applyIconUrl()`
+- `lib/Service/WidgetFormatter.php::applyApiVersions()`
+- `lib/Service/WidgetFormatter.php::applyButtons()`
+- `lib/Service/WidgetFormatter.php::applyOptions()`
+- `lib/Service/WidgetFormatter.php::applyReloadInterval()`
+- `lib/Service/WidgetItemLoader.php::loadItems()` (already partially annotated)
+- `lib/Service/WidgetItemLoader.php::loadSingleWidget()`
+- `lib/Service/WidgetItemLoader.php::loadV1Items()`
+- `lib/Service/WidgetItemLoader.php::loadV2Items()`
+
+## Approach
+
+- For each method: describe observed inputs, outputs, pre/postconditions, failure modes
+- Draft REQs that match behavior (not aspirational)
+- Notes section surfaces any observed-but-suspicious behavior
+
+The existing `widgets` spec covers the widget data contract end-to-end (REQ-WDG-001 .. REQ-WDG-023) but does not describe two service-class abstractions that implement that contract:
+
+1. **`WidgetFormatter`** — converts Nextcloud `IWidget` instances into the API response array shape. The existing spec describes the *shape* of the API payload but not the formatter abstraction that maps capability-interfaces (`IIconWidget`, `IButtonWidget`, `IOptionWidget`, `IReloadableWidget`, `IAPIWidget`, `IAPIWidgetV2`) to envelope fields.
+2. **`WidgetItemLoader`** — lazy loader that dispatches between V1 (`IAPIWidget::getItems`) and V2 (`IAPIWidgetV2::getItemsV2`) widget item APIs. The existing spec mentions V1/V2 widgets but not the loader strategy that fans out a list of widget IDs to per-widget item fetches.
+
+This retrofit adds:
+- REQ-WDG-024 — Widget formatter envelope contract (capability-interface fan-out)
+- REQ-WDG-025 — Widget item loader strategy (V2-preferred, V1-fallback, empty default)
+- REQ-WDG-026 — Widget item serialization and empty-content messaging
+
+## Notes
+
+- `WidgetFormatter::applyButtons()` calls `getWidgetButtons(userId: $userId)`; the underlying `IButtonWidget::getWidgetButtons()` is a per-user API, so button visibility may depend on permissions inside the widget implementation. The REQ documents the observed call site but does not constrain individual widget impls.
+- `WidgetItemLoader::loadItems()` silently skips unknown widget IDs (the `isset($widgets[$widgetId]) === false` guard). Documented as observed behaviour — callers cannot distinguish "no items" from "widget not registered".
+- Items are serialised via `jsonSerialize()` (V2) or implicit jsonSerialize (V1); empty-content messaging differs between V1 (always empty string) and V2 (read from `WidgetItems` getter). Documented as observed behaviour.
+
+Source: `openspec/coverage-report.md` generated 2026-05-24. See [retrofit playbook](../../../.github/docs/claude/retrofit.md).

--- a/openspec/changes/archive/2026-05-24-retrofit-widgets/specs/widgets/spec.md
+++ b/openspec/changes/archive/2026-05-24-retrofit-widgets/specs/widgets/spec.md
@@ -1,0 +1,91 @@
+---
+retrofit_extensions:
+  - REQ-WDG-024
+  - REQ-WDG-025
+  - REQ-WDG-026
+---
+
+## ADDED Requirements
+
+### REQ-WDG-024: Widget formatter envelope contract
+
+The system MUST format every Nextcloud `IWidget` into a canonical envelope via `WidgetFormatter::format()`. The envelope MUST include the base fields (`id`, `title`, `order`, `iconClass`, `iconUrl`, `widgetUrl`, `itemIconsRound`, `itemApiVersions`, `reloadInterval`, `buttons`) and MUST conditionally enrich them based on which Nextcloud capability interfaces the widget implements:
+
+- `IIconWidget` → populate `iconUrl` via `getIconUrl()`
+- `IAPIWidget` → append `1` to `itemApiVersions`
+- `IAPIWidgetV2` → append `2` to `itemApiVersions`
+- `IButtonWidget` → populate `buttons[]` via `getWidgetButtons($userId)`, each button serialized as `{type, text, link}`
+- `IOptionWidget` → set `itemIconsRound` from `getWidgetOptions()->withRoundItemIcons()`
+- `IReloadableWidget` → set `reloadInterval` from `getReloadInterval()`
+
+Widgets that implement none of the optional capability interfaces MUST receive the base envelope unchanged (`itemApiVersions: []`, `buttons: []`, `reloadInterval: 0`, `iconUrl: null`, `itemIconsRound: false`).
+
+#### Scenario: Format a basic widget with no optional capabilities
+
+- GIVEN an `IWidget` that does not implement any of the optional capability interfaces
+- WHEN `WidgetFormatter::format($widget, $userId)` is called
+- THEN the result has `itemApiVersions: []`, `buttons: []`, `reloadInterval: 0`, `iconUrl: null`, `itemIconsRound: false`
+- AND the result still includes the base `id`, `title`, `order`, `iconClass`, `widgetUrl` from the widget
+
+#### Scenario: Format a widget that implements both API versions
+
+- GIVEN an `IWidget` that implements both `IAPIWidget` and `IAPIWidgetV2`
+- WHEN `WidgetFormatter::format($widget, $userId)` is called
+- THEN the result has `itemApiVersions: [1, 2]` (in declaration order, V1 first)
+
+#### Scenario: Format a button widget includes per-button serialization
+
+- GIVEN an `IButtonWidget` whose `getWidgetButtons($userId)` returns two buttons (Add: `link=/add`, Settings: `link=/settings`)
+- WHEN `WidgetFormatter::format($widget, $userId)` is called
+- THEN `result.buttons` is `[{type: 'Add', text: '...', link: '/add'}, {type: 'Settings', text: '...', link: '/settings'}]`
+
+### REQ-WDG-025: Widget item loader strategy
+
+The system MUST load widget items via `WidgetItemLoader::loadItems()`, which accepts a map of registered widgets, a user ID, a list of widget IDs to load, and a per-widget item limit (default 7). For each requested widget ID:
+
+- If the widget is NOT in the registered-widgets map, the loader MUST silently skip it (no entry in the result)
+- If the widget implements `IAPIWidgetV2`, the loader MUST use the V2 API (`getItemsV2(userId, since: null, limit)`)
+- Else if the widget implements `IAPIWidget`, the loader MUST fall back to the V1 API (`getItems(userId, since: null, limit)`)
+- Else the loader MUST return the empty-default envelope `{items: [], emptyContentMessage: '', halfEmptyContentMessage: ''}` for that widget ID
+
+The result MUST be keyed by widget ID and MUST contain one entry per non-skipped widget ID.
+
+#### Scenario: Loader skips unknown widget IDs silently
+
+- GIVEN a registered-widgets map containing only `widget-a`
+- WHEN `loadItems($widgets, $userId, ['widget-a', 'widget-unknown'], 7)` is called
+- THEN the result contains exactly one key `'widget-a'` (no entry for `'widget-unknown'`)
+
+#### Scenario: V2-capable widget uses V2 API
+
+- GIVEN a widget that implements both `IAPIWidget` and `IAPIWidgetV2`
+- WHEN the loader processes that widget
+- THEN `getItemsV2()` is called (V1 API is NOT called)
+
+#### Scenario: Non-API widget gets empty-default envelope
+
+- GIVEN a widget that implements neither `IAPIWidget` nor `IAPIWidgetV2`
+- WHEN the loader processes that widget
+- THEN the entry for that widget ID is `{items: [], emptyContentMessage: '', halfEmptyContentMessage: ''}`
+
+### REQ-WDG-026: Widget item serialization and empty-content messaging
+
+The system MUST serialize widget items via `WidgetItem::jsonSerialize()` (both V1 and V2 APIs). The V2 API MUST additionally surface `emptyContentMessage` and `halfEmptyContentMessage` from the `WidgetItems` collection getter. The V1 API MUST set both messages to the empty string (the V1 contract does not provide them).
+
+#### Scenario: V2 serializes items and empty-content messages
+
+- GIVEN a V2 widget returning two items + empty message `'No items'` + half-empty message `'Almost empty'`
+- WHEN the loader processes that widget
+- THEN the entry has `items: [<2 serialized items>], emptyContentMessage: 'No items', halfEmptyContentMessage: 'Almost empty'`
+
+#### Scenario: V1 serializes items and returns empty messages
+
+- GIVEN a V1 widget returning three items
+- WHEN the loader processes that widget
+- THEN the entry has `items: [<3 serialized items>], emptyContentMessage: '', halfEmptyContentMessage: ''`
+
+#### Notes (REQ-WDG-024..026)
+
+- `applyButtons` reaches into the widget impl per-user; button visibility is a widget-impl concern, not the formatter's. The REQ documents the call site, not the underlying permission model.
+- Loader's silent-skip of unknown widget IDs means callers cannot distinguish "widget returned no items" from "widget not registered". Future tightening (e.g. return a `null` sentinel for skipped IDs) is deferred — would be a breaking API change.
+- The V1/V2 empty-message asymmetry is inherent in the Nextcloud `IAPIWidget` contract; V1 callers will always see `emptyContentMessage: ''`. The frontend already special-cases the empty string.

--- a/openspec/changes/archive/2026-05-24-retrofit-widgets/tasks.md
+++ b/openspec/changes/archive/2026-05-24-retrofit-widgets/tasks.md
@@ -1,0 +1,5 @@
+# Tasks
+
+- [x] task-1: widgets#REQ-WDG-024 — Widget formatter envelope contract (retroactive annotation)
+- [x] task-2: widgets#REQ-WDG-025 — Widget item loader strategy (retroactive annotation)
+- [x] task-3: widgets#REQ-WDG-026 — Widget item serialization and empty-content messaging (retroactive annotation)

--- a/openspec/specs/widgets/spec.md
+++ b/openspec/specs/widgets/spec.md
@@ -1,5 +1,9 @@
 ---
 status: implemented
+retrofit_extensions:
+  - REQ-WDG-024
+  - REQ-WDG-025
+  - REQ-WDG-026
 ---
 
 # Widgets Specification
@@ -769,3 +773,86 @@ When a new widget capability lands, the EXPECTED_TYPES constant MUST be updated 
 - Nextcloud Widget Item format: title, subtitle, link, iconUrl (from `IWidgetItem`)
 - WCAG 2.1 AA: Widget labels via customTitle or default widget title for screen readers
 - WAI-ARIA: Widget placements should have appropriate landmark roles for keyboard navigation
+
+### REQ-WDG-024: Widget formatter envelope contract
+
+The system MUST format every Nextcloud `IWidget` into a canonical envelope via `WidgetFormatter::format()`. The envelope MUST include the base fields (`id`, `title`, `order`, `iconClass`, `iconUrl`, `widgetUrl`, `itemIconsRound`, `itemApiVersions`, `reloadInterval`, `buttons`) and MUST conditionally enrich them based on which Nextcloud capability interfaces the widget implements:
+
+- `IIconWidget` → populate `iconUrl` via `getIconUrl()`
+- `IAPIWidget` → append `1` to `itemApiVersions`
+- `IAPIWidgetV2` → append `2` to `itemApiVersions`
+- `IButtonWidget` → populate `buttons[]` via `getWidgetButtons($userId)`, each button serialized as `{type, text, link}`
+- `IOptionWidget` → set `itemIconsRound` from `getWidgetOptions()->withRoundItemIcons()`
+- `IReloadableWidget` → set `reloadInterval` from `getReloadInterval()`
+
+Widgets that implement none of the optional capability interfaces MUST receive the base envelope unchanged (`itemApiVersions: []`, `buttons: []`, `reloadInterval: 0`, `iconUrl: null`, `itemIconsRound: false`).
+
+#### Scenario: Format a basic widget with no optional capabilities
+
+- GIVEN an `IWidget` that does not implement any of the optional capability interfaces
+- WHEN `WidgetFormatter::format($widget, $userId)` is called
+- THEN the result has `itemApiVersions: []`, `buttons: []`, `reloadInterval: 0`, `iconUrl: null`, `itemIconsRound: false`
+- AND the result still includes the base `id`, `title`, `order`, `iconClass`, `widgetUrl` from the widget
+
+#### Scenario: Format a widget that implements both API versions
+
+- GIVEN an `IWidget` that implements both `IAPIWidget` and `IAPIWidgetV2`
+- WHEN `WidgetFormatter::format($widget, $userId)` is called
+- THEN the result has `itemApiVersions: [1, 2]` (in declaration order, V1 first)
+
+#### Scenario: Format a button widget includes per-button serialization
+
+- GIVEN an `IButtonWidget` whose `getWidgetButtons($userId)` returns two buttons (Add: `link=/add`, Settings: `link=/settings`)
+- WHEN `WidgetFormatter::format($widget, $userId)` is called
+- THEN `result.buttons` is `[{type: 'Add', text: '...', link: '/add'}, {type: 'Settings', text: '...', link: '/settings'}]`
+
+### REQ-WDG-025: Widget item loader strategy
+
+The system MUST load widget items via `WidgetItemLoader::loadItems()`, which accepts a map of registered widgets, a user ID, a list of widget IDs to load, and a per-widget item limit (default 7). For each requested widget ID:
+
+- If the widget is NOT in the registered-widgets map, the loader MUST silently skip it (no entry in the result)
+- If the widget implements `IAPIWidgetV2`, the loader MUST use the V2 API (`getItemsV2(userId, since: null, limit)`)
+- Else if the widget implements `IAPIWidget`, the loader MUST fall back to the V1 API (`getItems(userId, since: null, limit)`)
+- Else the loader MUST return the empty-default envelope `{items: [], emptyContentMessage: '', halfEmptyContentMessage: ''}` for that widget ID
+
+The result MUST be keyed by widget ID and MUST contain one entry per non-skipped widget ID.
+
+#### Scenario: Loader skips unknown widget IDs silently
+
+- GIVEN a registered-widgets map containing only `widget-a`
+- WHEN `loadItems($widgets, $userId, ['widget-a', 'widget-unknown'], 7)` is called
+- THEN the result contains exactly one key `'widget-a'` (no entry for `'widget-unknown'`)
+
+#### Scenario: V2-capable widget uses V2 API
+
+- GIVEN a widget that implements both `IAPIWidget` and `IAPIWidgetV2`
+- WHEN the loader processes that widget
+- THEN `getItemsV2()` is called (V1 API is NOT called)
+
+#### Scenario: Non-API widget gets empty-default envelope
+
+- GIVEN a widget that implements neither `IAPIWidget` nor `IAPIWidgetV2`
+- WHEN the loader processes that widget
+- THEN the entry for that widget ID is `{items: [], emptyContentMessage: '', halfEmptyContentMessage: ''}`
+
+### REQ-WDG-026: Widget item serialization and empty-content messaging
+
+The system MUST serialize widget items via `WidgetItem::jsonSerialize()` (both V1 and V2 APIs). The V2 API MUST additionally surface `emptyContentMessage` and `halfEmptyContentMessage` from the `WidgetItems` collection getter. The V1 API MUST set both messages to the empty string (the V1 contract does not provide them).
+
+#### Scenario: V2 serializes items and empty-content messages
+
+- GIVEN a V2 widget returning two items + empty message `'No items'` + half-empty message `'Almost empty'`
+- WHEN the loader processes that widget
+- THEN the entry has `items: [<2 serialized items>], emptyContentMessage: 'No items', halfEmptyContentMessage: 'Almost empty'`
+
+#### Scenario: V1 serializes items and returns empty messages
+
+- GIVEN a V1 widget returning three items
+- WHEN the loader processes that widget
+- THEN the entry has `items: [<3 serialized items>], emptyContentMessage: '', halfEmptyContentMessage: ''`
+
+#### Notes (REQ-WDG-024..026)
+
+- `applyButtons` reaches into the widget impl per-user; button visibility is a widget-impl concern, not the formatter's. The REQ documents the call site, not the underlying permission model.
+- Loader's silent-skip of unknown widget IDs means callers cannot distinguish "widget returned no items" from "widget not registered". Future tightening (e.g. return a `null` sentinel for skipped IDs) is deferred — would be a breaking API change.
+- The V1/V2 empty-message asymmetry is inherent in the Nextcloud `IAPIWidget` contract; V1 callers will always see `emptyContentMessage: ''`. The frontend already special-cases the empty string.


### PR DESCRIPTION
## Retrofit — Reverse-Spec

Describes observed behavior of 9 methods under `widgets` (two service classes that implement the widget data contract) as 3 new REQs.

Ghost change: `archive/2026-05-24-retrofit-widgets` (archived in this PR).

### What this PR does

- Drafts 3 REQs as `retrofit_extensions: [REQ-WDG-024..026]` on the widgets spec frontmatter:
  - **REQ-WDG-024** — Widget formatter envelope contract (capability-interface fan-out into iconUrl / buttons / options / reload / V1+V2 API versions)
  - **REQ-WDG-025** — Widget item loader strategy (V2-preferred, V1-fallback, empty-default envelope for non-API widgets, silent-skip for unregistered IDs)
  - **REQ-WDG-026** — Widget item serialization and empty-content messaging (V2 surfaces empty/half-empty messages; V1 always returns empty string)
- Creates tasks.md with one task per REQ (all `[x]` — code already exists)
- Annotates 9 methods + 2 files with `@spec openspec/changes/archive/2026-05-24-retrofit-widgets/tasks.md#task-N` (Phase 2 annotations on `format()` and `loadItems()` are LEFT IN PLACE; new tags are appended)
- Archives the change (merges spec delta into `openspec/specs/widgets/spec.md`)

### What this PR does NOT do

- No code behaviour changes — pure annotation + spec
- Does not silently fix observed-but-suspicious behaviour:
  - `WidgetItemLoader::loadItems()` silent-skip of unknown widget IDs is documented (callers cannot distinguish skipped from no-items). Future tightening would be a breaking API change — deferred.
  - V1/V2 empty-message asymmetry is documented as inherent in the Nextcloud `IAPIWidget` contract, not a bug in our loader.

### Review focus

- REQ language matches observed behaviour (not aspirational)
- Scenarios are testable
- One REQ per distinct observable behaviour — 3 REQs (envelope, dispatch, serialization) reflect the actual responsibilities of the two service classes

Source: `openspec/coverage-report.md` generated 2026-05-24
Cluster: widgets (Bucket 2a)
Refs #292