### PR TITLE
retrofit: mint infrastructure-helpers capability (3 REQs / 6 methods)

### DIFF
--- a/lib/Controller/RequestDataExtractor.php
+++ b/lib/Controller/RequestDataExtractor.php
@@ -12,6 +12,8 @@
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @version   GIT:auto
  * @link      https://conduction.nl
+ *
+ * @spec openspec/changes/archive/2026-05-24-retrofit-infrastructure-helpers/tasks.md#task-3
  */
 
 declare(strict_types=1);
@@ -31,6 +33,8 @@ class RequestDataExtractor
      * @param IRequest $request The request.
      *
      * @return array The tile configuration data.
+     *
+     * @spec openspec/changes/archive/2026-05-24-retrofit-infrastructure-helpers/tasks.md#task-3
      */
     public static function extractTileData(IRequest $request): array
     {
@@ -80,6 +84,8 @@ class RequestDataExtractor
      * @param IRequest $request The request.
      *
      * @return array The non-null placement field values.
+     *
+     * @spec openspec/changes/archive/2026-05-24-retrofit-infrastructure-helpers/tasks.md#task-3
      */
     public static function extractPlacementData(IRequest $request): array
     {

--- a/lib/Service/SlugGenerator.php
+++ b/lib/Service/SlugGenerator.php
@@ -19,6 +19,8 @@
  *
  * SPDX-FileCopyrightText: 2026 MyDash Contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * @spec openspec/changes/archive/2026-05-24-retrofit-infrastructure-helpers/tasks.md#task-1
  */
 
 declare(strict_types=1);
@@ -66,6 +68,8 @@ class SlugGenerator
      * @param string $name The dashboard name.
      *
      * @return string The slugified value (may be empty).
+     *
+     * @spec openspec/changes/archive/2026-05-24-retrofit-infrastructure-helpers/tasks.md#task-1
      */
     public static function slugify(string $name): string
     {
@@ -99,6 +103,8 @@ class SlugGenerator
      * @param string $slug The candidate slug.
      *
      * @return bool True when the slug is acceptable.
+     *
+     * @spec openspec/changes/archive/2026-05-24-retrofit-infrastructure-helpers/tasks.md#task-1
      */
     public static function isValid(string $slug): bool
     {

--- a/lib/Service/UserAttributeResolver.php
+++ b/lib/Service/UserAttributeResolver.php
@@ -12,6 +12,8 @@
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @version   GIT:auto
  * @link      https://conduction.nl
+ *
+ * @spec openspec/changes/archive/2026-05-24-retrofit-infrastructure-helpers/tasks.md#task-2
  */
 
 declare(strict_types=1);
@@ -51,6 +53,7 @@ class UserAttributeResolver
      * @return string|null The attribute value or null.
      *
      * @spec openspec/changes/retrofit-2026-05-24-annotate-mydash/tasks.md#task-12
+     * @spec openspec/changes/archive/2026-05-24-retrofit-infrastructure-helpers/tasks.md#task-2
      */
     public function getUserAttributeValue(
         string $userId,
@@ -83,6 +86,8 @@ class UserAttributeResolver
      * @param string|null $value     The target comparison value.
      *
      * @return bool Whether the comparison matches.
+     *
+     * @spec openspec/changes/archive/2026-05-24-retrofit-infrastructure-helpers/tasks.md#task-2
      */
     public function evaluateOperator(
         string $userValue,

--- a/openspec/changes/archive/2026-05-24-retrofit-infrastructure-helpers/design.md
+++ b/openspec/changes/archive/2026-05-24-retrofit-infrastructure-helpers/design.md
@@ -1,0 +1,53 @@
+# Design — retrofit-2026-05-24-infrastructure-helpers
+
+**Retrofit change. Tasks describe retroactive annotation, not new implementation work.**
+
+## Context
+
+Three helper classes were flagged Bucket 2b by the 2026-05-24 coverage scan:
+
+- `lib/Service/SlugGenerator.php` (2 methods) — pure static slug helpers used by `DashboardFactory` and the dashboard tree update path
+- `lib/Service/UserAttributeResolver.php` (2 methods + ctor) — backs the attribute lookup half of `conditional-visibility`
+- `lib/Controller/RequestDataExtractor.php` (2 methods) — extracts tile + placement form data from `IRequest`
+
+The coverage scan notes (with the "no namespace-word warning" confirmation) that `infrastructure-helpers` is a behavioural grouping — these helpers don't fit any single existing capability.
+
+## Why mint a new capability rather than `--extend`?
+
+Per ADR-003 and the reverse-spec SKILL, the default is `--extend` to keep capability boundaries stable. Considered alternatives:
+
+| Option | Why rejected |
+|---|---|
+| `--extend dashboards` (SlugGenerator) | Slug helper is conceptually reusable beyond dashboards; tiles + future named resources need it too |
+| `--extend conditional-visibility` (UserAttributeResolver) | Resolver is a generic primitive (lookup + comparison) — the visibility logic that *uses* it stays in `conditional-visibility` |
+| `--extend tiles` + `--extend widgets` (RequestDataExtractor) | Splitting per-method would duplicate the helper's contract across two specs and obscure that it's one helper class with two methods |
+| `--extend` three different capabilities | Would scatter the helpers' shared architectural contract (statelessness, no persistence, no domain rules) across three specs |
+
+Minting `infrastructure-helpers` keeps these helpers' shared shape documented in one place. The capability spec includes a `## Scope` section that prevents drift — future helpers that *do* fit a domain capability should land there, not here.
+
+## Approach
+
+Three REQs, one per file:
+
+| REQ | File | Behaviour |
+|---|---|---|
+| REQ-INFRA-001 | `SlugGenerator` | Slug grammar, transform pipeline, empty-string-on-no-legal-chars, validation |
+| REQ-INFRA-002 | `UserAttributeResolver` | 4 supported attributes (locale/email/displayName/quota), null-on-unknown-user-or-attr, 5 comparison operators, false-on-unknown-operator |
+| REQ-INFRA-003 | `RequestDataExtractor` | Tile data shape with defaults + key remaps (textColor → txtColor, linkValue → linkVal), placement data null-filter for 16 fixed fields |
+
+## Annotation strategy
+
+File-level `@spec` tags on all three files. Per-method tags on each public method covered. Existing `@spec ...annotate-mydash...task-12` on `UserAttributeResolver::getUserAttributeValue()` is LEFT IN PLACE and the new tag is appended.
+
+## Notes — observed-but-suspicious
+
+- `RequestDataExtractor::extractPlacementData()` skips type casting (`gridX` stays a string), asymmetric with `extractTileData()` which casts. Documented for future cleanup.
+- `UserAttributeResolver::evaluateOperator()` silently returns false for unknown operators. Could throw `InvalidArgumentException` so frontend bugs surface louder; deferred.
+- `SlugGenerator::slugify('')` returns empty — caller responsibility to fall back to UUID. Intentional, documented to prevent regression.
+
+## Source
+
+- Coverage report: `openspec/coverage-report.json` generated 2026-05-24
+- Umbrella issue: ConductionNL/mydash#292
+- Bucket: 2b (no owning capability)
+- Cluster label: `infrastructure-helpers` (behavioural grouping; not a namespace word)

--- a/openspec/changes/archive/2026-05-24-retrofit-infrastructure-helpers/proposal.md
+++ b/openspec/changes/archive/2026-05-24-retrofit-infrastructure-helpers/proposal.md
@@ -1,0 +1,39 @@
+# Retrofit — infrastructure-helpers (Bucket 2b)
+
+Mints a new `infrastructure-helpers` capability for three cross-cutting helper classes that have no single owning capability. Code already exists — this change retroactively specifies the helpers' shared contract.
+
+## Affected code units
+
+- `lib/Service/SlugGenerator.php::slugify()`
+- `lib/Service/SlugGenerator.php::isValid()`
+- `lib/Service/UserAttributeResolver.php::getUserAttributeValue()` (already partially annotated)
+- `lib/Service/UserAttributeResolver.php::evaluateOperator()`
+- `lib/Controller/RequestDataExtractor.php::extractTileData()`
+- `lib/Controller/RequestDataExtractor.php::extractPlacementData()`
+
+(Constructors excluded — pure DI plumbing.)
+
+## Approach
+
+Three small helper classes share the same architectural shape: pure / nearly-pure utility methods, no persistence, used from multiple capabilities. Coverage scan flagged them as Bucket 2b because:
+
+- `SlugGenerator` is referenced by `dashboards` (REQ-DASH-024 inline) but the helper is conceptually reusable; it would also support `tiles`, `widgets`, or any future named-resource flow.
+- `UserAttributeResolver` is currently used by `conditional-visibility` (REQ-VIS-008 inline) but its contract (lookup user attributes via Nextcloud APIs, evaluate string comparison operators) is a generic primitive.
+- `RequestDataExtractor` extracts per-form data shapes for `tiles` (`extractTileData`) and `widgets`/placements (`extractPlacementData`), spanning two capabilities.
+
+Rather than splitting these into capability-specific REQs (which would duplicate the contract or fragment it), this change mints a thin `infrastructure-helpers` capability with three REQs — one per file/concern. Future cross-capability helpers can be appended here.
+
+This retrofit adds:
+- REQ-INFRA-001 — Slug generation and validation contract
+- REQ-INFRA-002 — User attribute resolution and operator evaluation
+- REQ-INFRA-003 — Request data extraction for tile + placement forms
+
+## Notes
+
+- `SlugGenerator::slugify()` returns an empty string when the input yields no legal characters; the caller (DashboardFactory) is responsible for substituting a UUID fallback. The REQ documents the empty-string return as observed behaviour.
+- `UserAttributeResolver::getUserAttributeValue()` defaults to `'en'` for `locale` when no per-user lang preference is set. Documented.
+- `UserAttributeResolver::evaluateOperator()` returns `false` for unknown operators (no exception, no warning). Documented as defensive behaviour.
+- `RequestDataExtractor::extractTileData()` ships default values for every field including the legacy `#0082c9` Nextcloud-blue background. The defaults are observed — keep as-is until a wider tile-defaults review.
+- `RequestDataExtractor::extractPlacementData()` does NOT validate field types; the caller (TileApiController / WidgetApiController) is responsible for downstream validation. Documented as a precondition.
+
+Source: `openspec/coverage-report.md` generated 2026-05-24. See [retrofit playbook](../../../.github/docs/claude/retrofit.md).

--- a/openspec/changes/archive/2026-05-24-retrofit-infrastructure-helpers/specs/infrastructure-helpers/spec.md
+++ b/openspec/changes/archive/2026-05-24-retrofit-infrastructure-helpers/specs/infrastructure-helpers/spec.md
@@ -1,0 +1,156 @@
+---
+retrofit: true
+---
+
+# Infrastructure Helpers Specification
+
+## Purpose
+
+The `infrastructure-helpers` capability collects small, pure (or nearly-pure) utility classes that are reused across multiple capability boundaries. These are not domain logic — they are primitives: string transformation, lookup, parameter extraction. Each helper has a single narrow contract, no persistence, and is invoked from multiple capability code paths. Grouping them here keeps each individual capability spec focused on domain behaviour rather than utility internals.
+
+## Scope
+
+This capability MUST contain only helpers that:
+
+- Are stateless or depend only on injected Nextcloud framework interfaces
+- Are used by at least two distinct capabilities (or are a primitive that obviously belongs nowhere else)
+- Have no persistence side effects
+- Have no domain-specific business rules — domain rules belong to the owning capability
+
+## ADDED Requirements
+
+### REQ-INFRA-001: Slug generation and validation
+
+The system MUST provide a static `SlugGenerator` helper that converts arbitrary user-supplied names into URL-safe slugs and validates caller-supplied slugs against the pinned grammar. The slug grammar is `^[a-z0-9_-]+$` (lowercase ASCII alphanumerics, dash, underscore), maximum 128 characters (matching the `slug VARCHAR(128)` database column).
+
+`slugify($name)` MUST:
+1. Lowercase the input
+2. Replace any run of whitespace with a single dash
+3. Strip every character outside the slug grammar
+4. Collapse consecutive dashes to a single dash
+5. Trim leading and trailing dashes
+6. Truncate to 128 characters (re-trim any trailing dash left by the cut)
+
+`slugify()` MUST return the empty string when the input is empty or yields no legal characters; the caller decides whether to substitute a UUID fallback or reject the request.
+
+`isValid($slug)` MUST return false for the empty string, for any string longer than 128 characters, and for any string not matching the grammar; true otherwise.
+
+#### Scenario: Multi-word name becomes dashed slug
+
+- WHEN `SlugGenerator::slugify('Q1 Campaigns')` is called
+- THEN the result is `'q1-campaigns'`
+
+#### Scenario: Special characters are stripped
+
+- WHEN `SlugGenerator::slugify('My Dashboard! (v2)')` is called
+- THEN the result is `'my-dashboard-v2'`
+
+#### Scenario: Empty input returns empty string
+
+- WHEN `SlugGenerator::slugify('***')` is called (no legal characters)
+- THEN the result is `''`
+
+#### Scenario: Over-length input is truncated without trailing dash
+
+- GIVEN a 200-character input
+- WHEN `SlugGenerator::slugify($input)` is called
+- THEN the result is at most 128 characters AND does not end with `-`
+
+#### Scenario: Validate rejects empty string
+
+- WHEN `SlugGenerator::isValid('')` is called
+- THEN the result is `false`
+
+#### Scenario: Validate rejects uppercase
+
+- WHEN `SlugGenerator::isValid('MyDashboard')` is called
+- THEN the result is `false`
+
+#### Scenario: Validate accepts grammar match
+
+- WHEN `SlugGenerator::isValid('q1-campaigns_v2')` is called
+- THEN the result is `true`
+
+### REQ-INFRA-002: User attribute resolution and operator evaluation
+
+The system MUST provide `UserAttributeResolver` to back attribute-based features (e.g. conditional visibility rules — REQ-VIS-008). The resolver MUST expose two methods:
+
+- `getUserAttributeValue($userId, $attribute)` — return the requested attribute as a string (or null when the user does not exist, or when the attribute is not in the supported set). Supported attributes: `locale` (defaults to `'en'` when no per-user `core/lang` preference is set), `email`, `displayName`, `quota` (stringified). Unknown attribute names MUST return null.
+- `evaluateOperator($userValue, $operator, $value)` — return whether the comparison matches. Supported operators: `equals`, `not_equals`, `contains`, `starts_with`, `ends_with`. Unknown operators MUST return false (no exception, no warning). When `$value` is null, the string-comparison operators treat it as an empty string.
+
+#### Scenario: Resolve locale falls back to 'en'
+
+- GIVEN a user with no `core/lang` preference set
+- WHEN `getUserAttributeValue($userId, 'locale')` is called
+- THEN the result is `'en'`
+
+#### Scenario: Unknown attribute returns null
+
+- WHEN `getUserAttributeValue($userId, 'twitter_handle')` is called
+- THEN the result is `null`
+
+#### Scenario: Non-existent user returns null
+
+- WHEN `getUserAttributeValue('does-not-exist', 'email')` is called
+- THEN the result is `null`
+
+#### Scenario: Operator evaluation — equals match
+
+- WHEN `evaluateOperator('en', 'equals', 'en')` is called
+- THEN the result is `true`
+
+#### Scenario: Operator evaluation — unknown operator returns false
+
+- WHEN `evaluateOperator('en', 'regex_match', '^en')` is called
+- THEN the result is `false` (no exception thrown)
+
+#### Scenario: Operator evaluation — null comparison value treated as empty string
+
+- WHEN `evaluateOperator('hello', 'contains', null)` is called
+- THEN the result is `true` (every string contains the empty string)
+
+### REQ-INFRA-003: Request data extraction for tile and placement forms
+
+The system MUST provide `RequestDataExtractor` to convert `IRequest` parameters into typed array shapes for tile creation and placement updates. The extractor MUST:
+
+- `extractTileData($request)` — return an associative array with the keys `title`, `icon`, `iconType`, `bgColor`, `txtColor`, `linkType`, `linkVal`, `gridX`, `gridY`. Every field has a default (`title='New Tile'`, `icon='icon-link'`, `iconType='class'`, `bgColor='#0082c9'`, `txtColor='#ffffff'`, `linkType='app'`, `linkVal=''`, `gridX=0`, `gridY=0`). `gridX` and `gridY` MUST be cast to integers. The request parameter name `textColor` MUST be mapped to the output key `txtColor`; the request parameter name `linkValue` MUST be mapped to the output key `linkVal`.
+- `extractPlacementData($request)` — iterate over the fixed list of 16 placement field names (`gridX`, `gridY`, `gridWidth`, `gridHeight`, `isVisible`, `showTitle`, `customTitle`, `customIcon`, `styleConfig`, `tileTitle`, `tileIcon`, `tileIconType`, `tileBackgroundColor`, `tileTextColor`, `tileLinkType`, `tileLinkValue`) and return only the fields whose request parameter is not null. The output preserves request-parameter values as-is (no type casting).
+
+Neither method validates field shapes or values — downstream callers are responsible for validation.
+
+#### Scenario: extractTileData returns defaults for missing params
+
+- GIVEN a request with no parameters set
+- WHEN `RequestDataExtractor::extractTileData($request)` is called
+- THEN the result is `{title: 'New Tile', icon: 'icon-link', iconType: 'class', bgColor: '#0082c9', txtColor: '#ffffff', linkType: 'app', linkVal: '', gridX: 0, gridY: 0}`
+
+#### Scenario: extractTileData maps textColor → txtColor and linkValue → linkVal
+
+- GIVEN a request with `textColor='#000'` and `linkValue='/foo'`
+- WHEN `extractTileData($request)` is called
+- THEN the result has `txtColor: '#000'` and `linkVal: '/foo'`
+
+#### Scenario: extractPlacementData filters null fields
+
+- GIVEN a request with only `gridX=2` set (all other 15 fields are null)
+- WHEN `extractPlacementData($request)` is called
+- THEN the result is `{gridX: 2}` (single key)
+
+#### Scenario: extractPlacementData preserves all 16 fields when all are set
+
+- GIVEN a request with all 16 placement fields set to non-null values
+- WHEN `extractPlacementData($request)` is called
+- THEN the result is an array of 16 entries, with values preserved as-is (no type casting)
+
+## Non-Functional Requirements
+
+- **Purity:** Helpers in this capability MUST be stateless or depend only on injected Nextcloud framework interfaces. No persistence side effects.
+- **Reusability:** Helpers in this capability MUST be useful to at least two capability code paths.
+- **Domain neutrality:** Helpers MUST NOT encode capability-specific business rules — those belong to the owning capability's spec.
+
+## Notes
+
+- `SlugGenerator::slugify()` empty-string return is intentional; callers (e.g. `DashboardFactory`) substitute a UUID. Documented to prevent regression to a "throw on empty" version.
+- `UserAttributeResolver::evaluateOperator()` returning false for unknown operators is observed defensive behaviour. A future tightening could throw `InvalidArgumentException` so frontend bugs surface louder; deferred.
+- `RequestDataExtractor::extractTileData()` defaults include the legacy `#0082c9` Nextcloud-blue background. This is preserved for backwards-compatibility with existing tiles; a wider tile-defaults review (e.g. brand-aligned colours) is out of scope here.
+- `RequestDataExtractor::extractPlacementData()` skips type casting — `gridX` arrives as a string from the HTTP layer and is cast downstream in the placement mapper. The asymmetry with `extractTileData` (which casts) is observed-but-suspicious; flagged for future cleanup.

--- a/openspec/changes/archive/2026-05-24-retrofit-infrastructure-helpers/tasks.md
+++ b/openspec/changes/archive/2026-05-24-retrofit-infrastructure-helpers/tasks.md
@@ -1,0 +1,5 @@
+# Tasks
+
+- [x] task-1: infrastructure-helpers#REQ-INFRA-001 — Slug generation and validation (retroactive annotation)
+- [x] task-2: infrastructure-helpers#REQ-INFRA-002 — User attribute resolution and operator evaluation (retroactive annotation)
+- [x] task-3: infrastructure-helpers#REQ-INFRA-003 — Request data extraction for tile and placement forms (retroactive annotation)

--- a/openspec/specs/infrastructure-helpers/spec.md
+++ b/openspec/specs/infrastructure-helpers/spec.md
@@ -1,0 +1,157 @@
+---
+status: implemented
+retrofit: true
+---
+
+# Infrastructure Helpers Specification
+
+## Purpose
+
+The `infrastructure-helpers` capability collects small, pure (or nearly-pure) utility classes that are reused across multiple capability boundaries. These are not domain logic — they are primitives: string transformation, lookup, parameter extraction. Each helper has a single narrow contract, no persistence, and is invoked from multiple capability code paths. Grouping them here keeps each individual capability spec focused on domain behaviour rather than utility internals.
+
+## Scope
+
+This capability MUST contain only helpers that:
+
+- Are stateless or depend only on injected Nextcloud framework interfaces
+- Are used by at least two distinct capabilities (or are a primitive that obviously belongs nowhere else)
+- Have no persistence side effects
+- Have no domain-specific business rules — domain rules belong to the owning capability
+
+## Requirements
+
+### REQ-INFRA-001: Slug generation and validation
+
+The system MUST provide a static `SlugGenerator` helper that converts arbitrary user-supplied names into URL-safe slugs and validates caller-supplied slugs against the pinned grammar. The slug grammar is `^[a-z0-9_-]+$` (lowercase ASCII alphanumerics, dash, underscore), maximum 128 characters (matching the `slug VARCHAR(128)` database column).
+
+`slugify($name)` MUST:
+1. Lowercase the input
+2. Replace any run of whitespace with a single dash
+3. Strip every character outside the slug grammar
+4. Collapse consecutive dashes to a single dash
+5. Trim leading and trailing dashes
+6. Truncate to 128 characters (re-trim any trailing dash left by the cut)
+
+`slugify()` MUST return the empty string when the input is empty or yields no legal characters; the caller decides whether to substitute a UUID fallback or reject the request.
+
+`isValid($slug)` MUST return false for the empty string, for any string longer than 128 characters, and for any string not matching the grammar; true otherwise.
+
+#### Scenario: Multi-word name becomes dashed slug
+
+- WHEN `SlugGenerator::slugify('Q1 Campaigns')` is called
+- THEN the result is `'q1-campaigns'`
+
+#### Scenario: Special characters are stripped
+
+- WHEN `SlugGenerator::slugify('My Dashboard! (v2)')` is called
+- THEN the result is `'my-dashboard-v2'`
+
+#### Scenario: Empty input returns empty string
+
+- WHEN `SlugGenerator::slugify('***')` is called (no legal characters)
+- THEN the result is `''`
+
+#### Scenario: Over-length input is truncated without trailing dash
+
+- GIVEN a 200-character input
+- WHEN `SlugGenerator::slugify($input)` is called
+- THEN the result is at most 128 characters AND does not end with `-`
+
+#### Scenario: Validate rejects empty string
+
+- WHEN `SlugGenerator::isValid('')` is called
+- THEN the result is `false`
+
+#### Scenario: Validate rejects uppercase
+
+- WHEN `SlugGenerator::isValid('MyDashboard')` is called
+- THEN the result is `false`
+
+#### Scenario: Validate accepts grammar match
+
+- WHEN `SlugGenerator::isValid('q1-campaigns_v2')` is called
+- THEN the result is `true`
+
+### REQ-INFRA-002: User attribute resolution and operator evaluation
+
+The system MUST provide `UserAttributeResolver` to back attribute-based features (e.g. conditional visibility rules — REQ-VIS-008). The resolver MUST expose two methods:
+
+- `getUserAttributeValue($userId, $attribute)` — return the requested attribute as a string (or null when the user does not exist, or when the attribute is not in the supported set). Supported attributes: `locale` (defaults to `'en'` when no per-user `core/lang` preference is set), `email`, `displayName`, `quota` (stringified). Unknown attribute names MUST return null.
+- `evaluateOperator($userValue, $operator, $value)` — return whether the comparison matches. Supported operators: `equals`, `not_equals`, `contains`, `starts_with`, `ends_with`. Unknown operators MUST return false (no exception, no warning). When `$value` is null, the string-comparison operators treat it as an empty string.
+
+#### Scenario: Resolve locale falls back to 'en'
+
+- GIVEN a user with no `core/lang` preference set
+- WHEN `getUserAttributeValue($userId, 'locale')` is called
+- THEN the result is `'en'`
+
+#### Scenario: Unknown attribute returns null
+
+- WHEN `getUserAttributeValue($userId, 'twitter_handle')` is called
+- THEN the result is `null`
+
+#### Scenario: Non-existent user returns null
+
+- WHEN `getUserAttributeValue('does-not-exist', 'email')` is called
+- THEN the result is `null`
+
+#### Scenario: Operator evaluation — equals match
+
+- WHEN `evaluateOperator('en', 'equals', 'en')` is called
+- THEN the result is `true`
+
+#### Scenario: Operator evaluation — unknown operator returns false
+
+- WHEN `evaluateOperator('en', 'regex_match', '^en')` is called
+- THEN the result is `false` (no exception thrown)
+
+#### Scenario: Operator evaluation — null comparison value treated as empty string
+
+- WHEN `evaluateOperator('hello', 'contains', null)` is called
+- THEN the result is `true` (every string contains the empty string)
+
+### REQ-INFRA-003: Request data extraction for tile and placement forms
+
+The system MUST provide `RequestDataExtractor` to convert `IRequest` parameters into typed array shapes for tile creation and placement updates. The extractor MUST:
+
+- `extractTileData($request)` — return an associative array with the keys `title`, `icon`, `iconType`, `bgColor`, `txtColor`, `linkType`, `linkVal`, `gridX`, `gridY`. Every field has a default (`title='New Tile'`, `icon='icon-link'`, `iconType='class'`, `bgColor='#0082c9'`, `txtColor='#ffffff'`, `linkType='app'`, `linkVal=''`, `gridX=0`, `gridY=0`). `gridX` and `gridY` MUST be cast to integers. The request parameter name `textColor` MUST be mapped to the output key `txtColor`; the request parameter name `linkValue` MUST be mapped to the output key `linkVal`.
+- `extractPlacementData($request)` — iterate over the fixed list of 16 placement field names (`gridX`, `gridY`, `gridWidth`, `gridHeight`, `isVisible`, `showTitle`, `customTitle`, `customIcon`, `styleConfig`, `tileTitle`, `tileIcon`, `tileIconType`, `tileBackgroundColor`, `tileTextColor`, `tileLinkType`, `tileLinkValue`) and return only the fields whose request parameter is not null. The output preserves request-parameter values as-is (no type casting).
+
+Neither method validates field shapes or values — downstream callers are responsible for validation.
+
+#### Scenario: extractTileData returns defaults for missing params
+
+- GIVEN a request with no parameters set
+- WHEN `RequestDataExtractor::extractTileData($request)` is called
+- THEN the result is `{title: 'New Tile', icon: 'icon-link', iconType: 'class', bgColor: '#0082c9', txtColor: '#ffffff', linkType: 'app', linkVal: '', gridX: 0, gridY: 0}`
+
+#### Scenario: extractTileData maps textColor → txtColor and linkValue → linkVal
+
+- GIVEN a request with `textColor='#000'` and `linkValue='/foo'`
+- WHEN `extractTileData($request)` is called
+- THEN the result has `txtColor: '#000'` and `linkVal: '/foo'`
+
+#### Scenario: extractPlacementData filters null fields
+
+- GIVEN a request with only `gridX=2` set (all other 15 fields are null)
+- WHEN `extractPlacementData($request)` is called
+- THEN the result is `{gridX: 2}` (single key)
+
+#### Scenario: extractPlacementData preserves all 16 fields when all are set
+
+- GIVEN a request with all 16 placement fields set to non-null values
+- WHEN `extractPlacementData($request)` is called
+- THEN the result is an array of 16 entries, with values preserved as-is (no type casting)
+
+## Non-Functional Requirements
+
+- **Purity:** Helpers in this capability MUST be stateless or depend only on injected Nextcloud framework interfaces. No persistence side effects.
+- **Reusability:** Helpers in this capability MUST be useful to at least two capability code paths.
+- **Domain neutrality:** Helpers MUST NOT encode capability-specific business rules — those belong to the owning capability's spec.
+
+## Notes
+
+- `SlugGenerator::slugify()` empty-string return is intentional; callers (e.g. `DashboardFactory`) substitute a UUID. Documented to prevent regression to a "throw on empty" version.
+- `UserAttributeResolver::evaluateOperator()` returning false for unknown operators is observed defensive behaviour. A future tightening could throw `InvalidArgumentException` so frontend bugs surface louder; deferred.
+- `RequestDataExtractor::extractTileData()` defaults include the legacy `#0082c9` Nextcloud-blue background. This is preserved for backwards-compatibility with existing tiles; a wider tile-defaults review (e.g. brand-aligned colours) is out of scope here.
+- `RequestDataExtractor::extractPlacementData()` skips type casting — `gridX` arrives as a string from the HTTP layer and is cast downstream in the placement mapper. The asymmetry with `extractTileData` (which casts) is observed-but-suspicious; flagged for future cleanup.


### PR DESCRIPTION
## Retrofit — Reverse-Spec

Mints a new \`infrastructure-helpers\` capability covering 6 methods across 3 cross-cutting helper classes flagged Bucket 2b by the 2026-05-24 coverage scan (no owning capability).

Ghost change: \`archive/2026-05-24-retrofit-infrastructure-helpers\` (archived in this PR).

### What this PR does

- Creates a new \`openspec/specs/infrastructure-helpers/spec.md\` with \`retrofit: true\` frontmatter
- Drafts 3 REQs (one per helper class):
  - **REQ-INFRA-001** — SlugGenerator: slug grammar, transform pipeline, validation
  - **REQ-INFRA-002** — UserAttributeResolver: 4 supported attributes + 5 comparison operators
  - **REQ-INFRA-003** — RequestDataExtractor: tile + placement form data extraction
- Creates tasks.md with one task per REQ (all \`[x]\` — code already exists)
- Annotates 6 methods + 3 files with \`@spec openspec/changes/archive/2026-05-24-retrofit-infrastructure-helpers/tasks.md#task-N\` (Phase 2's existing \`@spec\` on \`UserAttributeResolver::getUserAttributeValue\` is preserved; new tag is appended)
- Archives the change

### Why a new capability rather than \`--extend\`?

Per ADR-003 and the SKILL's bias-toward-\`--extend\` rule, considered alternatives:

| Option | Why rejected |
|---|---|
| \`--extend dashboards\` (SlugGenerator) | Slug helper is reusable beyond dashboards |
| \`--extend conditional-visibility\` (UserAttributeResolver) | Resolver is a generic primitive; the visibility logic that uses it stays put |
| Per-method splits across \`tiles\` + \`widgets\` (RequestDataExtractor) | Would duplicate the helper's contract across two specs |
| Split into three different capabilities | Would scatter the helpers' shared architectural shape |

The new capability includes a \`## Scope\` section that prevents drift: future helpers that DO fit a domain capability should land there, not here.

### What this PR does NOT do

- No code behaviour changes — pure annotation + spec
- Does not silently fix observed-but-suspicious behaviour:
  - \`RequestDataExtractor::extractPlacementData()\` type-casting asymmetry vs \`extractTileData()\` — documented in spec Notes
  - \`UserAttributeResolver::evaluateOperator()\` silent-false on unknown operators — documented (future-tightening TODO)
  - \`SlugGenerator::slugify('')\` empty-string return — documented as intentional (callers substitute UUID)

### Review focus

- REQ language matches observed behaviour (not aspirational)
- Scenarios are testable
- Capability scope is well-defined enough to prevent drift
- New capability genuinely earns its slot (not just a dumping ground)

Source: \`openspec/coverage-report.md\` generated 2026-05-24
Cluster: infrastructure-helpers (Bucket 2b)
Refs #292