### PR TITLE
fix(ui): bump @nextcloud/vue to ^8.39.0 (nav corner sliver on NC<34)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
 				"@nextcloud/initial-state": "^2.2.0",
 				"@nextcloud/l10n": "^3.2.0",
 				"@nextcloud/router": "^3.1.0",
-				"@nextcloud/vue": "^8.16.0",
+				"@nextcloud/vue": "^8.39.0",
 				"bootstrap-vue": "^2.23.1",
 				"dompurify": "^3.4.1",
 				"gridstack": "^12.2.1",
@@ -3939,12 +3939,14 @@
 			}
 		},
 		"node_modules/@nextcloud/vue": {
-			"version": "8.36.0",
+			"version": "8.39.0",
+			"resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.39.0.tgz",
+			"integrity": "sha512-TJgrFeVr82CN8ng4y+IxMBb7mKlww7Fot22z33+Q0zKgWvi5EoQ0vYescA3Drl8cIRSGktUdFm3xO2gAqvnwoA==",
 			"license": "AGPL-3.0-or-later",
 			"dependencies": {
-				"@floating-ui/dom": "^1.7.5",
+				"@floating-ui/dom": "^1.7.6",
 				"@linusborg/vue-simple-portal": "^0.1.5",
-				"@nextcloud/auth": "^2.5.3",
+				"@nextcloud/auth": "^2.6.0",
 				"@nextcloud/axios": "^2.5.2",
 				"@nextcloud/browser-storage": "^0.5.0",
 				"@nextcloud/capabilities": "^1.2.1",
@@ -3953,20 +3955,21 @@
 				"@nextcloud/l10n": "^3.4.1",
 				"@nextcloud/logger": "^3.0.3",
 				"@nextcloud/router": "^3.1.0",
-				"@nextcloud/sharing": "^0.3.0",
+				"@nextcloud/sharing": "^0.4.0",
 				"@nextcloud/vue-select": "^3.26.0",
 				"@vueuse/components": "^11.0.0",
 				"@vueuse/core": "^11.0.0",
 				"blurhash": "^2.0.5",
 				"clone": "^2.1.2",
 				"debounce": "^2.2.0",
-				"dompurify": "^3.3.1",
+				"dompurify": "^3.4.2",
 				"emoji-mart-vue-fast": "^15.0.5",
 				"escape-html": "^1.0.3",
 				"floating-vue": "^1.0.0-beta.19",
 				"focus-trap": "^7.8.0",
 				"linkify-string": "^4.3.2",
 				"md5": "^2.3.0",
+				"mdast-util-to-string": "^4.0.0",
 				"p-queue": "^8.1.1",
 				"rehype-external-links": "^3.0.0",
 				"rehype-highlight": "^7.0.2",
@@ -3982,7 +3985,7 @@
 				"tributejs": "^5.1.3",
 				"unified": "^11.0.1",
 				"unist-builder": "^4.0.0",
-				"unist-util-visit": "^5.1.0",
+				"unist-util-visit-parents": "^6.0.2",
 				"vue": "^2.7.16",
 				"vue-color": "^2.8.1",
 				"vue-frag": "^1.4.3",
@@ -4001,6 +4004,31 @@
 			},
 			"peerDependencies": {
 				"vue": "2.x"
+			}
+		},
+		"node_modules/@nextcloud/vue/node_modules/@nextcloud/sharing": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/@nextcloud/sharing/-/sharing-0.4.0.tgz",
+			"integrity": "sha512-1hUNyc7uJdBpnimOnEshJjEtAPAjzDYVl6qmWqF5ZxoN9wOvbExw0QjX3xFIbHbX2dmvbRNLBj0RzLzipmZyeg==",
+			"license": "GPL-3.0-or-later",
+			"dependencies": {
+				"@nextcloud/initial-state": "^3.0.0",
+				"is-svg": "^6.1.0"
+			},
+			"engines": {
+				"node": "^20.0.0 || ^22.0.0 || ^24.0.0"
+			},
+			"optionalDependencies": {
+				"@nextcloud/files": "^3.12.2 || ^4.0.0"
+			}
+		},
+		"node_modules/@nextcloud/vue/node_modules/@nextcloud/sharing/node_modules/@nextcloud/initial-state": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@nextcloud/initial-state/-/initial-state-3.0.0.tgz",
+			"integrity": "sha512-cV+HBdkQJGm8FxkBI5rFT/FbMNWNBvpbj6OPrg4Ae4YOOsQ15CL8InPOAw1t4XkOkQK2NEdUGQLVUz/19wXbdQ==",
+			"license": "GPL-3.0-or-later",
+			"engines": {
+				"node": "^20.0.0 || ^22.0.0 || ^24.0.0"
 			}
 		},
 		"node_modules/@nextcloud/vue/node_modules/p-queue": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
 		"@nextcloud/initial-state": "^2.2.0",
 		"@nextcloud/l10n": "^3.2.0",
 		"@nextcloud/router": "^3.1.0",
-		"@nextcloud/vue": "^8.16.0",
+		"@nextcloud/vue": "^8.39.0",
 		"bootstrap-vue": "^2.23.1",
 		"dompurify": "^3.4.1",
 		"gridstack": "^12.2.1",


### PR DESCRIPTION
## What

Bumps the direct `@nextcloud/vue` dependency from `^8.16.0` to `^8.39.0` (resolved `8.39.0`). Only `package.json` and `package-lock.json` change — the webpack bundle (`js/`) is gitignored.

## Why — root cause

Nextcloud 34 introduced a rounded `.app-content` layout. Versions of `@nextcloud/vue` before `8.39.0` rendered that NC34 rounded-corner styling unconditionally, including on **NC < 34**, where the surrounding chrome is still square. The mismatch produced a white sliver in the navigation corner.

`@nextcloud/vue@8.39.0` adds an `isLegacy34` guard that only applies the rounded layout on NC ≥ 34, restoring the square layout (and removing the white sliver) on older Nextcloud versions.

## Scope

- Direct dependency pin bumped to `^8.39.0`.
- No `@nextcloud/vue` entry exists in `overrides`, so nothing to change there. `@conduction/nextcloud-vue` is untouched.

Part of a fleet-wide sweep applying this fix across Conduction apps.