### PR TITLE
fix: resolve hydra mechanical gates (nc-input-labels, modal-isolation)

### DIFF
--- a/src/components/DashboardConfigModal.vue
+++ b/src/components/DashboardConfigModal.vue
@@ -90,6 +90,7 @@
 					:options="shareeOptions"
 					:filterable="false"
 					:loading="shareeLoading"
+					:aria-label-combobox="t('mydash', 'Share with users and groups')"
 					:placeholder="t('mydash', 'Search users and groups…')"
 					label="displayName"
 					track-by="key"
@@ -118,6 +119,7 @@
 						<NcSelect
 							:value="permissionOptionFor(share.permissionLevel)"
 							:options="permissionOptions"
+							:input-label="t('mydash', 'Permission level')"
 							label="label"
 							track-by="value"
 							:clearable="false"

--- a/src/components/admin/AdminSettings.vue
+++ b/src/components/admin/AdminSettings.vue
@@ -273,6 +273,7 @@
 						v-model="editingTemplate.targetGroups"
 						:options="availableGroups"
 						:multiple="true"
+						:aria-label-combobox="t('mydash', 'Target groups')"
 						:placeholder="t('mydash', 'Select groups (leave empty for all users)')" />
 				</div>
 

--- a/src/components/admin/RolePermissionsSection.vue
+++ b/src/components/admin/RolePermissionsSection.vue
@@ -69,48 +69,30 @@
 			{{ t('mydash', 'Add role permission') }}
 		</NcButton>
 
-		<NcModal v-if="showEditor" @close="closeEditor">
-			<div class="mydash-admin__editor">
-				<h3>{{ editorRow.id ? t('mydash', 'Edit role permission') : t('mydash', 'Add role permission') }}</h3>
-				<NcTextField :value.sync="editorRow.name"
-					:label="t('mydash', 'Name')"
-					required />
-				<NcTextField :value.sync="editorRow.groupId"
-					:label="t('mydash', 'Nextcloud group ID')"
-					required
-					:disabled="!!editorRow.id" />
-				<NcTextField :value.sync="editorRow.description"
-					:label="t('mydash', 'Description (optional)')" />
-				<NcTextField :value.sync="allowedWidgetsCsv"
-					:label="t('mydash', 'Allowed widget IDs (comma separated)')" />
-				<NcTextField :value.sync="deniedWidgetsCsv"
-					:label="t('mydash', 'Denied widget IDs (comma separated)')" />
-				<div class="mydash-admin__editor-actions">
-					<NcButton type="tertiary" @click="closeEditor">
-						{{ t('mydash', 'Cancel') }}
-					</NcButton>
-					<NcButton type="primary"
-						:disabled="store.saving || !editorRow.name || !editorRow.groupId"
-						@click="save">
-						{{ t('mydash', 'Save') }}
-					</NcButton>
-				</div>
-			</div>
-		</NcModal>
+		<RolePermissionEditorModal
+			v-if="showEditor"
+			:row="editorRow"
+			:allowed-widgets-csv="allowedWidgetsCsv"
+			:denied-widgets-csv="deniedWidgetsCsv"
+			:saving="store.saving"
+			@update:row="editorRow = $event"
+			@update:allowed-widgets-csv="allowedWidgetsCsv = $event"
+			@update:denied-widgets-csv="deniedWidgetsCsv = $event"
+			@save="save"
+			@close="closeEditor" />
 	</div>
 </template>
 
 <script>
 import {
 	NcButton,
-	NcModal,
-	NcTextField,
 	NcEmptyContent,
 } from '@conduction/nextcloud-vue'
 import AccountGroup from 'vue-material-design-icons/AccountGroup.vue'
 import Plus from 'vue-material-design-icons/Plus.vue'
 import Pencil from 'vue-material-design-icons/Pencil.vue'
 import Delete from 'vue-material-design-icons/Delete.vue'
+import RolePermissionEditorModal from '../../modals/RolePermissionEditorModal.vue'
 import { useRoleFeaturePermissionStore } from '../../stores/roleFeaturePermissions.js'
 
 export default {
@@ -118,13 +100,12 @@ export default {
 
 	components: {
 		NcButton,
-		NcModal,
-		NcTextField,
 		NcEmptyContent,
 		AccountGroup,
 		Plus,
 		Pencil,
 		Delete,
+		RolePermissionEditorModal,
 	},
 
 	/** @spec openspec/specs/admin-roles/spec.md */

--- a/src/modals/RolePermissionEditorModal.vue
+++ b/src/modals/RolePermissionEditorModal.vue
@@ -1,0 +1,108 @@
+<!--
+  - SPDX-FileCopyrightText: 2026 MyDash Contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<template>
+	<NcModal @close="$emit('close')">
+		<div class="mydash-admin__editor">
+			<h3>{{ row.id ? t('mydash', 'Edit role permission') : t('mydash', 'Add role permission') }}</h3>
+			<NcTextField :value="row.name"
+				:label="t('mydash', 'Name')"
+				required
+				@update:value="updateRow('name', $event)" />
+			<NcTextField :value="row.groupId"
+				:label="t('mydash', 'Nextcloud group ID')"
+				required
+				:disabled="!!row.id"
+				@update:value="updateRow('groupId', $event)" />
+			<NcTextField :value="row.description"
+				:label="t('mydash', 'Description (optional)')"
+				@update:value="updateRow('description', $event)" />
+			<NcTextField :value="allowedWidgetsCsv"
+				:label="t('mydash', 'Allowed widget IDs (comma separated)')"
+				@update:value="$emit('update:allowedWidgetsCsv', $event)" />
+			<NcTextField :value="deniedWidgetsCsv"
+				:label="t('mydash', 'Denied widget IDs (comma separated)')"
+				@update:value="$emit('update:deniedWidgetsCsv', $event)" />
+			<div class="mydash-admin__editor-actions">
+				<NcButton type="tertiary" @click="$emit('close')">
+					{{ t('mydash', 'Cancel') }}
+				</NcButton>
+				<NcButton type="primary"
+					:disabled="saving || !row.name || !row.groupId"
+					@click="$emit('save')">
+					{{ t('mydash', 'Save') }}
+				</NcButton>
+			</div>
+		</div>
+	</NcModal>
+</template>
+
+<script>
+import {
+	NcButton,
+	NcModal,
+	NcTextField,
+} from '@conduction/nextcloud-vue'
+
+export default {
+	name: 'RolePermissionEditorModal',
+
+	components: {
+		NcButton,
+		NcModal,
+		NcTextField,
+	},
+
+	props: {
+		row: {
+			type: Object,
+			required: true,
+		},
+		allowedWidgetsCsv: {
+			type: String,
+			default: '',
+		},
+		deniedWidgetsCsv: {
+			type: String,
+			default: '',
+		},
+		saving: {
+			type: Boolean,
+			default: false,
+		},
+	},
+
+	emits: [
+		'close',
+		'save',
+		'update:row',
+		'update:allowedWidgetsCsv',
+		'update:deniedWidgetsCsv',
+	],
+
+	methods: {
+		/** @spec openspec/specs/admin-roles/spec.md */
+		updateRow(key, value) {
+			this.$emit('update:row', { ...this.row, [key]: value })
+		},
+	},
+}
+</script>
+
+<style scoped>
+.mydash-admin__editor {
+	padding: calc(var(--default-grid-baseline) * 2);
+	display: flex;
+	flex-direction: column;
+	gap: var(--default-grid-baseline);
+	min-width: 480px;
+}
+.mydash-admin__editor-actions {
+	display: flex;
+	justify-content: flex-end;
+	gap: var(--default-grid-baseline);
+	margin-top: var(--default-grid-baseline);
+}
+</style>


### PR DESCRIPTION
Bucket-A safe fixes from the fleet-wide hydra-gates sweep: accessible labels on NcSelect + extracted RolePermissions modal to src/modals/. Security-semantic findings + stub-scan tracked in a separate backlog issue.