### PR TITLE
chore(spec): restore gate-16 coverage on updateActionMatrix

### DIFF
--- a/src/services/api.js
+++ b/src/services/api.js
@@ -430,6 +430,7 @@ export const api = {
 		return axios.get(`${baseUrl}/api/admin/action-matrix`)
 	},
 
+	/** @spec openspec/architecture/adr-023-action-authorization.md */
 	updateActionMatrix(matrix) {
 		return axios.put(`${baseUrl}/api/admin/action-matrix`, { matrix })
 	},


### PR DESCRIPTION
Adds @spec JSDoc to the ADR-023 matrix api helper added in #310/#312. gate-16 scoped=0.