### PR TITLE
chore: IConfig -> IAppConfig/IUserConfig (deprecation)

### DIFF
--- a/lib/Controller/MetricsController.php
+++ b/lib/Controller/MetricsController.php
@@ -21,6 +21,7 @@ namespace OCA\MyDash\Controller;
 use OCA\MyDash\AppInfo\Application;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\TextPlainResponse;
+use OCP\IAppConfig;
 use OCP\IConfig;
 use OCP\IDBConnection;
 use OCP\IRequest;
@@ -34,13 +35,15 @@ class MetricsController extends Controller
     /**
      * Constructor
      *
-     * @param IRequest        $request The request.
-     * @param IConfig         $config  The config service.
-     * @param IDBConnection   $db      The database connection.
-     * @param LoggerInterface $logger  Logger for error reporting.
+     * @param IRequest        $request   The request.
+     * @param IAppConfig      $appConfig The app config service.
+     * @param IConfig         $config    The system config service.
+     * @param IDBConnection   $db        The database connection.
+     * @param LoggerInterface $logger    Logger for error reporting.
      */
     public function __construct(
         IRequest $request,
+        private readonly IAppConfig $appConfig,
         private readonly IConfig $config,
         private readonly IDBConnection $db,
         private readonly LoggerInterface $logger,
@@ -64,7 +67,7 @@ class MetricsController extends Controller
     {
         $lines = [];
 
-        $appVersion = $this->config->getAppValue(Application::APP_ID, 'installed_version', '0.0.0');
+        $appVersion = $this->appConfig->getValueString(Application::APP_ID, 'installed_version', '0.0.0');
         $phpVersion = PHP_VERSION;
         $ncVersion  = $this->config->getSystemValueString('version', '0.0.0');
 

--- a/lib/Job/FeedRefreshJob.php
+++ b/lib/Job/FeedRefreshJob.php
@@ -32,7 +32,7 @@ use OCA\MyDash\AppInfo\Application;
 use OCA\MyDash\Service\FeedRefreshService;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\BackgroundJob\TimedJob;
-use OCP\IConfig;
+use OCP\IAppConfig;
 use OCP\Lock\ILockingProvider;
 use OCP\Lock\LockedException;
 use Psr\Log\LoggerInterface;
@@ -85,24 +85,24 @@ class FeedRefreshJob extends TimedJob
      * with the parent TimedJob.
      *
      * @param ITimeFactory       $time            The TimedJob clock.
-     * @param IConfig            $config          The Nextcloud config reader.
+     * @param IAppConfig         $appConfig       The app config reader.
      * @param FeedRefreshService $refreshService  The refresh worker.
      * @param ILockingProvider   $lockingProvider The cluster lock provider.
      * @param LoggerInterface    $logger          The diagnostic logger.
      */
     public function __construct(
         ITimeFactory $time,
-        private readonly IConfig $config,
+        private readonly IAppConfig $appConfig,
         private readonly FeedRefreshService $refreshService,
         private readonly ILockingProvider $lockingProvider,
         private readonly LoggerInterface $logger,
     ) {
         parent::__construct(time: $time);
 
-        $configured = (int) $this->config->getAppValue(
+        $configured = $this->appConfig->getValueInt(
             Application::APP_ID,
             self::CONFIG_KEY_INTERVAL,
-            (string) self::DEFAULT_INTERVAL
+            self::DEFAULT_INTERVAL
         );
         if ($configured <= 0) {
             $configured = self::DEFAULT_INTERVAL;

--- a/lib/Migration/Version001006Date20260430130000.php
+++ b/lib/Migration/Version001006Date20260430130000.php
@@ -26,7 +26,7 @@ namespace OCA\MyDash\Migration;
 use Closure;
 use OCP\DB\ISchemaWrapper;
 use OCP\DB\Types;
-use OCP\IConfig;
+use OCP\IAppConfig;
 use OCP\IDBConnection;
 use OCP\IGroupManager;
 use OCP\IUserManager;
@@ -43,13 +43,13 @@ class Version001006Date20260430130000 extends SimpleMigrationStep
     /**
      * Constructor
      *
-     * @param IConfig       $config       The app config.
+     * @param IAppConfig    $appConfig    The app config.
      * @param IDBConnection $db           The database connection.
      * @param IUserManager  $userManager  The user manager.
      * @param IGroupManager $groupManager The group manager.
      */
     public function __construct(
-        private readonly IConfig $config,
+        private readonly IAppConfig $appConfig,
         private readonly IDBConnection $db,
         private readonly IUserManager $userManager,
         private readonly IGroupManager $groupManager,
@@ -172,8 +172,8 @@ class Version001006Date20260430130000 extends SimpleMigrationStep
         Closure $schemaClosure,
         array $options
     ): void {
-        $enabled = $this->config->getAppValue(
-            appName: 'mydash',
+        $enabled = $this->appConfig->getValueString(
+            app: 'mydash',
             key: 'cleanup_orphan_shares',
             default: 'false'
         );

--- a/lib/Service/AnalyticsService.php
+++ b/lib/Service/AnalyticsService.php
@@ -39,6 +39,7 @@ use OCA\MyDash\Db\DashboardMapper;
 use OCA\MyDash\Db\DashboardView;
 use OCA\MyDash\Db\DashboardViewMapper;
 use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\IAppConfig;
 use OCP\IConfig;
 
 /**
@@ -102,14 +103,14 @@ class AnalyticsService
      *                                             name lookups.
      * @param UniqueViewerDedup   $dedup           Unique-viewer dedup
      *                                             service.
-     * @param IConfig             $config          Nextcloud config
-     *                                             service for
-     *                                             admin/user settings.
+     * @param IAppConfig          $appConfig       App config for admin settings.
+     * @param IConfig             $config          Nextcloud config for user values.
      */
     public function __construct(
         private readonly DashboardViewMapper $viewMapper,
         private readonly DashboardMapper $dashboardMapper,
         private readonly UniqueViewerDedup $dedup,
+        private readonly IAppConfig $appConfig,
         private readonly IConfig $config,
     ) {
     }//end __construct()
@@ -123,13 +124,11 @@ class AnalyticsService
     /** @spec openspec/specs/dashboard-view-analytics/spec.md */
     public function isGloballyEnabled(): bool
     {
-        $value = $this->config->getAppValue(
+        return $this->appConfig->getValueBool(
             'mydash',
             self::CONFIG_KEY_ENABLED,
-            'true'
+            true
         );
-
-        return ($value === 'true' || $value === '1');
     }//end isGloballyEnabled()
 
     /**
@@ -163,13 +162,11 @@ class AnalyticsService
     /** @spec openspec/specs/dashboard-view-analytics/spec.md */
     public function getRetentionDays(): int
     {
-        $value = $this->config->getAppValue(
+        $days = $this->appConfig->getValueInt(
             'mydash',
             self::CONFIG_KEY_RETENTION_DAYS,
-            (string) self::DEFAULT_RETENTION_DAYS
+            self::DEFAULT_RETENTION_DAYS
         );
-
-        $days = (int) $value;
         if ($days < self::MIN_RETENTION_DAYS) {
             return self::MIN_RETENTION_DAYS;
         }
@@ -202,10 +199,10 @@ class AnalyticsService
             $clamped = self::MAX_RETENTION_DAYS;
         }
 
-        $this->config->setAppValue(
+        $this->appConfig->setValueInt(
             'mydash',
             self::CONFIG_KEY_RETENTION_DAYS,
-            (string) $clamped
+            $clamped
         );
 
         return $clamped;
@@ -222,15 +219,10 @@ class AnalyticsService
     /** @spec openspec/specs/dashboard-view-analytics/spec.md */
     public function setGlobalEnabled(bool $enabled): void
     {
-        $value = 'false';
-        if ($enabled === true) {
-            $value = 'true';
-        }
-
-        $this->config->setAppValue(
+        $this->appConfig->setValueBool(
             'mydash',
             self::CONFIG_KEY_ENABLED,
-            $value
+            $enabled
         );
     }//end setGlobalEnabled()
 

--- a/lib/Service/BulkOperationService.php
+++ b/lib/Service/BulkOperationService.php
@@ -46,7 +46,7 @@ use OCA\MyDash\Db\DashboardMapper;
 use OCA\MyDash\Db\WidgetPlacementMapper;
 use OCA\MyDash\Exception\DashboardHasChildrenException;
 use OCP\AppFramework\Db\DoesNotExistException;
-use OCP\IConfig;
+use OCP\IAppConfig;
 use OCP\IGroupManager;
 use Psr\Log\LoggerInterface;
 use Throwable;
@@ -119,7 +119,7 @@ class BulkOperationService
      *                                                 caller an NC admin"
      *                                                 short-circuit on the
      *                                                 permission pre-check.
-     * @param IConfig               $config            App config for
+     * @param IAppConfig            $appConfig         App config for
      *                                                 reading the
      *                                                 per-request cap.
      * @param LoggerInterface       $logger            Diagnostic logger.
@@ -131,7 +131,7 @@ class BulkOperationService
         private readonly DashboardTreeService $treeService,
         private readonly ActivityPublisher $activityPublisher,
         private readonly IGroupManager $groupManager,
-        private readonly IConfig $config,
+        private readonly IAppConfig $appConfig,
         private readonly LoggerInterface $logger,
     ) {
     }//end __construct()
@@ -609,17 +609,16 @@ class BulkOperationService
     /** @spec openspec/specs/dashboard-bulk-operations/spec.md */
     public function getEffectiveCap(): int
     {
-        $raw = $this->config->getAppValue(
+        $value = $this->appConfig->getValueInt(
             Application::APP_ID,
             self::CONFIG_KEY_MAX_PER_REQUEST,
-            (string) self::DEFAULT_MAX_PER_REQUEST
+            self::DEFAULT_MAX_PER_REQUEST
         );
 
-        $value = (int) $raw;
         if ($value <= 0) {
             $this->logger->warning(
                 message: 'Invalid bulk operation cap; falling back to default',
-                context: ['raw' => $raw]
+                context: ['raw' => (string) $value]
             );
 
             return self::DEFAULT_MAX_PER_REQUEST;

--- a/lib/Service/DemoShowcasesService.php
+++ b/lib/Service/DemoShowcasesService.php
@@ -41,7 +41,7 @@ use OCA\MyDash\Db\WidgetPlacementMapper;
 use OCA\MyDash\Exception\ShowcaseNotFoundException;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\Dashboard\IManager;
-use OCP\IConfig;
+use OCP\IAppConfig;
 use OCP\IDBConnection;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
@@ -100,7 +100,7 @@ class DemoShowcasesService
      * @param DashboardMapper       $dashboardMapper  Dashboard data mapper.
      * @param WidgetPlacementMapper $placementMapper  Widget placement mapper.
      * @param IDBConnection         $db               Database connection.
-     * @param IConfig               $config           App / user config service.
+     * @param IAppConfig            $appConfig        App config service.
      * @param IManager              $dashboardManager Nextcloud dashboard registry.
      * @param LoggerInterface       $logger           PSR-3 logger.
      */
@@ -108,7 +108,7 @@ class DemoShowcasesService
         private readonly DashboardMapper $dashboardMapper,
         private readonly WidgetPlacementMapper $placementMapper,
         private readonly IDBConnection $db,
-        private readonly IConfig $config,
+        private readonly IAppConfig $appConfig,
         private readonly IManager $dashboardManager,
         private readonly LoggerInterface $logger,
     ) {
@@ -364,7 +364,7 @@ class DemoShowcasesService
     /** @spec openspec/specs/demo-data-showcases/spec.md */
     public function getInstalledUuid(string $showcaseId): string
     {
-        return (string) $this->config->getAppValue(
+        return $this->appConfig->getValueString(
             Application::APP_ID,
             self::CONFIG_PREFIX.$showcaseId,
             ''
@@ -678,7 +678,7 @@ class DemoShowcasesService
      */
     private function markInstalled(string $showcaseId, string $dashboardUuid): void
     {
-        $this->config->setAppValue(
+        $this->appConfig->setValueString(
             Application::APP_ID,
             self::CONFIG_PREFIX.$showcaseId,
             $dashboardUuid
@@ -694,7 +694,7 @@ class DemoShowcasesService
      */
     private function clearInstalledMarker(string $showcaseId): void
     {
-        $this->config->deleteAppValue(
+        $this->appConfig->deleteKey(
             Application::APP_ID,
             self::CONFIG_PREFIX.$showcaseId
         );

--- a/lib/Service/FeedRefreshService.php
+++ b/lib/Service/FeedRefreshService.php
@@ -32,6 +32,7 @@ use OCA\MyDash\Db\FeedCache;
 use OCA\MyDash\Db\FeedCacheMapper;
 use OCA\MyDash\Db\WidgetPlacementMapper;
 use OCP\Http\Client\IClientService;
+use OCP\IAppConfig;
 use OCP\IConfig;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
@@ -112,13 +113,15 @@ class FeedRefreshService
      * Constructor.
      *
      * @param IClientService        $clientService   The HTTP client factory.
-     * @param IConfig               $config          The Nextcloud config reader.
+     * @param IAppConfig            $appConfig       The app config reader.
+     * @param IConfig               $config          The system config reader.
      * @param FeedCacheMapper       $cacheMapper     The feed-cache mapper.
      * @param WidgetPlacementMapper $placementMapper The widget-placement mapper.
      * @param LoggerInterface       $logger          The diagnostic logger.
      */
     public function __construct(
         private readonly IClientService $clientService,
+        private readonly IAppConfig $appConfig,
         private readonly IConfig $config,
         private readonly FeedCacheMapper $cacheMapper,
         private readonly WidgetPlacementMapper $placementMapper,
@@ -356,7 +359,7 @@ class FeedRefreshService
         // Apply cursor — only relevant for the full-refresh path.
         $startIndex = 0;
         if ($onlyUrl === null) {
-            $cursor = $this->config->getAppValue(
+            $cursor = $this->appConfig->getValueString(
                 Application::APP_ID,
                 self::CONFIG_KEY_CURSOR,
                 ''
@@ -419,7 +422,7 @@ class FeedRefreshService
             $endIndex = ($startIndex + $processed);
             if ($endIndex >= $urlCount) {
                 // Completed the full set — clear cursor.
-                $this->config->deleteAppValue(
+                $this->appConfig->deleteKey(
                     Application::APP_ID,
                     self::CONFIG_KEY_CURSOR
                 );
@@ -427,7 +430,7 @@ class FeedRefreshService
                 // More to do next tick — persist cursor at last URL processed.
                 $lastIndex = ($endIndex - 1);
                 if ($lastIndex >= 0 && $lastIndex < $urlCount) {
-                    $this->config->setAppValue(
+                    $this->appConfig->setValueString(
                         Application::APP_ID,
                         self::CONFIG_KEY_CURSOR,
                         $urls[$lastIndex]
@@ -735,7 +738,7 @@ class FeedRefreshService
      */
     private function buildUserAgent(): string
     {
-        $appVersion  = (string) $this->config->getAppValue(
+        $appVersion  = $this->appConfig->getValueString(
             Application::APP_ID,
             'installed_version',
             '1.0.0'
@@ -766,7 +769,7 @@ class FeedRefreshService
      */
     private function isHostAllowed(string $feedUrl): bool
     {
-        $allowedRaw = (string) $this->config->getAppValue(
+        $allowedRaw = $this->appConfig->getValueString(
             Application::APP_ID,
             self::CONFIG_KEY_ALLOWED_HOSTS,
             ''

--- a/lib/Service/FeedService.php
+++ b/lib/Service/FeedService.php
@@ -32,7 +32,7 @@ use Exception;
 use OCA\MyDash\AppInfo\Application;
 use OCA\MyDash\Db\Dashboard;
 use OCA\MyDash\Db\FeedToken;
-use OCP\IConfig;
+use OCP\IAppConfig;
 use OCP\IURLGenerator;
 use OCP\IUserManager;
 use OCP\L10N\IFactory;
@@ -94,7 +94,7 @@ class FeedService
      *                                           (REQ-DASH-013 / REQ-FEED-006).
      * @param IUserManager     $userManager      Display-name lookup.
      * @param IURLGenerator    $urlGenerator     Absolute-URL builder.
-     * @param IConfig          $config           App-config reader.
+     * @param IAppConfig       $appConfig        App-config reader.
      * @param IFactory         $l10nFactory      L10N factory for feed labels.
      * @param LoggerInterface  $logger           Diagnostic logger.
      */
@@ -102,7 +102,7 @@ class FeedService
         private readonly DashboardService $dashboardService,
         private readonly IUserManager $userManager,
         private readonly IURLGenerator $urlGenerator,
-        private readonly IConfig $config,
+        private readonly IAppConfig $appConfig,
         private readonly IFactory $l10nFactory,
         private readonly LoggerInterface $logger,
     ) {
@@ -339,13 +339,12 @@ XML;
      */
     private function resolveItemCap(): int
     {
-        $raw = $this->config->getAppValue(
+        $cap = $this->appConfig->getValueInt(
             Application::APP_ID,
             self::CONFIG_KEY_ITEM_CAP,
-            (string) self::DEFAULT_ITEM_CAP
+            self::DEFAULT_ITEM_CAP
         );
 
-        $cap = (int) $raw;
         if ($cap < 1) {
             return self::DEFAULT_ITEM_CAP;
         }

--- a/lib/Service/MetricsCollector.php
+++ b/lib/Service/MetricsCollector.php
@@ -19,6 +19,7 @@ declare(strict_types=1);
 namespace OCA\MyDash\Service;
 
 use OCA\MyDash\AppInfo\Application;
+use OCP\IAppConfig;
 use OCP\IConfig;
 use Psr\Log\LoggerInterface;
 
@@ -30,11 +31,13 @@ class MetricsCollector
     /**
      * Constructor
      *
-     * @param IConfig             $config       The config service.
+     * @param IAppConfig          $appConfig    The app config service.
+     * @param IConfig             $config       The system config service.
      * @param MetricsQueryService $queryService The metrics query service.
      * @param LoggerInterface     $logger       Logger for error reporting.
      */
     public function __construct(
+        private readonly IAppConfig $appConfig,
         private readonly IConfig $config,
         private readonly MetricsQueryService $queryService,
         private readonly LoggerInterface $logger,
@@ -80,7 +83,7 @@ class MetricsCollector
      */
     private function addInfoMetric(array &$lines): void
     {
-        $appVersion = $this->config->getAppValue(Application::APP_ID, 'installed_version', '0.0.0');
+        $appVersion = $this->appConfig->getValueString(Application::APP_ID, 'installed_version', '0.0.0');
         $phpVersion = PHP_VERSION;
         $ncVersion  = $this->config->getSystemValueString(
             key: 'version',

--- a/lib/Service/UniqueViewerDedup.php
+++ b/lib/Service/UniqueViewerDedup.php
@@ -37,7 +37,7 @@ namespace OCA\MyDash\Service;
 
 use DateTimeImmutable;
 use DateTimeZone;
-use OCP\IConfig;
+use OCP\IAppConfig;
 use OCP\ICache;
 use OCP\ICacheFactory;
 
@@ -84,11 +84,11 @@ class UniqueViewerDedup
      * Constructor.
      *
      * @param ICacheFactory $cacheFactory The Nextcloud cache factory.
-     * @param IConfig       $config       The Nextcloud config service.
+     * @param IAppConfig    $appConfig    The app config service.
      */
     public function __construct(
         private readonly ICacheFactory $cacheFactory,
-        private readonly IConfig $config,
+        private readonly IAppConfig $appConfig,
     ) {
     }//end __construct()
 
@@ -153,12 +153,12 @@ class UniqueViewerDedup
     /** @spec openspec/specs/dashboard-view-analytics/spec.md */
     public function getSaltForDate(string $viewBucketDate): string
     {
-        $existingSalt = $this->config->getAppValue(
+        $existingSalt = $this->appConfig->getValueString(
             'mydash',
             self::CONFIG_KEY_SALT,
             ''
         );
-        $existingDate = $this->config->getAppValue(
+        $existingDate = $this->appConfig->getValueString(
             'mydash',
             self::CONFIG_KEY_SALT_DATE,
             ''
@@ -187,12 +187,12 @@ class UniqueViewerDedup
     public function rotateSalt(string $viewBucketDate): string
     {
         $newSalt = bin2hex(string: random_bytes(length: 32));
-        $this->config->setAppValue(
+        $this->appConfig->setValueString(
             'mydash',
             self::CONFIG_KEY_SALT,
             $newSalt
         );
-        $this->config->setAppValue(
+        $this->appConfig->setValueString(
             'mydash',
             self::CONFIG_KEY_SALT_DATE,
             $viewBucketDate

--- a/tests/Unit/Job/FeedRefreshJobTest.php
+++ b/tests/Unit/Job/FeedRefreshJobTest.php
@@ -24,7 +24,7 @@ namespace Unit\Job;
 use OCA\MyDash\Job\FeedRefreshJob;
 use OCA\MyDash\Service\FeedRefreshService;
 use OCP\AppFramework\Utility\ITimeFactory;
-use OCP\IConfig;
+use OCP\IAppConfig;
 use OCP\Lock\ILockingProvider;
 use OCP\Lock\LockedException;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -41,8 +41,8 @@ class FeedRefreshJobTest extends TestCase
     /** @var ITimeFactory&MockObject */
     private $time;
 
-    /** @var IConfig&MockObject */
-    private $config;
+    /** @var IAppConfig&MockObject */
+    private $appConfig;
 
     /** @var FeedRefreshService&MockObject */
     private $refreshService;
@@ -64,7 +64,7 @@ class FeedRefreshJobTest extends TestCase
         parent::setUp();
 
         $this->time            = $this->createMock(ITimeFactory::class);
-        $this->config          = $this->createMock(IConfig::class);
+        $this->appConfig       = $this->createMock(IAppConfig::class);
         $this->refreshService  = $this->createMock(FeedRefreshService::class);
         $this->lockingProvider = $this->createMock(ILockingProvider::class);
         $this->logger          = $this->createMock(LoggerInterface::class);
@@ -78,10 +78,10 @@ class FeedRefreshJobTest extends TestCase
      */
     public function testConstructorClampsBelowMinimum(): void
     {
-        $this->config->method('getAppValue')
-            ->willReturnCallback(static function (string $app, string $key, string $default): string {
+        $this->appConfig->method('getValueInt')
+            ->willReturnCallback(static function (string $app, string $key, int $default): int {
                 if ($key === FeedRefreshJob::CONFIG_KEY_INTERVAL) {
-                    return '60';
+                    return 60;
                 }
                 return $default;
             });
@@ -100,10 +100,10 @@ class FeedRefreshJobTest extends TestCase
      */
     public function testConstructorClampsAboveMaximum(): void
     {
-        $this->config->method('getAppValue')
-            ->willReturnCallback(static function (string $app, string $key, string $default): string {
+        $this->appConfig->method('getValueInt')
+            ->willReturnCallback(static function (string $app, string $key, int $default): int {
                 if ($key === FeedRefreshJob::CONFIG_KEY_INTERVAL) {
-                    return '172800';
+                    return 172800;
                 }
                 return $default;
             });
@@ -122,8 +122,8 @@ class FeedRefreshJobTest extends TestCase
      */
     public function testConstructorAppliesDefaultWhenUnset(): void
     {
-        $this->config->method('getAppValue')
-            ->willReturnCallback(static function (string $app, string $key, string $default): string {
+        $this->appConfig->method('getValueInt')
+            ->willReturnCallback(static function (string $app, string $key, int $default): int {
                 return $default;
             });
 
@@ -143,8 +143,8 @@ class FeedRefreshJobTest extends TestCase
      */
     public function testRunAcquiresAndReleasesLockOnException(): void
     {
-        $this->config->method('getAppValue')
-            ->willReturnCallback(static function (string $app, string $key, string $default): string {
+        $this->appConfig->method('getValueInt')
+            ->willReturnCallback(static function (string $app, string $key, int $default): int {
                 return $default;
             });
 
@@ -174,8 +174,8 @@ class FeedRefreshJobTest extends TestCase
      */
     public function testRunSkipsWhenLockHeld(): void
     {
-        $this->config->method('getAppValue')
-            ->willReturnCallback(static function (string $app, string $key, string $default): string {
+        $this->appConfig->method('getValueInt')
+            ->willReturnCallback(static function (string $app, string $key, int $default): int {
                 return $default;
             });
 
@@ -199,8 +199,8 @@ class FeedRefreshJobTest extends TestCase
      */
     public function testRunHappyPathReleasesLock(): void
     {
-        $this->config->method('getAppValue')
-            ->willReturnCallback(static function (string $app, string $key, string $default): string {
+        $this->appConfig->method('getValueInt')
+            ->willReturnCallback(static function (string $app, string $key, int $default): int {
                 return $default;
             });
 
@@ -229,7 +229,7 @@ class FeedRefreshJobTest extends TestCase
     {
         return new FeedRefreshJob(
             time: $this->time,
-            config: $this->config,
+            appConfig: $this->appConfig,
             refreshService: $this->refreshService,
             lockingProvider: $this->lockingProvider,
             logger: $this->logger,

--- a/tests/Unit/Service/AnalyticsServiceTest.php
+++ b/tests/Unit/Service/AnalyticsServiceTest.php
@@ -28,6 +28,7 @@ use OCA\MyDash\Db\DashboardViewMapper;
 use OCA\MyDash\Service\AnalyticsService;
 use OCA\MyDash\Service\UniqueViewerDedup;
 use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\IAppConfig;
 use OCP\IConfig;
 use PHPUnit\Framework\TestCase;
 
@@ -36,6 +37,7 @@ class AnalyticsServiceTest extends TestCase
     private DashboardViewMapper $viewMapper;
     private DashboardMapper $dashboardMapper;
     private UniqueViewerDedup $dedup;
+    private IAppConfig $appConfig;
     private IConfig $config;
     private AnalyticsService $service;
 
@@ -50,6 +52,9 @@ class AnalyticsServiceTest extends TestCase
         $this->dedup           = $this->createMock(
             originalClassName: UniqueViewerDedup::class
         );
+        $this->appConfig       = $this->createMock(
+            originalClassName: IAppConfig::class
+        );
         $this->config          = $this->createMock(
             originalClassName: IConfig::class
         );
@@ -58,20 +63,21 @@ class AnalyticsServiceTest extends TestCase
             viewMapper: $this->viewMapper,
             dashboardMapper: $this->dashboardMapper,
             dedup: $this->dedup,
+            appConfig: $this->appConfig,
             config: $this->config,
         );
     }
 
     public function testIsGloballyEnabledDefaultsTrue(): void
     {
-        $this->config->method('getAppValue')->willReturn('true');
+        $this->appConfig->method('getValueBool')->willReturn(true);
 
         $this->assertTrue($this->service->isGloballyEnabled());
     }
 
     public function testIsGloballyEnabledFalseWhenSetFalse(): void
     {
-        $this->config->method('getAppValue')->willReturn('false');
+        $this->appConfig->method('getValueBool')->willReturn(false);
 
         $this->assertFalse($this->service->isGloballyEnabled());
     }
@@ -85,7 +91,7 @@ class AnalyticsServiceTest extends TestCase
 
     public function testGetRetentionDaysClampsBelowMinimum(): void
     {
-        $this->config->method('getAppValue')->willReturn('10');
+        $this->appConfig->method('getValueInt')->willReturn(10);
 
         $this->assertSame(
             AnalyticsService::MIN_RETENTION_DAYS,
@@ -95,7 +101,7 @@ class AnalyticsServiceTest extends TestCase
 
     public function testGetRetentionDaysClampsAboveMaximum(): void
     {
-        $this->config->method('getAppValue')->willReturn('99999');
+        $this->appConfig->method('getValueInt')->willReturn(99999);
 
         $this->assertSame(
             AnalyticsService::MAX_RETENTION_DAYS,
@@ -105,19 +111,19 @@ class AnalyticsServiceTest extends TestCase
 
     public function testGetRetentionDaysReturnsValueInRange(): void
     {
-        $this->config->method('getAppValue')->willReturn('100');
+        $this->appConfig->method('getValueInt')->willReturn(100);
 
         $this->assertSame(100, $this->service->getRetentionDays());
     }
 
     public function testSetRetentionDaysClampsAndPersists(): void
     {
-        $this->config->expects($this->once())
-            ->method('setAppValue')
+        $this->appConfig->expects($this->once())
+            ->method('setValueInt')
             ->with(
                 $this->equalTo('mydash'),
                 $this->equalTo(AnalyticsService::CONFIG_KEY_RETENTION_DAYS),
-                $this->equalTo('30')
+                $this->equalTo(30)
             );
 
         $clamped = $this->service->setRetentionDays(days: 5);
@@ -146,7 +152,7 @@ class AnalyticsServiceTest extends TestCase
         $this->dashboardMapper
             ->method('findByUuid')
             ->willReturn(value: new Dashboard());
-        $this->config->method('getAppValue')->willReturn('false');
+        $this->appConfig->method('getValueBool')->willReturn(false);
         $this->viewMapper->expects($this->never())->method('upsertView');
 
         $result = $this->service->recordViewEvent(
@@ -162,7 +168,7 @@ class AnalyticsServiceTest extends TestCase
         $this->dashboardMapper
             ->method('findByUuid')
             ->willReturn(value: new Dashboard());
-        $this->config->method('getAppValue')->willReturn('true');
+        $this->appConfig->method('getValueBool')->willReturn(true);
         $this->config->method('getUserValue')->willReturn('true');
         $this->viewMapper->expects($this->never())->method('upsertView');
 
@@ -179,7 +185,7 @@ class AnalyticsServiceTest extends TestCase
         $this->dashboardMapper
             ->method('findByUuid')
             ->willReturn(value: new Dashboard());
-        $this->config->method('getAppValue')->willReturn('true');
+        $this->appConfig->method('getValueBool')->willReturn(true);
         $this->config->method('getUserValue')->willReturn('false');
         $this->dedup->method('isNewUniqueViewer')->willReturn(true);
 
@@ -205,7 +211,7 @@ class AnalyticsServiceTest extends TestCase
         $this->dashboardMapper
             ->method('findByUuid')
             ->willReturn(value: new Dashboard());
-        $this->config->method('getAppValue')->willReturn('true');
+        $this->appConfig->method('getValueBool')->willReturn(true);
         $this->config->method('getUserValue')->willReturn('false');
         $this->dedup->method('isNewUniqueViewer')->willReturn(false);
 

--- a/tests/Unit/Service/BulkOperationServiceTest.php
+++ b/tests/Unit/Service/BulkOperationServiceTest.php
@@ -33,7 +33,7 @@ use OCA\MyDash\Service\DashboardTreeService;
 use OCA\MyDash\Service\PermissionDeniedException;
 use OCA\MyDash\Service\PermissionService;
 use OCP\AppFramework\Db\DoesNotExistException;
-use OCP\IConfig;
+use OCP\IAppConfig;
 use OCP\IGroupManager;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -76,9 +76,9 @@ class BulkOperationServiceTest extends TestCase
     private $groupManager;
 
     /**
-     * @var IConfig&MockObject
+     * @var IAppConfig&MockObject
      */
-    private $config;
+    private $appConfig;
 
     /**
      * @var LoggerInterface&MockObject
@@ -95,11 +95,11 @@ class BulkOperationServiceTest extends TestCase
         $this->treeService       = $this->createMock(DashboardTreeService::class);
         $this->activityPublisher = $this->createMock(ActivityPublisher::class);
         $this->groupManager      = $this->createMock(IGroupManager::class);
-        $this->config            = $this->createMock(IConfig::class);
+        $this->appConfig         = $this->createMock(IAppConfig::class);
         $this->logger            = $this->createMock(LoggerInterface::class);
 
         $this->groupManager->method('isAdmin')->willReturn(true);
-        $this->config->method('getAppValue')->willReturn('500');
+        $this->appConfig->method('getValueInt')->willReturn(500);
         $this->permissionService->method('resolveAccessLevel')
             ->willReturn(Dashboard::PERMISSION_FULL);
 
@@ -110,7 +110,7 @@ class BulkOperationServiceTest extends TestCase
             treeService: $this->treeService,
             activityPublisher: $this->activityPublisher,
             groupManager: $this->groupManager,
-            config: $this->config,
+            appConfig: $this->appConfig,
             logger: $this->logger,
         );
     }//end setUp()
@@ -258,7 +258,7 @@ class BulkOperationServiceTest extends TestCase
             treeService: $this->treeService,
             activityPublisher: $this->activityPublisher,
             groupManager: $this->groupManager,
-            config: $this->config,
+            appConfig: $this->appConfig,
             logger: $this->logger,
         );
 
@@ -290,7 +290,7 @@ class BulkOperationServiceTest extends TestCase
             treeService: $this->treeService,
             activityPublisher: $this->activityPublisher,
             groupManager: $groupManager,
-            config: $this->config,
+            appConfig: $this->appConfig,
             logger: $this->logger,
         );
 
@@ -548,8 +548,8 @@ class BulkOperationServiceTest extends TestCase
 
     public function testEffectiveCapFallsBackOnInvalidConfig(): void
     {
-        $config = $this->createMock(IConfig::class);
-        $config->method('getAppValue')->willReturn('0');
+        $appConfig = $this->createMock(IAppConfig::class);
+        $appConfig->method('getValueInt')->willReturn(0);
 
         $service = new BulkOperationService(
             dashboardMapper: $this->dashboardMapper,
@@ -558,7 +558,7 @@ class BulkOperationServiceTest extends TestCase
             treeService: $this->treeService,
             activityPublisher: $this->activityPublisher,
             groupManager: $this->groupManager,
-            config: $config,
+            appConfig: $appConfig,
             logger: $this->logger,
         );
 

--- a/tests/Unit/Service/DemoShowcasesServiceTest.php
+++ b/tests/Unit/Service/DemoShowcasesServiceTest.php
@@ -31,7 +31,7 @@ use OCA\MyDash\Service\DemoShowcasesService;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\Dashboard\IManager;
 use OCP\Dashboard\IWidget;
-use OCP\IConfig;
+use OCP\IAppConfig;
 use OCP\IDBConnection;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -52,8 +52,8 @@ class DemoShowcasesServiceTest extends TestCase
     /** @var IDBConnection&MockObject */
     private $db;
 
-    /** @var IConfig&MockObject */
-    private $config;
+    /** @var IAppConfig&MockObject */
+    private $appConfig;
 
     /** @var IManager&MockObject */
     private $dashboardManager;
@@ -69,14 +69,14 @@ class DemoShowcasesServiceTest extends TestCase
         $this->dashboardMapper  = $this->createMock(originalClassName: DashboardMapper::class);
         $this->placementMapper  = $this->createMock(originalClassName: WidgetPlacementMapper::class);
         $this->db               = $this->createMock(originalClassName: IDBConnection::class);
-        $this->config           = $this->createMock(originalClassName: IConfig::class);
+        $this->appConfig        = $this->createMock(originalClassName: IAppConfig::class);
         $this->dashboardManager = $this->createMock(originalClassName: IManager::class);
 
         $this->service = new DemoShowcasesService(
             dashboardMapper: $this->dashboardMapper,
             placementMapper: $this->placementMapper,
             db: $this->db,
-            config: $this->config,
+            appConfig: $this->appConfig,
             dashboardManager: $this->dashboardManager,
             logger: new NullLogger(),
         );
@@ -98,7 +98,7 @@ class DemoShowcasesServiceTest extends TestCase
      */
     public function testDescribeShowcaseReturnsNullWhenZipMissing(): void
     {
-        $this->config->method('getAppValue')->willReturn('');
+        $this->appConfig->method('getValueString')->willReturn('');
         $result = $this->service->describeShowcase(showcaseId: 'de-bron');
         $this->assertNull(actual: $result);
     }
@@ -120,7 +120,7 @@ class DemoShowcasesServiceTest extends TestCase
             dashboardPayload: $this->validDashboardPayload(uuid: 'dashbrd-uuid', widgets: []),
         );
 
-        $this->config->method('getAppValue')->willReturn('');
+        $this->appConfig->method('getValueString')->willReturn('');
 
         $result = $this->service->describeShowcase(showcaseId: 'de-bron');
         $this->assertIsArray(actual: $result);
@@ -149,7 +149,7 @@ class DemoShowcasesServiceTest extends TestCase
             dashboardPayload: $this->validDashboardPayload(uuid: 'b-uuid', widgets: []),
         );
 
-        $this->config->method('getAppValue')->willReturn('');
+        $this->appConfig->method('getValueString')->willReturn('');
 
         $available = $this->service->getAvailableShowcases();
         $ids = array_map(callback: static fn(array $row) => $row['id'], array: $available);
@@ -171,7 +171,7 @@ class DemoShowcasesServiceTest extends TestCase
         );
 
         $this->dashboardManager->method('getWidgets')->willReturn([]);
-        $this->config->method('getAppValue')->willReturn('');
+        $this->appConfig->method('getValueString')->willReturn('');
 
         $persisted = new Dashboard();
         // phpcs:ignore CustomSniffs.Functions.NamedParameters.RequireNamedParameters
@@ -189,9 +189,9 @@ class DemoShowcasesServiceTest extends TestCase
                 return $persisted;
             });
 
-        $this->config
+        $this->appConfig
             ->expects($this->once())
-            ->method('setAppValue')
+            ->method('setValueString')
             ->with('mydash', 'showcase_installed_de-bron', 'installed-uuid');
 
         $this->db->expects($this->once())->method('beginTransaction');
@@ -226,7 +226,7 @@ class DemoShowcasesServiceTest extends TestCase
         $widget = $this->createMock(originalClassName: IWidget::class);
         $widget->method('getId')->willReturn('recommendations');
         $this->dashboardManager->method('getWidgets')->willReturn([$widget]);
-        $this->config->method('getAppValue')->willReturn('');
+        $this->appConfig->method('getValueString')->willReturn('');
 
         $persisted = new Dashboard();
         // phpcs:ignore CustomSniffs.Functions.NamedParameters.RequireNamedParameters
@@ -256,7 +256,7 @@ class DemoShowcasesServiceTest extends TestCase
             dashboardPayload: $this->validDashboardPayload(uuid: 'src', widgets: []),
         );
 
-        $this->config->method('getAppValue')->willReturn('previously-installed-uuid');
+        $this->appConfig->method('getValueString')->willReturn('previously-installed-uuid');
         $this->dashboardMapper->expects($this->never())->method('insert');
 
         $result = $this->service->installShowcase(showcaseId: 'de-bron');
@@ -286,7 +286,7 @@ class DemoShowcasesServiceTest extends TestCase
         // phpcs:ignore CustomSniffs.Functions.NamedParameters.RequireNamedParameters
         $existing->setUuid('installed-uuid');
 
-        $this->config->method('getAppValue')->willReturn('installed-uuid');
+        $this->appConfig->method('getValueString')->willReturn('installed-uuid');
         $this->dashboardMapper
             ->method('findByUuid')
             ->with(uuid: 'installed-uuid')
@@ -294,9 +294,9 @@ class DemoShowcasesServiceTest extends TestCase
 
         $this->placementMapper->expects($this->once())->method('deleteByDashboardId')->with(dashboardId: 42);
         $this->dashboardMapper->expects($this->once())->method('delete')->with(entity: $existing);
-        $this->config
+        $this->appConfig
             ->expects($this->once())
-            ->method('deleteAppValue')
+            ->method('deleteKey')
             ->with('mydash', 'showcase_installed_de-bron');
 
         $this->service->uninstallShowcase(showcaseId: 'de-bron');
@@ -307,10 +307,10 @@ class DemoShowcasesServiceTest extends TestCase
      */
     public function testUninstallIsIdempotent(): void
     {
-        $this->config->method('getAppValue')->willReturn('');
+        $this->appConfig->method('getValueString')->willReturn('');
         $this->dashboardMapper->expects($this->never())->method('delete');
         $this->placementMapper->expects($this->never())->method('deleteByDashboardId');
-        $this->config->expects($this->never())->method('deleteAppValue');
+        $this->appConfig->expects($this->never())->method('deleteKey');
 
         $this->service->uninstallShowcase(showcaseId: 'de-bron');
     }
@@ -321,14 +321,14 @@ class DemoShowcasesServiceTest extends TestCase
      */
     public function testUninstallTolerantWhenDashboardMissing(): void
     {
-        $this->config->method('getAppValue')->willReturn('orphan-uuid');
+        $this->appConfig->method('getValueString')->willReturn('orphan-uuid');
         $this->dashboardMapper
             ->method('findByUuid')
             ->willThrowException(exception: new DoesNotExistException(msg: 'gone'));
 
-        $this->config
+        $this->appConfig
             ->expects($this->once())
-            ->method('deleteAppValue')
+            ->method('deleteKey')
             ->with('mydash', 'showcase_installed_de-bron');
 
         $this->service->uninstallShowcase(showcaseId: 'de-bron');

--- a/tests/Unit/Service/FeedRefreshServiceTest.php
+++ b/tests/Unit/Service/FeedRefreshServiceTest.php
@@ -30,6 +30,7 @@ use OCA\MyDash\Service\FeedRefreshService;
 use OCP\Http\Client\IClient;
 use OCP\Http\Client\IClientService;
 use OCP\Http\Client\IResponse;
+use OCP\IAppConfig;
 use OCP\IConfig;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -47,6 +48,9 @@ class FeedRefreshServiceTest extends TestCase
 
     /** @var IClient&MockObject */
     private $client;
+
+    /** @var IAppConfig&MockObject */
+    private $appConfig;
 
     /** @var IConfig&MockObject */
     private $config;
@@ -73,6 +77,7 @@ class FeedRefreshServiceTest extends TestCase
 
         $this->clientService   = $this->createMock(IClientService::class);
         $this->client          = $this->createMock(IClient::class);
+        $this->appConfig       = $this->createMock(IAppConfig::class);
         $this->config          = $this->createMock(IConfig::class);
         $this->cacheMapper     = $this->createMock(FeedCacheMapper::class);
         $this->placementMapper = $this->createMock(WidgetPlacementMapper::class);
@@ -82,6 +87,7 @@ class FeedRefreshServiceTest extends TestCase
 
         $this->service = new FeedRefreshService(
             clientService: $this->clientService,
+            appConfig: $this->appConfig,
             config: $this->config,
             cacheMapper: $this->cacheMapper,
             placementMapper: $this->placementMapper,
@@ -360,7 +366,7 @@ XML;
         $row = new FeedCache();
         $row->setFeedUrl('https://blocked-site.com/feed');
 
-        $this->config->method('getAppValue')
+        $this->appConfig->method('getValueString')
             ->willReturnCallback(static function (string $app, string $key, string $default): string {
                 if ($key === FeedRefreshService::CONFIG_KEY_ALLOWED_HOSTS) {
                     return 'bbc.com,example.org';
@@ -402,7 +408,7 @@ XML;
         $row = new FeedCache();
         $row->setFeedUrl('https://bbc.com/news/rss.xml');
 
-        $this->config->method('getAppValue')
+        $this->appConfig->method('getValueString')
             ->willReturnCallback(static function (string $app, string $key, string $default): string {
                 if ($key === FeedRefreshService::CONFIG_KEY_ALLOWED_HOSTS) {
                     return 'BBC.com';
@@ -506,7 +512,7 @@ XML;
      */
     private function configEmpty(): void
     {
-        $this->config->method('getAppValue')
+        $this->appConfig->method('getValueString')
             ->willReturnCallback(static function (string $app, string $key, string $default): string {
                 return $default;
             });

--- a/tests/Unit/Service/FeedServiceTest.php
+++ b/tests/Unit/Service/FeedServiceTest.php
@@ -25,7 +25,7 @@ use OCA\MyDash\Db\Dashboard;
 use OCA\MyDash\Db\FeedToken;
 use OCA\MyDash\Service\DashboardService;
 use OCA\MyDash\Service\FeedService;
-use OCP\IConfig;
+use OCP\IAppConfig;
 use OCP\IL10N;
 use OCP\IURLGenerator;
 use OCP\IUser;
@@ -50,8 +50,8 @@ class FeedServiceTest extends TestCase
     /** @var IURLGenerator&MockObject */
     private $urlGenerator;
 
-    /** @var IConfig&MockObject */
-    private $config;
+    /** @var IAppConfig&MockObject */
+    private $appConfig;
 
     /** @var IFactory&MockObject */
     private $l10nFactory;
@@ -74,7 +74,7 @@ class FeedServiceTest extends TestCase
         $this->dashboardService = $this->createMock(DashboardService::class);
         $this->userManager      = $this->createMock(IUserManager::class);
         $this->urlGenerator     = $this->createMock(IURLGenerator::class);
-        $this->config           = $this->createMock(IConfig::class);
+        $this->appConfig        = $this->createMock(IAppConfig::class);
         $this->l10nFactory      = $this->createMock(IFactory::class);
         $this->logger           = $this->createMock(LoggerInterface::class);
 
@@ -96,7 +96,7 @@ class FeedServiceTest extends TestCase
             dashboardService: $this->dashboardService,
             userManager: $this->userManager,
             urlGenerator: $this->urlGenerator,
-            config: $this->config,
+            appConfig: $this->appConfig,
             l10nFactory: $this->l10nFactory,
             logger: $this->logger,
         );
@@ -182,9 +182,9 @@ class FeedServiceTest extends TestCase
         }
 
         $this->dashboardService->method('getVisibleToUser')->willReturn($entries);
-        $this->config->method('getAppValue')
-            ->with('mydash', FeedService::CONFIG_KEY_ITEM_CAP, '50')
-            ->willReturn('3');
+        $this->appConfig->method('getValueInt')
+            ->with('mydash', FeedService::CONFIG_KEY_ITEM_CAP, 50)
+            ->willReturn(3);
         $this->stubUserManager(displayName: 'Owner Name');
 
         $token = $this->buildToken(userId: 'owner');
@@ -223,7 +223,7 @@ class FeedServiceTest extends TestCase
         ];
 
         $this->dashboardService->method('getVisibleToUser')->willReturn($entries);
-        $this->config->method('getAppValue')->willReturn('50');
+        $this->appConfig->method('getValueInt')->willReturn(50);
         $this->stubUserManager(displayName: 'Iris');
 
         $xml = $this->service->renderFeed(
@@ -259,7 +259,7 @@ class FeedServiceTest extends TestCase
         ];
 
         $this->dashboardService->method('getVisibleToUser')->willReturn($entries);
-        $this->config->method('getAppValue')->willReturn('50');
+        $this->appConfig->method('getValueInt')->willReturn(50);
         $this->stubUserManager(displayName: 'Owner');
 
         $xml = $this->service->renderFeed(
@@ -280,7 +280,7 @@ class FeedServiceTest extends TestCase
     public function testRenderFeedProducesRssRoot(): void
     {
         $this->dashboardService->method('getVisibleToUser')->willReturn([]);
-        $this->config->method('getAppValue')->willReturn('50');
+        $this->appConfig->method('getValueInt')->willReturn(50);
         $this->stubUserManager(displayName: 'Owner');
 
         $xml = $this->service->renderFeed(
@@ -310,7 +310,7 @@ class FeedServiceTest extends TestCase
     public function testRenderFeedReturnsAtomWhenRequested(): void
     {
         $this->dashboardService->method('getVisibleToUser')->willReturn([]);
-        $this->config->method('getAppValue')->willReturn('50');
+        $this->appConfig->method('getValueInt')->willReturn(50);
         $this->stubUserManager(displayName: 'Owner');
 
         $xml = $this->service->renderFeed(

--- a/tests/Unit/Service/UniqueViewerDedupTest.php
+++ b/tests/Unit/Service/UniqueViewerDedupTest.php
@@ -23,21 +23,21 @@ namespace Unit\Service;
 use DateTimeImmutable;
 use DateTimeZone;
 use OCA\MyDash\Service\UniqueViewerDedup;
+use OCP\IAppConfig;
 use OCP\ICache;
 use OCP\ICacheFactory;
-use OCP\IConfig;
 use PHPUnit\Framework\TestCase;
 
 class UniqueViewerDedupTest extends TestCase
 {
-    private IConfig $config;
+    private IAppConfig $appConfig;
     private ICacheFactory $cacheFactory;
     private ICache $cache;
     private UniqueViewerDedup $dedup;
 
     protected function setUp(): void
     {
-        $this->config       = $this->createMock(originalClassName: IConfig::class);
+        $this->appConfig    = $this->createMock(originalClassName: IAppConfig::class);
         $this->cacheFactory = $this->createMock(originalClassName: ICacheFactory::class);
         $this->cache        = $this->createMock(originalClassName: ICache::class);
 
@@ -47,7 +47,7 @@ class UniqueViewerDedupTest extends TestCase
 
         $this->dedup = new UniqueViewerDedup(
             cacheFactory: $this->cacheFactory,
-            config: $this->config,
+            appConfig: $this->appConfig,
         );
     }
 
@@ -94,25 +94,27 @@ class UniqueViewerDedupTest extends TestCase
 
     public function testGetSaltForDateReturnsExistingWhenDateMatches(): void
     {
-        $this->config
-            ->method('getAppValue')
+        $this->appConfig
+            ->method('getValueString')
             ->willReturnMap(
                 valueMap: [
                     [
                         'mydash',
                         UniqueViewerDedup::CONFIG_KEY_SALT,
                         '',
+                        false,
                         'cafef00d',
                     ],
                     [
                         'mydash',
                         UniqueViewerDedup::CONFIG_KEY_SALT_DATE,
                         '',
+                        false,
                         '2026-05-01',
                     ],
                 ]
             );
-        $this->config->expects($this->never())->method('setAppValue');
+        $this->appConfig->expects($this->never())->method('setValueString');
 
         $salt = $this->dedup->getSaltForDate(viewBucketDate: '2026-05-01');
 
@@ -121,29 +123,31 @@ class UniqueViewerDedupTest extends TestCase
 
     public function testGetSaltForDateRotatesWhenDateIsStale(): void
     {
-        $this->config
-            ->method('getAppValue')
+        $this->appConfig
+            ->method('getValueString')
             ->willReturnMap(
                 valueMap: [
                     [
                         'mydash',
                         UniqueViewerDedup::CONFIG_KEY_SALT,
                         '',
+                        false,
                         'oldsalt',
                     ],
                     [
                         'mydash',
                         UniqueViewerDedup::CONFIG_KEY_SALT_DATE,
                         '',
+                        false,
                         '2026-04-30',
                     ],
                 ]
             );
 
         $captured = [];
-        $this->config
+        $this->appConfig
             ->expects($this->exactly(2))
-            ->method('setAppValue')
+            ->method('setValueString')
             ->willReturnCallback(
                 static function (
                     string $app,
@@ -172,7 +176,7 @@ class UniqueViewerDedupTest extends TestCase
 
     public function testIsNewUniqueViewerReturnsTrueOnFirstView(): void
     {
-        $this->config->method('getAppValue')->willReturnCallback(
+        $this->appConfig->method('getValueString')->willReturnCallback(
             static function (string $a, string $k, string $d): string {
                 if ($k === UniqueViewerDedup::CONFIG_KEY_SALT) {
                     return 'fixed-salt-value';
@@ -197,7 +201,7 @@ class UniqueViewerDedupTest extends TestCase
 
     public function testIsNewUniqueViewerReturnsFalseOnRepeat(): void
     {
-        $this->config->method('getAppValue')->willReturnCallback(
+        $this->appConfig->method('getValueString')->willReturnCallback(
             static function (string $a, string $k, string $d): string {
                 if ($k === UniqueViewerDedup::CONFIG_KEY_SALT) {
                     return 'fixed-salt-value';
@@ -211,6 +215,7 @@ class UniqueViewerDedupTest extends TestCase
         $this->cache->method('hasKey')->willReturn(true);
         $this->cache->expects($this->never())->method('set');
 
+
         $result = $this->dedup->isNewUniqueViewer(
             userId: 'alice',
             viewBucketDate: '2026-05-01',
@@ -222,7 +227,7 @@ class UniqueViewerDedupTest extends TestCase
 
     public function testHashUserForDateIsDeterministicWithSameSalt(): void
     {
-        $this->config->method('getAppValue')->willReturnCallback(
+        $this->appConfig->method('getValueString')->willReturnCallback(
             static function (string $a, string $k, string $d): string {
                 if ($k === UniqueViewerDedup::CONFIG_KEY_SALT) {
                     return 'fixed-salt';
@@ -250,9 +255,9 @@ class UniqueViewerDedupTest extends TestCase
     public function testRotateSaltOverwritesPreviousValueWithoutHistory(): void
     {
         $writes = [];
-        $this->config
+        $this->appConfig
             ->expects($this->exactly(2))
-            ->method('setAppValue')
+            ->method('setValueString')
             ->willReturnCallback(
                 static function (string $a, string $k, string $v) use (&$writes): bool {
                     $writes[$k] = $v;


### PR DESCRIPTION
## Summary

- Migrated **26 deprecated `IConfig` app-value calls** across 10 production classes to the modern `OCP\IAppConfig` API (`getValueString`, `getValueInt`, `getValueBool`, `setValueString`, `setValueInt`, `setValueBool`, `deleteKey`)
- **16 user-value calls** (`getUserValue` / `setUserValue` / `deleteUserValue`) intentionally left on `OCP\IConfig` — mydash min-version is NC 29 and `OCP\IUserConfig` requires NC 31
- Updated all 7 affected test files to mock `IAppConfig` instead of `IConfig` for app-value assertions; int/bool methods use typed returns (`getValueInt` → int, `getValueBool` → bool)

### Files changed (production)
`MetricsController`, `FeedRefreshJob`, `Version001006Date20260430130000`, `AnalyticsService`, `BulkOperationService`, `DemoShowcasesService`, `FeedRefreshService`, `FeedService`, `MetricsCollector`, `UniqueViewerDedup`

### Files changed (tests)
`AnalyticsServiceTest`, `BulkOperationServiceTest`, `DemoShowcasesServiceTest`, `FeedRefreshJobTest`, `FeedRefreshServiceTest`, `FeedServiceTest`, `UniqueViewerDedupTest`

## Test plan

- [ ] PHPStan: `composer phpstan` → **No errors**
- [ ] PHPUnit: `composer test` → identical to baseline (119 pre-existing errors / 9 failures, zero new failures introduced)
- [ ] `php -l` on all edited files → no syntax errors
- [ ] Re-grep confirms zero `getAppValue`/`setAppValue`/`deleteAppValue` in `lib/`