### PR TITLE
fix: resolve gate-3 stub-scan (canHaveMultipleDashboards unused $userId)

### DIFF
--- a/lib/Controller/DashboardApiController.php
+++ b/lib/Controller/DashboardApiController.php
@@ -1575,9 +1575,7 @@ class DashboardApiController extends Controller
             userId: $userId
         );
         if (empty($existing) === false
-            && $this->permissionService->canHaveMultipleDashboards(
-                userId: $userId
-            ) === false
+            && $this->permissionService->canHaveMultipleDashboards() === false
         ) {
             return ResponseHelper::forbidden(
                 message: 'Multiple dashboards not allowed'

--- a/lib/Controller/DashboardRequestValidator.php
+++ b/lib/Controller/DashboardRequestValidator.php
@@ -98,9 +98,7 @@ class DashboardRequestValidator
             userId: $userId
         );
         if (empty($existing) === false
-            && $this->permissionService->canHaveMultipleDashboards(
-                userId: $userId
-            ) === false
+            && $this->permissionService->canHaveMultipleDashboards() === false
         ) {
             return ResponseHelper::forbidden(
                 message: $this->l10n->t('Multiple dashboards not allowed')

--- a/lib/Service/PermissionService.php
+++ b/lib/Service/PermissionService.php
@@ -331,16 +331,20 @@ class PermissionService
     }//end canCreateDashboard()
 
     /**
-     * Check if user can have multiple dashboards.
+     * Check if multiple dashboards are allowed (global admin setting).
      *
-     * @param string $userId The user ID.
+     * This is a global configuration flag, not per-user — the admin setting
+     * `allow_multiple_dashboards` either permits or blocks all users from
+     * owning more than one dashboard. Call-sites already hold the user's
+     * dashboard list; they only need this flag to decide whether to allow
+     * the creation of an additional one.
      *
-     * @return bool Whether the user can have multiple dashboards.
+     * @return bool Whether multiple dashboards are allowed.
      */
     /** @spec openspec/specs/permissions/spec.md */
-    public function canHaveMultipleDashboards(string $userId): bool
+    public function canHaveMultipleDashboards(): bool
     {
-        return $this->settingMapper->getValue(
+        return (bool) $this->settingMapper->getValue(
             key: AdminSetting::KEY_ALLOW_MULTIPLE_DASHBOARDS,
             default: true
         );


### PR DESCRIPTION
## What the stub was
`PermissionService::canHaveMultipleDashboards(string $userId)` declared a `$userId` parameter that was **never referenced in its body** — it simply reads a global admin setting (`allow_multiple_dashboards`) and returns the result. The gate-3 caller-identity-ignored rule correctly flagged this as an unfinished stub (a per-user check that was never actually implemented).

## Fix decision: remove `$userId` from the signature (global config, not per-user)

The method's sole purpose is to read the `KEY_ALLOW_MULTIPLE_DASHBOARDS` admin setting, which is instance-wide. There is no per-user override anywhere in the codebase, and the two call-sites only needed the boolean answer — they already held the relevant `$userId` context separately. Adding a fake per-user lookup would have been the wrong fix.

**Changes:**
- `lib/Service/PermissionService.php` — signature changed from `canHaveMultipleDashboards(string $userId): bool` to `canHaveMultipleDashboards(): bool`; added `(bool)` cast for correctness
- `lib/Controller/DashboardApiController.php` — removed `userId: $userId` named arg from the call
- `lib/Controller/DashboardRequestValidator.php` — same

## Gate-3 result
`[gate-3] stub-scan: PASS`