### PR TITLE
fix(ci): bring PHPCS, PHPUnit, and Psalm to green

### DIFF
--- a/lib/BackgroundJob/OrphanedDataCleanupJob.php
+++ b/lib/BackgroundJob/OrphanedDataCleanupJob.php
@@ -103,8 +103,9 @@ class OrphanedDataCleanupJob extends TimedJob
      * @param mixed $argument Ignored — the job carries no arguments.
      *
      * @return void
+     *
+     * @spec openspec/specs/orphaned-data-cleanup/spec.md
      */
-    /** @spec openspec/specs/orphaned-data-cleanup/spec.md */
     protected function run($argument): void
     {
         $categories = $this->resolveCategories();

--- a/lib/BackgroundJob/PurgeViewsJob.php
+++ b/lib/BackgroundJob/PurgeViewsJob.php
@@ -72,8 +72,9 @@ class PurgeViewsJob extends TimedJob
      * @param mixed $argument Required by the base class; unused.
      *
      * @return void
+     *
+     * @spec openspec/specs/dashboard-view-analytics/spec.md
      */
-    /** @spec openspec/specs/dashboard-view-analytics/spec.md */
     protected function run($argument): void
     {
         $cutoff  = $this->analyticsService->getPurgeCutoffDate();

--- a/lib/BackgroundJob/SaltRotationJob.php
+++ b/lib/BackgroundJob/SaltRotationJob.php
@@ -68,8 +68,9 @@ class SaltRotationJob extends TimedJob
      * @param mixed $argument Required by the base class; unused.
      *
      * @return void
+     *
+     * @spec openspec/specs/dashboard-view-analytics/spec.md
      */
-    /** @spec openspec/specs/dashboard-view-analytics/spec.md */
     protected function run($argument): void
     {
         $today = UniqueViewerDedup::utcDateFor();

--- a/lib/Command/CleanupPurgeCommand.php
+++ b/lib/Command/CleanupPurgeCommand.php
@@ -65,8 +65,9 @@ class CleanupPurgeCommand extends Command
      * Configure the command name, description and options.
      *
      * @return void
+     *
+     * @spec openspec/specs/orphaned-data-cleanup/spec.md
      */
-    /** @spec openspec/specs/orphaned-data-cleanup/spec.md */
     protected function configure(): void
     {
         $this->setName(name: 'mydash:cleanup:purge')
@@ -100,8 +101,9 @@ class CleanupPurgeCommand extends Command
      * @param OutputInterface $output The console output.
      *
      * @return int 0 on success, 1 on validation failure.
+     *
+     * @spec openspec/specs/orphaned-data-cleanup/spec.md
      */
-    /** @spec openspec/specs/orphaned-data-cleanup/spec.md */
     protected function execute(
         InputInterface $input,
         OutputInterface $output

--- a/lib/Command/CleanupScanCommand.php
+++ b/lib/Command/CleanupScanCommand.php
@@ -53,8 +53,9 @@ class CleanupScanCommand extends Command
      * Configure the command name + description.
      *
      * @return void
+     *
+     * @spec openspec/specs/orphaned-data-cleanup/spec.md
      */
-    /** @spec openspec/specs/orphaned-data-cleanup/spec.md */
     protected function configure(): void
     {
         $this->setName(name: 'mydash:cleanup:scan')
@@ -70,8 +71,9 @@ class CleanupScanCommand extends Command
      * @param OutputInterface $output The console output.
      *
      * @return int 0 when no orphans, 1 otherwise.
+     *
+     * @spec openspec/specs/orphaned-data-cleanup/spec.md
      */
-    /** @spec openspec/specs/orphaned-data-cleanup/spec.md */
     protected function execute(
         InputInterface $input,
         OutputInterface $output

--- a/lib/Command/CommandBase.php
+++ b/lib/Command/CommandBase.php
@@ -67,8 +67,9 @@ abstract class CommandBase extends Command
      * (REQ-CLI-002), then defer to the child for per-command options.
      *
      * @return void
+     *
+     * @spec openspec/specs/cli-commands/spec.md
      */
-    /** @spec openspec/specs/cli-commands/spec.md */
     final protected function configure(): void
     {
         $this->addOption(
@@ -99,8 +100,9 @@ abstract class CommandBase extends Command
      * {@see configure()}; subclasses MUST NOT re-declare them.
      *
      * @return void
+     *
+     * @spec openspec/specs/cli-commands/spec.md
      */
-    /** @spec openspec/specs/cli-commands/spec.md */
     abstract protected function configureCommand(): void;
 
     /**
@@ -115,8 +117,9 @@ abstract class CommandBase extends Command
      *                                and `--json`).
      *
      * @return int
+     *
+     * @spec openspec/specs/cli-commands/spec.md
      */
-    /** @spec openspec/specs/cli-commands/spec.md */
     abstract protected function handle(
         InputInterface $input,
         OutputInterface $output
@@ -131,8 +134,9 @@ abstract class CommandBase extends Command
      * @param OutputInterface $output CLI output.
      *
      * @return int
+     *
+     * @spec openspec/specs/cli-commands/spec.md
      */
-    /** @spec openspec/specs/cli-commands/spec.md */
     final protected function execute(
         InputInterface $input,
         OutputInterface $output
@@ -216,8 +220,9 @@ abstract class CommandBase extends Command
      * @param string                               $human  Optional human-readable line.
      *
      * @return void
+     *
+     * @spec openspec/specs/cli-commands/spec.md
      */
-    /** @spec openspec/specs/cli-commands/spec.md */
     final protected function emitSuccess(
         InputInterface $input,
         OutputInterface $output,
@@ -251,8 +256,9 @@ abstract class CommandBase extends Command
      * @param array<string,mixed>|null $context  Optional metadata.
      *
      * @return int Echoes back the exit code for caller convenience.
+     *
+     * @spec openspec/specs/cli-commands/spec.md
      */
-    /** @spec openspec/specs/cli-commands/spec.md */
     final protected function emitError(
         InputInterface $input,
         OutputInterface $output,

--- a/lib/Command/DashboardDebugShareCommand.php
+++ b/lib/Command/DashboardDebugShareCommand.php
@@ -59,8 +59,9 @@ class DashboardDebugShareCommand extends CommandBase
      * Wire command name, description, and per-command options.
      *
      * @return void
+     *
+     * @spec openspec/specs/cli-commands/spec.md
      */
-    /** @spec openspec/specs/cli-commands/spec.md */
     protected function configureCommand(): void
     {
         $this->setName(name: 'mydash:dashboard:debug-share')
@@ -91,8 +92,9 @@ class DashboardDebugShareCommand extends CommandBase
      * @param OutputInterface $output CLI output.
      *
      * @return int
+     *
+     * @spec openspec/specs/cli-commands/spec.md
      */
-    /** @spec openspec/specs/cli-commands/spec.md */
     protected function handle(
         InputInterface $input,
         OutputInterface $output

--- a/lib/Command/DashboardDeleteCommand.php
+++ b/lib/Command/DashboardDeleteCommand.php
@@ -66,8 +66,9 @@ class DashboardDeleteCommand extends CommandBase
      * Wire command name, description, and per-command options.
      *
      * @return void
+     *
+     * @spec openspec/specs/cli-commands/spec.md
      */
-    /** @spec openspec/specs/cli-commands/spec.md */
     protected function configureCommand(): void
     {
         $this->setName(name: 'mydash:dashboard:delete')
@@ -104,8 +105,9 @@ class DashboardDeleteCommand extends CommandBase
      * @param OutputInterface $output CLI output.
      *
      * @return int
+     *
+     * @spec openspec/specs/cli-commands/spec.md
      */
-    /** @spec openspec/specs/cli-commands/spec.md */
     protected function handle(
         InputInterface $input,
         OutputInterface $output

--- a/lib/Command/DashboardListCommand.php
+++ b/lib/Command/DashboardListCommand.php
@@ -65,8 +65,9 @@ class DashboardListCommand extends CommandBase
      * Wire command name, description, and per-command options.
      *
      * @return void
+     *
+     * @spec openspec/specs/cli-commands/spec.md
      */
-    /** @spec openspec/specs/cli-commands/spec.md */
     protected function configureCommand(): void
     {
         $this->setName(name: 'mydash:dashboard:list')
@@ -115,8 +116,9 @@ class DashboardListCommand extends CommandBase
      * @param OutputInterface $output CLI output.
      *
      * @return int
+     *
+     * @spec openspec/specs/cli-commands/spec.md
      */
-    /** @spec openspec/specs/cli-commands/spec.md */
     protected function handle(
         InputInterface $input,
         OutputInterface $output

--- a/lib/Command/DashboardShowCommand.php
+++ b/lib/Command/DashboardShowCommand.php
@@ -66,8 +66,9 @@ class DashboardShowCommand extends CommandBase
      * Wire command name, description, and per-command options.
      *
      * @return void
+     *
+     * @spec openspec/specs/cli-commands/spec.md
      */
-    /** @spec openspec/specs/cli-commands/spec.md */
     protected function configureCommand(): void
     {
         $this->setName(name: 'mydash:dashboard:show')
@@ -98,8 +99,9 @@ class DashboardShowCommand extends CommandBase
      * @param OutputInterface $output CLI output.
      *
      * @return int
+     *
+     * @spec openspec/specs/cli-commands/spec.md
      */
-    /** @spec openspec/specs/cli-commands/spec.md */
     protected function handle(
         InputInterface $input,
         OutputInterface $output

--- a/lib/Command/DemoShowcasesInstallCommand.php
+++ b/lib/Command/DemoShowcasesInstallCommand.php
@@ -54,8 +54,9 @@ class DemoShowcasesInstallCommand extends Command
      * Configure CLI options.
      *
      * @return void
+     *
+     * @spec openspec/specs/demo-data-showcases/spec.md
      */
-    /** @spec openspec/specs/demo-data-showcases/spec.md */
     protected function configure(): void
     {
         $this->setName(name: 'mydash:demo-showcases:install')
@@ -87,8 +88,9 @@ class DemoShowcasesInstallCommand extends Command
      * @param OutputInterface $output CLI output.
      *
      * @return int Exit code.
+     *
+     * @spec openspec/specs/demo-data-showcases/spec.md
      */
-    /** @spec openspec/specs/demo-data-showcases/spec.md */
     protected function execute(
         InputInterface $input,
         OutputInterface $output

--- a/lib/Command/DemoShowcasesListCommand.php
+++ b/lib/Command/DemoShowcasesListCommand.php
@@ -51,8 +51,9 @@ class DemoShowcasesListCommand extends Command
      * Configure CLI options.
      *
      * @return void
+     *
+     * @spec openspec/specs/demo-data-showcases/spec.md
      */
-    /** @spec openspec/specs/demo-data-showcases/spec.md */
     protected function configure(): void
     {
         $this->setName(name: 'mydash:demo-showcases:list')
@@ -72,8 +73,9 @@ class DemoShowcasesListCommand extends Command
      * @param OutputInterface $output CLI output.
      *
      * @return int Exit code.
+     *
+     * @spec openspec/specs/demo-data-showcases/spec.md
      */
-    /** @spec openspec/specs/demo-data-showcases/spec.md */
     protected function execute(
         InputInterface $input,
         OutputInterface $output

--- a/lib/Command/ExportCommand.php
+++ b/lib/Command/ExportCommand.php
@@ -57,8 +57,9 @@ class ExportCommand extends Command
      * Configure CLI options.
      *
      * @return void
+     *
+     * @spec openspec/specs/dashboard-export-import/spec.md
      */
-    /** @spec openspec/specs/dashboard-export-import/spec.md */
     protected function configure(): void
     {
         $this->setName(name: 'mydash:export')
@@ -91,8 +92,9 @@ class ExportCommand extends Command
      * @param OutputInterface $output CLI output.
      *
      * @return int Exit code (0 success, 1 error).
+     *
+     * @spec openspec/specs/dashboard-export-import/spec.md
      */
-    /** @spec openspec/specs/dashboard-export-import/spec.md */
     protected function execute(
         InputInterface $input,
         OutputInterface $output

--- a/lib/Command/I18nCopyNavigationCommand.php
+++ b/lib/Command/I18nCopyNavigationCommand.php
@@ -62,8 +62,9 @@ class I18nCopyNavigationCommand extends CommandBase
      * Wire command name, description, and per-command options.
      *
      * @return void
+     *
+     * @spec openspec/specs/cli-commands/spec.md
      */
-    /** @spec openspec/specs/cli-commands/spec.md */
     protected function configureCommand(): void
     {
         $this->setName(name: 'mydash:i18n:copy-navigation')
@@ -108,8 +109,9 @@ class I18nCopyNavigationCommand extends CommandBase
      * @param OutputInterface $output CLI output.
      *
      * @return int
+     *
+     * @spec openspec/specs/cli-commands/spec.md
      */
-    /** @spec openspec/specs/cli-commands/spec.md */
     protected function handle(
         InputInterface $input,
         OutputInterface $output

--- a/lib/Command/I18nExportStringsCommand.php
+++ b/lib/Command/I18nExportStringsCommand.php
@@ -68,8 +68,9 @@ class I18nExportStringsCommand extends CommandBase
      * Wire command name, description, and per-command options.
      *
      * @return void
+     *
+     * @spec openspec/specs/cli-commands/spec.md
      */
-    /** @spec openspec/specs/cli-commands/spec.md */
     protected function configureCommand(): void
     {
         $this->setName(name: 'mydash:i18n:export-strings')
@@ -96,8 +97,9 @@ class I18nExportStringsCommand extends CommandBase
      * @param OutputInterface $output CLI output.
      *
      * @return int
+     *
+     * @spec openspec/specs/cli-commands/spec.md
      */
-    /** @spec openspec/specs/cli-commands/spec.md */
     protected function handle(
         InputInterface $input,
         OutputInterface $output

--- a/lib/Command/I18nMigrateLanguageStructureCommand.php
+++ b/lib/Command/I18nMigrateLanguageStructureCommand.php
@@ -67,8 +67,9 @@ class I18nMigrateLanguageStructureCommand extends CommandBase
      * Wire command name, description, and per-command options.
      *
      * @return void
+     *
+     * @spec openspec/specs/cli-commands/spec.md
      */
-    /** @spec openspec/specs/cli-commands/spec.md */
     protected function configureCommand(): void
     {
         $this->setName(name: 'mydash:i18n:migrate-language-structure')
@@ -96,8 +97,9 @@ class I18nMigrateLanguageStructureCommand extends CommandBase
      * @param OutputInterface $output CLI output.
      *
      * @return int
+     *
+     * @spec openspec/specs/cli-commands/spec.md
      */
-    /** @spec openspec/specs/cli-commands/spec.md */
     protected function handle(
         InputInterface $input,
         OutputInterface $output

--- a/lib/Command/ImportCommand.php
+++ b/lib/Command/ImportCommand.php
@@ -50,8 +50,9 @@ class ImportCommand extends Command
      * Configure CLI options.
      *
      * @return void
+     *
+     * @spec openspec/specs/dashboard-export-import/spec.md
      */
-    /** @spec openspec/specs/dashboard-export-import/spec.md */
     protected function configure(): void
     {
         $this->setName(name: 'mydash:import')
@@ -84,8 +85,9 @@ class ImportCommand extends Command
      * @param OutputInterface $output CLI output.
      *
      * @return int Exit code (0 success, 1 error).
+     *
+     * @spec openspec/specs/dashboard-export-import/spec.md
      */
-    /** @spec openspec/specs/dashboard-export-import/spec.md */
     protected function execute(
         InputInterface $input,
         OutputInterface $output

--- a/lib/Command/ImportConfluenceCommand.php
+++ b/lib/Command/ImportConfluenceCommand.php
@@ -54,8 +54,9 @@ class ImportConfluenceCommand extends Command
      * Configure CLI options.
      *
      * @return void
+     *
+     * @spec openspec/specs/confluence-html-import/spec.md
      */
-    /** @spec openspec/specs/confluence-html-import/spec.md */
     protected function configure(): void
     {
         $this->setName(name: 'mydash:import:confluence')
@@ -94,8 +95,9 @@ class ImportConfluenceCommand extends Command
      * @param OutputInterface $output CLI output.
      *
      * @return int Exit code (0 success, 1 failure).
+     *
+     * @spec openspec/specs/confluence-html-import/spec.md
      */
-    /** @spec openspec/specs/confluence-html-import/spec.md */
     protected function execute(
         InputInterface $input,
         OutputInterface $output

--- a/lib/Command/SetupCommand.php
+++ b/lib/Command/SetupCommand.php
@@ -60,8 +60,9 @@ class SetupCommand extends Command
      * Configure CLI options.
      *
      * @return void
+     *
+     * @spec openspec/specs/setup-wizard/spec.md
      */
-    /** @spec openspec/specs/setup-wizard/spec.md */
     protected function configure(): void
     {
         $this->setName(name: 'mydash:setup')
@@ -83,8 +84,9 @@ class SetupCommand extends Command
      * @param OutputInterface $output CLI output.
      *
      * @return int Exit code (0 success, 1 error).
+     *
+     * @spec openspec/specs/setup-wizard/spec.md
      */
-    /** @spec openspec/specs/setup-wizard/spec.md */
     protected function execute(
         InputInterface $input,
         OutputInterface $output

--- a/lib/Command/UserRevokeFeedTokenCommand.php
+++ b/lib/Command/UserRevokeFeedTokenCommand.php
@@ -68,8 +68,9 @@ class UserRevokeFeedTokenCommand extends CommandBase
      * Wire command name, description, and per-command options.
      *
      * @return void
+     *
+     * @spec openspec/specs/dashboard-rss-feeds/spec.md
      */
-    /** @spec openspec/specs/dashboard-rss-feeds/spec.md */
     protected function configureCommand(): void
     {
         $this->setName(name: 'mydash:user:revoke-feed-token')
@@ -101,8 +102,9 @@ class UserRevokeFeedTokenCommand extends CommandBase
      * @param OutputInterface $output CLI output.
      *
      * @return int
+     *
+     * @spec openspec/specs/dashboard-rss-feeds/spec.md
      */
-    /** @spec openspec/specs/dashboard-rss-feeds/spec.md */
     protected function handle(
         InputInterface $input,
         OutputInterface $output

--- a/lib/Controller/AdminBulkController.php
+++ b/lib/Controller/AdminBulkController.php
@@ -40,6 +40,7 @@ use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\AuthorizedAdminSetting;
 use OCP\AppFramework\Http\JSONResponse;
+use OCP\IGroupManager;
 use OCP\IRequest;
 use OCP\IUserSession;
 
@@ -58,17 +59,45 @@ class AdminBulkController extends Controller
      * @param IRequest             $request      The current request.
      * @param BulkOperationService $bulkService  The bulk service.
      * @param IUserSession         $userSession  The user session.
+     * @param IGroupManager        $groupManager NC group manager for inline admin guard.
      */
     public function __construct(
         IRequest $request,
         private readonly BulkOperationService $bulkService,
         private readonly IUserSession $userSession,
+        private readonly IGroupManager $groupManager,
     ) {
         parent::__construct(
             appName: Application::APP_ID,
             request: $request
         );
     }//end __construct()
+
+    /**
+     * Inline admin guard — returns a 401/403 JSONResponse when the caller
+     * is not authenticated or not an NC admin, or null when the guard passes.
+     *
+     * @return JSONResponse|null Non-null means the request must be rejected.
+     */
+    private function assertAdmin(): ?JSONResponse
+    {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
+            return new JSONResponse(
+                data: ['error' => 'Not authenticated'],
+                statusCode: Http::STATUS_UNAUTHORIZED
+            );
+        }
+
+        if ($this->groupManager->isAdmin(userId: $user->getUID()) === false) {
+            return new JSONResponse(
+                data: ['error' => 'Admin required'],
+                statusCode: Http::STATUS_FORBIDDEN
+            );
+        }
+
+        return null;
+    }//end assertAdmin()
 
     /**
      * `POST /api/admin/dashboards/bulk-delete` — REQ-BULK-001.
@@ -78,15 +107,20 @@ class AdminBulkController extends Controller
      * @param bool|null $cascade        When true, cascade into children.
      *
      * @return JSONResponse The bulk-delete envelope.
-     *
-     */
+         *
+     * @spec openspec/specs/dashboard-bulk-operations/spec.md
+ */
     #[AuthorizedAdminSetting(Application::APP_ID)]
-    /** @spec openspec/specs/dashboard-bulk-operations/spec.md */
     public function bulkDelete(
         mixed $dashboardUuids=null,
         ?bool $dryRun=null,
         ?bool $cascade=null
     ): JSONResponse {
+        $guard = $this->assertAdmin();
+        if ($guard !== null) {
+            return $guard;
+        }
+
         $uuids = $this->extractUuids(value: $dashboardUuids);
         if ($uuids === null) {
             return new JSONResponse(
@@ -133,15 +167,20 @@ class AdminBulkController extends Controller
      * @param bool|null   $dryRun         When true, preview only.
      *
      * @return JSONResponse The bulk-move envelope.
-     *
-     */
+         *
+     * @spec openspec/specs/dashboard-bulk-operations/spec.md
+ */
     #[AuthorizedAdminSetting(Application::APP_ID)]
-    /** @spec openspec/specs/dashboard-bulk-operations/spec.md */
     public function bulkMove(
         mixed $dashboardUuids=null,
         ?string $parentUuid=null,
         ?bool $dryRun=null
     ): JSONResponse {
+        $guard = $this->assertAdmin();
+        if ($guard !== null) {
+            return $guard;
+        }
+
         $uuids = $this->extractUuids(value: $dashboardUuids);
         if ($uuids === null) {
             return new JSONResponse(
@@ -187,16 +226,21 @@ class AdminBulkController extends Controller
      * @param bool|null   $dryRun            When true, preview only.
      *
      * @return JSONResponse The bulk-status envelope.
-     *
-     */
+         *
+     * @spec openspec/specs/dashboard-bulk-operations/spec.md
+ */
     #[AuthorizedAdminSetting(Application::APP_ID)]
-    /** @spec openspec/specs/dashboard-bulk-operations/spec.md */
     public function bulkStatus(
         mixed $dashboardUuids=null,
         ?string $publicationStatus=null,
         ?string $publishAt=null,
         ?bool $dryRun=null
     ): JSONResponse {
+        $guard = $this->assertAdmin();
+        if ($guard !== null) {
+            return $guard;
+        }
+
         $uuids = $this->extractUuids(value: $dashboardUuids);
         if ($uuids === null) {
             return new JSONResponse(
@@ -248,14 +292,19 @@ class AdminBulkController extends Controller
      * @param bool|null $dryRun         When true, preview only.
      *
      * @return JSONResponse The bulk-reindex envelope.
-     *
-     */
+         *
+     * @spec openspec/specs/dashboard-bulk-operations/spec.md
+ */
     #[AuthorizedAdminSetting(Application::APP_ID)]
-    /** @spec openspec/specs/dashboard-bulk-operations/spec.md */
     public function bulkReindex(
         mixed $dashboardUuids=null,
         ?bool $dryRun=null
     ): JSONResponse {
+        $guard = $this->assertAdmin();
+        if ($guard !== null) {
+            return $guard;
+        }
+
         $uuids = $this->extractUuids(value: $dashboardUuids);
         if ($uuids === null) {
             return new JSONResponse(
@@ -347,5 +396,4 @@ class AdminBulkController extends Controller
         $lower = strtolower((string) $raw);
         return in_array(needle: $lower, haystack: ['1', 'true', 'yes', 'on'], strict: true);
     }//end resolveBool()
-
 }//end class

--- a/lib/Controller/AdminCleanupController.php
+++ b/lib/Controller/AdminCleanupController.php
@@ -39,6 +39,7 @@ use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\AuthorizedAdminSetting;
 use OCP\AppFramework\Http\JSONResponse;
+use OCP\IGroupManager;
 use OCP\IRequest;
 use OCP\IUserSession;
 
@@ -56,18 +57,45 @@ class AdminCleanupController extends Controller
      *                                                   (for unknown-name
      *                                                   error messages).
      * @param IUserSession               $userSession    Current user.
+     * @param IGroupManager              $groupManager   Admin check.
      */
     public function __construct(
         IRequest $request,
         private readonly OrphanedDataCleanupService $cleanupService,
         private readonly CategoryRegistryService $registry,
         private readonly IUserSession $userSession,
+        private readonly IGroupManager $groupManager,
     ) {
         parent::__construct(
             appName: Application::APP_ID,
             request: $request
         );
     }//end __construct()
+
+    /**
+     * Inline admin guard.
+     *
+     * @return JSONResponse|null Non-null = caller must be rejected.
+     */
+    private function assertAdmin(): ?JSONResponse
+    {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
+            return new JSONResponse(
+                data: ['error' => 'Not authenticated'],
+                statusCode: Http::STATUS_FORBIDDEN
+            );
+        }
+
+        if ($this->groupManager->isAdmin(userId: $user->getUID()) === false) {
+            return new JSONResponse(
+                data: ['error' => 'Admin required'],
+                statusCode: Http::STATUS_FORBIDDEN
+            );
+        }
+
+        return null;
+    }//end assertAdmin()
 
     /**
      * `GET /api/admin/cleanup/scan` — REQ-CLN-004.
@@ -78,11 +106,17 @@ class AdminCleanupController extends Controller
      * can display "last refreshed" badges.
      *
      * @return JSONResponse The scan result.
-     */
+         *
+     * @spec openspec/specs/orphaned-data-cleanup/spec.md
+ */
     #[AuthorizedAdminSetting(Application::APP_ID)]
-    /** @spec openspec/specs/orphaned-data-cleanup/spec.md */
     public function scan(): JSONResponse
     {
+        $guard = $this->assertAdmin();
+        if ($guard !== null) {
+            return $guard;
+        }
+
         $cached = $this->cleanupService->getCachedScanResult();
         if ($cached !== null) {
             return new JSONResponse(
@@ -128,11 +162,17 @@ class AdminCleanupController extends Controller
      * @param bool|null              $dryRun     Dry-run flag.
      *
      * @return JSONResponse The purge result.
-     */
+         *
+     * @spec openspec/specs/orphaned-data-cleanup/spec.md
+ */
     #[AuthorizedAdminSetting(Application::APP_ID)]
-    /** @spec openspec/specs/orphaned-data-cleanup/spec.md */
     public function purge(?array $categories=null, ?bool $dryRun=null): JSONResponse
     {
+        $guard = $this->assertAdmin();
+        if ($guard !== null) {
+            return $guard;
+        }
+
         $names = $this->normaliseCategories(input: ($categories ?? []));
         if ($names === null) {
             return new JSONResponse(
@@ -201,5 +241,4 @@ class AdminCleanupController extends Controller
 
         return $normalised;
     }//end normaliseCategories()
-
 }//end class

--- a/lib/Controller/AdminController.php
+++ b/lib/Controller/AdminController.php
@@ -136,6 +136,34 @@ class AdminController extends Controller
     }//end __construct()
 
     /**
+     * Inline admin guard — checks session and group membership.
+     *
+     * Returns a 401/403 JSONResponse when the caller is not authenticated or
+     * not an NC admin, or null when the guard passes.
+     *
+     * @return JSONResponse|null Non-null means the request must be rejected.
+     */
+    private function assertAdmin(): ?JSONResponse
+    {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
+            return new JSONResponse(
+                data: ['error' => 'Not authenticated'],
+                statusCode: Http::STATUS_UNAUTHORIZED
+            );
+        }
+
+        if ($this->groupManager->isAdmin(userId: $user->getUID()) === false) {
+            return new JSONResponse(
+                data: ['error' => 'Admin required'],
+                statusCode: Http::STATUS_FORBIDDEN
+            );
+        }
+
+        return null;
+    }//end assertAdmin()
+
+    /**
      * List all admin dashboard templates.
      *
      * @return JSONResponse The list of templates.
@@ -158,9 +186,10 @@ class AdminController extends Controller
      * @param int $id The template ID.
      *
      * @return JSONResponse The template data.
-     */
+         *
+     * @spec openspec/specs/admin-templates/spec.md
+ */
     #[AuthorizedAdminSetting(Application::APP_ID)]
-    /** @spec openspec/specs/admin-templates/spec.md */
     public function getTemplate(int $id): JSONResponse
     {
         try {
@@ -355,12 +384,17 @@ class AdminController extends Controller
      * potentially-sensitive draft footer copy.
      *
      * @return JSONResponse The settings object, or 401/403 on guard failure.
-     *
-     */
+         *
+     * @spec openspec/specs/admin-templates/spec.md
+ */
     #[AuthorizedAdminSetting(Application::APP_ID)]
-    /** @spec openspec/specs/admin-templates/spec.md */
     public function getFooterSettings(): JSONResponse
     {
+        $guard = $this->assertAdmin();
+        if ($guard !== null) {
+            return $guard;
+        }
+
         return ResponseHelper::success(
             data: $this->footerService->getGlobalSettings()
         );
@@ -386,10 +420,10 @@ class AdminController extends Controller
      *
      * @return JSONResponse Status 200 on success, 400/413 on validation,
      *                      401/403 on guard failure.
-     *
-     */
+         *
+     * @spec openspec/specs/admin-templates/spec.md
+ */
     #[AuthorizedAdminSetting(Application::APP_ID)]
-    /** @spec openspec/specs/admin-templates/spec.md */
     public function updateFooterSettings(
         ?bool $footerEnabled=null,
         mixed $footerHtml=null,
@@ -397,6 +431,10 @@ class AdminController extends Controller
         ?string $footerBackgroundColor=null,
         ?string $footerTextColor=null
     ): JSONResponse {
+        $guard = $this->assertAdmin();
+        if ($guard !== null) {
+            return $guard;
+        }
 
         // Build the patch from only those args that the caller actually
         // supplied — `array_key_exists` semantics on the body let admins
@@ -446,13 +484,18 @@ class AdminController extends Controller
      * @return StreamResponse|JSONResponse The streamed ZIP, or a JSON error.
      *
      * @NoCSRFRequired
-     */
+         *
+     * @spec openspec/specs/admin-templates/spec.md
+ */
     #[AuthorizedAdminSetting(Application::APP_ID)]
-    /** @spec openspec/specs/admin-templates/spec.md */
     public function export(
         string $scope='site',
         ?string $dashboardUuid=null
     ): StreamResponse|JSONResponse {
+        $guard = $this->assertAdmin();
+        if ($guard !== null) {
+            return $guard;
+        }
 
         if (in_array(needle: $scope, haystack: ['site', 'dashboard'], strict: true) === false) {
             return new JSONResponse(
@@ -507,11 +550,16 @@ class AdminController extends Controller
      * @return JSONResponse The import summary, or an error response.
      *
      * @NoCSRFRequired
-     */
+         *
+     * @spec openspec/specs/admin-templates/spec.md
+ */
     #[AuthorizedAdminSetting(Application::APP_ID)]
-    /** @spec openspec/specs/admin-templates/spec.md */
     public function import(bool $preserveUuids=false): JSONResponse
     {
+        $guard = $this->assertAdmin();
+        if ($guard !== null) {
+            return $guard;
+        }
 
         // Multipart uploads bind to $_FILES; PHP only populates this for
         // POST requests, which is what the route declares (REQ-EXIM-004).
@@ -571,10 +619,10 @@ class AdminController extends Controller
      * caller MUST be a Nextcloud admin; non-admins receive HTTP 403.
      *
      * @return JSONResponse The list of role assignments, or 401/403.
-     *
-     */
+         *
+     * @spec openspec/specs/admin-templates/spec.md
+ */
     #[AuthorizedAdminSetting(Application::APP_ID)]
-    /** @spec openspec/specs/admin-templates/spec.md */
     public function listRoles(): JSONResponse
     {
 
@@ -598,10 +646,10 @@ class AdminController extends Controller
      * @param string|null $role    The role name (admin / editor / viewer).
      *
      * @return JSONResponse The created assignment, or an error envelope.
-     *
-     */
+         *
+     * @spec openspec/specs/admin-templates/spec.md
+ */
     #[AuthorizedAdminSetting(Application::APP_ID)]
-    /** @spec openspec/specs/admin-templates/spec.md */
     public function createRole(
         ?string $userId=null,
         ?string $groupId=null,
@@ -649,10 +697,10 @@ class AdminController extends Controller
      * @param int $id The role assignment ID.
      *
      * @return JSONResponse Empty success or error envelope.
-     *
-     */
+         *
+     * @spec openspec/specs/admin-templates/spec.md
+ */
     #[AuthorizedAdminSetting(Application::APP_ID)]
-    /** @spec openspec/specs/admin-templates/spec.md */
     public function deleteRole(int $id): JSONResponse
     {
 
@@ -677,10 +725,10 @@ class AdminController extends Controller
      * Response shape: `{role: string|null, source: string|null}`.
      *
      * @return JSONResponse The role / source envelope, or 401.
-     *
-     */
+         *
+     * @spec openspec/specs/admin-templates/spec.md
+ */
     #[NoAdminRequired]
-    /** @spec openspec/specs/admin-templates/spec.md */
     public function getMyRole(): JSONResponse
     {
         $user = $this->userSession->getUser();
@@ -708,12 +756,16 @@ class AdminController extends Controller
      * @param string|null $feedUrl Optional single URL to refresh.
      *
      * @return JSONResponse The aggregate refresh summary.
-     *
-     */
+         *
+     * @spec openspec/specs/admin-templates/spec.md
+ */
     #[AuthorizedAdminSetting(Application::APP_ID)]
-    /** @spec openspec/specs/admin-templates/spec.md */
     public function refreshFeedsNow(?string $feedUrl=null): JSONResponse
     {
+        $guard = $this->assertAdmin();
+        if ($guard !== null) {
+            return $guard;
+        }
 
         if ($feedUrl !== null && $feedUrl !== '') {
             $scheme = strtolower(
@@ -754,9 +806,10 @@ class AdminController extends Controller
      *                      on success.
      *
      * @NoCSRFRequired
-     */
+         *
+     * @spec openspec/specs/admin-templates/spec.md
+ */
     #[AuthorizedAdminSetting(Application::APP_ID)]
-    /** @spec openspec/specs/admin-templates/spec.md */
     public function uploadTemplatePreviewImage(
         string $uuid,
         string $base64=''
@@ -818,12 +871,16 @@ class AdminController extends Controller
      * `{complete, currentRecommendedStep, stepStatuses}`.
      *
      * @return JSONResponse The wizard state, or 401/403.
-     *
-     */
+         *
+     * @spec openspec/specs/admin-templates/spec.md
+ */
     #[AuthorizedAdminSetting(Application::APP_ID)]
-    /** @spec openspec/specs/admin-templates/spec.md */
     public function getWizardState(): JSONResponse
     {
+        $guard = $this->assertAdmin();
+        if ($guard !== null) {
+            return $guard;
+        }
 
         return ResponseHelper::success(
             data: $this->setupWizardService->getWizardState()
@@ -837,12 +894,16 @@ class AdminController extends Controller
      * same payload. Admin-only.
      *
      * @return JSONResponse The post-completion wizard state, or 401/403.
-     *
-     */
+         *
+     * @spec openspec/specs/admin-templates/spec.md
+ */
     #[AuthorizedAdminSetting(Application::APP_ID)]
-    /** @spec openspec/specs/admin-templates/spec.md */
     public function completeWizard(): JSONResponse
     {
+        $guard = $this->assertAdmin();
+        if ($guard !== null) {
+            return $guard;
+        }
 
         return ResponseHelper::success(
             data: $this->setupWizardService->markWizardComplete()
@@ -860,12 +921,16 @@ class AdminController extends Controller
      * @param string|null $storage The chosen backend.
      *
      * @return JSONResponse The post-write wizard state, or 400/401/403.
-     *
-     */
+         *
+     * @spec openspec/specs/admin-templates/spec.md
+ */
     #[AuthorizedAdminSetting(Application::APP_ID)]
-    /** @spec openspec/specs/admin-templates/spec.md */
     public function setWizardStorage(?string $storage=null): JSONResponse
     {
+        $guard = $this->assertAdmin();
+        if ($guard !== null) {
+            return $guard;
+        }
 
         if ($storage === null || $storage === '') {
             return new JSONResponse(
@@ -896,7 +961,6 @@ class AdminController extends Controller
             data: $this->setupWizardService->getWizardState()
         );
     }//end setWizardStorage()
-
 
     /**
      * Build the update data array from nullable parameters.

--- a/lib/Controller/AdminDemoShowcasesController.php
+++ b/lib/Controller/AdminDemoShowcasesController.php
@@ -38,7 +38,9 @@ use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\AuthorizedAdminSetting;
 use OCP\AppFramework\Http\JSONResponse;
+use OCP\IGroupManager;
 use OCP\IRequest;
+use OCP\IUserSession;
 use Psr\Log\LoggerInterface;
 use Throwable;
 
@@ -52,14 +54,15 @@ class AdminDemoShowcasesController extends Controller
      *
      * @param IRequest             $request      The HTTP request.
      * @param DemoShowcasesService $showcasesSvc Showcase service.
-     *                                           (admin gate).
-     * @param LoggerInterface      $logger       PSR-3 logger for
-     *                                           ADR-005
-     *                                           redaction.
+     * @param IUserSession         $userSession  Active user session.
+     * @param IGroupManager        $groupManager Admin check.
+     * @param LoggerInterface      $logger       PSR-3 logger.
      */
     public function __construct(
         IRequest $request,
         private readonly DemoShowcasesService $showcasesSvc,
+        private readonly IUserSession $userSession,
+        private readonly IGroupManager $groupManager,
         private readonly LoggerInterface $logger,
     ) {
         parent::__construct(
@@ -69,15 +72,45 @@ class AdminDemoShowcasesController extends Controller
     }//end __construct()
 
     /**
+     * Inline admin guard.
+     *
+     * @return JSONResponse|null Non-null = caller must be rejected.
+     */
+    private function assertAdmin(): ?JSONResponse
+    {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
+            return new JSONResponse(
+                data: ['error' => 'Not authenticated'],
+                statusCode: Http::STATUS_UNAUTHORIZED
+            );
+        }
+
+        if ($this->groupManager->isAdmin(userId: $user->getUID()) === false) {
+            return new JSONResponse(
+                data: ['error' => 'Admin required'],
+                statusCode: Http::STATUS_FORBIDDEN
+            );
+        }
+
+        return null;
+    }//end assertAdmin()
+
+    /**
      * List bundled showcases with installation status (REQ-DEMO-002).
      *
      * @return JSONResponse Showcase descriptors, or 401/403.
-     *
-     */
+         *
+     * @spec openspec/specs/demo-data-showcases/spec.md
+ */
     #[AuthorizedAdminSetting(Application::APP_ID)]
-    /** @spec openspec/specs/demo-data-showcases/spec.md */
     public function index(): JSONResponse
     {
+        $guard = $this->assertAdmin();
+        if ($guard !== null) {
+            return $guard;
+        }
+
         return ResponseHelper::success(
             data: $this->showcasesSvc->getAvailableShowcases()
         );
@@ -98,15 +131,20 @@ class AdminDemoShowcasesController extends Controller
      *                      dashboard if any.
      *
      * @return JSONResponse The install result, or an error.
-     *
-     */
+         *
+     * @spec openspec/specs/demo-data-showcases/spec.md
+ */
     #[AuthorizedAdminSetting(Application::APP_ID)]
-    /** @spec openspec/specs/demo-data-showcases/spec.md */
     public function install(
         string $id,
         string $lang='nl',
         bool $force=false
     ): JSONResponse {
+        $guard = $this->assertAdmin();
+        if ($guard !== null) {
+            return $guard;
+        }
+
         try {
             $result = $this->showcasesSvc->installShowcase(
                 showcaseId: $id,
@@ -156,12 +194,17 @@ class AdminDemoShowcasesController extends Controller
      * @param string $id The showcase ID (path segment).
      *
      * @return JSONResponse Empty 204, or 401/403.
-     *
-     */
+         *
+     * @spec openspec/specs/demo-data-showcases/spec.md
+ */
     #[AuthorizedAdminSetting(Application::APP_ID)]
-    /** @spec openspec/specs/demo-data-showcases/spec.md */
     public function destroy(string $id): JSONResponse
     {
+        $guard = $this->assertAdmin();
+        if ($guard !== null) {
+            return $guard;
+        }
+
         try {
             $this->showcasesSvc->uninstallShowcase(showcaseId: $id);
         } catch (Throwable $e) {
@@ -180,5 +223,4 @@ class AdminDemoShowcasesController extends Controller
 
         return new JSONResponse(data: [], statusCode: Http::STATUS_NO_CONTENT);
     }//end destroy()
-
 }//end class

--- a/lib/Controller/AdminOrgNavigationController.php
+++ b/lib/Controller/AdminOrgNavigationController.php
@@ -42,6 +42,7 @@ use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\AuthorizedAdminSetting;
 use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\JSONResponse;
+use OCP\IGroupManager;
 use OCP\IRequest;
 use OCP\IUserSession;
 
@@ -88,18 +89,45 @@ class AdminOrgNavigationController extends Controller
      * @param AdminSettingMapper   $settings     Persistence layer for
      *                                           the position scalar.
      * @param IUserSession         $userSession  Current user session.
+     * @param IGroupManager        $groupManager Admin check for write endpoints.
      */
     public function __construct(
         IRequest $request,
         private readonly OrgNavigationService $service,
         private readonly AdminSettingMapper $settings,
         private readonly IUserSession $userSession,
+        private readonly IGroupManager $groupManager,
     ) {
         parent::__construct(
             appName: Application::APP_ID,
             request: $request
         );
     }//end __construct()
+
+    /**
+     * Inline admin guard (returns null when the caller is an NC admin).
+     *
+     * @return JSONResponse|null Non-null = caller must be rejected.
+     */
+    private function assertAdmin(): ?JSONResponse
+    {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
+            return new JSONResponse(
+                data: ['error' => 'Not authenticated'],
+                statusCode: Http::STATUS_UNAUTHORIZED
+            );
+        }
+
+        if ($this->groupManager->isAdmin(userId: $user->getUID()) === false) {
+            return new JSONResponse(
+                data: ['error' => 'Admin required'],
+                statusCode: Http::STATUS_FORBIDDEN
+            );
+        }
+
+        return null;
+    }//end assertAdmin()
 
     /**
      * Read the org-navigation tree filtered for the current user.
@@ -110,10 +138,10 @@ class AdminOrgNavigationController extends Controller
      *
      * @return JSONResponse The filtered tree under `tree` plus the
      *                      effective `language`.
-     *
-     */
+         *
+     * @spec openspec/specs/navigation-editor-org/spec.md
+ */
     #[NoAdminRequired]
-    /** @spec openspec/specs/navigation-editor-org/spec.md */
     public function getOrgNavigation(string $lang=OrgNavigationService::DEFAULT_LANGUAGE): JSONResponse
     {
         $user = $this->userSession->getUser();
@@ -152,14 +180,18 @@ class AdminOrgNavigationController extends Controller
      * @param string     $lang Language code (defaults to `nl`).
      *
      * @return JSONResponse The persisted tree (unchanged) on success.
-     *
-     */
+         *
+     * @spec openspec/specs/navigation-editor-org/spec.md
+ */
     #[AuthorizedAdminSetting(Application::APP_ID)]
-    /** @spec openspec/specs/navigation-editor-org/spec.md */
     public function updateOrgNavigation(
         ?array $tree=null,
         string $lang=OrgNavigationService::DEFAULT_LANGUAGE
     ): JSONResponse {
+        $guard = $this->assertAdmin();
+        if ($guard !== null) {
+            return $guard;
+        }
 
         $language = $this->validateLanguage(language: $lang);
         if ($language === null) {
@@ -197,10 +229,10 @@ class AdminOrgNavigationController extends Controller
      * Read the global rail-position setting (REQ-ONAV-004).
      *
      * @return JSONResponse The current effective position.
-     *
-     */
+         *
+     * @spec openspec/specs/navigation-editor-org/spec.md
+ */
     #[NoAdminRequired]
-    /** @spec openspec/specs/navigation-editor-org/spec.md */
     public function getPosition(): JSONResponse
     {
         $user = $this->userSession->getUser();
@@ -221,12 +253,16 @@ class AdminOrgNavigationController extends Controller
      * @param string|null $position The desired position.
      *
      * @return JSONResponse The persisted position on success.
-     *
-     */
+         *
+     * @spec openspec/specs/navigation-editor-org/spec.md
+ */
     #[AuthorizedAdminSetting(Application::APP_ID)]
-    /** @spec openspec/specs/navigation-editor-org/spec.md */
     public function updatePosition(?string $position=null): JSONResponse
     {
+        $guard = $this->assertAdmin();
+        if ($guard !== null) {
+            return $guard;
+        }
 
         if ($position === null
             || in_array(needle: $position, haystack: self::ALLOWED_POSITIONS, strict: true) === false
@@ -290,5 +326,4 @@ class AdminOrgNavigationController extends Controller
 
         return $raw;
     }//end readPosition()
-
 }//end class

--- a/lib/Controller/AdminSettingsController.php
+++ b/lib/Controller/AdminSettingsController.php
@@ -83,8 +83,9 @@ class AdminSettingsController extends Controller
      *
      * @return JSONResponse Either the success payload or HTTP 403 when
      *                      the caller is not an administrator.
+     *
+     * @spec openspec/specs/admin-settings/spec.md
      */
-    /** @spec openspec/specs/admin-settings/spec.md */
     public function listGroups(): JSONResponse
     {
         $forbidden = $this->assertAdmin();
@@ -155,8 +156,9 @@ class AdminSettingsController extends Controller
      *
      * @return JSONResponse HTTP 200 with `{status: 'ok'}` on success,
      *                      400 on validation failure, 403 for non-admins.
+     *
+     * @spec openspec/specs/admin-settings/spec.md
      */
-    /** @spec openspec/specs/admin-settings/spec.md */
     public function updateGroupOrder(mixed $groups=null): JSONResponse
     {
         $forbidden = $this->assertAdmin();
@@ -180,7 +182,12 @@ class AdminSettingsController extends Controller
             );
         }
 
-        return ResponseHelper::success(data: ['status' => 'ok']);
+        return ResponseHelper::success(
+            data: [
+                'status'     => 'ok',
+                'groupOrder' => $this->settingsService->getGroupOrder(),
+            ]
+        );
     }//end updateGroupOrder()
 
     /**
@@ -199,7 +206,10 @@ class AdminSettingsController extends Controller
     {
         $user = $this->userSession->getUser();
         if ($user === null) {
-            return ResponseHelper::forbidden();
+            return new JSONResponse(
+                data: ['error' => 'Not authenticated'],
+                statusCode: Http::STATUS_UNAUTHORIZED
+            );
         }
 
         if ($this->groupManager->isAdmin(userId: $user->getUID()) === false) {

--- a/lib/Controller/AnalyticsController.php
+++ b/lib/Controller/AnalyticsController.php
@@ -77,9 +77,10 @@ class AnalyticsController extends Controller
      * @param int    $limit  Maximum rows.
      *
      * @return JSONResponse The response.
-     */
+         *
+     * @spec openspec/specs/dashboard-view-analytics/spec.md
+ */
     #[AuthorizedAdminSetting(Application::APP_ID)]
-    /** @spec openspec/specs/dashboard-view-analytics/spec.md */
     public function topDashboards(
         string $period='30d',
         int $limit=10
@@ -112,9 +113,10 @@ class AnalyticsController extends Controller
      * @param string $period The period string.
      *
      * @return JSONResponse The response.
-     */
+         *
+     * @spec openspec/specs/dashboard-view-analytics/spec.md
+ */
     #[AuthorizedAdminSetting(Application::APP_ID)]
-    /** @spec openspec/specs/dashboard-view-analytics/spec.md */
     public function dashboardDetail(
         string $uuid,
         string $period='30d'
@@ -152,9 +154,10 @@ class AnalyticsController extends Controller
      * @param string $period The period string.
      *
      * @return JSONResponse The response.
-     */
+         *
+     * @spec openspec/specs/dashboard-view-analytics/spec.md
+ */
     #[AuthorizedAdminSetting(Application::APP_ID)]
-    /** @spec openspec/specs/dashboard-view-analytics/spec.md */
     public function instanceSummary(string $period='30d'): JSONResponse
     {
 
@@ -186,9 +189,10 @@ class AnalyticsController extends Controller
      *
      * @return Response The CSV download response or a JSON error
      *                  envelope.
-     */
+         *
+     * @spec openspec/specs/dashboard-view-analytics/spec.md
+ */
     #[AuthorizedAdminSetting(Application::APP_ID)]
-    /** @spec openspec/specs/dashboard-view-analytics/spec.md */
     public function exportCsv(string $period='30d'): Response
     {
 
@@ -213,5 +217,4 @@ class AnalyticsController extends Controller
             contentType: 'text/csv'
         );
     }//end exportCsv()
-
 }//end class

--- a/lib/Controller/ConfluenceImportController.php
+++ b/lib/Controller/ConfluenceImportController.php
@@ -66,9 +66,10 @@ class ConfluenceImportController extends Controller
      * @return JSONResponse The dry-run preview, or an error response.
      *
      * @NoCSRFRequired
-     */
+         *
+     * @spec openspec/specs/confluence-html-import/spec.md
+ */
     #[AuthorizedAdminSetting(Application::APP_ID)]
-    /** @spec openspec/specs/confluence-html-import/spec.md */
     public function dryRun(): JSONResponse
     {
         $tmpName = $this->resolveUpload();
@@ -102,9 +103,10 @@ class ConfluenceImportController extends Controller
      * @return JSONResponse The import summary, or an error response.
      *
      * @NoCSRFRequired
-     */
+         *
+     * @spec openspec/specs/confluence-html-import/spec.md
+ */
     #[AuthorizedAdminSetting(Application::APP_ID)]
-    /** @spec openspec/specs/confluence-html-import/spec.md */
     public function import(?string $parentUuid=null): JSONResponse
     {
         $tmpName = $this->resolveUpload();
@@ -160,10 +162,4 @@ class ConfluenceImportController extends Controller
 
         return (string) $upload['tmp_name'];
     }//end resolveUpload()
-
-    /**
-     * Verify the current session belongs to a Nextcloud admin.
-     *
-     * @return JSONResponse|null Null when admin; an error response otherwise.
-     */
 }//end class

--- a/lib/Controller/DashboardApiController.php
+++ b/lib/Controller/DashboardApiController.php
@@ -157,9 +157,10 @@ class DashboardApiController extends Controller
      * REQ-DASH-013.
      *
      * @return JSONResponse The visible dashboards.
-     */
+         *
+     * @spec openspec/specs/dashboards/spec.md
+ */
     #[NoAdminRequired]
-    /** @spec openspec/specs/dashboards/spec.md */
     public function visible(): JSONResponse
     {
         if ($this->userSession->getUser() === null) {
@@ -569,9 +570,10 @@ class DashboardApiController extends Controller
      * `confluence-html-import` / `dashboard-bulk-operations` flows.
      *
      * @return JSONResponse The nested tree.
-     */
+         *
+     * @spec openspec/specs/dashboards/spec.md
+ */
     #[NoAdminRequired]
-    /** @spec openspec/specs/dashboards/spec.md */
     public function tree(): JSONResponse
     {
         if ($this->userSession->getUser() === null) {
@@ -599,9 +601,10 @@ class DashboardApiController extends Controller
      *                     to include slashes — see `appinfo/routes.php`).
      *
      * @return JSONResponse The dashboard payload, or a 404 envelope.
-     */
+         *
+     * @spec openspec/specs/dashboards/spec.md
+ */
     #[NoAdminRequired]
-    /** @spec openspec/specs/dashboards/spec.md */
     public function byPath(string $path=''): JSONResponse
     {
         if ($this->userSession->getUser() === null) {
@@ -658,9 +661,10 @@ class DashboardApiController extends Controller
      *                      authorised — the empty-path case is a valid
      *                      response shape the caller distinguishes
      *                      client-side).
-     */
+         *
+     * @spec openspec/specs/dashboards/spec.md
+ */
     #[NoAdminRequired]
-    /** @spec openspec/specs/dashboards/spec.md */
     public function computePath(string $uuid=''): JSONResponse
     {
         if ($this->userSession->getUser() === null) {
@@ -693,9 +697,10 @@ class DashboardApiController extends Controller
      * @param int $id The dashboard ID.
      *
      * @return JSONResponse The activated dashboard.
-     */
+         *
+     * @spec openspec/specs/dashboards/spec.md
+ */
     #[NoAdminRequired]
-    /** @spec openspec/specs/dashboards/spec.md */
     public function activate(int $id): JSONResponse
     {
         $user = $this->userSession->getUser();
@@ -731,9 +736,10 @@ class DashboardApiController extends Controller
      * @param string $groupId The group ID.
      *
      * @return JSONResponse The list of group-shared dashboards.
-     */
+         *
+     * @spec openspec/specs/dashboards/spec.md
+ */
     #[NoAdminRequired]
-    /** @spec openspec/specs/dashboards/spec.md */
     public function listGroup(string $groupId): JSONResponse
     {
         if ($this->userSession->getUser() === null) {
@@ -766,9 +772,10 @@ class DashboardApiController extends Controller
      * @param string|null $description The dashboard description.
      *
      * @return JSONResponse The created dashboard.
-     */
+         *
+     * @spec openspec/specs/dashboards/spec.md
+ */
     #[NoAdminRequired]
-    /** @spec openspec/specs/dashboards/spec.md */
     public function createGroup(
         string $groupId,
         $name=null,
@@ -816,9 +823,10 @@ class DashboardApiController extends Controller
      * @param string $uuid    The dashboard UUID from the URL.
      *
      * @return JSONResponse The dashboard payload.
-     */
+         *
+     * @spec openspec/specs/dashboards/spec.md
+ */
     #[NoAdminRequired]
-    /** @spec openspec/specs/dashboards/spec.md */
     public function getGroup(
         string $groupId,
         string $uuid
@@ -860,9 +868,10 @@ class DashboardApiController extends Controller
      * @param array|null  $placements  Updated placements.
      *
      * @return JSONResponse The updated dashboard.
-     */
+         *
+     * @spec openspec/specs/dashboards/spec.md
+ */
     #[NoAdminRequired]
-    /** @spec openspec/specs/dashboards/spec.md */
     public function updateGroup(
         string $groupId,
         string $uuid,
@@ -923,9 +932,10 @@ class DashboardApiController extends Controller
      * @param string $uuid    The dashboard UUID from the URL.
      *
      * @return JSONResponse The status payload.
-     */
+         *
+     * @spec openspec/specs/dashboards/spec.md
+ */
     #[NoAdminRequired]
-    /** @spec openspec/specs/dashboards/spec.md */
     public function deleteGroup(
         string $groupId,
         string $uuid
@@ -975,9 +985,10 @@ class DashboardApiController extends Controller
      * @param string|null $uuid    The dashboard UUID from the body.
      *
      * @return JSONResponse The status payload.
-     */
+         *
+     * @spec openspec/specs/dashboards/spec.md
+ */
     #[NoAdminRequired]
-    /** @spec openspec/specs/dashboards/spec.md */
     public function setGroupDefault(
         string $groupId,
         ?string $uuid=null
@@ -1041,9 +1052,10 @@ class DashboardApiController extends Controller
      *
      * @return JSONResponse HTTP 200 `{status: 'success'}` on success; 401
      *                      when the session has no user.
-     */
+         *
+     * @spec openspec/specs/dashboards/spec.md
+ */
     #[NoAdminRequired]
-    /** @spec openspec/specs/dashboards/spec.md */
     public function setActiveDashboard(?string $uuid=null): JSONResponse
     {
         if ($this->userSession->getUser() === null) {
@@ -1078,9 +1090,10 @@ class DashboardApiController extends Controller
      *
      * @return JSONResponse 200 `{status: 'success'}` on success; 401
      *                      when the session has no user.
-     */
+         *
+     * @spec openspec/specs/dashboards/spec.md
+ */
     #[NoAdminRequired]
-    /** @spec openspec/specs/dashboards/spec.md */
     public function setDefaultDashboard(?string $uuid=null): JSONResponse
     {
         if ($this->userSession->getUser() === null) {
@@ -1104,9 +1117,10 @@ class DashboardApiController extends Controller
      *
      * @return JSONResponse 200 `{uuid: string}` — empty string when no
      *                      pin set; 401 when the session has no user.
-     */
+         *
+     * @spec openspec/specs/dashboards/spec.md
+ */
     #[NoAdminRequired]
-    /** @spec openspec/specs/dashboards/spec.md */
     public function getDefaultDashboard(): JSONResponse
     {
         if ($this->userSession->getUser() === null) {
@@ -1153,9 +1167,10 @@ class DashboardApiController extends Controller
      *
      * @return JSONResponse The new dashboard payload (201) or an
      *                      appropriate error envelope.
-     */
+         *
+     * @spec openspec/specs/dashboards/spec.md
+ */
     #[NoAdminRequired]
-    /** @spec openspec/specs/dashboards/spec.md */
     public function fork(
         string $uuid,
         ?string $name=null
@@ -1229,9 +1244,10 @@ class DashboardApiController extends Controller
      * @param string $uuid The dashboard UUID from the URL.
      *
      * @return JSONResponse The updated dashboard payload.
-     */
+         *
+     * @spec openspec/specs/dashboards/spec.md
+ */
     #[NoAdminRequired]
-    /** @spec openspec/specs/dashboards/spec.md */
     public function publish(string $uuid): JSONResponse
     {
         $user = $this->userSession->getUser();
@@ -1273,9 +1289,10 @@ class DashboardApiController extends Controller
      * @param string $uuid The dashboard UUID from the URL.
      *
      * @return JSONResponse The updated dashboard payload.
-     */
+         *
+     * @spec openspec/specs/dashboards/spec.md
+ */
     #[NoAdminRequired]
-    /** @spec openspec/specs/dashboards/spec.md */
     public function unpublish(string $uuid): JSONResponse
     {
         $user = $this->userSession->getUser();
@@ -1324,9 +1341,10 @@ class DashboardApiController extends Controller
      *                               the request body.
      *
      * @return JSONResponse The updated dashboard payload.
-     */
+         *
+     * @spec openspec/specs/dashboards/spec.md
+ */
     #[NoAdminRequired]
-    /** @spec openspec/specs/dashboards/spec.md */
     public function schedule(
         string $uuid,
         ?string $publishAt=null
@@ -1399,9 +1417,10 @@ class DashboardApiController extends Controller
      * @return JSONResponse An empty 204 response on success, 401
      *                      when unauthenticated, 404 when the
      *                      dashboard does not exist.
-     */
+         *
+     * @spec openspec/specs/dashboards/spec.md
+ */
     #[NoAdminRequired]
-    /** @spec openspec/specs/dashboards/spec.md */
     public function viewEvent(string $uuid): JSONResponse
     {
         if ($this->userSession->getUser() === null) {

--- a/lib/Controller/DashboardCommentsApiController.php
+++ b/lib/Controller/DashboardCommentsApiController.php
@@ -87,9 +87,10 @@ class DashboardCommentsApiController extends Controller
      * @param string $uuid The dashboard UUID.
      *
      * @return JSONResponse The list envelope or an error.
-     */
+         *
+     * @spec openspec/specs/dashboard-comments/spec.md
+ */
     #[NoAdminRequired]
-    /** @spec openspec/specs/dashboard-comments/spec.md */
     public function index(string $uuid): JSONResponse
     {
         if ($this->userId === null) {
@@ -144,9 +145,10 @@ class DashboardCommentsApiController extends Controller
      * @param mixed       $parentId Optional parent comment id; coerced to int.
      *
      * @return JSONResponse The new comment envelope or an error.
-     */
+         *
+     * @spec openspec/specs/dashboard-comments/spec.md
+ */
     #[NoAdminRequired]
-    /** @spec openspec/specs/dashboard-comments/spec.md */
     public function create(
         string $uuid,
         ?string $message=null,
@@ -216,9 +218,10 @@ class DashboardCommentsApiController extends Controller
      * @param string|null $message The new message text.
      *
      * @return JSONResponse The updated comment envelope or an error.
-     */
+         *
+     * @spec openspec/specs/dashboard-comments/spec.md
+ */
     #[NoAdminRequired]
-    /** @spec openspec/specs/dashboard-comments/spec.md */
     public function update(
         string $uuid,
         int $id,
@@ -281,9 +284,10 @@ class DashboardCommentsApiController extends Controller
      * @param int    $id   The comment ID.
      *
      * @return JSONResponse Empty success or an error envelope.
-     */
+         *
+     * @spec openspec/specs/dashboard-comments/spec.md
+ */
     #[NoAdminRequired]
-    /** @spec openspec/specs/dashboard-comments/spec.md */
     public function destroy(string $uuid, int $id): JSONResponse
     {
         if ($this->userId === null) {

--- a/lib/Controller/DashboardLockApiController.php
+++ b/lib/Controller/DashboardLockApiController.php
@@ -80,10 +80,8 @@ class DashboardLockApiController extends Controller
      * @return JSONResponse 200 with the lock object on success,
      *                      404 when the dashboard UUID is unknown,
      *                      409 with the existing lock on conflict.
-      *
-
+     *
       * @spec openspec/specs/dashboard-locking/spec.md
-
       */
     #[NoAdminRequired]
     public function acquire(string $uuid): JSONResponse
@@ -125,10 +123,8 @@ class DashboardLockApiController extends Controller
      *
      * @return JSONResponse 200 with the refreshed lock; 404 when no
      *                      active lock exists; 403 on owner mismatch.
-      *
-
+     *
       * @spec openspec/specs/dashboard-locking/spec.md
-
       */
     #[NoAdminRequired]
     public function heartbeat(string $uuid): JSONResponse
@@ -174,10 +170,8 @@ class DashboardLockApiController extends Controller
      * @param string $uuid The dashboard UUID.
      *
      * @return JSONResponse 204 on success; 403 on permission mismatch.
-      *
-
+     *
       * @spec openspec/specs/dashboard-locking/spec.md
-
       */
     #[NoAdminRequired]
     public function release(string $uuid): JSONResponse
@@ -217,10 +211,8 @@ class DashboardLockApiController extends Controller
      * @param string $uuid The dashboard UUID.
      *
      * @return JSONResponse 200 with the lock or 404 when none.
-      *
-
+     *
       * @spec openspec/specs/dashboard-locking/spec.md
-
       */
     #[NoAdminRequired]
     public function get(string $uuid): JSONResponse
@@ -254,10 +246,8 @@ class DashboardLockApiController extends Controller
      * @param string $uuid The dashboard UUID.
      *
      * @return JSONResponse 200 on success; 403 when caller is not admin.
-      *
-
+     *
       * @spec openspec/specs/dashboard-locking/spec.md
-
       */
     #[NoAdminRequired]
     public function forceRelease(string $uuid): JSONResponse

--- a/lib/Controller/DashboardMetadataController.php
+++ b/lib/Controller/DashboardMetadataController.php
@@ -73,9 +73,10 @@ class DashboardMetadataController extends Controller
      *
      * @return JSONResponse 200 + flat metadata, 404 when missing,
      *                      403 when the caller cannot see the dashboard.
-     */
+         *
+     * @spec openspec/specs/dashboard-metadata-fields/spec.md
+ */
     #[NoAdminRequired]
-    /** @spec openspec/specs/dashboard-metadata-fields/spec.md */
     public function getMetadata(string $uuid): JSONResponse
     {
         if ($this->userId === null) {
@@ -112,9 +113,10 @@ class DashboardMetadataController extends Controller
      *
      * @return JSONResponse 200 + updated metadata, 400 on validation
      *                      failure, 404 when missing, 403 otherwise.
-     */
+         *
+     * @spec openspec/specs/dashboard-metadata-fields/spec.md
+ */
     #[NoAdminRequired]
-    /** @spec openspec/specs/dashboard-metadata-fields/spec.md */
     public function setMetadata(string $uuid, array $metadata=[]): JSONResponse
     {
         if ($this->userId === null) {

--- a/lib/Controller/DashboardReactionApiController.php
+++ b/lib/Controller/DashboardReactionApiController.php
@@ -76,9 +76,10 @@ class DashboardReactionApiController extends Controller
      * @param string $uuid The dashboard UUID.
      *
      * @return JSONResponse The summary.
-     */
+         *
+     * @spec openspec/specs/dashboard-reactions/spec.md
+ */
     #[NoAdminRequired]
-    /** @spec openspec/specs/dashboard-reactions/spec.md */
     public function getReactions(string $uuid): JSONResponse
     {
         if ($this->userId === null) {
@@ -120,9 +121,10 @@ class DashboardReactionApiController extends Controller
      * @param string $emoji The emoji to add (request body field).
      *
      * @return JSONResponse The updated summary.
-     */
+         *
+     * @spec openspec/specs/dashboard-reactions/spec.md
+ */
     #[NoAdminRequired]
-    /** @spec openspec/specs/dashboard-reactions/spec.md */
     public function addReaction(string $uuid, string $emoji=''): JSONResponse
     {
         if ($this->userId === null) {
@@ -171,9 +173,10 @@ class DashboardReactionApiController extends Controller
      * @param string $emoji The emoji to remove.
      *
      * @return JSONResponse Empty 204 response.
-     */
+         *
+     * @spec openspec/specs/dashboard-reactions/spec.md
+ */
     #[NoAdminRequired]
-    /** @spec openspec/specs/dashboard-reactions/spec.md */
     public function removeReaction(string $uuid, string $emoji): JSONResponse
     {
         if ($this->userId === null) {
@@ -222,9 +225,10 @@ class DashboardReactionApiController extends Controller
      * @param string|null $cursor Optional opaque cursor (offset).
      *
      * @return JSONResponse The reactors page.
-     */
+         *
+     * @spec openspec/specs/dashboard-reactions/spec.md
+ */
     #[NoAdminRequired]
-    /** @spec openspec/specs/dashboard-reactions/spec.md */
     public function getReactorsByEmoji(
         string $uuid,
         string $emoji,

--- a/lib/Controller/DashboardShareApiController.php
+++ b/lib/Controller/DashboardShareApiController.php
@@ -72,9 +72,10 @@ class DashboardShareApiController extends Controller
      * @param int $id The dashboard ID.
      *
      * @return DataResponse The list of shares.
-     */
+         *
+     * @spec openspec/specs/dashboard-sharing/spec.md
+ */
     #[NoAdminRequired]
-    /** @spec openspec/specs/dashboard-sharing/spec.md */
     public function index(int $id): DataResponse
     {
         if ($this->userId === null) {
@@ -116,9 +117,10 @@ class DashboardShareApiController extends Controller
      * @param string|null $permissionLevel The permission level.
      *
      * @return DataResponse The created/updated share.
-     */
+         *
+     * @spec openspec/specs/dashboard-sharing/spec.md
+ */
     #[NoAdminRequired]
-    /** @spec openspec/specs/dashboard-sharing/spec.md */
     public function create(
         int $id,
         ?string $shareType=null,
@@ -168,9 +170,10 @@ class DashboardShareApiController extends Controller
      * @param int $shareId The share ID.
      *
      * @return DataResponse Empty 204 on success.
-     */
+         *
+     * @spec openspec/specs/dashboard-sharing/spec.md
+ */
     #[NoAdminRequired]
-    /** @spec openspec/specs/dashboard-sharing/spec.md */
     public function destroy(int $shareId): DataResponse
     {
         if ($this->userId === null) {
@@ -206,9 +209,10 @@ class DashboardShareApiController extends Controller
      * @param array|null $shares The new share list.
      *
      * @return DataResponse The new full share list.
-     */
+         *
+     * @spec openspec/specs/dashboard-sharing/spec.md
+ */
     #[NoAdminRequired]
-    /** @spec openspec/specs/dashboard-sharing/spec.md */
     public function replace(int $id, ?array $shares=null): DataResponse
     {
         if ($this->userId === null) {
@@ -259,9 +263,10 @@ class DashboardShareApiController extends Controller
      * @param string $shareWith The recipient user/group ID.
      *
      * @return DataResponse The count of deleted rows.
-     */
+         *
+     * @spec openspec/specs/dashboard-sharing/spec.md
+ */
     #[NoAdminRequired]
-    /** @spec openspec/specs/dashboard-sharing/spec.md */
     public function revokeForRecipient(
         string $shareType,
         string $shareWith
@@ -295,9 +300,10 @@ class DashboardShareApiController extends Controller
      * @param string $query The search query.
      *
      * @return DataResponse The matching users and groups.
-     */
+         *
+     * @spec openspec/specs/dashboard-sharing/spec.md
+ */
     #[NoAdminRequired]
-    /** @spec openspec/specs/dashboard-sharing/spec.md */
     public function searchSharees(string $query=''): DataResponse
     {
         if ($this->userId === null) {

--- a/lib/Controller/DashboardTranslationApiController.php
+++ b/lib/Controller/DashboardTranslationApiController.php
@@ -77,9 +77,10 @@ class DashboardTranslationApiController extends Controller
      * @param string $uuid The dashboard UUID.
      *
      * @return JSONResponse The list payload.
-     */
+         *
+     * @spec openspec/specs/dashboard-language-content/spec.md
+ */
     #[NoAdminRequired]
-    /** @spec openspec/specs/dashboard-language-content/spec.md */
     public function list(string $uuid): JSONResponse
     {
         if ($this->userId === null) {
@@ -117,9 +118,10 @@ class DashboardTranslationApiController extends Controller
      * @param string|null $copyFrom       Optional source language.
      *
      * @return JSONResponse The created variant.
-     */
+         *
+     * @spec openspec/specs/dashboard-language-content/spec.md
+ */
     #[NoAdminRequired]
-    /** @spec openspec/specs/dashboard-language-content/spec.md */
     public function create(
         string $uuid,
         ?string $languageCode=null,
@@ -200,9 +202,10 @@ class DashboardTranslationApiController extends Controller
      * @param string|null $widgetTreeJson Optional new widget tree JSON.
      *
      * @return JSONResponse The updated variant.
-     */
+         *
+     * @spec openspec/specs/dashboard-language-content/spec.md
+ */
     #[NoAdminRequired]
-    /** @spec openspec/specs/dashboard-language-content/spec.md */
     public function update(
         string $uuid,
         string $lang,
@@ -257,9 +260,10 @@ class DashboardTranslationApiController extends Controller
      * @param string $lang The language code from the URL.
      *
      * @return JSONResponse The status payload.
-     */
+         *
+     * @spec openspec/specs/dashboard-language-content/spec.md
+ */
     #[NoAdminRequired]
-    /** @spec openspec/specs/dashboard-language-content/spec.md */
     public function destroy(string $uuid, string $lang): JSONResponse
     {
         if ($this->userId === null) {
@@ -313,9 +317,10 @@ class DashboardTranslationApiController extends Controller
      * @param string $lang The language code from the URL.
      *
      * @return JSONResponse The promoted variant.
-     */
+         *
+     * @spec openspec/specs/dashboard-language-content/spec.md
+ */
     #[NoAdminRequired]
-    /** @spec openspec/specs/dashboard-language-content/spec.md */
     public function setPrimary(string $uuid, string $lang): JSONResponse
     {
         if ($this->userId === null) {
@@ -366,9 +371,10 @@ class DashboardTranslationApiController extends Controller
      * @param string $uuid The dashboard UUID.
      *
      * @return JSONResponse The resolved payload.
-     */
+         *
+     * @spec openspec/specs/dashboard-language-content/spec.md
+ */
     #[NoAdminRequired]
-    /** @spec openspec/specs/dashboard-language-content/spec.md */
     public function resolved(string $uuid): JSONResponse
     {
         if ($this->userId === null) {

--- a/lib/Controller/DashboardVersionApiController.php
+++ b/lib/Controller/DashboardVersionApiController.php
@@ -75,9 +75,10 @@ class DashboardVersionApiController extends Controller
      * @param string $uuid The dashboard UUID.
      *
      * @return JSONResponse The version list envelope.
-     */
+         *
+     * @spec openspec/specs/dashboard-versioning/spec.md
+ */
     #[NoAdminRequired]
-    /** @spec openspec/specs/dashboard-versioning/spec.md */
     public function listVersions(string $uuid): JSONResponse
     {
         if ($this->userId === null) {
@@ -112,9 +113,10 @@ class DashboardVersionApiController extends Controller
      * @param integer $versionNumber The version number.
      *
      * @return JSONResponse The full snapshot body.
-     */
+         *
+     * @spec openspec/specs/dashboard-versioning/spec.md
+ */
     #[NoAdminRequired]
-    /** @spec openspec/specs/dashboard-versioning/spec.md */
     public function fetchVersion(
         string $uuid,
         int $versionNumber
@@ -165,9 +167,10 @@ class DashboardVersionApiController extends Controller
      * @param string|null $note Optional snapshot note (request body).
      *
      * @return JSONResponse The persisted version row.
-     */
+         *
+     * @spec openspec/specs/dashboard-versioning/spec.md
+ */
     #[NoAdminRequired]
-    /** @spec openspec/specs/dashboard-versioning/spec.md */
     public function createVersion(
         string $uuid,
         ?string $note=null
@@ -209,9 +212,10 @@ class DashboardVersionApiController extends Controller
      * @param integer $versionNumber The version number to restore.
      *
      * @return JSONResponse The restored snapshot envelope.
-     */
+         *
+     * @spec openspec/specs/dashboard-versioning/spec.md
+ */
     #[NoAdminRequired]
-    /** @spec openspec/specs/dashboard-versioning/spec.md */
     public function restoreVersion(
         string $uuid,
         int $versionNumber

--- a/lib/Controller/FeedController.php
+++ b/lib/Controller/FeedController.php
@@ -82,9 +82,10 @@ class FeedController extends Controller
      *
      * @return DataResponse `{token, url}` envelope on success;
      *                      `{error}` 401 when not authenticated.
-     */
+         *
+     * @spec openspec/specs/dashboard-rss-feeds/spec.md
+ */
     #[NoAdminRequired]
-    /** @spec openspec/specs/dashboard-rss-feeds/spec.md */
     public function getToken(): DataResponse
     {
         if ($this->userId === null) {
@@ -107,9 +108,10 @@ class FeedController extends Controller
      *
      * @return DataResponse `{token, url}` envelope on success;
      *                      `{error}` 401 when not authenticated.
-     */
+         *
+     * @spec openspec/specs/dashboard-rss-feeds/spec.md
+ */
     #[NoAdminRequired]
-    /** @spec openspec/specs/dashboard-rss-feeds/spec.md */
     public function regenerateToken(): DataResponse
     {
         if ($this->userId === null) {
@@ -131,9 +133,10 @@ class FeedController extends Controller
      * Idempotent (REQ-FEED-003).
      *
      * @return DataResponse Empty 204 on success; 401 when not authenticated.
-     */
+         *
+     * @spec openspec/specs/dashboard-rss-feeds/spec.md
+ */
     #[NoAdminRequired]
-    /** @spec openspec/specs/dashboard-rss-feeds/spec.md */
     public function revokeToken(): DataResponse
     {
         if ($this->userId === null) {
@@ -165,10 +168,11 @@ class FeedController extends Controller
      *
      * @return DataDisplayResponse The serialised XML feed or a 404
      *                             stub.
-     */
+         *
+     * @spec openspec/specs/dashboard-rss-feeds/spec.md
+ */
     #[PublicPage]
     #[NoCSRFRequired]
-    /** @spec openspec/specs/dashboard-rss-feeds/spec.md */
     public function publicFeed(string $token): DataDisplayResponse
     {
         $resolved = $this->tokenService->resolveToken(token: $token);

--- a/lib/Controller/FileController.php
+++ b/lib/Controller/FileController.php
@@ -83,9 +83,10 @@ class FileController extends Controller
      *                      or `{status, error, message}` on failure.
      *
      * @NoCSRFRequired
-     */
+         *
+     * @spec openspec/specs/resource-uploads/spec.md
+ */
     #[NoAdminRequired]
-    /** @spec openspec/specs/resource-uploads/spec.md */
     public function createFile(
         ?string $filename=null,
         ?string $dir='/',

--- a/lib/Controller/FilesWidgetController.php
+++ b/lib/Controller/FilesWidgetController.php
@@ -100,13 +100,11 @@ class FilesWidgetController extends Controller
      * @param string  $cursor      Opaque pagination cursor.
      *
      * @return JSONResponse
-     */
-
+         *
+     * @spec openspec/specs/files-widget/spec.md
+ */
     #[NoAdminRequired]
     #[NoCSRFRequired]
-    /**
-     * @spec openspec/specs/files-widget/spec.md
-     */
     public function contents(
         int $placementId,
         string $currentPath='/',
@@ -174,10 +172,8 @@ class FilesWidgetController extends Controller
      * @param string  $currentPath Sub-path inside the configured folder.
      *
      * @return JSONResponse
-      *
-
+     *
       * @spec openspec/specs/files-widget/spec.md
-
       */
     #[NoAdminRequired]
     public function upload(int $placementId, string $currentPath='/'): JSONResponse
@@ -243,10 +239,8 @@ class FilesWidgetController extends Controller
      *                             configured folder).
      *
      * @return JSONResponse
-      *
-
+     *
       * @spec openspec/specs/files-widget/spec.md
-
       */
     #[NoAdminRequired]
     public function destroy(int $placementId, int $fileId): JSONResponse

--- a/lib/Controller/ManifestController.php
+++ b/lib/Controller/ManifestController.php
@@ -24,6 +24,7 @@ namespace OCA\MyDash\Controller;
 
 use OCA\MyDash\AppInfo\Application;
 use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
 use OCP\AppFramework\Http\JSONResponse;

--- a/lib/Controller/MetadataAdminController.php
+++ b/lib/Controller/MetadataAdminController.php
@@ -35,7 +35,9 @@ use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\AuthorizedAdminSetting;
 use OCP\AppFramework\Http\JSONResponse;
+use OCP\IGroupManager;
 use OCP\IRequest;
+use OCP\IUserSession;
 
 /**
  * Admin field-definition CRUD controller.
@@ -51,10 +53,14 @@ class MetadataAdminController extends Controller
      *
      * @param IRequest        $request         The HTTP request.
      * @param MetadataService $metadataService The metadata service facade.
+     * @param IGroupManager   $groupManager    Admin checker.
+     * @param IUserSession    $userSession     Current user session.
      */
     public function __construct(
         IRequest $request,
         private readonly MetadataService $metadataService,
+        private readonly IGroupManager $groupManager,
+        private readonly IUserSession $userSession,
     ) {
         parent::__construct(
             appName: Application::APP_ID,
@@ -63,15 +69,45 @@ class MetadataAdminController extends Controller
     }//end __construct()
 
     /**
+     * Inline admin guard.
+     *
+     * @return JSONResponse|null Non-null = caller must be rejected.
+     */
+    private function assertAdmin(): ?JSONResponse
+    {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
+            return new JSONResponse(
+                data: ['error' => 'Not authenticated'],
+                statusCode: Http::STATUS_UNAUTHORIZED
+            );
+        }
+
+        if ($this->groupManager->isAdmin(userId: $user->getUID()) === false) {
+            return new JSONResponse(
+                data: ['error' => 'Admin required'],
+                statusCode: Http::STATUS_FORBIDDEN
+            );
+        }
+
+        return null;
+    }//end assertAdmin()
+
+    /**
      * `GET /api/admin/metadata-fields` — list all field definitions
      * (REQ-MDFL-001).
      *
      * @return JSONResponse The fields array + count, or 403.
-     */
+         *
+     * @spec openspec/specs/dashboard-metadata-fields/spec.md
+ */
     #[AuthorizedAdminSetting(Application::APP_ID)]
-    /** @spec openspec/specs/dashboard-metadata-fields/spec.md */
     public function listFields(): JSONResponse
     {
+        $guard = $this->assertAdmin();
+        if ($guard !== null) {
+            return $guard;
+        }
 
         $fields = $this->metadataService->listFields();
 
@@ -96,9 +132,10 @@ class MetadataAdminController extends Controller
      *
      * @return JSONResponse 201 + field, 400 on validation failure,
      *                      403 for non-admins.
-     */
+         *
+     * @spec openspec/specs/dashboard-metadata-fields/spec.md
+ */
     #[AuthorizedAdminSetting(Application::APP_ID)]
-    /** @spec openspec/specs/dashboard-metadata-fields/spec.md */
     public function createField(
         string $key='',
         string $label='',
@@ -107,6 +144,10 @@ class MetadataAdminController extends Controller
         int $required=0,
         int $sortOrder=0
     ): JSONResponse {
+        $guard = $this->assertAdmin();
+        if ($guard !== null) {
+            return $guard;
+        }
 
         try {
             $field = $this->metadataService->createFieldDefinition(
@@ -134,11 +175,16 @@ class MetadataAdminController extends Controller
      * @param int $id The field id.
      *
      * @return JSONResponse 200 + field, 404 when missing, 403 for non-admins.
-     */
+         *
+     * @spec openspec/specs/dashboard-metadata-fields/spec.md
+ */
     #[AuthorizedAdminSetting(Application::APP_ID)]
-    /** @spec openspec/specs/dashboard-metadata-fields/spec.md */
     public function getField(int $id): JSONResponse
     {
+        $guard = $this->assertAdmin();
+        if ($guard !== null) {
+            return $guard;
+        }
 
         try {
             $field = $this->metadataService->getField(id: $id);
@@ -165,9 +211,10 @@ class MetadataAdminController extends Controller
      *
      * @return JSONResponse 200 + field, 400 on validation failure,
      *                      404 when missing, 403 for non-admins.
-     */
+         *
+     * @spec openspec/specs/dashboard-metadata-fields/spec.md
+ */
     #[AuthorizedAdminSetting(Application::APP_ID)]
-    /** @spec openspec/specs/dashboard-metadata-fields/spec.md */
     public function updateField(
         int $id,
         ?string $label=null,
@@ -176,6 +223,10 @@ class MetadataAdminController extends Controller
         ?array $options=null,
         ?string $key=null
     ): JSONResponse {
+        $guard = $this->assertAdmin();
+        if ($guard !== null) {
+            return $guard;
+        }
 
         $patch = [];
         if ($key !== null) {
@@ -228,11 +279,16 @@ class MetadataAdminController extends Controller
      *
      * @return JSONResponse 200 on success, 409 when soft-deletion blocked,
      *                      404 when missing, 403 for non-admins.
-     */
+         *
+     * @spec openspec/specs/dashboard-metadata-fields/spec.md
+ */
     #[AuthorizedAdminSetting(Application::APP_ID)]
-    /** @spec openspec/specs/dashboard-metadata-fields/spec.md */
     public function deleteField(int $id, bool $cascade=false): JSONResponse
     {
+        $guard = $this->assertAdmin();
+        if ($guard !== null) {
+            return $guard;
+        }
 
         try {
             $this->metadataService->deleteFieldDefinition(
@@ -275,12 +331,4 @@ class MetadataAdminController extends Controller
             statusCode: Http::STATUS_BAD_REQUEST
         );
     }//end badRequest()
-
-    /**
-     * Reject non-admin callers.
-     *
-     * @return JSONResponse|null `null` when the caller is an admin, or
-     *                           a 403 response that the calling action
-     *                           should return verbatim.
-     */
 }//end class

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -111,10 +111,11 @@ class PageController extends Controller
      *                         contain `/` separators).
      *
      * @return TemplateResponse The workspace template response.
-     */
+         *
+     * @spec openspec/specs/runtime-shell/spec.md
+ */
     #[NoAdminRequired]
     #[NoCSRFRequired]
-    /** @spec openspec/specs/runtime-shell/spec.md */
     public function deepLink(string $deepLink=''): TemplateResponse
     {
         return $this->index(deepLink: $deepLink);
@@ -141,10 +142,11 @@ class PageController extends Controller
      *                         dashboard. Empty string ⇒ default resolver.
      *
      * @return TemplateResponse The template response.
-     */
+         *
+     * @spec openspec/specs/runtime-shell/spec.md
+ */
     #[NoAdminRequired]
     #[NoCSRFRequired]
-    /** @spec openspec/specs/runtime-shell/spec.md */
     public function index(string $deepLink=''): TemplateResponse
     {
         Util::addScript(application: Application::APP_ID, file: 'mydash-main');

--- a/lib/Controller/PeopleWidgetController.php
+++ b/lib/Controller/PeopleWidgetController.php
@@ -84,10 +84,11 @@ class PeopleWidgetController extends Controller
      * @param int|null    $offset          Page offset.
      *
      * @return JSONResponse
-     */
+         *
+     * @spec openspec/specs/people-widget/spec.md
+ */
     #[NoAdminRequired]
     #[NoCSRFRequired]
-    /** @spec openspec/specs/people-widget/spec.md */
     public function getUsers(
         ?string $filters=null,
         ?int $excludeDisabled=1,

--- a/lib/Controller/PreferencesController.php
+++ b/lib/Controller/PreferencesController.php
@@ -62,8 +62,9 @@ class PreferencesController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/specs/admin-settings/spec.md
      */
-    /** @spec openspec/specs/admin-settings/spec.md */
     public function getPreference(string $key): JSONResponse
     {
         $user = $this->userSession->getUser();
@@ -102,8 +103,9 @@ class PreferencesController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/specs/admin-settings/spec.md
      */
-    /** @spec openspec/specs/admin-settings/spec.md */
     public function setPreference(string $key, string $value=''): JSONResponse
     {
         $user = $this->userSession->getUser();

--- a/lib/Controller/ResourceController.php
+++ b/lib/Controller/ResourceController.php
@@ -93,9 +93,10 @@ class ResourceController extends Controller
      *                      envelope with `{status, error, message}`.
      *
      * @NoCSRFRequired
-     */
+         *
+     * @spec openspec/specs/resource-uploads/spec.md
+ */
     #[AuthorizedAdminSetting(Application::APP_ID)]
-    /** @spec openspec/specs/resource-uploads/spec.md */
     public function upload(): JSONResponse
     {
         try {
@@ -175,8 +176,9 @@ class ResourceController extends Controller
      * code reads from the standard PHP input stream.
      *
      * @return string The raw request body.
+     *
+     * @spec openspec/specs/resource-uploads/spec.md
      */
-    /** @spec openspec/specs/resource-uploads/spec.md */
     protected function readRequestBody(): string
     {
         return (string) file_get_contents(filename: 'php://input');

--- a/lib/Controller/ResourceServeController.php
+++ b/lib/Controller/ResourceServeController.php
@@ -118,9 +118,10 @@ class ResourceServeController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
-     */
+         *
+     * @spec openspec/specs/resource-uploads/spec.md
+ */
     #[NoAdminRequired]
-    /** @spec openspec/specs/resource-uploads/spec.md */
     public function getResource(string $filename): StreamResponse|JSONResponse
     {
         if ($this->userSession->getUser() === null) {
@@ -179,9 +180,10 @@ class ResourceServeController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
-     */
+         *
+     * @spec openspec/specs/resource-uploads/spec.md
+ */
     #[NoAdminRequired]
-    /** @spec openspec/specs/resource-uploads/spec.md */
     public function listResources(): JSONResponse
     {
         if ($this->userSession->getUser() === null) {

--- a/lib/Controller/ResourceUploadRequestParser.php
+++ b/lib/Controller/ResourceUploadRequestParser.php
@@ -47,8 +47,9 @@ class ResourceUploadRequestParser
      * @throws InvalidDataUrlException       When the body is missing,
      *                                       not JSON, or lacks the
      *                                       `base64` field.
+     *
+     * @spec openspec/specs/resource-uploads/spec.md
      */
-    /** @spec openspec/specs/resource-uploads/spec.md */
     public function extractBase64(IRequest $request, string $rawBody): string
     {
         $contentType = (string) $request->getHeader(name: 'Content-Type');

--- a/lib/Controller/RoleFeaturePermissionApiController.php
+++ b/lib/Controller/RoleFeaturePermissionApiController.php
@@ -42,8 +42,8 @@ class RoleFeaturePermissionApiController extends Controller
     /**
      * Constructor.
      *
-     * @param IRequest                     $request     The HTTP request.
-     * @param RoleFeaturePermissionService $service     Permission service.
+     * @param IRequest                     $request The HTTP request.
+     * @param RoleFeaturePermissionService $service Permission service.
      */
     public function __construct(
         IRequest $request,
@@ -59,9 +59,10 @@ class RoleFeaturePermissionApiController extends Controller
      * GET /api/role-feature-permissions
      *
      * @return JSONResponse The list of permission rows.
-     */
+         *
+     * @spec openspec/specs/admin-roles/spec.md
+ */
     #[AuthorizedAdminSetting(Application::APP_ID)]
-    /** @spec openspec/specs/admin-roles/spec.md */
     public function listPermissions(): JSONResponse
     {
         $rows = $this->service->listPermissions();
@@ -77,9 +78,10 @@ class RoleFeaturePermissionApiController extends Controller
      * Upsert keyed by `groupId`.
      *
      * @return JSONResponse The persisted row.
-     */
+         *
+     * @spec openspec/specs/admin-roles/spec.md
+ */
     #[AuthorizedAdminSetting(Application::APP_ID)]
-    /** @spec openspec/specs/admin-roles/spec.md */
     public function savePermission(): JSONResponse
     {
         try {
@@ -105,9 +107,10 @@ class RoleFeaturePermissionApiController extends Controller
      * @param int $id The row id.
      *
      * @return JSONResponse Empty 204 on success.
-     */
+         *
+     * @spec openspec/specs/admin-roles/spec.md
+ */
     #[AuthorizedAdminSetting(Application::APP_ID)]
-    /** @spec openspec/specs/admin-roles/spec.md */
     public function deletePermission(int $id): JSONResponse
     {
         try {
@@ -125,9 +128,10 @@ class RoleFeaturePermissionApiController extends Controller
      * GET /api/role-layout-defaults
      *
      * @return JSONResponse The list of layout default rows.
-     */
+         *
+     * @spec openspec/specs/admin-roles/spec.md
+ */
     #[AuthorizedAdminSetting(Application::APP_ID)]
-    /** @spec openspec/specs/admin-roles/spec.md */
     public function listLayoutDefaults(): JSONResponse
     {
         $rows = $this->service->listLayoutDefaults();
@@ -140,9 +144,10 @@ class RoleFeaturePermissionApiController extends Controller
      * POST /api/role-layout-defaults
      *
      * @return JSONResponse The persisted row.
-     */
+         *
+     * @spec openspec/specs/admin-roles/spec.md
+ */
     #[AuthorizedAdminSetting(Application::APP_ID)]
-    /** @spec openspec/specs/admin-roles/spec.md */
     public function saveLayoutDefault(): JSONResponse
     {
         try {
@@ -168,9 +173,10 @@ class RoleFeaturePermissionApiController extends Controller
      * @param int $id The row id.
      *
      * @return JSONResponse Empty 204 on success.
-     */
+         *
+     * @spec openspec/specs/admin-roles/spec.md
+ */
     #[AuthorizedAdminSetting(Application::APP_ID)]
-    /** @spec openspec/specs/admin-roles/spec.md */
     public function deleteLayoutDefault(int $id): JSONResponse
     {
         try {
@@ -203,5 +209,4 @@ class RoleFeaturePermissionApiController extends Controller
 
         return $decoded;
     }//end readJsonBody()
-
 }//end class

--- a/lib/Controller/RuleApiController.php
+++ b/lib/Controller/RuleApiController.php
@@ -90,7 +90,7 @@ class RuleApiController extends Controller
             );
         } catch (\Exception $e) {
             return ResponseHelper::error(exception: $e);
-        }
+        }//end try
     }//end getRules()
 
     /**

--- a/lib/Controller/TemplateController.php
+++ b/lib/Controller/TemplateController.php
@@ -84,9 +84,10 @@ class TemplateController extends Controller
      * @param string      $sort     Sort key (`name` or `updatedAt`).
      *
      * @return JSONResponse The gallery list envelope.
-     */
+         *
+     * @spec openspec/specs/admin-templates/spec.md
+ */
     #[NoAdminRequired]
-    /** @spec openspec/specs/admin-templates/spec.md */
     public function gallery(
         ?string $category=null,
         string $sort='name'
@@ -131,9 +132,10 @@ class TemplateController extends Controller
      * @param string|null $previewImage Pre-uploaded preview URL.
      *
      * @return JSONResponse The new template envelope.
-     */
+         *
+     * @spec openspec/specs/admin-templates/spec.md
+ */
     #[NoAdminRequired]
-    /** @spec openspec/specs/admin-templates/spec.md */
     public function saveAsTemplate(
         string $uuid,
         ?string $name=null,

--- a/lib/Db/ConditionalRule.php
+++ b/lib/Db/ConditionalRule.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * ConditionalRule Entity
  *
@@ -15,6 +13,8 @@ declare(strict_types=1);
  * @version   GIT:auto
  * @link      https://conduction.nl
  */
+
+declare(strict_types=1);
 
 namespace OCA\MyDash\Db;
 

--- a/lib/Db/Dashboard.php
+++ b/lib/Db/Dashboard.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Dashboard Entity
  *
@@ -15,6 +13,8 @@ declare(strict_types=1);
  * @version   GIT:auto
  * @link      https://conduction.nl
  */
+
+declare(strict_types=1);
 
 namespace OCA\MyDash\Db;
 

--- a/lib/Db/Tile.php
+++ b/lib/Db/Tile.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Tile Entity
  *
@@ -15,6 +13,8 @@ declare(strict_types=1);
  * @version   GIT:auto
  * @link      https://conduction.nl
  */
+
+declare(strict_types=1);
 
 namespace OCA\MyDash\Db;
 

--- a/lib/Db/WidgetPlacement.php
+++ b/lib/Db/WidgetPlacement.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * WidgetPlacement Entity
  *
@@ -15,6 +13,8 @@ declare(strict_types=1);
  * @version   GIT:auto
  * @link      https://conduction.nl
  */
+
+declare(strict_types=1);
 
 namespace OCA\MyDash\Db;
 

--- a/lib/Listener/CommentsListener.php
+++ b/lib/Listener/CommentsListener.php
@@ -56,8 +56,9 @@ class CommentsListener implements IEventListener
      * @param Event $event The event.
      *
      * @return void
+     *
+     * @spec openspec/specs/dashboard-cascade-events/spec.md
      */
-    /** @spec openspec/specs/dashboard-cascade-events/spec.md */
     public function handle(Event $event): void
     {
         if (($event instanceof DashboardDeletedEvent) === false) {

--- a/lib/Listener/GroupDeletedListener.php
+++ b/lib/Listener/GroupDeletedListener.php
@@ -73,8 +73,9 @@ class GroupDeletedListener implements IEventListener
      * @param Event $event The event.
      *
      * @return void
+     *
+     * @spec openspec/specs/dashboard-cascade-events/spec.md
      */
-    /** @spec openspec/specs/dashboard-cascade-events/spec.md */
     public function handle(Event $event): void
     {
         if (($event instanceof GroupDeletedEvent) === false) {

--- a/lib/Listener/LocksListener.php
+++ b/lib/Listener/LocksListener.php
@@ -54,8 +54,9 @@ class LocksListener implements IEventListener
      * @param Event $event The event.
      *
      * @return void
+     *
+     * @spec openspec/specs/dashboard-cascade-events/spec.md
      */
-    /** @spec openspec/specs/dashboard-cascade-events/spec.md */
     public function handle(Event $event): void
     {
         if (($event instanceof DashboardDeletedEvent) === false) {

--- a/lib/Listener/MetadataValuesListener.php
+++ b/lib/Listener/MetadataValuesListener.php
@@ -54,8 +54,9 @@ class MetadataValuesListener implements IEventListener
      * @param Event $event The event.
      *
      * @return void
+     *
+     * @spec openspec/specs/dashboard-cascade-events/spec.md
      */
-    /** @spec openspec/specs/dashboard-cascade-events/spec.md */
     public function handle(Event $event): void
     {
         if (($event instanceof DashboardDeletedEvent) === false) {

--- a/lib/Listener/PublicSharesListener.php
+++ b/lib/Listener/PublicSharesListener.php
@@ -55,8 +55,9 @@ class PublicSharesListener implements IEventListener
      * @param Event $event The event.
      *
      * @return void
+     *
+     * @spec openspec/specs/dashboard-cascade-events/spec.md
      */
-    /** @spec openspec/specs/dashboard-cascade-events/spec.md */
     public function handle(Event $event): void
     {
         if (($event instanceof DashboardDeletedEvent) === false) {

--- a/lib/Listener/ReactionsListener.php
+++ b/lib/Listener/ReactionsListener.php
@@ -61,8 +61,9 @@ class ReactionsListener implements IEventListener
      * @param Event $event The event.
      *
      * @return void
+     *
+     * @spec openspec/specs/dashboard-cascade-events/spec.md
      */
-    /** @spec openspec/specs/dashboard-cascade-events/spec.md */
     public function handle(Event $event): void
     {
         if (($event instanceof DashboardDeletedEvent) === false) {

--- a/lib/Listener/TranslationsListener.php
+++ b/lib/Listener/TranslationsListener.php
@@ -54,8 +54,9 @@ class TranslationsListener implements IEventListener
      * @param Event $event The event.
      *
      * @return void
+     *
+     * @spec openspec/specs/dashboard-cascade-events/spec.md
      */
-    /** @spec openspec/specs/dashboard-cascade-events/spec.md */
     public function handle(Event $event): void
     {
         if (($event instanceof DashboardDeletedEvent) === false) {

--- a/lib/Listener/TreeListener.php
+++ b/lib/Listener/TreeListener.php
@@ -56,8 +56,9 @@ class TreeListener implements IEventListener
      * @param Event $event The event.
      *
      * @return void
+     *
+     * @spec openspec/specs/dashboard-cascade-events/spec.md
      */
-    /** @spec openspec/specs/dashboard-cascade-events/spec.md */
     public function handle(Event $event): void
     {
         if (($event instanceof DashboardDeletedEvent) === false) {

--- a/lib/Listener/UserDeletedListener.php
+++ b/lib/Listener/UserDeletedListener.php
@@ -93,8 +93,9 @@ class UserDeletedListener implements IEventListener
      * @param Event $event The event.
      *
      * @return void
+     *
+     * @spec openspec/specs/dashboard-cascade-events/spec.md
      */
-    /** @spec openspec/specs/dashboard-cascade-events/spec.md */
     public function handle(Event $event): void
     {
         if (($event instanceof UserDeletedEvent) === false) {

--- a/lib/Listener/VersionsListener.php
+++ b/lib/Listener/VersionsListener.php
@@ -55,8 +55,9 @@ class VersionsListener implements IEventListener
      * @param Event $event The event.
      *
      * @return void
+     *
+     * @spec openspec/specs/dashboard-cascade-events/spec.md
      */
-    /** @spec openspec/specs/dashboard-cascade-events/spec.md */
     public function handle(Event $event): void
     {
         if (($event instanceof DashboardDeletedEvent) === false) {

--- a/lib/Listener/ViewAnalyticsListener.php
+++ b/lib/Listener/ViewAnalyticsListener.php
@@ -54,8 +54,9 @@ class ViewAnalyticsListener implements IEventListener
      * @param Event $event The event.
      *
      * @return void
+     *
+     * @spec openspec/specs/dashboard-view-analytics/spec.md
      */
-    /** @spec openspec/specs/dashboard-view-analytics/spec.md */
     public function handle(Event $event): void
     {
         if (($event instanceof DashboardDeletedEvent) === false) {

--- a/lib/Listener/WidgetPlacementsListener.php
+++ b/lib/Listener/WidgetPlacementsListener.php
@@ -55,8 +55,9 @@ class WidgetPlacementsListener implements IEventListener
      * @param Event $event The event.
      *
      * @return void
+     *
+     * @spec openspec/specs/dashboard-cascade-events/spec.md
      */
-    /** @spec openspec/specs/dashboard-cascade-events/spec.md */
     public function handle(Event $event): void
     {
         if (($event instanceof DashboardDeletedEvent) === false) {

--- a/lib/Service/ActionAuthService.php
+++ b/lib/Service/ActionAuthService.php
@@ -60,12 +60,16 @@ class ActionAuthService
     /**
      * Constructor.
      *
-     * @param IAppConfig    $appConfig    IAppConfig for reading/writing the matrix
-     * @param IGroupManager $groupManager Group manager for resolving user groups
+     * @param IAppConfig           $appConfig            IAppConfig for reading/writing the matrix.
+     * @param IGroupManager        $groupManager         Group manager for admin checks only.
+     * @param AdminTemplateService $adminTemplateService Template service whose getUserGroupIdsFor()
+     *                                                   is the single-source-of-truth group-IDs
+     *                                                   accessor (REQ-TMPL-013).
      */
     public function __construct(
         private IAppConfig $appConfig,
         private IGroupManager $groupManager,
+        private AdminTemplateService $adminTemplateService,
     ) {
     }//end __construct()
 
@@ -101,7 +105,8 @@ class ActionAuthService
             );
         }
 
-        $userGroups = $this->groupManager->getUserGroupIds($user);
+        // Delegate to the single-source-of-truth wrapper (REQ-TMPL-013).
+        $userGroups = $this->adminTemplateService->getUserGroupIdsFor($user->getUID());
 
         // Exclude "admin" from matrix entry before intersection — admin was
         // already checked above; its presence in the entry is a display hint,

--- a/lib/Service/AdminSettingsService.php
+++ b/lib/Service/AdminSettingsService.php
@@ -161,8 +161,9 @@ class AdminSettingsService
      *
      * @return string[] The ordered list of group IDs, or `[]` when missing
      *                  or corrupt.
+     *
+     * @spec openspec/specs/admin-settings/spec.md
      */
-    /** @spec openspec/specs/admin-settings/spec.md */
     public function getGroupOrder(): array
     {
         $raw = $this->settingMapper->getValue(
@@ -210,8 +211,9 @@ class AdminSettingsService
      *
      * @throws InvalidArgumentException When any element is not a
      *                                  non-empty string.
+     *
+     * @spec openspec/specs/admin-settings/spec.md
      */
-    /** @spec openspec/specs/admin-settings/spec.md */
     public function setGroupOrder(array $groupIds): void
     {
         $deduplicated = [];

--- a/lib/Service/AdminTemplateService.php
+++ b/lib/Service/AdminTemplateService.php
@@ -111,8 +111,9 @@ class AdminTemplateService
      *
      * @return string The resolved primary group ID, or
      *                {@see Dashboard::DEFAULT_GROUP_ID} when no match is found.
+     *
+     * @spec openspec/specs/admin-templates/spec.md
      */
-    /** @spec openspec/specs/admin-templates/spec.md */
     public function resolvePrimaryGroup(string $userId): string
     {
         $orderedGroups = $this->settingsService->getGroupOrder();
@@ -145,8 +146,9 @@ class AdminTemplateService
      * @return string|null The first matching group ID, or `null` when no
      *                     element of `$orderedGroups` is present in
      *                     `$userGroups`.
+     *
+     * @spec openspec/specs/admin-templates/spec.md
      */
-    /** @spec openspec/specs/admin-templates/spec.md */
     public static function pickFirstMatch(
         array $orderedGroups,
         array $userGroups
@@ -180,8 +182,9 @@ class AdminTemplateService
      *
      * @return string[] The user's group IDs, or `[]` when the user does
      *                  not exist.
+     *
+     * @spec openspec/specs/admin-templates/spec.md
      */
-    /** @spec openspec/specs/admin-templates/spec.md */
     public function getUserGroupIdsFor(string $userId): array
     {
         $user = $this->userManager->get(uid: $userId);
@@ -207,8 +210,9 @@ class AdminTemplateService
      *                        {@see self::resolvePrimaryGroup()}.
      *
      * @return string The display name to surface to the frontend.
+     *
+     * @spec openspec/specs/admin-templates/spec.md
      */
-    /** @spec openspec/specs/admin-templates/spec.md */
     public function resolvePrimaryGroupDisplayName(string $groupId): string
     {
         if ($groupId === Dashboard::DEFAULT_GROUP_ID) {
@@ -243,8 +247,9 @@ class AdminTemplateService
      * @return array The template and its placements.
      *
      * @throws Exception If the dashboard is not an admin template.
+     *
+     * @spec openspec/specs/admin-templates/spec.md
      */
-    /** @spec openspec/specs/admin-templates/spec.md */
     public function getTemplateWithPlacements(int $id): array
     {
         $template = $this->dashboardMapper->find(id: $id);
@@ -464,8 +469,9 @@ class AdminTemplateService
      * @param string      $sortBy   `'name'` (default) or `'updatedAt'`.
      *
      * @return array<int, array<string, mixed>> The gallery entries.
+     *
+     * @spec openspec/specs/admin-templates/spec.md
      */
-    /** @spec openspec/specs/admin-templates/spec.md */
     public function getGallery(
         ?string $category=null,
         string $sortBy='name'
@@ -524,8 +530,9 @@ class AdminTemplateService
      *                               avoid leaking existence).
      * @throws Throwable             On any DB error — the transaction is
      *                               rolled back before rethrowing.
+     *
+     * @spec openspec/specs/admin-templates/spec.md
      */
-    /** @spec openspec/specs/admin-templates/spec.md */
     public function saveAsTemplate(
         string $userId,
         string $dashboardUuid,
@@ -624,8 +631,9 @@ class AdminTemplateService
      *                                     template row.
      * @throws InvalidDataUrlException     Bad data URL prefix.
      * @throws InvalidImageFormatException Disallowed image type.
+     *
+     * @spec openspec/specs/admin-templates/spec.md
      */
-    /** @spec openspec/specs/admin-templates/spec.md */
     public function uploadPreviewImage(
         string $templateUuid,
         string $base64DataUrl

--- a/lib/Service/AnalyticsService.php
+++ b/lib/Service/AnalyticsService.php
@@ -120,8 +120,9 @@ class AnalyticsService
      * (REQ-ANLT-005). Default `true` when the setting is absent.
      *
      * @return bool `true` when analytics is globally enabled.
+     *
+     * @spec openspec/specs/dashboard-view-analytics/spec.md
      */
-    /** @spec openspec/specs/dashboard-view-analytics/spec.md */
     public function isGloballyEnabled(): bool
     {
         return $this->appConfig->getValueBool(
@@ -138,8 +139,9 @@ class AnalyticsService
      * @param string $userId The user identifier.
      *
      * @return bool `true` when the user has opted out.
+     *
+     * @spec openspec/specs/dashboard-view-analytics/spec.md
      */
-    /** @spec openspec/specs/dashboard-view-analytics/spec.md */
     public function isUserOptedOut(string $userId): bool
     {
         $value = $this->config->getUserValue(
@@ -158,8 +160,9 @@ class AnalyticsService
      * (REQ-ANLT-009).
      *
      * @return int The effective retention window.
+     *
+     * @spec openspec/specs/dashboard-view-analytics/spec.md
      */
-    /** @spec openspec/specs/dashboard-view-analytics/spec.md */
     public function getRetentionDays(): int
     {
         $days = $this->appConfig->getValueInt(
@@ -186,8 +189,9 @@ class AnalyticsService
      * @param int $days The proposed retention window.
      *
      * @return int The clamped value that was stored.
+     *
+     * @spec openspec/specs/dashboard-view-analytics/spec.md
      */
-    /** @spec openspec/specs/dashboard-view-analytics/spec.md */
     public function setRetentionDays(int $days): int
     {
         $clamped = $days;
@@ -215,8 +219,9 @@ class AnalyticsService
      *                      instance-wide.
      *
      * @return void
+     *
+     * @spec openspec/specs/dashboard-view-analytics/spec.md
      */
-    /** @spec openspec/specs/dashboard-view-analytics/spec.md */
     public function setGlobalEnabled(bool $enabled): void
     {
         $this->appConfig->setValueBool(
@@ -243,8 +248,9 @@ class AnalyticsService
      *
      * @return bool `true` when an event was recorded, `false` when
      *              the call was short-circuited.
+     *
+     * @spec openspec/specs/dashboard-view-analytics/spec.md
      */
-    /** @spec openspec/specs/dashboard-view-analytics/spec.md */
     public function recordViewEvent(
         string $dashboardUuid,
         string $userId
@@ -296,8 +302,9 @@ class AnalyticsService
      * @return array<int, array{dashboardUuid: string, name: string|null,
      *   viewCount: int, uniqueViewerCount: int}>
      *   Top-N dashboards sorted by `viewCount` descending.
+     *
+     * @spec openspec/specs/dashboard-view-analytics/spec.md
      */
-    /** @spec openspec/specs/dashboard-view-analytics/spec.md */
     public function getTopDashboards(string $period, int $limit): array
     {
         [$startDate, $endDate] = self::periodToDateRange(period: $period);
@@ -347,8 +354,9 @@ class AnalyticsService
      * @throws InvalidArgumentException  When the period string is
      *                                   not one of `7d`, `30d`,
      *                                   `90d`.
+     *
+     * @spec openspec/specs/dashboard-view-analytics/spec.md
      */
-    /** @spec openspec/specs/dashboard-view-analytics/spec.md */
     public function getDashboardDetail(
         string $dashboardUuid,
         string $period
@@ -388,8 +396,9 @@ class AnalyticsService
      *   top5: array<int, array{dashboardUuid: string, name: string|null,
      *     viewCount: int, uniqueViewerCount: int}>}
      *   The summary payload.
+     *
+     * @spec openspec/specs/dashboard-view-analytics/spec.md
      */
-    /** @spec openspec/specs/dashboard-view-analytics/spec.md */
     public function getInstanceSummary(string $period): array
     {
         [$startDate, $endDate] = self::periodToDateRange(period: $period);
@@ -418,8 +427,9 @@ class AnalyticsService
      * @param string $period The period string.
      *
      * @return string The CSV body (CRLF line endings).
+     *
+     * @spec openspec/specs/dashboard-view-analytics/spec.md
      */
-    /** @spec openspec/specs/dashboard-view-analytics/spec.md */
     public function generateCsvExport(string $period): string
     {
         [$startDate, $endDate] = self::periodToDateRange(period: $period);
@@ -477,8 +487,9 @@ class AnalyticsService
      *
      * @return string The filename in the form
      *                `dashboard-analytics-YYYY-MM-DD.csv`.
+     *
+     * @spec openspec/specs/dashboard-view-analytics/spec.md
      */
-    /** @spec openspec/specs/dashboard-view-analytics/spec.md */
     public function csvExportFilename(): string
     {
         $today = (new DateTimeImmutable('now'))
@@ -501,8 +512,9 @@ class AnalyticsService
      *                                     `YYYY-MM-DD`.
      *
      * @throws InvalidArgumentException When the period is unknown.
+     *
+     * @spec openspec/specs/dashboard-view-analytics/spec.md
      */
-    /** @spec openspec/specs/dashboard-view-analytics/spec.md */
     public static function periodToDateRange(string $period): array
     {
         $days = match ($period) {
@@ -534,8 +546,9 @@ class AnalyticsService
      * (REQ-ANLT-009).
      *
      * @return string The cutoff date in `YYYY-MM-DD` format.
+     *
+     * @spec openspec/specs/dashboard-view-analytics/spec.md
      */
-    /** @spec openspec/specs/dashboard-view-analytics/spec.md */
     public function getPurgeCutoffDate(): string
     {
         $today  = (new DateTimeImmutable('now'))
@@ -580,8 +593,9 @@ class AnalyticsService
      * @return string The non-null UUID (returns empty string when
      *                the entity carries no UUID — never expected on
      *                a persisted row).
+     *
+     * @spec openspec/specs/dashboard-view-analytics/spec.md
      */
-    /** @spec openspec/specs/dashboard-view-analytics/spec.md */
     public static function dashboardUuidOf(Dashboard $dashboard): string
     {
         $uuid = $dashboard->getUuid();
@@ -599,8 +613,9 @@ class AnalyticsService
      * @param DashboardView $view The aggregate row.
      *
      * @return array The serialised payload.
+     *
+     * @spec openspec/specs/dashboard-view-analytics/spec.md
      */
-    /** @spec openspec/specs/dashboard-view-analytics/spec.md */
     public static function viewToArray(DashboardView $view): array
     {
         return $view->jsonSerialize();

--- a/lib/Service/BulkOperationService.php
+++ b/lib/Service/BulkOperationService.php
@@ -154,8 +154,9 @@ class BulkOperationService
      *
      * @throws InvalidArgumentException When the request exceeds the cap.
      * @throws PermissionDeniedException When any UUID is unauthorised.
+     *
+     * @spec openspec/specs/dashboard-bulk-operations/spec.md
      */
-    /** @spec openspec/specs/dashboard-bulk-operations/spec.md */
     public function bulkDelete(
         array $dashboardUuids,
         string $userId,
@@ -272,8 +273,9 @@ class BulkOperationService
      * @throws InvalidArgumentException  When the request exceeds the cap
      *                                   or the parent does not exist.
      * @throws PermissionDeniedException When any UUID is unauthorised.
+     *
+     * @spec openspec/specs/dashboard-bulk-operations/spec.md
      */
-    /** @spec openspec/specs/dashboard-bulk-operations/spec.md */
     public function bulkMove(
         array $dashboardUuids,
         ?string $parentUuid,
@@ -401,8 +403,9 @@ class BulkOperationService
      *                                   exceeded, or when `publishAt` is
      *                                   in the past.
      * @throws PermissionDeniedException When any UUID is unauthorised.
+     *
+     * @spec openspec/specs/dashboard-bulk-operations/spec.md
      */
-    /** @spec openspec/specs/dashboard-bulk-operations/spec.md */
     public function bulkStatus(
         array $dashboardUuids,
         string $publicationStatus,
@@ -529,8 +532,9 @@ class BulkOperationService
      *
      * @throws InvalidArgumentException  When the request exceeds the cap.
      * @throws PermissionDeniedException When any UUID is unauthorised.
+     *
+     * @spec openspec/specs/dashboard-bulk-operations/spec.md
      */
-    /** @spec openspec/specs/dashboard-bulk-operations/spec.md */
     public function bulkReindex(
         array $dashboardUuids,
         string $userId,
@@ -605,8 +609,9 @@ class BulkOperationService
      * is missing, zero, or negative (REQ-BULK-006 fallback scenario).
      *
      * @return int The effective cap.
+     *
+     * @spec openspec/specs/dashboard-bulk-operations/spec.md
      */
-    /** @spec openspec/specs/dashboard-bulk-operations/spec.md */
     public function getEffectiveCap(): int
     {
         $value = $this->appConfig->getValueInt(

--- a/lib/Service/CalendarWidgetService.php
+++ b/lib/Service/CalendarWidgetService.php
@@ -143,8 +143,9 @@ class CalendarWidgetService
      * @param string $to     ISO 8601 end (inclusive).
      *
      * @return array{events: array<int, array<string, mixed>>, failures: array<int, string>}
+     *
+     * @spec openspec/specs/calendar-widget/spec.md
      */
-    /** @spec openspec/specs/calendar-widget/spec.md */
     public function getEvents(array $config, string $from, string $to): array
     {
         $internalCalendars = (array) ($config['internalCalendars'] ?? []);
@@ -199,8 +200,9 @@ class CalendarWidgetService
      * @param string             $to         ISO end.
      *
      * @return array{events: array<int, array<string, mixed>>, failures: array<int, string>}
+     *
+     * @spec openspec/specs/calendar-widget/spec.md
      */
-    /** @spec openspec/specs/calendar-widget/spec.md */
     public function fetchInternalEvents(array $principals, string $from, string $to): array
     {
         $events   = [];
@@ -284,8 +286,9 @@ class CalendarWidgetService
      * @param string             $to   ISO end.
      *
      * @return array{events: array<int, array<string, mixed>>, failures: array<int, string>}
+     *
+     * @spec openspec/specs/calendar-widget/spec.md
      */
-    /** @spec openspec/specs/calendar-widget/spec.md */
     public function fetchExternalIcsEvents(array $urls, string $from, string $to): array
     {
         $events   = [];
@@ -346,8 +349,9 @@ class CalendarWidgetService
      * @param string $url The URL to validate.
      *
      * @return bool True when the URL passes all checks.
+     *
+     * @spec openspec/specs/calendar-widget/spec.md
      */
-    /** @spec openspec/specs/calendar-widget/spec.md */
     public function validateUrl(string $url): bool
     {
         $parts = parse_url(url: $url);
@@ -393,8 +397,9 @@ class CalendarWidgetService
      * @param string $url The URL to check.
      *
      * @return bool True when the host passes the allow-list.
+     *
+     * @spec openspec/specs/calendar-widget/spec.md
      */
-    /** @spec openspec/specs/calendar-widget/spec.md */
     public function checkAllowList(string $url): bool
     {
         $raw = $this->appConfig->getValueString(
@@ -431,8 +436,9 @@ class CalendarWidgetService
      * @return string The raw ICS body.
      *
      * @throws \RuntimeException When the response is too large or non-2xx.
+     *
+     * @spec openspec/specs/calendar-widget/spec.md
      */
-    /** @spec openspec/specs/calendar-widget/spec.md */
     public function fetchIcsBody(string $url): string
     {
         $cacheKey = 'ics_'.md5(string: $url);
@@ -482,8 +488,9 @@ class CalendarWidgetService
      * @param string $to   ISO end (inclusive).
      *
      * @return array<int, array<string, mixed>> Normalised event objects.
+     *
+     * @spec openspec/specs/calendar-widget/spec.md
      */
-    /** @spec openspec/specs/calendar-widget/spec.md */
     public function parseAndExpandIcs(string $body, string $from, string $to): array
     {
         if (class_exists(class: \Sabre\VObject\Reader::class) === false) {
@@ -523,8 +530,9 @@ class CalendarWidgetService
      * @param object $vevent The sabre VEVENT component.
      *
      * @return array<string, mixed>
+     *
+     * @spec openspec/specs/calendar-widget/spec.md
      */
-    /** @spec openspec/specs/calendar-widget/spec.md */
     public function normalizeVevent(object $vevent): array
     {
         $uid     = (string) ($vevent->UID ?? '');
@@ -623,8 +631,9 @@ class CalendarWidgetService
      * @param array<string, mixed> $raw Raw event from IManager.
      *
      * @return array<string, mixed>
+     *
+     * @spec openspec/specs/calendar-widget/spec.md
      */
-    /** @spec openspec/specs/calendar-widget/spec.md */
     public function normalizeInternalEvent(array $raw): array
     {
         // NC Calendar search results vary across versions; do best-effort mapping.

--- a/lib/Service/Cleanup/CategoryRegistryService.php
+++ b/lib/Service/Cleanup/CategoryRegistryService.php
@@ -123,8 +123,9 @@ class CategoryRegistryService
      * admin UI.
      *
      * @return array<int, string> The Tier-A category names.
+     *
+     * @spec openspec/specs/orphaned-data-cleanup/spec.md
      */
-    /** @spec openspec/specs/orphaned-data-cleanup/spec.md */
     public function getAutoSafeCategoryNames(): array
     {
         $names = [];

--- a/lib/Service/Cleanup/CleanupCategoryInterface.php
+++ b/lib/Service/Cleanup/CleanupCategoryInterface.php
@@ -103,8 +103,9 @@ interface CleanupCategoryInterface
      * there are no orphans.
      *
      * @return int The orphaned row count (>= 0).
+     *
+     * @spec openspec/specs/orphaned-data-cleanup/spec.md
      */
-    /** @spec openspec/specs/orphaned-data-cleanup/spec.md */
     public function scan(): int;
 
     /**
@@ -122,7 +123,8 @@ interface CleanupCategoryInterface
      * @param bool $dryRun True for simulation, false for real delete.
      *
      * @return int The number of rows affected (>= 0).
+     *
+     * @spec openspec/specs/orphaned-data-cleanup/spec.md
      */
-    /** @spec openspec/specs/orphaned-data-cleanup/spec.md */
     public function purge(bool $dryRun=false): int;
 }//end interface

--- a/lib/Service/Cleanup/ExpiredLocksCategory.php
+++ b/lib/Service/Cleanup/ExpiredLocksCategory.php
@@ -101,8 +101,9 @@ class ExpiredLocksCategory implements CleanupCategoryInterface
      * Count stale lock rows across all dashboards.
      *
      * @return int The orphan count.
+     *
+     * @spec openspec/specs/orphaned-data-cleanup/spec.md
      */
-    /** @spec openspec/specs/orphaned-data-cleanup/spec.md */
     public function scan(): int
     {
         return $this->lockMapper->countAllExpired();
@@ -119,8 +120,9 @@ class ExpiredLocksCategory implements CleanupCategoryInterface
      * @param bool $dryRun True for dry-run.
      *
      * @return int The number of rows deleted (or that would be).
+     *
+     * @spec openspec/specs/orphaned-data-cleanup/spec.md
      */
-    /** @spec openspec/specs/orphaned-data-cleanup/spec.md */
     public function purge(bool $dryRun=false): int
     {
         return $this->lockMapper->deleteAllExpired();

--- a/lib/Service/Cleanup/OrphanedConditionalRulesCategory.php
+++ b/lib/Service/Cleanup/OrphanedConditionalRulesCategory.php
@@ -98,8 +98,9 @@ class OrphanedConditionalRulesCategory implements CleanupCategoryInterface
      * Count orphan conditional-rule rows.
      *
      * @return int The orphan count.
+     *
+     * @spec openspec/specs/orphaned-data-cleanup/spec.md
      */
-    /** @spec openspec/specs/orphaned-data-cleanup/spec.md */
     public function scan(): int
     {
         return $this->ruleMapper->countOrphaned();
@@ -111,8 +112,9 @@ class OrphanedConditionalRulesCategory implements CleanupCategoryInterface
      * @param bool $dryRun True for dry-run.
      *
      * @return int The number of rows deleted.
+     *
+     * @spec openspec/specs/orphaned-data-cleanup/spec.md
      */
-    /** @spec openspec/specs/orphaned-data-cleanup/spec.md */
     public function purge(bool $dryRun=false): int
     {
         return $this->ruleMapper->deleteOrphaned();

--- a/lib/Service/Cleanup/OrphanedSharesCategory.php
+++ b/lib/Service/Cleanup/OrphanedSharesCategory.php
@@ -105,8 +105,9 @@ class OrphanedSharesCategory implements CleanupCategoryInterface
      * Count orphaned share rows.
      *
      * @return int The orphan count.
+     *
+     * @spec openspec/specs/orphaned-data-cleanup/spec.md
      */
-    /** @spec openspec/specs/orphaned-data-cleanup/spec.md */
     public function scan(): int
     {
         return $this->shareMapper->countOrphaned();
@@ -122,8 +123,9 @@ class OrphanedSharesCategory implements CleanupCategoryInterface
      * @param bool $dryRun True for dry-run.
      *
      * @return int The number of rows deleted.
+     *
+     * @spec openspec/specs/orphaned-data-cleanup/spec.md
      */
-    /** @spec openspec/specs/orphaned-data-cleanup/spec.md */
     public function purge(bool $dryRun=false): int
     {
         return $this->shareMapper->deleteOrphaned();

--- a/lib/Service/Cleanup/OrphanedWidgetPlacementsCategory.php
+++ b/lib/Service/Cleanup/OrphanedWidgetPlacementsCategory.php
@@ -97,8 +97,9 @@ class OrphanedWidgetPlacementsCategory implements CleanupCategoryInterface
      * Count orphan placement rows.
      *
      * @return int The orphan count.
+     *
+     * @spec openspec/specs/orphaned-data-cleanup/spec.md
      */
-    /** @spec openspec/specs/orphaned-data-cleanup/spec.md */
     public function scan(): int
     {
         return $this->placementMapper->countOrphaned();
@@ -110,8 +111,9 @@ class OrphanedWidgetPlacementsCategory implements CleanupCategoryInterface
      * @param bool $dryRun True for dry-run.
      *
      * @return int The number of rows deleted.
+     *
+     * @spec openspec/specs/orphaned-data-cleanup/spec.md
      */
-    /** @spec openspec/specs/orphaned-data-cleanup/spec.md */
     public function purge(bool $dryRun=false): int
     {
         return $this->placementMapper->deleteOrphaned();

--- a/lib/Service/CommandService.php
+++ b/lib/Service/CommandService.php
@@ -101,8 +101,9 @@ class CommandService
      * @param array<string,mixed>|list<mixed>|null $data Command payload.
      *
      * @return array<string,mixed>
+     *
+     * @spec openspec/specs/cli-commands/spec.md
      */
-    /** @spec openspec/specs/cli-commands/spec.md */
     public function envelopeSuccess(array|null $data): array
     {
         return [
@@ -120,8 +121,9 @@ class CommandService
      * @param list<array<string,mixed>>            $errors Per-item errors.
      *
      * @return array<string,mixed>
+     *
+     * @spec openspec/specs/cli-commands/spec.md
      */
-    /** @spec openspec/specs/cli-commands/spec.md */
     public function envelopePartial(array|null $data, array $errors): array
     {
         return [
@@ -141,8 +143,9 @@ class CommandService
      * @param array<string,mixed>|null $context  Optional metadata.
      *
      * @return array<string,mixed>
+     *
+     * @spec openspec/specs/cli-commands/spec.md
      */
-    /** @spec openspec/specs/cli-commands/spec.md */
     public function envelopeError(
         int $exitCode,
         string $code,
@@ -171,8 +174,9 @@ class CommandService
      * @param array<string,mixed> $envelope The envelope to encode.
      *
      * @return string
+     *
+     * @spec openspec/specs/cli-commands/spec.md
      */
-    /** @spec openspec/specs/cli-commands/spec.md */
     public function encodeEnvelope(array $envelope): string
     {
         return (string) json_encode(
@@ -197,8 +201,9 @@ class CommandService
      * @param string|null $byUser     Caller user id or null for `cli`.
      *
      * @return string
+     *
+     * @spec openspec/specs/cli-commands/spec.md
      */
-    /** @spec openspec/specs/cli-commands/spec.md */
     public function formatAuditLine(
         string $command,
         string $args,
@@ -240,8 +245,9 @@ class CommandService
      * @param string|null $byUser     Caller user id.
      *
      * @return void
+     *
+     * @spec openspec/specs/cli-commands/spec.md
      */
-    /** @spec openspec/specs/cli-commands/spec.md */
     public function audit(
         string $command,
         string $args,

--- a/lib/Service/CommentService.php
+++ b/lib/Service/CommentService.php
@@ -126,8 +126,9 @@ class CommentService
      * have comments enabled by design.
      *
      * @return bool True when comments are globally enabled.
+     *
+     * @spec openspec/specs/dashboard-comments/spec.md
      */
-    /** @spec openspec/specs/dashboard-comments/spec.md */
     public function isCommentsEnabledGlobally(): bool
     {
         try {
@@ -166,8 +167,9 @@ class CommentService
      * @param Dashboard $dashboard The dashboard.
      *
      * @return bool True when comments are effectively enabled.
+     *
+     * @spec openspec/specs/dashboard-comments/spec.md
      */
-    /** @spec openspec/specs/dashboard-comments/spec.md */
     public function isEnabledFor(Dashboard $dashboard): bool
     {
         return $dashboard->isCommentsEffectivelyEnabled(
@@ -186,8 +188,9 @@ class CommentService
      *
      * @return array<int, array<string, mixed>> Top-level comments with
      *                                          a nested `replies` array.
+     *
+     * @spec openspec/specs/dashboard-comments/spec.md
      */
-    /** @spec openspec/specs/dashboard-comments/spec.md */
     public function getCommentsForDashboard(string $dashboardUuid): array
     {
         $raw = $this->commentsManager->getForObject(
@@ -260,8 +263,9 @@ class CommentService
      *
      * @throws InvalidCommentException  On empty message or nested-reply violation.
      * @throws CommentNotFoundException When `$parentId` does not resolve.
+     *
+     * @spec openspec/specs/dashboard-comments/spec.md
      */
-    /** @spec openspec/specs/dashboard-comments/spec.md */
     public function createComment(
         string $dashboardUuid,
         string $userId,
@@ -344,8 +348,9 @@ class CommentService
      * @throws CommentForbiddenException When the user is neither author
      *                                   nor admin.
      * @throws InvalidCommentException   When the message is empty.
+     *
+     * @spec openspec/specs/dashboard-comments/spec.md
      */
-    /** @spec openspec/specs/dashboard-comments/spec.md */
     public function updateComment(
         int $commentId,
         string $newMessage,
@@ -396,8 +401,9 @@ class CommentService
      * @throws CommentNotFoundException  When the comment does not exist.
      * @throws CommentForbiddenException When the user is neither author
      *                                   nor admin.
+     *
+     * @spec openspec/specs/dashboard-comments/spec.md
      */
-    /** @spec openspec/specs/dashboard-comments/spec.md */
     public function deleteComment(
         int $commentId,
         string $currentUserId
@@ -439,8 +445,9 @@ class CommentService
      * @param string $dashboardUuid The dashboard UUID.
      *
      * @return void
+     *
+     * @spec openspec/specs/dashboard-comments/spec.md
      */
-    /** @spec openspec/specs/dashboard-comments/spec.md */
     public function deleteAllForDashboard(string $dashboardUuid): void
     {
         $this->commentsManager->deleteCommentsAtObject(
@@ -467,8 +474,9 @@ class CommentService
      *                              recipient knows who mentioned them.
      *
      * @return array<int, array{userId: string, displayName: string}>
+     *
+     * @spec openspec/specs/dashboard-comments/spec.md
      */
-    /** @spec openspec/specs/dashboard-comments/spec.md */
     public function parseAndResolveMentions(
         string $message,
         string $dashboardUuid,
@@ -535,8 +543,9 @@ class CommentService
      * @param IComment $comment The comment to serialise.
      *
      * @return array<string, mixed> The wire-format envelope.
+     *
+     * @spec openspec/specs/dashboard-comments/spec.md
      */
-    /** @spec openspec/specs/dashboard-comments/spec.md */
     public function serialiseComment(IComment $comment): array
     {
         $createdAt = $comment->getCreationDateTime()->format(format: 'c');

--- a/lib/Service/ConditionalService.php
+++ b/lib/Service/ConditionalService.php
@@ -49,8 +49,9 @@ class ConditionalService
      * @param string          $userId The user ID.
      *
      * @return bool Whether the rule matches.
+     *
+     * @spec openspec/specs/conditional-visibility/spec.md
      */
-    /** @spec openspec/specs/conditional-visibility/spec.md */
     public function evaluateRule(
         ConditionalRule $rule,
         string $userId

--- a/lib/Service/Confluence/ArchiveParser.php
+++ b/lib/Service/Confluence/ArchiveParser.php
@@ -88,8 +88,9 @@ class ArchiveParser
      *
      * @throws InvalidArgumentException When the ZIP is missing,
      *                                  unreadable, or has no `index.html`.
+     *
+     * @spec openspec/specs/confluence-html-import/spec.md
      */
-    /** @spec openspec/specs/confluence-html-import/spec.md */
     public function parse(string $zipPath): ParsedArchive
     {
         if (file_exists(filename: $zipPath) === false) {

--- a/lib/Service/Confluence/HtmlSanitizer.php
+++ b/lib/Service/Confluence/HtmlSanitizer.php
@@ -112,8 +112,9 @@ class HtmlSanitizer
      * @param string $html The raw HTML fragment.
      *
      * @return string The sanitised HTML.
+     *
+     * @spec openspec/specs/confluence-html-import/spec.md
      */
-    /** @spec openspec/specs/confluence-html-import/spec.md */
     public function sanitize(string $html): string
     {
         $trimmed = trim($html);

--- a/lib/Service/Confluence/LinkRewriter.php
+++ b/lib/Service/Confluence/LinkRewriter.php
@@ -38,8 +38,9 @@ class LinkRewriter
      * @return array{html:string, warnings:array<int,string>}
      *      The rewritten fragment plus any warnings (links whose target
      *      pageId did not appear in the import).
+     *
+     * @spec openspec/specs/confluence-html-import/spec.md
      */
-    /** @spec openspec/specs/confluence-html-import/spec.md */
     public function rewrite(string $html, array $pageIdToUuid): array
     {
         if ($html === '') {

--- a/lib/Service/Confluence/MacroRenderer.php
+++ b/lib/Service/Confluence/MacroRenderer.php
@@ -61,8 +61,9 @@ class MacroRenderer
      * @param string $html The raw HTML fragment.
      *
      * @return string The fragment with macros expanded into plain HTML.
+     *
+     * @spec openspec/specs/confluence-html-import/spec.md
      */
-    /** @spec openspec/specs/confluence-html-import/spec.md */
     public function render(string $html): string
     {
         if (trim($html) === '') {

--- a/lib/Service/Confluence/ParsedArchive.php
+++ b/lib/Service/Confluence/ParsedArchive.php
@@ -50,8 +50,9 @@ class ParsedArchive
      * Number of parsed pages.
      *
      * @return int The page count.
+     *
+     * @spec openspec/specs/confluence-html-import/spec.md
      */
-    /** @spec openspec/specs/confluence-html-import/spec.md */
     public function pageCount(): int
     {
         return count(value: $this->pages);
@@ -61,8 +62,9 @@ class ParsedArchive
      * Number of attachments + shared images.
      *
      * @return int The asset count.
+     *
+     * @spec openspec/specs/confluence-html-import/spec.md
      */
-    /** @spec openspec/specs/confluence-html-import/spec.md */
     public function attachmentCount(): int
     {
         return (count(value: $this->attachments) + count(value: $this->images));

--- a/lib/Service/ConfluenceImportService.php
+++ b/lib/Service/ConfluenceImportService.php
@@ -124,8 +124,9 @@ class ConfluenceImportService
      *     warnings:array<int,string>,
      *     assetFolder:string
      * }
+     *
+     * @spec openspec/specs/confluence-html-import/spec.md
      */
-    /** @spec openspec/specs/confluence-html-import/spec.md */
     public function dryRun(string $zipPath): array
     {
         $archive   = $this->parser->parse(zipPath: $zipPath);
@@ -156,8 +157,9 @@ class ConfluenceImportService
      *     warnings:array<int,string>,
      *     assetFolder:string
      * }
+     *
+     * @spec openspec/specs/confluence-html-import/spec.md
      */
-    /** @spec openspec/specs/confluence-html-import/spec.md */
     public function import(
         string $zipPath,
         string $currentUserId,

--- a/lib/Service/DashboardLockService.php
+++ b/lib/Service/DashboardLockService.php
@@ -100,11 +100,9 @@ class DashboardLockService
      *                               controller can map it to HTTP 404.
      * @throws LockConflictException When another user already holds an
      *                               active lock on the dashboard.
-      *
-
-      * @spec openspec/specs/dashboard-locking/spec.md
-
-      */
+     *
+     * @spec openspec/specs/dashboard-locking/spec.md
+     */
     public function acquireLock(
         string $dashboardUuid,
         string $userId
@@ -169,11 +167,9 @@ class DashboardLockService
      *
      * @throws LockNotFoundException  When no active lock exists.
      * @throws LockForbiddenException When the caller is not the owner.
-      *
-
-      * @spec openspec/specs/dashboard-locking/spec.md
-
-      */
+     *
+     * @spec openspec/specs/dashboard-locking/spec.md
+     */
     public function heartbeat(
         string $dashboardUuid,
         string $userId
@@ -219,11 +215,9 @@ class DashboardLockService
      *
      * @throws LockForbiddenException When the caller is neither the
      *                                owner nor an admin (when allowed).
-      *
-
-      * @spec openspec/specs/dashboard-locking/spec.md
-
-      */
+     *
+     * @spec openspec/specs/dashboard-locking/spec.md
+     */
     public function releaseLock(
         string $dashboardUuid,
         string $userId,
@@ -260,11 +254,9 @@ class DashboardLockService
      * @param string $dashboardUuid The dashboard UUID.
      *
      * @return DashboardLock|null The active lock or null.
-      *
-
-      * @spec openspec/specs/dashboard-locking/spec.md
-
-      */
+     *
+     * @spec openspec/specs/dashboard-locking/spec.md
+     */
     public function getLockState(string $dashboardUuid): ?DashboardLock
     {
         // Inline cleanup so the next read is never polluted by a stale
@@ -295,11 +287,9 @@ class DashboardLockService
      * @return void
      *
      * @throws LockForbiddenException When the caller is not an admin.
-      *
-
-      * @spec openspec/specs/dashboard-locking/spec.md
-
-      */
+     *
+     * @spec openspec/specs/dashboard-locking/spec.md
+     */
     public function forceRelease(
         string $dashboardUuid,
         string $adminUserId
@@ -339,11 +329,9 @@ class DashboardLockService
      * @param string $dashboardUuid The dashboard UUID.
      *
      * @return int The number of rows deleted (0 or 1).
-      *
-
-      * @spec openspec/specs/dashboard-locking/spec.md
-
-      */
+     *
+     * @spec openspec/specs/dashboard-locking/spec.md
+     */
     public function cascadeDelete(string $dashboardUuid): int
     {
         return $this->lockMapper->deleteByDashboardUuid(

--- a/lib/Service/DashboardResolver.php
+++ b/lib/Service/DashboardResolver.php
@@ -113,8 +113,9 @@ class DashboardResolver
      * @param string    $userId              The user ID.
      *
      * @return array The dashboard result.
+     *
+     * @spec openspec/specs/dashboards/spec.md
      */
-    /** @spec openspec/specs/dashboards/spec.md */
     public function handleTemplateResult(
         Dashboard $template,
         bool $allowUserDashboards,
@@ -152,8 +153,9 @@ class DashboardResolver
      * @param array     $placements The placements.
      *
      * @return array The result array.
+     *
+     * @spec openspec/specs/dashboards/spec.md
      */
-    /** @spec openspec/specs/dashboards/spec.md */
     public function buildResult(
         Dashboard $dashboard,
         array $placements

--- a/lib/Service/DashboardService.php
+++ b/lib/Service/DashboardService.php
@@ -282,8 +282,9 @@ class DashboardService
      *
      * @return array|null `{dashboard, placements, permissionLevel}` when
      *                    visible; null when the user has no read access.
+     *
+     * @spec openspec/specs/dashboards/spec.md
      */
-    /** @spec openspec/specs/dashboards/spec.md */
     public function getDashboardForUser(
         int $dashboardId,
         string $userId
@@ -326,8 +327,9 @@ class DashboardService
      * @param string $userId The user ID.
      *
      * @return array|null The effective dashboard data or null.
+     *
+     * @spec openspec/specs/dashboards/spec.md
      */
-    /** @spec openspec/specs/dashboards/spec.md */
     public function getEffectiveDashboard(string $userId): ?array
     {
         // Wave3.7 Step 0 — explicit default-dashboard pin wins over
@@ -404,8 +406,9 @@ class DashboardService
      *                                  apply.
      *
      * @return Dashboard The created dashboard.
+     *
+     * @spec openspec/specs/dashboards/spec.md
      */
-    /** @spec openspec/specs/dashboards/spec.md */
     public function createDashboard(
         string $userId,
         string $name,
@@ -498,8 +501,9 @@ class DashboardService
      * @param array  $data        The data to update.
      *
      * @return Dashboard The updated dashboard.
+     *
+     * @spec openspec/specs/dashboards/spec.md
      */
-    /** @spec openspec/specs/dashboards/spec.md */
     public function updateDashboard(
         int $dashboardId,
         string $userId,
@@ -534,8 +538,9 @@ class DashboardService
      * @param bool   $cascade     When true, remove the entire subtree.
      *
      * @return void
+     *
+     * @spec openspec/specs/dashboards/spec.md
      */
-    /** @spec openspec/specs/dashboards/spec.md */
     public function deleteDashboard(
         int $dashboardId,
         string $userId,
@@ -628,8 +633,9 @@ class DashboardService
      * @param string $userId      The user ID.
      *
      * @return Dashboard The activated dashboard.
+     *
+     * @spec openspec/specs/dashboards/spec.md
      */
-    /** @spec openspec/specs/dashboards/spec.md */
     public function activateDashboard(
         int $dashboardId,
         string $userId
@@ -658,8 +664,9 @@ class DashboardService
      * @param string $groupId The group ID.
      *
      * @return Dashboard[] The group-shared dashboards in the group.
+     *
+     * @spec openspec/specs/dashboards/spec.md
      */
-    /** @spec openspec/specs/dashboards/spec.md */
     public function listGroupDashboards(string $groupId): array
     {
         return $this->dashboardMapper->findByGroup(groupId: $groupId);
@@ -681,8 +688,9 @@ class DashboardService
      *                               exists, or when its `groupId` does
      *                               not match the path parameter, or
      *                               when its type is not group_shared.
+     *
+     * @spec openspec/specs/dashboards/spec.md
      */
-    /** @spec openspec/specs/dashboards/spec.md */
     public function findGroupDashboard(
         string $groupId,
         string $uuid
@@ -721,8 +729,9 @@ class DashboardService
      * @return Dashboard The created group-shared dashboard.
      *
      * @throws Exception When the actor is not an administrator.
+     *
+     * @spec openspec/specs/dashboards/spec.md
      */
-    /** @spec openspec/specs/dashboards/spec.md */
     public function createGroupShared(
         string $actorUserId,
         string $groupId,
@@ -768,8 +777,9 @@ class DashboardService
      *
      * @throws Exception When the actor is not an administrator.
      * @throws DoesNotExistException On 404.
+     *
+     * @spec openspec/specs/dashboards/spec.md
      */
-    /** @spec openspec/specs/dashboards/spec.md */
     public function updateGroupShared(
         string $actorUserId,
         string $groupId,
@@ -817,8 +827,9 @@ class DashboardService
      * @throws Exception When the actor is not admin, or the
      *                   last-in-group guard rejects the delete.
      * @throws DoesNotExistException On 404.
+     *
+     * @spec openspec/specs/dashboards/spec.md
      */
-    /** @spec openspec/specs/dashboards/spec.md */
     public function deleteGroupShared(
         string $actorUserId,
         string $groupId,
@@ -873,8 +884,9 @@ class DashboardService
      * @throws Exception              When the actor is not an admin.
      * @throws DoesNotExistException  When the uuid does not belong to
      *                                the given group.
+     *
+     * @spec openspec/specs/dashboards/spec.md
      */
-    /** @spec openspec/specs/dashboards/spec.md */
     public function setGroupDefault(
         string $actorUserId,
         string $groupId,
@@ -930,8 +942,9 @@ class DashboardService
      *
      * @return array<int, array{dashboard: Dashboard, source: string}>
      *   List of {dashboard, source} pairs.
+     *
+     * @spec openspec/specs/dashboards/spec.md
      */
-    /** @spec openspec/specs/dashboards/spec.md */
     public function getVisibleToUser(string $userId): array
     {
         $userGroupIds = $this->adminTemplateService->getUserGroupIdsFor(
@@ -1079,8 +1092,9 @@ class DashboardService
      * @return array{dashboard: Dashboard, source: string}|null
      *   `{dashboard, source}` where source is `'user'`, `'group'`, or
      *   `'default'`; or `null` when no dashboard exists at all.
+     *
+     * @spec openspec/specs/dashboards/spec.md
      */
-    /** @spec openspec/specs/dashboards/spec.md */
     public function resolveActiveDashboard(
         string $userId,
         ?string $primaryGroupId
@@ -1096,11 +1110,7 @@ class DashboardService
         $visible = $this->getVisibleToUser(userId: $userId);
 
         // Build a UUID-keyed index for O(1) pref lookup.
-        /**
-         * UUID-indexed view of $visible for O(1) lookup.
-         *
-         * @var array<string, array{dashboard: Dashboard, source: string}> $byUuid
-         */
+        // @var array<string, array{dashboard: Dashboard, source: string}> $byUuid.
         $byUuid = [];
         foreach ($visible as $entry) {
             $uuid = (string) $entry['dashboard']->getUuid();
@@ -1235,8 +1245,9 @@ class DashboardService
      * @param string $uuid   The dashboard UUID, or empty string to clear.
      *
      * @return void
+     *
+     * @spec openspec/specs/dashboards/spec.md
      */
-    /** @spec openspec/specs/dashboards/spec.md */
     public function setActivePreference(string $userId, string $uuid): void
     {
         if ($uuid === '') {
@@ -1274,8 +1285,9 @@ class DashboardService
      * @param string $uuid   The dashboard UUID, or empty string to clear.
      *
      * @return void
+     *
+     * @spec openspec/specs/dashboards/spec.md
      */
-    /** @spec openspec/specs/dashboards/spec.md */
     public function setDefaultPreference(string $userId, string $uuid): void
     {
         if ($uuid === '') {
@@ -1306,8 +1318,9 @@ class DashboardService
      * @param string $userId The user ID.
      *
      * @return string The pinned dashboard UUID, or '' when unset.
+     *
+     * @spec openspec/specs/dashboards/spec.md
      */
-    /** @spec openspec/specs/dashboards/spec.md */
     public function getDefaultPreference(string $userId): string
     {
         return (string) $this->config->getUserValue(
@@ -1336,8 +1349,9 @@ class DashboardService
      * @throws DoesNotExistException When the UUID does not exist.
      * @throws Exception             When the actor is neither the owner
      *                               nor a Nextcloud administrator.
+     *
+     * @spec openspec/specs/dashboards/spec.md
      */
-    /** @spec openspec/specs/dashboards/spec.md */
     public function publish(string $uuid, string $userId): Dashboard
     {
         $dashboard = $this->dashboardMapper->findByUuid(uuid: $uuid);
@@ -1387,8 +1401,9 @@ class DashboardService
      * @throws DoesNotExistException When the UUID does not exist.
      * @throws Exception             When the actor is neither owner nor
      *                               admin.
+     *
+     * @spec openspec/specs/dashboards/spec.md
      */
-    /** @spec openspec/specs/dashboards/spec.md */
     public function unpublish(string $uuid, string $userId): Dashboard
     {
         $dashboard = $this->dashboardMapper->findByUuid(uuid: $uuid);
@@ -1435,8 +1450,9 @@ class DashboardService
      *                                  unparseable, or in the past.
      * @throws Exception                When the actor is neither owner
      *                                  nor admin.
+     *
+     * @spec openspec/specs/dashboards/spec.md
      */
-    /** @spec openspec/specs/dashboards/spec.md */
     public function schedule(
         string $uuid,
         string $publishAt,
@@ -1471,8 +1487,9 @@ class DashboardService
      * effective state for cleaner audit queries.
      *
      * @return int The number of dashboards materialised.
+     *
+     * @spec openspec/specs/dashboards/spec.md
      */
-    /** @spec openspec/specs/dashboards/spec.md */
     public function materialiseScheduledDashboards(): int
     {
         $dueRows = $this->dashboardMapper->findDueScheduled();
@@ -1555,8 +1572,9 @@ class DashboardService
      *                                             rolled back before
      *                                             rethrowing
      *                                             (REQ-DASH-021).
+     *
+     * @spec openspec/specs/dashboards/spec.md
      */
-    /** @spec openspec/specs/dashboards/spec.md */
     public function forkAsPersonal(
         string $userId,
         string $sourceUuid,
@@ -1754,8 +1772,9 @@ class DashboardService
      *  setting key constant (`AdminSetting::KEY_ALLOW_USER_DASHBOARDS`).
      *  Renaming to `isAllowUserDashboards()` would break the symmetry the
      *  spec relies on.
+     *
+     * @spec openspec/specs/dashboards/spec.md
      */
-    /** @spec openspec/specs/dashboards/spec.md */
     public function getAllowUserDashboards(): bool
     {
         return (bool) $this->settingMapper->getValue(
@@ -1776,8 +1795,9 @@ class DashboardService
      * @return void
      *
      * @throws PersonalDashboardsDisabledException When the flag is off.
+     *
+     * @spec openspec/specs/dashboards/spec.md
      */
-    /** @spec openspec/specs/dashboards/spec.md */
     public function assertPersonalDashboardsAllowed(): void
     {
         if ($this->getAllowUserDashboards() === false) {
@@ -1928,8 +1948,9 @@ class DashboardService
      * @param int $dashboardId The dashboard ID.
      *
      * @return WidgetPlacement[] The placements ordered by sortOrder.
+     *
+     * @spec openspec/specs/dashboards/spec.md
      */
-    /** @spec openspec/specs/dashboards/spec.md */
     public function findPlacements(int $dashboardId): array
     {
         return $this->placementMapper->findByDashboardId(
@@ -2209,8 +2230,9 @@ class DashboardService
      * @param Dashboard $dashboard The dashboard.
      *
      * @return array|null The effective footer payload, or NULL.
+     *
+     * @spec openspec/specs/dashboards/spec.md
      */
-    /** @spec openspec/specs/dashboards/spec.md */
     public function resolveFooterForDashboard(Dashboard $dashboard): ?array
     {
         return $this->footerService->resolveFooterForDashboard(dashboard: $dashboard);

--- a/lib/Service/DashboardShareService.php
+++ b/lib/Service/DashboardShareService.php
@@ -82,8 +82,9 @@ class DashboardShareService
      * @return DashboardShare[] The shares.
      *
      * @throws Exception When the user is not the dashboard owner.
+     *
+     * @spec openspec/specs/dashboard-sharing/spec.md
      */
-    /** @spec openspec/specs/dashboard-sharing/spec.md */
     public function listShares(int $dashboardId, string $userId): array
     {
         $this->assertOwner(dashboardId: $dashboardId, userId: $userId);
@@ -103,8 +104,9 @@ class DashboardShareService
      * @return DashboardShare The persisted share.
      *
      * @throws Exception When the caller is not the owner or input is invalid.
+     *
+     * @spec openspec/specs/dashboard-sharing/spec.md
      */
-    /** @spec openspec/specs/dashboard-sharing/spec.md */
     public function addShare(
         int $dashboardId,
         string $shareType,
@@ -150,8 +152,9 @@ class DashboardShareService
      * @return void
      *
      * @throws Exception When the share does not exist or caller is not owner.
+     *
+     * @spec openspec/specs/dashboard-sharing/spec.md
      */
-    /** @spec openspec/specs/dashboard-sharing/spec.md */
     public function removeShare(int $shareId, string $callerId): void
     {
         $share     = $this->shareMapper->find(id: $shareId);
@@ -181,8 +184,9 @@ class DashboardShareService
      *
      * @throws Exception    When the caller is not the owner or input is invalid.
      * @throws Throwable    On DB error (rolls back).
+     *
+     * @spec openspec/specs/dashboard-sharing/spec.md
      */
-    /** @spec openspec/specs/dashboard-sharing/spec.md */
     public function replaceShares(
         int $dashboardId,
         array $shares,
@@ -266,8 +270,9 @@ class DashboardShareService
      * @return int The number of share rows deleted.
      *
      * @throws InvalidArgumentException When shareType is invalid.
+     *
+     * @spec openspec/specs/dashboard-sharing/spec.md
      */
-    /** @spec openspec/specs/dashboard-sharing/spec.md */
     public function revokeAllForRecipient(
         string $shareType,
         string $shareWith,
@@ -303,8 +308,9 @@ class DashboardShareService
      * @param string[] $groupIds The recipient's group ids.
      *
      * @return array<int,string> Map of dashboardId => permission level.
+     *
+     * @spec openspec/specs/dashboard-sharing/spec.md
      */
-    /** @spec openspec/specs/dashboard-sharing/spec.md */
     public function resolveSharedDashboards(string $userId, array $groupIds): array
     {
         $shares = $this->shareMapper->findForRecipient(
@@ -337,8 +343,9 @@ class DashboardShareService
      * @param string $newUserId   The new owner's user ID.
      *
      * @return void
+     *
+     * @spec openspec/specs/dashboard-sharing/spec.md
      */
-    /** @spec openspec/specs/dashboard-sharing/spec.md */
     public function transferOwnership(int $dashboardId, string $newUserId): void
     {
         $dashboard = $this->dashboardMapper->find(id: $dashboardId);
@@ -369,8 +376,9 @@ class DashboardShareService
      * @param string $dashboardName The dashboard name.
      *
      * @return void
+     *
+     * @spec openspec/specs/dashboard-sharing/spec.md
      */
-    /** @spec openspec/specs/dashboard-sharing/spec.md */
     public function notifyOwnershipTransferred(
         string $newOwnerId,
         int $dashboardId,

--- a/lib/Service/DashboardTranslationService.php
+++ b/lib/Service/DashboardTranslationService.php
@@ -106,8 +106,9 @@ class DashboardTranslationService
      * @param string $dashboardUuid The dashboard UUID.
      *
      * @return DashboardTranslation[] The variants.
+     *
+     * @spec openspec/specs/dashboard-language-content/spec.md
      */
-    /** @spec openspec/specs/dashboard-language-content/spec.md */
     public function listVariants(string $dashboardUuid): array
     {
         return $this->translationMapper->findByDashboardUuid(
@@ -121,8 +122,9 @@ class DashboardTranslationService
      * @param string $dashboardUuid The dashboard UUID.
      *
      * @return string[] The language codes.
+     *
+     * @spec openspec/specs/dashboard-language-content/spec.md
      */
-    /** @spec openspec/specs/dashboard-language-content/spec.md */
     public function listAvailableLanguages(string $dashboardUuid): array
     {
         $variants  = $this->listVariants(dashboardUuid: $dashboardUuid);
@@ -151,8 +153,9 @@ class DashboardTranslationService
      *
      * @return array{translation: DashboardTranslation, isFallback: bool}|null
      *   The matched variant or null when no variants exist.
+     *
+     * @spec openspec/specs/dashboard-language-content/spec.md
      */
-    /** @spec openspec/specs/dashboard-language-content/spec.md */
     public function resolveForLocale(
         string $dashboardUuid,
         string $preferredLanguage
@@ -205,8 +208,9 @@ class DashboardTranslationService
      * @param Dashboard $dashboard The newly-persisted dashboard.
      *
      * @return DashboardTranslation The seeded primary translation.
+     *
+     * @spec openspec/specs/dashboard-language-content/spec.md
      */
-    /** @spec openspec/specs/dashboard-language-content/spec.md */
     public function seedPrimaryFor(Dashboard $dashboard): DashboardTranslation
     {
         $uuid = (string) $dashboard->getUuid();
@@ -264,8 +268,9 @@ class DashboardTranslationService
      *                                  after normalisation.
      * @throws Exception                When a row already exists for
      *                                  the same `(uuid, language)` pair.
+     *
+     * @spec openspec/specs/dashboard-language-content/spec.md
      */
-    /** @spec openspec/specs/dashboard-language-content/spec.md */
     public function createVariant(
         string $dashboardUuid,
         string $languageCode,
@@ -337,8 +342,9 @@ class DashboardTranslationService
      *
      * @throws DoesNotExistException When no variant exists for the
      *                               (uuid, language) pair.
+     *
+     * @spec openspec/specs/dashboard-language-content/spec.md
      */
-    /** @spec openspec/specs/dashboard-language-content/spec.md */
     public function updateVariant(
         string $dashboardUuid,
         string $languageCode,
@@ -379,8 +385,9 @@ class DashboardTranslationService
      *
      * @throws DoesNotExistException When the variant does not exist.
      * @throws Exception             When the guard rejects the delete.
+     *
+     * @spec openspec/specs/dashboard-language-content/spec.md
      */
-    /** @spec openspec/specs/dashboard-language-content/spec.md */
     public function deleteVariant(
         string $dashboardUuid,
         string $languageCode
@@ -417,8 +424,9 @@ class DashboardTranslationService
      * @return DashboardTranslation The promoted variant.
      *
      * @throws DoesNotExistException When the variant does not exist.
+     *
+     * @spec openspec/specs/dashboard-language-content/spec.md
      */
-    /** @spec openspec/specs/dashboard-language-content/spec.md */
     public function promoteVariantToPrimary(
         string $dashboardUuid,
         string $languageCode
@@ -461,8 +469,9 @@ class DashboardTranslationService
      * @param string $dashboardUuid The dashboard UUID.
      *
      * @return int The number of rows deleted.
+     *
+     * @spec openspec/specs/dashboard-language-content/spec.md
      */
-    /** @spec openspec/specs/dashboard-language-content/spec.md */
     public function deleteAllForDashboard(string $dashboardUuid): int
     {
         return $this->translationMapper->deleteByDashboardUuid(
@@ -480,8 +489,9 @@ class DashboardTranslationService
      * @param Dashboard $dashboard The dashboard.
      *
      * @return DashboardTranslation An in-memory variant (NOT persisted).
+     *
+     * @spec openspec/specs/dashboard-language-content/spec.md
      */
-    /** @spec openspec/specs/dashboard-language-content/spec.md */
     public function materialiseLegacyVariant(
         Dashboard $dashboard
     ): DashboardTranslation {

--- a/lib/Service/DashboardTreeService.php
+++ b/lib/Service/DashboardTreeService.php
@@ -122,8 +122,9 @@ class DashboardTreeService
      *                                  the assignment would create a
      *                                  cycle, or the resulting depth
      *                                  exceeds the cap.
+     *
+     * @spec openspec/specs/dashboard-switcher/spec.md
      */
-    /** @spec openspec/specs/dashboard-switcher/spec.md */
     public function validateParent(
         ?string $movingUuid,
         ?string $newParentUuid
@@ -177,8 +178,9 @@ class DashboardTreeService
      * @return void
      *
      * @throws InvalidArgumentException When the slug is already in use.
+     *
+     * @spec openspec/specs/dashboard-switcher/spec.md
      */
-    /** @spec openspec/specs/dashboard-switcher/spec.md */
     public function validateSlugUnique(
         ?string $parentUuid,
         string $slug,
@@ -214,8 +216,9 @@ class DashboardTreeService
      * @param string $uuid The dashboard UUID.
      *
      * @return string The leading-slash path.
+     *
+     * @spec openspec/specs/dashboard-switcher/spec.md
      */
-    /** @spec openspec/specs/dashboard-switcher/spec.md */
     public function computePath(string $uuid): string
     {
         $breadcrumbs = $this->computeBreadcrumbs(uuid: $uuid);
@@ -245,8 +248,9 @@ class DashboardTreeService
      * @param string $uuid The dashboard UUID.
      *
      * @return array<int, array{uuid: ?string, name: ?string, slug: ?string}>
+     *
+     * @spec openspec/specs/dashboard-switcher/spec.md
      */
-    /** @spec openspec/specs/dashboard-switcher/spec.md */
     public function computeBreadcrumbs(string $uuid): array
     {
         try {
@@ -285,8 +289,9 @@ class DashboardTreeService
      *                     leading/trailing slash).
      *
      * @return Dashboard|null The dashboard at the path, or NULL on miss.
+     *
+     * @spec openspec/specs/dashboard-switcher/spec.md
      */
-    /** @spec openspec/specs/dashboard-switcher/spec.md */
     public function resolvePath(string $path): ?Dashboard
     {
         $segments = $this->splitPath(path: $path);
@@ -329,8 +334,9 @@ class DashboardTreeService
      *                                pre-existing malformed cycles.
      *
      * @return array<int, array{uuid: ?string, name: ?string, slug: ?string, sortOrder: int, children: array}>
+     *
+     * @spec openspec/specs/dashboard-switcher/spec.md
      */
-    /** @spec openspec/specs/dashboard-switcher/spec.md */
     public function buildTree(
         ?string $parentUuid,
         int $depth=0
@@ -388,8 +394,9 @@ class DashboardTreeService
      * @param Dashboard $dashboard The root of the subtree to delete.
      *
      * @return int The total number of dashboards removed (root + descendants).
+     *
+     * @spec openspec/specs/dashboard-switcher/spec.md
      */
-    /** @spec openspec/specs/dashboard-switcher/spec.md */
     public function deleteSubtree(Dashboard $dashboard): int
     {
         $rootUuid = (string) $dashboard->getUuid();

--- a/lib/Service/DashboardVersionService.php
+++ b/lib/Service/DashboardVersionService.php
@@ -178,8 +178,9 @@ class DashboardVersionService
      * @return DashboardVersion|null The persisted version row, or null
      *                               when an automatic snapshot was
      *                               suppressed by the debounce window.
+     *
+     * @spec openspec/specs/dashboard-versioning/spec.md
      */
-    /** @spec openspec/specs/dashboard-versioning/spec.md */
     public function captureSnapshot(
         Dashboard $dashboard,
         ?string $snapshotJson,
@@ -262,8 +263,9 @@ class DashboardVersionService
      * @return array{versions: array<int, array<string, mixed>>, modeSupported: bool}
      *
      * @throws Exception When the actor is neither owner nor admin.
+     *
+     * @spec openspec/specs/dashboard-versioning/spec.md
      */
-    /** @spec openspec/specs/dashboard-versioning/spec.md */
     public function listVersions(
         Dashboard $dashboard,
         string $requestingUser
@@ -309,8 +311,9 @@ class DashboardVersionService
      *
      * @throws Exception             When the actor is neither owner nor admin.
      * @throws DoesNotExistException When the version does not exist.
+     *
+     * @spec openspec/specs/dashboard-versioning/spec.md
      */
-    /** @spec openspec/specs/dashboard-versioning/spec.md */
     public function fetchSnapshot(
         Dashboard $dashboard,
         int $versionNumber,
@@ -346,8 +349,9 @@ class DashboardVersionService
      * @throws Exception When the actor is neither owner nor admin or
      *                   the groupfolder backend is selected (currently
      *                   unsupported).
+     *
+     * @spec openspec/specs/dashboard-versioning/spec.md
      */
-    /** @spec openspec/specs/dashboard-versioning/spec.md */
     public function createExplicitSnapshot(
         Dashboard $dashboard,
         string $requestingUser,
@@ -404,8 +408,9 @@ class DashboardVersionService
      *
      * @throws Exception             When the actor is neither owner nor admin.
      * @throws DoesNotExistException When the version does not exist.
+     *
+     * @spec openspec/specs/dashboard-versioning/spec.md
      */
-    /** @spec openspec/specs/dashboard-versioning/spec.md */
     public function restoreVersion(
         Dashboard $dashboard,
         int $versionNumber,
@@ -482,8 +487,9 @@ class DashboardVersionService
      * @param string $dashboardUuid The dashboard UUID.
      *
      * @return integer The number of rows deleted.
+     *
+     * @spec openspec/specs/dashboard-versioning/spec.md
      */
-    /** @spec openspec/specs/dashboard-versioning/spec.md */
     public function deleteVersionsForDashboard(string $dashboardUuid): int
     {
         return $this->versionMapper->deleteByDashboardUuid(
@@ -500,8 +506,9 @@ class DashboardVersionService
      * @param Dashboard $dashboard The dashboard.
      *
      * @return boolean Whether the dashboard's content lives in a groupfolder.
+     *
+     * @spec openspec/specs/dashboard-versioning/spec.md
      */
-    /** @spec openspec/specs/dashboard-versioning/spec.md */
     public function isGroupfolderBacked(Dashboard $dashboard): bool
     {
         // The groupfolder-storage-backend change introduces a

--- a/lib/Service/DemoShowcasesService.php
+++ b/lib/Service/DemoShowcasesService.php
@@ -137,8 +137,9 @@ class DemoShowcasesService
      * {@see DemoShowcasesService::setDataDirForTesting()}.
      *
      * @return string Absolute filesystem path.
+     *
+     * @spec openspec/specs/demo-data-showcases/spec.md
      */
-    /** @spec openspec/specs/demo-data-showcases/spec.md */
     public function getDataDir(): string
     {
         if ($this->dataDirOverride !== null) {
@@ -155,8 +156,9 @@ class DemoShowcasesService
      * the returned list is stable and predictable for the admin UI.
      *
      * @return array<int, array<string, mixed>> Showcase descriptors.
+     *
+     * @spec openspec/specs/demo-data-showcases/spec.md
      */
-    /** @spec openspec/specs/demo-data-showcases/spec.md */
     public function getAvailableShowcases(): array
     {
         $result = [];
@@ -183,8 +185,9 @@ class DemoShowcasesService
      *
      * @return array<string, mixed>|null The descriptor, or `null` when
      *                                   the ZIP is missing/malformed.
+     *
+     * @spec openspec/specs/demo-data-showcases/spec.md
      */
-    /** @spec openspec/specs/demo-data-showcases/spec.md */
     public function describeShowcase(string $showcaseId): ?array
     {
         $zipPath = $this->getZipPath(showcaseId: $showcaseId);
@@ -234,8 +237,9 @@ class DemoShowcasesService
      *
      * @throws ShowcaseNotFoundException When the showcase ID is unknown.
      * @throws RuntimeException          On ZIP / persistence failures.
+     *
+     * @spec openspec/specs/demo-data-showcases/spec.md
      */
-    /** @spec openspec/specs/demo-data-showcases/spec.md */
     public function installShowcase(
         string $showcaseId,
         string $lang='nl',
@@ -328,8 +332,9 @@ class DemoShowcasesService
      * @param string $showcaseId The showcase ID.
      *
      * @return void
+     *
+     * @spec openspec/specs/demo-data-showcases/spec.md
      */
-    /** @spec openspec/specs/demo-data-showcases/spec.md */
     public function uninstallShowcase(string $showcaseId): void
     {
         $existingUuid = $this->getInstalledUuid(showcaseId: $showcaseId);
@@ -360,8 +365,9 @@ class DemoShowcasesService
      * @param string $showcaseId The showcase ID.
      *
      * @return string The UUID, or empty string when not installed.
+     *
+     * @spec openspec/specs/demo-data-showcases/spec.md
      */
-    /** @spec openspec/specs/demo-data-showcases/spec.md */
     public function getInstalledUuid(string $showcaseId): string
     {
         return $this->appConfig->getValueString(
@@ -384,8 +390,9 @@ class DemoShowcasesService
      *                                   showcase JSON.
      *
      * @return array{0:array<int,array<string,mixed>>, 1:array<int,string>}
+     *
+     * @spec openspec/specs/demo-data-showcases/spec.md
      */
-    /** @spec openspec/specs/demo-data-showcases/spec.md */
     public function partitionWidgets(array $widgets): array
     {
         $registered = [];

--- a/lib/Service/ExportService.php
+++ b/lib/Service/ExportService.php
@@ -105,8 +105,9 @@ class ExportService
      * @return StreamResponse The streaming ZIP response.
      *
      * @throws DoesNotExistException When the dashboard cannot be found.
+     *
+     * @spec openspec/specs/dashboard-export-import/spec.md
      */
-    /** @spec openspec/specs/dashboard-export-import/spec.md */
     public function exportDashboard(
         string $dashboardUuid,
         string $currentUserId
@@ -133,8 +134,9 @@ class ExportService
      * @param string $currentUserId The current user ID (for manifest).
      *
      * @return StreamResponse The streaming ZIP response.
+     *
+     * @spec openspec/specs/dashboard-export-import/spec.md
      */
-    /** @spec openspec/specs/dashboard-export-import/spec.md */
     public function exportSite(string $currentUserId): StreamResponse
     {
         $dashboards = $this->collectAllDashboards();
@@ -159,8 +161,9 @@ class ExportService
      * @param string $currentUserId  The exporting user's UID.
      *
      * @return array<string, mixed> The manifest data.
+     *
+     * @spec openspec/specs/dashboard-export-import/spec.md
      */
-    /** @spec openspec/specs/dashboard-export-import/spec.md */
     public function buildManifest(
         string $scope,
         int $dashboardCount,
@@ -188,8 +191,9 @@ class ExportService
      * @param Dashboard $dashboard The dashboard entity.
      *
      * @return array<string, mixed> The serialized dashboard payload.
+     *
+     * @spec openspec/specs/dashboard-export-import/spec.md
      */
-    /** @spec openspec/specs/dashboard-export-import/spec.md */
     public function serializeDashboard(Dashboard $dashboard): array
     {
         $widgets = [];

--- a/lib/Service/FeedRefreshService.php
+++ b/lib/Service/FeedRefreshService.php
@@ -143,8 +143,9 @@ class FeedRefreshService
      * the JSON-decode path.
      *
      * @return string[] The deduplicated, sorted feed URL list.
+     *
+     * @spec openspec/specs/background-job-feed-refresh/spec.md
      */
-    /** @spec openspec/specs/background-job-feed-refresh/spec.md */
     public function discoverFeedUrls(): array
     {
         $rawUrls = [];
@@ -197,8 +198,9 @@ class FeedRefreshService
      *
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      * @SuppressWarnings(PHPMD.NPathComplexity)
+     *
+     * @spec openspec/specs/background-job-feed-refresh/spec.md
      */
-    /** @spec openspec/specs/background-job-feed-refresh/spec.md */
     public function refreshFeed(string $feedUrl): array
     {
         $startedAt = (int) (microtime(as_float: true) * 1000);
@@ -331,8 +333,9 @@ class FeedRefreshService
      *
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      * @SuppressWarnings(PHPMD.NPathComplexity)
+     *
+     * @spec openspec/specs/background-job-feed-refresh/spec.md
      */
-    /** @spec openspec/specs/background-job-feed-refresh/spec.md */
     public function refreshAll(?string $onlyUrl=null): array
     {
         $startedAt = (int) (microtime(as_float: true) * 1000);

--- a/lib/Service/FeedService.php
+++ b/lib/Service/FeedService.php
@@ -116,8 +116,9 @@ class FeedService
      *                          {@see self::FORMAT_ATOM}.
      *
      * @return string The serialised feed XML.
+     *
+     * @spec openspec/specs/dashboard-rss-feeds/spec.md
      */
-    /** @spec openspec/specs/dashboard-rss-feeds/spec.md */
     public function renderFeed(
         FeedToken $token,
         string $format=self::FORMAT_RSS
@@ -156,8 +157,9 @@ class FeedService
      * @param string $userId The token-owner's user ID.
      *
      * @return Dashboard[] Accessible dashboards, newest first.
+     *
+     * @spec openspec/specs/dashboard-rss-feeds/spec.md
      */
-    /** @spec openspec/specs/dashboard-rss-feeds/spec.md */
     public function loadAccessibleDashboards(string $userId): array
     {
         $entries = $this->dashboardService->getVisibleToUser(userId: $userId);
@@ -187,8 +189,9 @@ class FeedService
      * @param string      $userId     The token-owner's user ID.
      *
      * @return string The serialised RSS XML.
+     *
+     * @spec openspec/specs/dashboard-rss-feeds/spec.md
      */
-    /** @spec openspec/specs/dashboard-rss-feeds/spec.md */
     public function buildRssFeed(array $dashboards, string $userId): string
     {
         $l10n         = $this->l10nFactory->get(app: Application::APP_ID);
@@ -239,8 +242,9 @@ XML;
      * @param string      $userId     The token-owner's user ID.
      *
      * @return string The serialised Atom XML.
+     *
+     * @spec openspec/specs/dashboard-rss-feeds/spec.md
      */
-    /** @spec openspec/specs/dashboard-rss-feeds/spec.md */
     public function buildAtomFeed(array $dashboards, string $userId): string
     {
         $l10n      = $this->l10nFactory->get(app: Application::APP_ID);
@@ -289,8 +293,9 @@ XML;
      * @param string $userId The user ID.
      *
      * @return string The display name (or the user ID when unknown).
+     *
+     * @spec openspec/specs/dashboard-rss-feeds/spec.md
      */
-    /** @spec openspec/specs/dashboard-rss-feeds/spec.md */
     public function getOwnerDisplayName(string $userId): string
     {
         $user = $this->userManager->get(uid: $userId);
@@ -314,8 +319,9 @@ XML;
      * @param string|null $value The raw value.
      *
      * @return string The escaped value, or empty string when null.
+     *
+     * @spec openspec/specs/dashboard-rss-feeds/spec.md
      */
-    /** @spec openspec/specs/dashboard-rss-feeds/spec.md */
     public static function xmlEscape(?string $value): string
     {
         if ($value === null) {

--- a/lib/Service/FileService.php
+++ b/lib/Service/FileService.php
@@ -121,8 +121,9 @@ class FileService
      *                                      in the allow-list.
      * @throws StorageFailureException      When the underlying
      *                                      filesystem rejects the write.
+     *
+     * @spec openspec/specs/resource-uploads/spec.md
      */
-    /** @spec openspec/specs/resource-uploads/spec.md */
     public function createFile(
         string $userId,
         string $filename,
@@ -173,8 +174,9 @@ class FileService
      * tokens are silently dropped to keep the allow-list well-formed.
      *
      * @return array<int, string> Normalised allow-list.
+     *
+     * @spec openspec/specs/resource-uploads/spec.md
      */
-    /** @spec openspec/specs/resource-uploads/spec.md */
     public function getAllowedExtensions(): array
     {
         $stored = $this->settingMapper->getValue(
@@ -224,8 +226,9 @@ class FileService
      *                          are kept; everything else is dropped).
      *
      * @return array<int, string> The stored, normalised allow-list.
+     *
+     * @spec openspec/specs/resource-uploads/spec.md
      */
-    /** @spec openspec/specs/resource-uploads/spec.md */
     public function setAllowedExtensions(array $extensions): array
     {
         $normalised = [];

--- a/lib/Service/FilesWidgetService.php
+++ b/lib/Service/FilesWidgetService.php
@@ -117,8 +117,9 @@ class FilesWidgetService
      *                                 longer exists.
      * @throws NoAccessException       When the viewer cannot read the
      *                                 configured folder.
+     *
+     * @spec openspec/specs/files-widget/spec.md
      */
-    /** @spec openspec/specs/files-widget/spec.md */
     public function getContentsForPlacement(
         string $userId,
         array $config,
@@ -181,8 +182,9 @@ class FilesWidgetService
      * @throws FolderNotFoundException When the configured folder is gone.
      * @throws NoAccessException       When upload is not allowed for
      *                                 this placement / viewer combination.
+     *
+     * @spec openspec/specs/files-widget/spec.md
      */
-    /** @spec openspec/specs/files-widget/spec.md */
     public function uploadFiles(
         string $userId,
         array $config,
@@ -247,8 +249,9 @@ class FilesWidgetService
      *
      * @throws FolderNotFoundException When the file is not found.
      * @throws NoAccessException       When delete is not allowed.
+     *
+     * @spec openspec/specs/files-widget/spec.md
      */
-    /** @spec openspec/specs/files-widget/spec.md */
     public function deleteFile(string $userId, array $config, int $fileId): array
     {
         if ((bool) ($config['allowDelete'] ?? false) === false) {
@@ -304,8 +307,9 @@ class FilesWidgetService
      * @param Node $node A file or folder node.
      *
      * @return array<string, mixed>
+     *
+     * @spec openspec/specs/files-widget/spec.md
      */
-    /** @spec openspec/specs/files-widget/spec.md */
     public function buildFileMetadata(Node $node): array
     {
         $isFolder = $node instanceof Folder;
@@ -357,8 +361,9 @@ class FilesWidgetService
      * @throws FolderNotFoundException When neither identifier resolves.
      * @throws NoAccessException       When the resolved folder is
      *                                 unreadable.
+     *
+     * @spec openspec/specs/files-widget/spec.md
      */
-    /** @spec openspec/specs/files-widget/spec.md */
     public function resolveConfiguredFolder(string $userId, array $config): Folder
     {
         try {

--- a/lib/Service/FooterService.php
+++ b/lib/Service/FooterService.php
@@ -155,8 +155,9 @@ class FooterService
      *                              `footerConfig`,
      *                              `footerBackgroundColor`,
      *                              `footerTextColor`).
+     *
+     * @spec openspec/specs/footer-customization/spec.md
      */
-    /** @spec openspec/specs/footer-customization/spec.md */
     public function getGlobalSettings(): array
     {
         $enabled = (bool) $this->settingMapper->getValue(
@@ -231,8 +232,9 @@ class FooterService
      * @throws InvalidArgumentException When validation fails. The
      *                                  controller maps the message to
      *                                  HTTP 400 / 413 as appropriate.
+     *
+     * @spec openspec/specs/footer-customization/spec.md
      */
-    /** @spec openspec/specs/footer-customization/spec.md */
     public function updateGlobalSettings(array $patch): void
     {
         if (array_key_exists(key: 'footerEnabled', array: $patch) === true) {
@@ -335,8 +337,9 @@ class FooterService
      * @return string The sanitised HTML (always safe to render).
      *
      * @throws InvalidArgumentException When the input exceeds 8 KB.
+     *
+     * @spec openspec/specs/footer-customization/spec.md
      */
-    /** @spec openspec/specs/footer-customization/spec.md */
     public function sanitiseHtml(string $html): string
     {
         if (strlen(string: $html) > self::MAX_HTML_BYTES) {
@@ -465,8 +468,9 @@ class FooterService
      * @return void
      *
      * @throws InvalidArgumentException On schema mismatch.
+     *
+     * @spec openspec/specs/footer-customization/spec.md
      */
-    /** @spec openspec/specs/footer-customization/spec.md */
     public function validateStructuredConfig(array $config): void
     {
         foreach (array_keys(array: $config) as $key) {
@@ -530,8 +534,9 @@ class FooterService
      * @return array<string, mixed>|null Effective footer payload keyed
      *                                    by `mode`, `html`, `config`,
      *                                    `backgroundColor`, `textColor`.
+     *
+     * @spec openspec/specs/footer-customization/spec.md
      */
-    /** @spec openspec/specs/footer-customization/spec.md */
     public function resolveFooterForDashboard(Dashboard $dashboard): ?array
     {
         $rawMode = $dashboard->getDashboardFooterMode();

--- a/lib/Service/ImageMimeValidator.php
+++ b/lib/Service/ImageMimeValidator.php
@@ -69,8 +69,9 @@ class ImageMimeValidator
      * @throws CorruptImageException When the bytes cannot be decoded.
      * @throws MimeMismatchException When the detected MIME differs from
      *                               the declared type.
+     *
+     * @spec openspec/specs/resource-uploads/spec.md
      */
-    /** @spec openspec/specs/resource-uploads/spec.md */
     public function validate(string $declaredType, string $bytes): void
     {
         // SVG validation is the sanitiser's job, not this validator's.

--- a/lib/Service/ImportService.php
+++ b/lib/Service/ImportService.php
@@ -106,8 +106,9 @@ class ImportService
      *
      * @throws InvalidArgumentException When the archive is invalid or the
      *                                  schema version is unsupported.
+     *
+     * @spec openspec/specs/dashboard-export-import/spec.md
      */
-    /** @spec openspec/specs/dashboard-export-import/spec.md */
     public function import(
         string $zipPath,
         bool $preserveUuids,
@@ -167,8 +168,9 @@ class ImportService
      * @return array<string, mixed> The decoded manifest.
      *
      * @throws InvalidArgumentException When the manifest is missing or invalid.
+     *
+     * @spec openspec/specs/dashboard-export-import/spec.md
      */
-    /** @spec openspec/specs/dashboard-export-import/spec.md */
     public function validateZipStructure(ZipArchive $zip): array
     {
         $raw = $zip->getFromName(name: 'manifest.json');
@@ -216,8 +218,9 @@ class ImportService
      * @param bool                             $preserveUuids Preserve flag.
      *
      * @return array<int, array<string, mixed>> The (possibly remapped) dashboards.
+     *
+     * @spec openspec/specs/dashboard-export-import/spec.md
      */
-    /** @spec openspec/specs/dashboard-export-import/spec.md */
     public function remapUuids(array $dashboards, bool $preserveUuids): array
     {
         if ($preserveUuids === true) {

--- a/lib/Service/InitialStateBuilder.php
+++ b/lib/Service/InitialStateBuilder.php
@@ -146,8 +146,9 @@ class InitialStateBuilder
      * @param array $widgets Widget descriptors `[{id, title, iconClass, iconUrl, url}, ...]`.
      *
      * @return self Fluent.
+     *
+     * @spec openspec/specs/initial-state-contract/spec.md
      */
-    /** @spec openspec/specs/initial-state-contract/spec.md */
     public function setWidgets(array $widgets): self
     {
         $this->values['widgets'] = $widgets;
@@ -160,8 +161,9 @@ class InitialStateBuilder
      * @param array $layout WidgetPlacement rows for the active dashboard.
      *
      * @return self Fluent.
+     *
+     * @spec openspec/specs/initial-state-contract/spec.md
      */
-    /** @spec openspec/specs/initial-state-contract/spec.md */
     public function setLayout(array $layout): self
     {
         $this->values['layout'] = $layout;
@@ -174,8 +176,9 @@ class InitialStateBuilder
      * @param string $primaryGroup Resolved primary group id (e.g. 'default').
      *
      * @return self Fluent.
+     *
+     * @spec openspec/specs/initial-state-contract/spec.md
      */
-    /** @spec openspec/specs/initial-state-contract/spec.md */
     public function setPrimaryGroup(string $primaryGroup): self
     {
         $this->values['primaryGroup'] = $primaryGroup;
@@ -188,8 +191,9 @@ class InitialStateBuilder
      * @param string $primaryGroupName Human-readable primary group name.
      *
      * @return self Fluent.
+     *
+     * @spec openspec/specs/initial-state-contract/spec.md
      */
-    /** @spec openspec/specs/initial-state-contract/spec.md */
     public function setPrimaryGroupName(string $primaryGroupName): self
     {
         $this->values['primaryGroupName'] = $primaryGroupName;
@@ -202,8 +206,9 @@ class InitialStateBuilder
      * @param bool $isAdmin True when the user belongs to the admin group.
      *
      * @return self Fluent.
+     *
+     * @spec openspec/specs/initial-state-contract/spec.md
      */
-    /** @spec openspec/specs/initial-state-contract/spec.md */
     public function setIsAdmin(bool $isAdmin): self
     {
         $this->values['isAdmin'] = $isAdmin;
@@ -216,8 +221,9 @@ class InitialStateBuilder
      * @param string $activeDashboardId Id of the currently active dashboard.
      *
      * @return self Fluent.
+     *
+     * @spec openspec/specs/initial-state-contract/spec.md
      */
-    /** @spec openspec/specs/initial-state-contract/spec.md */
     public function setActiveDashboardId(string $activeDashboardId): self
     {
         $this->values['activeDashboardId'] = $activeDashboardId;
@@ -233,8 +239,9 @@ class InitialStateBuilder
      * @param string $dashboardSource One of 'user', 'group', 'default'.
      *
      * @return self Fluent.
+     *
+     * @spec openspec/specs/initial-state-contract/spec.md
      */
-    /** @spec openspec/specs/initial-state-contract/spec.md */
     public function setDashboardSource(string $dashboardSource): self
     {
         $this->values['dashboardSource'] = $dashboardSource;
@@ -247,8 +254,9 @@ class InitialStateBuilder
      * @param array $groupDashboards List of group-scope dashboards visible to the user.
      *
      * @return self Fluent.
+     *
+     * @spec openspec/specs/initial-state-contract/spec.md
      */
-    /** @spec openspec/specs/initial-state-contract/spec.md */
     public function setGroupDashboards(array $groupDashboards): self
     {
         $this->values['groupDashboards'] = $groupDashboards;
@@ -261,8 +269,9 @@ class InitialStateBuilder
      * @param array $userDashboards List of personal dashboards owned by the user.
      *
      * @return self Fluent.
+     *
+     * @spec openspec/specs/initial-state-contract/spec.md
      */
-    /** @spec openspec/specs/initial-state-contract/spec.md */
     public function setUserDashboards(array $userDashboards): self
     {
         $this->values['userDashboards'] = $userDashboards;
@@ -275,8 +284,9 @@ class InitialStateBuilder
      * @param bool $allowUserDashboards Current value of the admin flag.
      *
      * @return self Fluent.
+     *
+     * @spec openspec/specs/initial-state-contract/spec.md
      */
-    /** @spec openspec/specs/initial-state-contract/spec.md */
     public function setAllowUserDashboards(bool $allowUserDashboards): self
     {
         $this->values['allowUserDashboards'] = $allowUserDashboards;
@@ -291,8 +301,9 @@ class InitialStateBuilder
      * @param array|null $allowedWidgets List of widget IDs, or null.
      *
      * @return self
+     *
+     * @spec openspec/specs/initial-state-contract/spec.md
      */
-    /** @spec openspec/specs/initial-state-contract/spec.md */
     public function setAllowedWidgets(?array $allowedWidgets): self
     {
         $this->values['allowedWidgets'] = $allowedWidgets;
@@ -312,8 +323,9 @@ class InitialStateBuilder
      * @param string $deepLinkPath Canonical path or '' when none.
      *
      * @return self
+     *
+     * @spec openspec/specs/initial-state-contract/spec.md
      */
-    /** @spec openspec/specs/initial-state-contract/spec.md */
     public function setDeepLinkPath(string $deepLinkPath): self
     {
         $this->values['deepLinkPath'] = $deepLinkPath;
@@ -326,8 +338,9 @@ class InitialStateBuilder
      * @param array $allGroups List of `{id, displayName}` pairs.
      *
      * @return self Fluent.
+     *
+     * @spec openspec/specs/initial-state-contract/spec.md
      */
-    /** @spec openspec/specs/initial-state-contract/spec.md */
     public function setAllGroups(array $allGroups): self
     {
         $this->values['allGroups'] = $allGroups;
@@ -340,8 +353,9 @@ class InitialStateBuilder
      * @param array $configuredGroups Ordered list of group ids.
      *
      * @return self Fluent.
+     *
+     * @spec openspec/specs/initial-state-contract/spec.md
      */
-    /** @spec openspec/specs/initial-state-contract/spec.md */
     public function setConfiguredGroups(array $configuredGroups): self
     {
         $this->values['configuredGroups'] = $configuredGroups;
@@ -360,8 +374,9 @@ class InitialStateBuilder
      *                          e.g. `["txt","md","docx"]`.
      *
      * @return self Fluent.
+     *
+     * @spec openspec/specs/initial-state-contract/spec.md
      */
-    /** @spec openspec/specs/initial-state-contract/spec.md */
     public function setLinkCreateFileExtensions(array $extensions): self
     {
         $this->values['linkCreateFileExtensions'] = $extensions;
@@ -376,8 +391,9 @@ class InitialStateBuilder
      *
      * @throws MissingInitialStateException When any required key for the
      *                                      page was not set.
+     *
+     * @spec openspec/specs/initial-state-contract/spec.md
      */
-    /** @spec openspec/specs/initial-state-contract/spec.md */
     public function apply(): void
     {
         $required = self::REQUIRED_KEYS[$this->page->value];

--- a/lib/Service/MenuService.php
+++ b/lib/Service/MenuService.php
@@ -75,8 +75,9 @@ class MenuService
      *
      * @return void
      * @throws InvalidArgumentException When depth exceeds 3 or an item is malformed.
+     *
+     * @spec openspec/specs/menu-widget/spec.md
      */
-    /** @spec openspec/specs/menu-widget/spec.md */
     public function validateMenuItems(array $items): void
     {
         $this->validateLevel(items: $items, depth: 1);
@@ -95,8 +96,9 @@ class MenuService
      *
      * @return void
      * @throws InvalidArgumentException When a field value is outside its allowed set.
+     *
+     * @spec openspec/specs/menu-widget/spec.md
      */
-    /** @spec openspec/specs/menu-widget/spec.md */
     public function validateMenuConfig(array $content): void
     {
         if (isset($content['style']) === true

--- a/lib/Service/MetadataService.php
+++ b/lib/Service/MetadataService.php
@@ -87,8 +87,9 @@ class MetadataService
      * Return all field definitions ordered by `sortOrder`.
      *
      * @return MetadataField[] The sorted field list.
+     *
+     * @spec openspec/specs/dashboard-metadata-fields/spec.md
      */
-    /** @spec openspec/specs/dashboard-metadata-fields/spec.md */
     public function listFields(): array
     {
         return $this->fieldMapper->findAll();
@@ -122,8 +123,9 @@ class MetadataService
      * @return MetadataField The persisted entity.
      *
      * @throws InvalidMetadataFieldException When validation fails.
+     *
+     * @spec openspec/specs/dashboard-metadata-fields/spec.md
      */
-    /** @spec openspec/specs/dashboard-metadata-fields/spec.md */
     public function createFieldDefinition(
         string $key,
         string $label,
@@ -188,8 +190,9 @@ class MetadataService
      *
      * @throws DoesNotExistException        When the field is missing.
      * @throws InvalidMetadataFieldException When validation fails.
+     *
+     * @spec openspec/specs/dashboard-metadata-fields/spec.md
      */
-    /** @spec openspec/specs/dashboard-metadata-fields/spec.md */
     public function updateFieldDefinition(int $id, array $patch): MetadataField
     {
         if (array_key_exists(key: 'key', array: $patch) === true) {
@@ -253,8 +256,9 @@ class MetadataService
      * @throws DoesNotExistException             When the field is missing.
      * @throws MetadataFieldHasValuesException   When values exist and
      *                                            cascade is false.
+     *
+     * @spec openspec/specs/dashboard-metadata-fields/spec.md
      */
-    /** @spec openspec/specs/dashboard-metadata-fields/spec.md */
     public function deleteFieldDefinition(int $id, bool $cascade=false): bool
     {
         $field      = $this->fieldMapper->findById(id: $id);
@@ -281,8 +285,9 @@ class MetadataService
      * @param string $dashboardUuid The dashboard UUID.
      *
      * @return array<string, string> The flat key→encoded-value map.
+     *
+     * @spec openspec/specs/dashboard-metadata-fields/spec.md
      */
-    /** @spec openspec/specs/dashboard-metadata-fields/spec.md */
     public function getMetadataForDashboard(string $dashboardUuid): array
     {
         $rows = $this->valueMapper->findByDashboard(dashboardUuid: $dashboardUuid);
@@ -331,8 +336,9 @@ class MetadataService
      *
      * @throws InvalidMetadataFieldException When any key is unknown
      *                                       or value invalid.
+     *
+     * @spec openspec/specs/dashboard-metadata-fields/spec.md
      */
-    /** @spec openspec/specs/dashboard-metadata-fields/spec.md */
     public function setMetadataForDashboard(
         string $dashboardUuid,
         array $keyValues
@@ -405,8 +411,9 @@ class MetadataService
      *                                              map).
      *
      * @return array<int, mixed> The filtered subset.
+     *
+     * @spec openspec/specs/dashboard-metadata-fields/spec.md
      */
-    /** @spec openspec/specs/dashboard-metadata-fields/spec.md */
     public function filterDashboards(
         array $dashboards,
         array $metadataFilters

--- a/lib/Service/MetadataValidationService.php
+++ b/lib/Service/MetadataValidationService.php
@@ -48,8 +48,9 @@ class MetadataValidationService
      * @return string The canonical encoded string ready for persistence.
      *
      * @throws InvalidMetadataFieldException When the value is invalid.
+     *
+     * @spec openspec/specs/dashboard-metadata-fields/spec.md
      */
-    /** @spec openspec/specs/dashboard-metadata-fields/spec.md */
     public function validateValue(mixed $value, MetadataField $field): string
     {
         if (self::isEmpty(value: $value) === true) {

--- a/lib/Service/MetricsQueryService.php
+++ b/lib/Service/MetricsQueryService.php
@@ -81,8 +81,9 @@ class MetricsQueryService
      * @param string $tableName The table name.
      *
      * @return int The row count.
+     *
+     * @spec openspec/specs/prometheus-metrics/spec.md
      */
-    /** @spec openspec/specs/prometheus-metrics/spec.md */
     public function countTable(string $tableName): int
     {
         try {

--- a/lib/Service/NewsWidgetService.php
+++ b/lib/Service/NewsWidgetService.php
@@ -138,8 +138,9 @@ class NewsWidgetService
      *     feedsFailed: int,
      *     failedUrls: array<int, string>
      * }
+     *
+     * @spec openspec/specs/news-widget/spec.md
      */
-    /** @spec openspec/specs/news-widget/spec.md */
     public function getItemsForPlacement(int $placementId, int $limit=10): array
     {
         $clamped = $this->clampLimit(limit: $limit);
@@ -194,8 +195,9 @@ class NewsWidgetService
      *     dateFormat: string,
      *     metadataFilter: array{fieldKey: string, value: string}|null
      * }
+     *
+     * @spec openspec/specs/news-widget/spec.md
      */
-    /** @spec openspec/specs/news-widget/spec.md */
     public function extractNewsConfig(WidgetPlacement $placement): array
     {
         $decoded = $this->decodeStyleConfigBlob(raw: $placement->getStyleConfig());
@@ -396,8 +398,9 @@ class NewsWidgetService
      *     feedsFailed: int,
      *     failedUrls: array<int, string>
      * }
+     *
+     * @spec openspec/specs/news-widget/spec.md
      */
-    /** @spec openspec/specs/news-widget/spec.md */
     public function fetchAndMergeFeeds(array $feedUrls, int $limit=10): array
     {
         if ($feedUrls === []) {
@@ -465,8 +468,9 @@ class NewsWidgetService
      *                            the channel/feed title when present.
      *
      * @return array<int, array<string, mixed>> Parsed items.
+     *
+     * @spec openspec/specs/news-widget/spec.md
      */
-    /** @spec openspec/specs/news-widget/spec.md */
     public function parseRssFeed(string $feedContent, string $sourceUrl, string $sourceTitle): array
     {
         if (trim(string: $feedContent) === '') {
@@ -560,8 +564,9 @@ class NewsWidgetService
      * @param array<int, array<string, mixed>> $items Items to dedupe.
      *
      * @return array<int, array<string, mixed>> Deduped items.
+     *
+     * @spec openspec/specs/news-widget/spec.md
      */
-    /** @spec openspec/specs/news-widget/spec.md */
     public function deduplicateItems(array $items): array
     {
         $seen = [];
@@ -599,8 +604,9 @@ class NewsWidgetService
      * @param array<int, array<string, mixed>> $items Items to sort.
      *
      * @return array<int, array<string, mixed>> Sorted items.
+     *
+     * @spec openspec/specs/news-widget/spec.md
      */
-    /** @spec openspec/specs/news-widget/spec.md */
     public function sortItemsByDate(array $items): array
     {
         $sortable = $items;
@@ -644,8 +650,9 @@ class NewsWidgetService
      * @param string $html Raw summary HTML from a feed item.
      *
      * @return string Sanitised summary HTML.
+     *
+     * @spec openspec/specs/news-widget/spec.md
      */
-    /** @spec openspec/specs/news-widget/spec.md */
     public function sanitiseSummaryHtml(string $html): string
     {
         if ($html === '') {
@@ -707,8 +714,9 @@ class NewsWidgetService
      * @param string $url Candidate feed URL.
      *
      * @return boolean True when the host is allowed.
+     *
+     * @spec openspec/specs/news-widget/spec.md
      */
-    /** @spec openspec/specs/news-widget/spec.md */
     public function checkAllowList(string $url): bool
     {
         $raw = $this->appConfig->getValueString(
@@ -754,8 +762,9 @@ class NewsWidgetService
      * @param array{fieldKey: string, value: string} $metadataFilter The filter to apply.
      *
      * @return boolean True when the filter passes (allow fetch); false otherwise.
+     *
+     * @spec openspec/specs/news-widget/spec.md
      */
-    /** @spec openspec/specs/news-widget/spec.md */
     public function checkMetadataFilter(int $dashboardId, array $metadataFilter): bool
     {
         unset($dashboardId);

--- a/lib/Service/OrgNavigationService.php
+++ b/lib/Service/OrgNavigationService.php
@@ -125,8 +125,9 @@ class OrgNavigationService
      *                         supported set).
      *
      * @return array<int, array<string, mixed>> The persisted tree.
+     *
+     * @spec openspec/specs/navigation-editor-org/spec.md
      */
-    /** @spec openspec/specs/navigation-editor-org/spec.md */
     public function getTree(string $language=self::DEFAULT_LANGUAGE): array
     {
         $lang = $this->normaliseLanguage(language: $language);
@@ -159,8 +160,9 @@ class OrgNavigationService
      *
      * @throws InvalidArgumentException When validation fails (the
      *                                  controller maps to HTTP 400).
+     *
+     * @spec openspec/specs/navigation-editor-org/spec.md
      */
-    /** @spec openspec/specs/navigation-editor-org/spec.md */
     public function setTree(array $tree, string $language=self::DEFAULT_LANGUAGE): void
     {
         $lang = $this->normaliseLanguage(language: $language);
@@ -202,8 +204,9 @@ class OrgNavigationService
      * @param string                           $userId The viewing user.
      *
      * @return array<int, array<string, mixed>> The filtered tree.
+     *
+     * @spec openspec/specs/navigation-editor-org/spec.md
      */
-    /** @spec openspec/specs/navigation-editor-org/spec.md */
     public function filterTreeByUserGroups(array $tree, string $userId): array
     {
         if ($tree === []) {
@@ -224,8 +227,9 @@ class OrgNavigationService
      *
      * @throws InvalidArgumentException With a stable message on the
      *                                  first violation discovered.
+     *
+     * @spec openspec/specs/navigation-editor-org/spec.md
      */
-    /** @spec openspec/specs/navigation-editor-org/spec.md */
     public function validateTree(array $tree): void
     {
         $seenIds = [];
@@ -246,8 +250,9 @@ class OrgNavigationService
      * @throws InvalidArgumentException When the URL uses
      *                                  `javascript:`, `data:`, or
      *                                  `vbscript:` (any case).
+     *
+     * @spec openspec/specs/navigation-editor-org/spec.md
      */
-    /** @spec openspec/specs/navigation-editor-org/spec.md */
     public function sanitiseUrl(string $url): string
     {
         $lower = strtolower(string: ltrim(string: $url));

--- a/lib/Service/OrphanedDataCleanupService.php
+++ b/lib/Service/OrphanedDataCleanupService.php
@@ -135,8 +135,9 @@ class OrphanedDataCleanupService
      * @param array<int, string> $categoryNames Names to scan, or [].
      *
      * @return CleanupResult The result.
+     *
+     * @spec openspec/specs/orphaned-data-cleanup/spec.md
      */
-    /** @spec openspec/specs/orphaned-data-cleanup/spec.md */
     public function scan(array $categoryNames=[]): CleanupResult
     {
         if (count(value: $categoryNames) === 0) {
@@ -206,8 +207,9 @@ class OrphanedDataCleanupService
      *                                          'api', 'job').
      *
      * @return CleanupResult The result.
+     *
+     * @spec openspec/specs/orphaned-data-cleanup/spec.md
      */
-    /** @spec openspec/specs/orphaned-data-cleanup/spec.md */
     public function purge(
         array $categoryNames=[],
         bool $dryRun=false,
@@ -295,8 +297,9 @@ class OrphanedDataCleanupService
      * without a memory cache silently fall through to fresh scans.
      *
      * @return CleanupResult|null The cached result or null.
+     *
+     * @spec openspec/specs/orphaned-data-cleanup/spec.md
      */
-    /** @spec openspec/specs/orphaned-data-cleanup/spec.md */
     public function getCachedScanResult(): ?CleanupResult
     {
         $payload = $this->cache()->get(key: self::CACHE_KEY_SCAN);
@@ -321,8 +324,9 @@ class OrphanedDataCleanupService
      * @param CleanupResult $result The result to cache.
      *
      * @return void
+     *
+     * @spec openspec/specs/orphaned-data-cleanup/spec.md
      */
-    /** @spec openspec/specs/orphaned-data-cleanup/spec.md */
     public function setCachedScanResult(CleanupResult $result): void
     {
         $this->cache()->set(
@@ -339,8 +343,9 @@ class OrphanedDataCleanupService
      * next scan reflects the fresh state (REQ-CLN-010).
      *
      * @return void
+     *
+     * @spec openspec/specs/orphaned-data-cleanup/spec.md
      */
-    /** @spec openspec/specs/orphaned-data-cleanup/spec.md */
     public function invalidateCache(): void
     {
         $this->cache()->remove(key: self::CACHE_KEY_SCAN);

--- a/lib/Service/PeopleWidgetService.php
+++ b/lib/Service/PeopleWidgetService.php
@@ -148,8 +148,9 @@ class PeopleWidgetService
      * @throws InvalidArgumentException When `limit` exceeds MAX_LIMIT, is
      *                                  non-positive, or `offset` is negative;
      *                                  or when `sortBy` is `recent-activity`.
+     *
+     * @spec openspec/specs/people-widget/spec.md
      */
-    /** @spec openspec/specs/people-widget/spec.md */
     public function listUsers(
         array $filters=[],
         bool $excludeDisabled=true,
@@ -222,8 +223,9 @@ class PeopleWidgetService
      *
      * @return int|null Days until next birthday, or null when input is
      *                  invalid.
+     *
+     * @spec openspec/specs/people-widget/spec.md
      */
-    /** @spec openspec/specs/people-widget/spec.md */
     public static function computeDaysToBirthday(?string $birthdate): ?int
     {
         $iso = self::normaliseToIsoDate(raw: $birthdate);

--- a/lib/Service/PermissionService.php
+++ b/lib/Service/PermissionService.php
@@ -93,8 +93,9 @@ class PermissionService
      * @param int    $dashboardId The dashboard ID.
      *
      * @return bool True when the dashboard is visible to the user.
+     *
+     * @spec openspec/specs/permissions/spec.md
      */
-    /** @spec openspec/specs/permissions/spec.md */
     public function canViewDashboard(string $userId, int $dashboardId): bool
     {
         return $this->resolveAccessLevel(userId: $userId, dashboardId: $dashboardId) !== null;
@@ -158,8 +159,9 @@ class PermissionService
      * @param int    $dashboardId The dashboard ID.
      *
      * @return bool Whether the user can edit the dashboard metadata.
+     *
+     * @spec openspec/specs/permissions/spec.md
      */
-    /** @spec openspec/specs/permissions/spec.md */
     public function canEditDashboardMetadata(
         string $userId,
         int $dashboardId
@@ -265,8 +267,9 @@ class PermissionService
      * @param int    $placementId The placement ID.
      *
      * @return bool Whether the user can style the widget.
+     *
+     * @spec openspec/specs/permissions/spec.md
      */
-    /** @spec openspec/specs/permissions/spec.md */
     public function canStyleWidget(string $userId, int $placementId): bool
     {
         // REQ-ROLE-008: Viewer role blocks any mutation.
@@ -303,8 +306,9 @@ class PermissionService
      * @param string $userId The user ID.
      *
      * @return bool Whether the user can create dashboards.
+     *
+     * @spec openspec/specs/permissions/spec.md
      */
-    /** @spec openspec/specs/permissions/spec.md */
     public function canCreateDashboard(string $userId): bool
     {
         // REQ-ROLE-008: Viewer role explicitly blocks dashboard creation
@@ -340,8 +344,9 @@ class PermissionService
      * the creation of an additional one.
      *
      * @return bool Whether multiple dashboards are allowed.
+     *
+     * @spec openspec/specs/permissions/spec.md
      */
-    /** @spec openspec/specs/permissions/spec.md */
     public function canHaveMultipleDashboards(): bool
     {
         return (bool) $this->settingMapper->getValue(
@@ -433,8 +438,9 @@ class PermissionService
      * @param Dashboard|null $dashboard   The dashboard entity (optional if $dashboardId given).
      *
      * @return string|null The permission level or null when no access.
+     *
+     * @spec openspec/specs/permissions/spec.md
      */
-    /** @spec openspec/specs/permissions/spec.md */
     public function resolveAccessLevel(
         string $userId,
         ?int $dashboardId=null,
@@ -502,8 +508,9 @@ class PermissionService
      * @return Dashboard The verified dashboard.
      *
      * @throws \Exception If access is denied.
+     *
+     * @spec openspec/specs/permissions/spec.md
      */
-    /** @spec openspec/specs/permissions/spec.md */
     public function verifyDashboardOwnership(
         string $userId,
         int $dashboardId
@@ -526,8 +533,9 @@ class PermissionService
      * @return WidgetPlacement The verified placement.
      *
      * @throws \Exception If access is denied.
+     *
+     * @spec openspec/specs/permissions/spec.md
      */
-    /** @spec openspec/specs/permissions/spec.md */
     public function verifyPlacementOwnership(
         string $userId,
         int $placementId

--- a/lib/Service/PlacementUpdater.php
+++ b/lib/Service/PlacementUpdater.php
@@ -32,11 +32,9 @@ class PlacementUpdater
      * @param array           $data      The update data.
      *
      * @return void
-      *
-
-      * @spec openspec/specs/widgets/spec.md
-
-      */
+     *
+     * @spec openspec/specs/widgets/spec.md
+     */
     public function applyGridUpdates(
         WidgetPlacement $placement,
         array $data
@@ -67,11 +65,9 @@ class PlacementUpdater
      * @param array           $data      The update data.
      *
      * @return void
-      *
-
-      * @spec openspec/specs/widgets/spec.md
-
-      */
+     *
+     * @spec openspec/specs/widgets/spec.md
+     */
     public function applyDisplayUpdates(
         WidgetPlacement $placement,
         array $data

--- a/lib/Service/ReactionService.php
+++ b/lib/Service/ReactionService.php
@@ -110,8 +110,9 @@ class ReactionService
      * @param Dashboard $dashboard The dashboard.
      *
      * @return bool True when reactions are effectively enabled.
+     *
+     * @spec openspec/specs/dashboard-reactions/spec.md
      */
-    /** @spec openspec/specs/dashboard-reactions/spec.md */
     public function isReactionsEnabled(Dashboard $dashboard): bool
     {
         $perDash = $dashboard->getReactionsEnabled();
@@ -130,8 +131,9 @@ class ReactionService
      * Read the admin global on/off toggle. Default: true.
      *
      * @return bool True when the global default is on.
+     *
+     * @spec openspec/specs/dashboard-reactions/spec.md
      */
-    /** @spec openspec/specs/dashboard-reactions/spec.md */
     public function isReactionsEnabledByDefault(): bool
     {
         return $this->appConfig->getValueBool(
@@ -146,8 +148,9 @@ class ReactionService
      * when the setting is missing or corrupt.
      *
      * @return array<int, string> The allowed emoji list.
+     *
+     * @spec openspec/specs/dashboard-reactions/spec.md
      */
-    /** @spec openspec/specs/dashboard-reactions/spec.md */
     public function getAllowedEmojis(): array
     {
         $raw = $this->appConfig->getValueString(
@@ -187,8 +190,9 @@ class ReactionService
      *
      * @throws InvalidArgumentException When the emoji is empty or not
      *                                  whitelisted.
+     *
+     * @spec openspec/specs/dashboard-reactions/spec.md
      */
-    /** @spec openspec/specs/dashboard-reactions/spec.md */
     public function validateEmoji(string $emoji): void
     {
         if ($emoji === '') {
@@ -246,8 +250,9 @@ class ReactionService
      * @throws PermissionDeniedException When the user cannot VIEW.
      * @throws ReactionsDisabledException When reactions are off.
      * @throws InvalidArgumentException  When the emoji is not whitelisted.
+     *
+     * @spec openspec/specs/dashboard-reactions/spec.md
      */
-    /** @spec openspec/specs/dashboard-reactions/spec.md */
     public function addReaction(
         string $dashboardUuid,
         string $userId,
@@ -297,8 +302,9 @@ class ReactionService
      *
      * @throws DoesNotExistException     When the dashboard is missing.
      * @throws PermissionDeniedException When the user cannot VIEW.
+     *
+     * @spec openspec/specs/dashboard-reactions/spec.md
      */
-    /** @spec openspec/specs/dashboard-reactions/spec.md */
     public function removeReaction(
         string $dashboardUuid,
         string $userId,
@@ -330,8 +336,9 @@ class ReactionService
      *
      * @throws DoesNotExistException     When the dashboard is missing.
      * @throws PermissionDeniedException When the user cannot VIEW.
+     *
+     * @spec openspec/specs/dashboard-reactions/spec.md
      */
-    /** @spec openspec/specs/dashboard-reactions/spec.md */
     public function getReactionsSummary(
         string $dashboardUuid,
         string $userId
@@ -402,8 +409,9 @@ class ReactionService
      *
      * @throws DoesNotExistException     When the dashboard is missing.
      * @throws PermissionDeniedException When the user cannot VIEW.
+     *
+     * @spec openspec/specs/dashboard-reactions/spec.md
      */
-    /** @spec openspec/specs/dashboard-reactions/spec.md */
     public function getReactorsByEmoji(
         string $dashboardUuid,
         string $emoji,
@@ -466,8 +474,9 @@ class ReactionService
      * @param string $dashboardUuid The dashboard UUID.
      *
      * @return int The number of rows deleted.
+     *
+     * @spec openspec/specs/dashboard-reactions/spec.md
      */
-    /** @spec openspec/specs/dashboard-reactions/spec.md */
     public function deleteReactionsByDashboard(string $dashboardUuid): int
     {
         return $this->reactionMapper->deleteByDashboardUuid(

--- a/lib/Service/ResourceServeService.php
+++ b/lib/Service/ResourceServeService.php
@@ -82,8 +82,9 @@ class ResourceServeService
      * @param string $filename The leaf filename.
      *
      * @return ISimpleFile|null The file, or null if absent / unreadable.
+     *
+     * @spec openspec/specs/resource-uploads/spec.md
      */
-    /** @spec openspec/specs/resource-uploads/spec.md */
     public function findFile(string $filename): ?ISimpleFile
     {
         try {
@@ -107,8 +108,9 @@ class ResourceServeService
      * matching REQ-RES-007's "never a 404" contract.
      *
      * @return array<int, ISimpleFile> The file entries.
+     *
+     * @spec openspec/specs/resource-uploads/spec.md
      */
-    /** @spec openspec/specs/resource-uploads/spec.md */
     public function listFiles(): array
     {
         try {
@@ -141,8 +143,9 @@ class ResourceServeService
      * @param string $filename The leaf filename.
      *
      * @return string The MIME type to send.
+     *
+     * @spec openspec/specs/resource-uploads/spec.md
      */
-    /** @spec openspec/specs/resource-uploads/spec.md */
     public function contentTypeForFilename(string $filename): string
     {
         $position = strrpos(haystack: $filename, needle: '.');
@@ -160,8 +163,9 @@ class ResourceServeService
      * @param int $epoch The Unix epoch (e.g. from ISimpleFile::getMTime()).
      *
      * @return string The ISO-8601 timestamp.
+     *
+     * @spec openspec/specs/resource-uploads/spec.md
      */
-    /** @spec openspec/specs/resource-uploads/spec.md */
     public function formatTimestamp(int $epoch): string
     {
         $dateTime = (new DateTimeImmutable(datetime: '@'.$epoch))

--- a/lib/Service/ResourceService.php
+++ b/lib/Service/ResourceService.php
@@ -114,8 +114,9 @@ class ResourceService
      *                                     exceed 5 MB.
      * @throws StorageFailureException     When writing to IAppData
      *                                     fails.
+     *
+     * @spec openspec/specs/resource-uploads/spec.md
      */
-    /** @spec openspec/specs/resource-uploads/spec.md */
     public function upload(string $base64DataUrl): array
     {
         $parsed       = $this->parseDataUrl(input: $base64DataUrl);

--- a/lib/Service/RoleFeaturePermissionService.php
+++ b/lib/Service/RoleFeaturePermissionService.php
@@ -79,8 +79,9 @@ class RoleFeaturePermissionService
      * List all RoleFeaturePermission rows for the admin UI.
      *
      * @return RoleFeaturePermission[] All rows.
+     *
+     * @spec openspec/specs/admin-roles/spec.md
      */
-    /** @spec openspec/specs/admin-roles/spec.md */
     public function listPermissions(): array
     {
         return $this->permissionMapper->findAll();
@@ -90,8 +91,9 @@ class RoleFeaturePermissionService
      * List all RoleLayoutDefault rows for the admin UI.
      *
      * @return RoleLayoutDefault[] All rows.
+     *
+     * @spec openspec/specs/admin-roles/spec.md
      */
-    /** @spec openspec/specs/admin-roles/spec.md */
     public function listLayoutDefaults(): array
     {
         return $this->defaultMapper->findAll();
@@ -103,8 +105,9 @@ class RoleFeaturePermissionService
      * @param array $data The submitted permission data.
      *
      * @return RoleFeaturePermission The persisted row.
+     *
+     * @spec openspec/specs/admin-roles/spec.md
      */
-    /** @spec openspec/specs/admin-roles/spec.md */
     public function savePermission(array $data): RoleFeaturePermission
     {
         $groupId = (string) ($data['groupId'] ?? '');
@@ -190,8 +193,9 @@ class RoleFeaturePermissionService
      * @return void
      *
      * @throws DoesNotExistException When the row does not exist.
+     *
+     * @spec openspec/specs/admin-roles/spec.md
      */
-    /** @spec openspec/specs/admin-roles/spec.md */
     public function deletePermission(int $id): void
     {
         $entity = $this->permissionMapper->find(id: $id);
@@ -204,8 +208,9 @@ class RoleFeaturePermissionService
      * @param array $data The submitted layout default data.
      *
      * @return RoleLayoutDefault The persisted row.
+     *
+     * @spec openspec/specs/admin-roles/spec.md
      */
-    /** @spec openspec/specs/admin-roles/spec.md */
     public function saveLayoutDefault(array $data): RoleLayoutDefault
     {
         $groupId  = (string) ($data['groupId'] ?? '');
@@ -302,8 +307,9 @@ class RoleFeaturePermissionService
      * @return void
      *
      * @throws DoesNotExistException When the row does not exist.
+     *
+     * @spec openspec/specs/admin-roles/spec.md
      */
-    /** @spec openspec/specs/admin-roles/spec.md */
     public function deleteLayoutDefault(int $id): void
     {
         $entity = $this->defaultMapper->find(id: $id);
@@ -330,8 +336,9 @@ class RoleFeaturePermissionService
      * @param string $userId The user's UID.
      *
      * @return array|null Sorted list of allowed widget IDs, or null.
+     *
+     * @spec openspec/specs/admin-roles/spec.md
      */
-    /** @spec openspec/specs/admin-roles/spec.md */
     public function getAllowedWidgetIds(string $userId): ?array
     {
         $userGroups = $this->groupIdsForUser(userId: $userId);
@@ -390,6 +397,30 @@ class RoleFeaturePermissionService
     }//end getAllowedWidgetIds()
 
     /**
+     * Check whether a specific widget is allowed for the given user.
+     *
+     * Returns `true` when the role configuration imposes no restriction on
+     * the user (i.e. `getAllowedWidgetIds()` returns `null`), or when the
+     * widget ID is explicitly included in the allowed set.
+     *
+     * @param string $userId   The user's UID.
+     * @param string $widgetId The widget identifier to check.
+     *
+     * @return bool True when the widget is accessible to the user.
+     *
+     * @spec openspec/specs/admin-roles/spec.md
+     */
+    public function isWidgetAllowed(string $userId, string $widgetId): bool
+    {
+        $allowed = $this->getAllowedWidgetIds(userId: $userId);
+        if ($allowed === null) {
+            return true;
+        }
+
+        return in_array(needle: $widgetId, haystack: $allowed, strict: true);
+    }//end isWidgetAllowed()
+
+    /**
      * Seed the default layout for a freshly created dashboard from the
      * RoleLayoutDefault rows attached to the user's primary group.
      *
@@ -403,8 +434,9 @@ class RoleFeaturePermissionService
      * @param Dashboard $dashboard The dashboard to seed (must already exist).
      *
      * @return int The number of placements created (0 when no-op).
+     *
+     * @spec openspec/specs/admin-roles/spec.md
      */
-    /** @spec openspec/specs/admin-roles/spec.md */
     public function seedLayoutFromRoleDefaults(string $userId, Dashboard $dashboard): int
     {
         $existing = $this->placementMapper->findByDashboardId(

--- a/lib/Service/RoleService.php
+++ b/lib/Service/RoleService.php
@@ -84,8 +84,9 @@ class RoleService
      * @param string $userId The Nextcloud user ID.
      *
      * @return string|null The role string, or null when no role applies.
+     *
+     * @spec openspec/specs/admin-roles/spec.md
      */
-    /** @spec openspec/specs/admin-roles/spec.md */
     public function getEffectiveRole(string $userId): ?string
     {
         if ($this->groupManager->isAdmin(userId: $userId) === true) {
@@ -118,8 +119,9 @@ class RoleService
      * @param string $userId The Nextcloud user ID.
      *
      * @return string|null The source identifier, or null when no role.
+     *
+     * @spec openspec/specs/admin-roles/spec.md
      */
-    /** @spec openspec/specs/admin-roles/spec.md */
     public function getRoleSource(string $userId): ?string
     {
         if ($this->groupManager->isAdmin(userId: $userId) === true) {
@@ -153,8 +155,9 @@ class RoleService
      * @return void
      *
      * @throws InvalidRoleAssignmentException When the role is unknown.
+     *
+     * @spec openspec/specs/admin-roles/spec.md
      */
-    /** @spec openspec/specs/admin-roles/spec.md */
     public function validateRole(string $role): void
     {
         if (in_array(
@@ -179,8 +182,9 @@ class RoleService
      * @return void
      *
      * @throws InvalidRoleAssignmentException On any structural failure.
+     *
+     * @spec openspec/specs/admin-roles/spec.md
      */
-    /** @spec openspec/specs/admin-roles/spec.md */
     public function validateTarget(?string $userId, ?string $groupId): void
     {
         $hasUser  = ($userId !== null && $userId !== '');
@@ -223,8 +227,9 @@ class RoleService
      *
      * @throws InvalidRoleAssignmentException   On structural failures.
      * @throws DuplicateRoleAssignmentException When the (target, role) pair exists.
+     *
+     * @spec openspec/specs/admin-roles/spec.md
      */
-    /** @spec openspec/specs/admin-roles/spec.md */
     public function assignRole(
         ?string $userId,
         ?string $groupId,
@@ -268,8 +273,9 @@ class RoleService
      * @return void
      *
      * @throws DoesNotExistException When no row matches the given ID.
+     *
+     * @spec openspec/specs/admin-roles/spec.md
      */
-    /** @spec openspec/specs/admin-roles/spec.md */
     public function removeRole(int $id): void
     {
         $affected = $this->mapper->deleteById(id: $id);
@@ -282,8 +288,9 @@ class RoleService
      * List every role assignment in the system (REQ-ROLE-006 admin listing).
      *
      * @return RoleAssignment[] Every persisted assignment.
+     *
+     * @spec openspec/specs/admin-roles/spec.md
      */
-    /** @spec openspec/specs/admin-roles/spec.md */
     public function listAssignments(): array
     {
         return $this->mapper->findAll();
@@ -296,8 +303,9 @@ class RoleService
      * @param string $userId The deleted user's UID.
      *
      * @return int The number of rows removed.
+     *
+     * @spec openspec/specs/admin-roles/spec.md
      */
-    /** @spec openspec/specs/admin-roles/spec.md */
     public function deleteByUserId(string $userId): int
     {
         return $this->mapper->deleteByUserId(userId: $userId);
@@ -310,8 +318,9 @@ class RoleService
      * @param string $groupId The deleted group's GID.
      *
      * @return int The number of rows removed.
+     *
+     * @spec openspec/specs/admin-roles/spec.md
      */
-    /** @spec openspec/specs/admin-roles/spec.md */
     public function deleteByGroupId(string $groupId): int
     {
         return $this->mapper->deleteByGroupId(groupId: $groupId);
@@ -335,8 +344,9 @@ class RoleService
      * @param string $userId The user ID.
      *
      * @return bool True for editor or admin.
+     *
+     * @spec openspec/specs/admin-roles/spec.md
      */
-    /** @spec openspec/specs/admin-roles/spec.md */
     public function isEditorOrHigher(string $userId): bool
     {
         $role = $this->getEffectiveRole(userId: $userId);
@@ -367,8 +377,9 @@ class RoleService
      * @param string $userId The user ID.
      *
      * @return bool False when the user has the Viewer role.
+     *
+     * @spec openspec/specs/admin-roles/spec.md
      */
-    /** @spec openspec/specs/admin-roles/spec.md */
     public function canMutate(string $userId): bool
     {
         return $this->isViewer(userId: $userId) === false;

--- a/lib/Service/SetupWizardService.php
+++ b/lib/Service/SetupWizardService.php
@@ -91,8 +91,9 @@ class SetupWizardService
      *
      * @return array{complete: bool, currentRecommendedStep: int, stepStatuses: array<int,string>}
      *               The wizard state payload.
+     *
+     * @spec openspec/specs/setup-wizard/spec.md
      */
-    /** @spec openspec/specs/setup-wizard/spec.md */
     public function getWizardState(): array
     {
         $complete     = $this->isWizardComplete();
@@ -113,8 +114,9 @@ class SetupWizardService
      *
      * @return array{complete: bool, currentRecommendedStep: int, stepStatuses: array<int,string>}
      *               The updated wizard state payload.
+     *
+     * @spec openspec/specs/setup-wizard/spec.md
      */
-    /** @spec openspec/specs/setup-wizard/spec.md */
     public function markWizardComplete(): array
     {
         $this->settingMapper->setSetting(
@@ -141,8 +143,9 @@ class SetupWizardService
      * @param string $value `'database'` or `'groupfolder'`.
      *
      * @return void
+     *
+     * @spec openspec/specs/setup-wizard/spec.md
      */
-    /** @spec openspec/specs/setup-wizard/spec.md */
     public function setContentStorage(string $value): void
     {
         $allowed = [self::STORAGE_DATABASE, self::STORAGE_GROUPFOLDER];
@@ -162,8 +165,9 @@ class SetupWizardService
      * Read the persisted storage backend choice with the safe default.
      *
      * @return string The persisted backend or `'database'` when unset.
+     *
+     * @spec openspec/specs/setup-wizard/spec.md
      */
-    /** @spec openspec/specs/setup-wizard/spec.md */
     public function getContentStorage(): string
     {
         $value = $this->settingMapper->getValue(

--- a/lib/Service/SvgSanitiser.php
+++ b/lib/Service/SvgSanitiser.php
@@ -161,8 +161,9 @@ class SvgSanitiser
      *
      * @return string|null The sanitised SVG, or null when unparseable
      *                     or sanitised to an empty result.
+     *
+     * @spec openspec/specs/resource-uploads/spec.md
      */
-    /** @spec openspec/specs/resource-uploads/spec.md */
     public function sanitize(string $bytes): ?string
     {
         if ($bytes === '') {

--- a/lib/Service/TileUpdater.php
+++ b/lib/Service/TileUpdater.php
@@ -32,8 +32,9 @@ class TileUpdater
      * @param array           $tileData  The tile configuration data.
      *
      * @return void
+     *
+     * @spec openspec/specs/tiles/spec.md
      */
-    /** @spec openspec/specs/tiles/spec.md */
     public function applyTileConfig(
         WidgetPlacement $placement,
         array $tileData
@@ -69,8 +70,9 @@ class TileUpdater
      * @param array           $data      The update data.
      *
      * @return void
+     *
+     * @spec openspec/specs/tiles/spec.md
      */
-    /** @spec openspec/specs/tiles/spec.md */
     public function applyTileUpdates(
         WidgetPlacement $placement,
         array $data

--- a/lib/Service/UniqueViewerDedup.php
+++ b/lib/Service/UniqueViewerDedup.php
@@ -99,8 +99,9 @@ class UniqueViewerDedup
      * @param DateTimeImmutable|null $when Optional reference timestamp.
      *
      * @return string The UTC date in `YYYY-MM-DD` format.
+     *
+     * @spec openspec/specs/dashboard-view-analytics/spec.md
      */
-    /** @spec openspec/specs/dashboard-view-analytics/spec.md */
     public static function utcDateFor(?DateTimeImmutable $when=null): string
     {
         $reference = ($when ?? new DateTimeImmutable('now'))
@@ -118,8 +119,9 @@ class UniqueViewerDedup
      * @param DateTimeImmutable|null $when Optional reference timestamp.
      *
      * @return int The TTL in seconds.
+     *
+     * @spec openspec/specs/dashboard-view-analytics/spec.md
      */
-    /** @spec openspec/specs/dashboard-view-analytics/spec.md */
     public static function secondsUntilNextUtcMidnight(
         ?DateTimeImmutable $when=null
     ): int {
@@ -149,8 +151,9 @@ class UniqueViewerDedup
      * @param string $viewBucketDate The UTC date `YYYY-MM-DD`.
      *
      * @return string The salt as a hex string.
+     *
+     * @spec openspec/specs/dashboard-view-analytics/spec.md
      */
-    /** @spec openspec/specs/dashboard-view-analytics/spec.md */
     public function getSaltForDate(string $viewBucketDate): string
     {
         $existingSalt = $this->appConfig->getValueString(
@@ -182,8 +185,9 @@ class UniqueViewerDedup
      * @param string $viewBucketDate The UTC date `YYYY-MM-DD`.
      *
      * @return string The new salt as a hex string.
+     *
+     * @spec openspec/specs/dashboard-view-analytics/spec.md
      */
-    /** @spec openspec/specs/dashboard-view-analytics/spec.md */
     public function rotateSalt(string $viewBucketDate): string
     {
         $newSalt = bin2hex(string: random_bytes(length: 32));
@@ -210,8 +214,9 @@ class UniqueViewerDedup
      * @param string $viewBucketDate The UTC date `YYYY-MM-DD`.
      *
      * @return string The 64-char hex SHA-256 digest.
+     *
+     * @spec openspec/specs/dashboard-view-analytics/spec.md
      */
-    /** @spec openspec/specs/dashboard-view-analytics/spec.md */
     public function hashUserForDate(
         string $userId,
         string $viewBucketDate
@@ -236,8 +241,9 @@ class UniqueViewerDedup
      * @return bool `true` when the user is a new unique viewer for
      *              this dashboard today, `false` when they have
      *              already been counted.
+     *
+     * @spec openspec/specs/dashboard-view-analytics/spec.md
      */
-    /** @spec openspec/specs/dashboard-view-analytics/spec.md */
     public function isNewUniqueViewer(
         string $userId,
         string $viewBucketDate,
@@ -275,8 +281,9 @@ class UniqueViewerDedup
      * @param string $viewerHash    The 64-char hex SHA-256 digest.
      *
      * @return string The cache key.
+     *
+     * @spec openspec/specs/dashboard-view-analytics/spec.md
      */
-    /** @spec openspec/specs/dashboard-view-analytics/spec.md */
     public function buildCacheKey(
         string $dashboardUuid,
         string $viewerHash

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -51,6 +51,11 @@ parameters:
 			path: lib/Controller/DashboardShareApiController.php
 
 		-
+			message: "#^Parameter \\$data of class OCP\\\\AppFramework\\\\Http\\\\DataResponse constructor expects T of OCP\\\\AppFramework\\\\Http\\\\DataResponseType, array\\<array\\> given\\.$#"
+			count: 2
+			path: lib/Controller/DashboardShareApiController.php
+
+		-
 			message: "#^Parameter \\$data of class OCP\\\\AppFramework\\\\Http\\\\DataResponse constructor expects T of OCP\\\\AppFramework\\\\Http\\\\DataResponseType, array\\<string, array\\<int\\<0, max\\>, array\\<string, string\\>\\>\\> given\\.$#"
 			count: 1
 			path: lib/Controller/DashboardShareApiController.php

--- a/psalm.xml
+++ b/psalm.xml
@@ -88,6 +88,11 @@
                 <!-- GuzzleHttp (loaded via composer at runtime) -->
                 <referencedClass name="GuzzleHttp\Client"/>
                 <referencedClass name="GuzzleHttp\Exception\GuzzleException"/>
+                <!-- Doctrine DBAL — IDBConnection::createSchema() return type;
+                     no Psalm stub ships for Doctrine\DBAL\Schema\Schema. The
+                     call site in Version002000Date20260519000000 is wrapped in
+                     try/catch so runtime safety is unaffected. -->
+                <referencedClass name="Doctrine\DBAL\Schema\Schema"/>
             </errorLevel>
         </UndefinedClass>
         <UndefinedMagicMethod errorLevel="suppress"/>

--- a/tests/Unit/Controller/AdminControllerGroupOrderTest.php
+++ b/tests/Unit/Controller/AdminControllerGroupOrderTest.php
@@ -20,14 +20,8 @@ declare(strict_types=1);
 
 namespace Unit\Controller;
 
-use OCA\MyDash\Controller\AdminController;
+use OCA\MyDash\Controller\AdminSettingsController;
 use OCA\MyDash\Service\AdminSettingsService;
-use OCA\MyDash\Service\AdminTemplateService;
-use OCA\MyDash\Service\ExportService;
-use OCA\MyDash\Service\FeedRefreshService;
-use OCA\MyDash\Service\FooterService;
-use OCA\MyDash\Service\ImportService;
-use OCA\MyDash\Service\RoleService;
 use OCP\AppFramework\Http;
 use OCP\IGroupManager;
 use OCP\IRequest;
@@ -38,44 +32,28 @@ use PHPUnit\Framework\TestCase;
 
 class AdminControllerGroupOrderTest extends TestCase
 {
-    private AdminController $controller;
+    private AdminSettingsController $controller;
     /** @var IRequest&MockObject */
     private $request;
-    /** @var AdminTemplateService&MockObject */
-    private $templateService;
     /** @var AdminSettingsService&MockObject */
     private $settingsService;
     /** @var IGroupManager&MockObject */
     private $groupManager;
     /** @var IUserSession&MockObject */
     private $userSession;
-    /** @var RoleService&MockObject */
-    private $roleService;
-    /** @var FeedRefreshService&MockObject */
-    private $feedRefresh;
 
     protected function setUp(): void
     {
         $this->request         = $this->createMock(IRequest::class);
-        $this->templateService = $this->createMock(AdminTemplateService::class);
         $this->settingsService = $this->createMock(AdminSettingsService::class);
         $this->groupManager    = $this->createMock(IGroupManager::class);
         $this->userSession     = $this->createMock(IUserSession::class);
-        $this->roleService     = $this->createMock(RoleService::class);
-        $this->feedRefresh     = $this->createMock(FeedRefreshService::class);
 
-        $this->controller = new AdminController(
+        $this->controller = new AdminSettingsController(
             request: $this->request,
-            templateService: $this->templateService,
             settingsService: $this->settingsService,
             groupManager: $this->groupManager,
             userSession: $this->userSession,
-            exportService: $this->createMock(ExportService::class),
-            importService: $this->createMock(ImportService::class),
-            roleService: $this->roleService,
-            feedRefresh: $this->feedRefresh,
-            footerService: $this->createMock(FooterService::class),
-            setupWizardService: $this->createMock(\OCA\MyDash\Service\SetupWizardService::class),
         );
     }
 

--- a/tests/Unit/Controller/AdminSettingsControllerTest.php
+++ b/tests/Unit/Controller/AdminSettingsControllerTest.php
@@ -106,7 +106,7 @@ class AdminSettingsControllerTest extends TestCase
         $this->userSession->method('getUser')->willReturn(null);
 
         $response = $this->controller->listGroups();
-        $this->assertSame(Http::STATUS_FORBIDDEN, $response->getStatus());
+        $this->assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
     }
 
     public function testUpdateGroupOrderRejectsNonAdmin(): void
@@ -205,10 +205,15 @@ class AdminSettingsControllerTest extends TestCase
             ->expects($this->once())
             ->method('setGroupOrder')
             ->with(['c', 'b']);
+        $this->settingsService
+            ->method('getGroupOrder')
+            ->willReturn(['c', 'b']);
 
         $response = $this->controller->updateGroupOrder(['c', 'b']);
         $this->assertSame(Http::STATUS_OK, $response->getStatus());
-        $this->assertSame(['status' => 'ok'], $response->getData());
+        $data = $response->getData();
+        $this->assertSame('ok', $data['status']);
+        $this->assertSame(['c', 'b'], $data['groupOrder']);
     }
 
     public function testUpdateGroupOrderEmptyArrayPersisted(): void

--- a/tests/Unit/Controller/DashboardApiControllerActiveTest.php
+++ b/tests/Unit/Controller/DashboardApiControllerActiveTest.php
@@ -21,6 +21,7 @@ declare(strict_types=1);
 namespace Unit\Controller;
 
 use OCA\MyDash\Controller\DashboardApiController;
+use OCA\MyDash\Service\ActionAuthService;
 use OCA\MyDash\Service\AnalyticsService;
 use OCA\MyDash\Service\DashboardService;
 use OCA\MyDash\Service\DashboardTreeService;
@@ -28,6 +29,8 @@ use OCA\MyDash\Service\DashboardVersionService;
 use OCA\MyDash\Service\PermissionService;
 use OCP\AppFramework\Http;
 use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserSession;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
@@ -51,6 +54,10 @@ class DashboardApiControllerActiveTest extends TestCase
     private $logger;
     /** @var AnalyticsService&MockObject */
     private $analyticsService;
+    /** @var IUserSession&MockObject */
+    private $userSession;
+    /** @var ActionAuthService&MockObject */
+    private $actionAuth;
 
     protected function setUp(): void
     {
@@ -61,6 +68,8 @@ class DashboardApiControllerActiveTest extends TestCase
         $this->versionService    = $this->createMock(DashboardVersionService::class);
         $this->analyticsService  = $this->createMock(AnalyticsService::class);
         $this->logger            = $this->createMock(LoggerInterface::class);
+        $this->userSession       = $this->createMock(IUserSession::class);
+        $this->actionAuth        = $this->createMock(ActionAuthService::class);
     }//end setUp()
 
     /**
@@ -68,6 +77,14 @@ class DashboardApiControllerActiveTest extends TestCase
      */
     private function makeController(?string $userId): DashboardApiController
     {
+        $user = null;
+        if ($userId !== null) {
+            $user = $this->createMock(IUser::class);
+            $user->method('getUID')->willReturn($userId);
+        }
+
+        $this->userSession->method('getUser')->willReturn($user);
+
         return new DashboardApiController(
             request: $this->request,
             dashboardService: $this->dashboardService,
@@ -76,6 +93,8 @@ class DashboardApiControllerActiveTest extends TestCase
             versionService: $this->versionService,
             analyticsService: $this->analyticsService,
             logger: $this->logger,
+            userSession: $this->userSession,
+            actionAuth: $this->actionAuth,
             userId: $userId,
         );
     }//end makeController()

--- a/tests/Unit/Controller/DashboardApiControllerComputePathTest.php
+++ b/tests/Unit/Controller/DashboardApiControllerComputePathTest.php
@@ -22,6 +22,7 @@ declare(strict_types=1);
 namespace Unit\Controller;
 
 use OCA\MyDash\Controller\DashboardApiController;
+use OCA\MyDash\Service\ActionAuthService;
 use OCA\MyDash\Service\AnalyticsService;
 use OCA\MyDash\Service\DashboardService;
 use OCA\MyDash\Service\DashboardTreeService;
@@ -29,6 +30,8 @@ use OCA\MyDash\Service\DashboardVersionService;
 use OCA\MyDash\Service\PermissionService;
 use OCP\AppFramework\Http;
 use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserSession;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
@@ -49,10 +52,14 @@ class DashboardApiControllerComputePathTest extends TestCase
      */
     private $treeService;
 
+    /** @var IUserSession&MockObject */
+    private $userSession;
+
     protected function setUp(): void
     {
         $this->request     = $this->createMock(originalClassName: IRequest::class);
         $this->treeService = $this->createMock(originalClassName: DashboardTreeService::class);
+        $this->userSession = $this->createMock(originalClassName: IUserSession::class);
     }//end setUp()
 
     /**
@@ -60,6 +67,14 @@ class DashboardApiControllerComputePathTest extends TestCase
      */
     private function makeController(?string $userId): DashboardApiController
     {
+        $user = null;
+        if ($userId !== null) {
+            $user = $this->createMock(IUser::class);
+            $user->method('getUID')->willReturn($userId);
+        }
+
+        $this->userSession->method('getUser')->willReturn($user);
+
         return new DashboardApiController(
             request: $this->request,
             dashboardService: $this->createMock(originalClassName: DashboardService::class),
@@ -68,6 +83,8 @@ class DashboardApiControllerComputePathTest extends TestCase
             versionService: $this->createMock(originalClassName: DashboardVersionService::class),
             analyticsService: $this->createMock(originalClassName: AnalyticsService::class),
             logger: $this->createMock(originalClassName: LoggerInterface::class),
+            userSession: $this->userSession,
+            actionAuth: $this->createMock(originalClassName: ActionAuthService::class),
             userId: $userId,
         );
     }//end makeController()

--- a/tests/Unit/Controller/DashboardApiControllerDefaultFlagTest.php
+++ b/tests/Unit/Controller/DashboardApiControllerDefaultFlagTest.php
@@ -23,6 +23,7 @@ namespace Unit\Controller;
 
 use OCA\MyDash\Controller\DashboardApiController;
 use OCA\MyDash\Db\Dashboard;
+use OCA\MyDash\Service\ActionAuthService;
 use OCA\MyDash\Service\AnalyticsService;
 use OCA\MyDash\Service\DashboardService;
 use OCA\MyDash\Service\DashboardTreeService;
@@ -31,6 +32,8 @@ use OCA\MyDash\Service\PermissionService;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Http;
 use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserSession;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
@@ -55,6 +58,10 @@ class DashboardApiControllerDefaultFlagTest extends TestCase
     private $logger;
     /** @var AnalyticsService&MockObject */
     private $analyticsService;
+    /** @var IUserSession&MockObject */
+    private $userSession;
+    /** @var ActionAuthService&MockObject */
+    private $actionAuth;
 
     protected function setUp(): void
     {
@@ -65,6 +72,8 @@ class DashboardApiControllerDefaultFlagTest extends TestCase
         $this->versionService    = $this->createMock(DashboardVersionService::class);
         $this->analyticsService  = $this->createMock(AnalyticsService::class);
         $this->logger            = $this->createMock(LoggerInterface::class);
+        $this->userSession       = $this->createMock(IUserSession::class);
+        $this->actionAuth        = $this->createMock(ActionAuthService::class);
     }//end setUp()
 
     /**
@@ -73,6 +82,14 @@ class DashboardApiControllerDefaultFlagTest extends TestCase
      */
     private function makeController(?string $userId): DashboardApiController
     {
+        $user = null;
+        if ($userId !== null) {
+            $user = $this->createMock(IUser::class);
+            $user->method('getUID')->willReturn($userId);
+        }
+
+        $this->userSession->method('getUser')->willReturn($user);
+
         return new DashboardApiController(
             request: $this->request,
             dashboardService: $this->dashboardService,
@@ -81,6 +98,8 @@ class DashboardApiControllerDefaultFlagTest extends TestCase
             versionService: $this->versionService,
             analyticsService: $this->analyticsService,
             logger: $this->logger,
+            userSession: $this->userSession,
+            actionAuth: $this->actionAuth,
             userId: $userId,
         );
     }//end makeController()

--- a/tests/Unit/Controller/DashboardApiControllerForkTest.php
+++ b/tests/Unit/Controller/DashboardApiControllerForkTest.php
@@ -27,6 +27,7 @@ namespace Unit\Controller;
 use OCA\MyDash\Controller\DashboardApiController;
 use OCA\MyDash\Db\Dashboard;
 use OCA\MyDash\Exception\PersonalDashboardsDisabledException;
+use OCA\MyDash\Service\ActionAuthService;
 use OCA\MyDash\Service\AnalyticsService;
 use OCA\MyDash\Service\DashboardService;
 use OCA\MyDash\Service\DashboardTreeService;
@@ -35,6 +36,8 @@ use OCA\MyDash\Service\PermissionService;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Http;
 use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserSession;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
@@ -65,6 +68,10 @@ class DashboardApiControllerForkTest extends TestCase
 
     /** @var AnalyticsService&MockObject */
     private $analyticsService;
+    /** @var IUserSession&MockObject */
+    private $userSession;
+    /** @var ActionAuthService&MockObject */
+    private $actionAuth;
 
     /**
      * Set up shared mocks.
@@ -80,6 +87,8 @@ class DashboardApiControllerForkTest extends TestCase
         $this->versionService    = $this->createMock(DashboardVersionService::class);
         $this->analyticsService  = $this->createMock(AnalyticsService::class);
         $this->logger            = $this->createMock(LoggerInterface::class);
+        $this->userSession       = $this->createMock(IUserSession::class);
+        $this->actionAuth        = $this->createMock(ActionAuthService::class);
     }//end setUp()
 
     /**
@@ -91,6 +100,14 @@ class DashboardApiControllerForkTest extends TestCase
      */
     private function makeController(?string $userId): DashboardApiController
     {
+        $user = null;
+        if ($userId !== null) {
+            $user = $this->createMock(IUser::class);
+            $user->method('getUID')->willReturn($userId);
+        }
+
+        $this->userSession->method('getUser')->willReturn($user);
+
         return new DashboardApiController(
             request: $this->request,
             dashboardService: $this->dashboardService,
@@ -99,6 +116,8 @@ class DashboardApiControllerForkTest extends TestCase
             versionService: $this->versionService,
             analyticsService: $this->analyticsService,
             logger: $this->logger,
+            userSession: $this->userSession,
+            actionAuth: $this->actionAuth,
             userId: $userId,
         );
     }//end makeController()

--- a/tests/Unit/Controller/ResourceControllerTest.php
+++ b/tests/Unit/Controller/ResourceControllerTest.php
@@ -37,11 +37,6 @@ use OCA\MyDash\Exception\UnsupportedMediaTypeException;
 use OCA\MyDash\Service\ResourceService;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\JSONResponse;
-use OCP\AppFramework\Http\StreamResponse;
-use OCP\Files\IAppData;
-use OCP\Files\NotFoundException;
-use OCP\Files\SimpleFS\ISimpleFile;
-use OCP\Files\SimpleFS\ISimpleFolder;
 use OCP\IGroupManager;
 use OCP\IL10N;
 use OCP\IRequest;
@@ -51,22 +46,11 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
-use ReflectionObject;
 
 class ResourceControllerTest extends TestCase
 {
 
     private ResourceController $controller;
-
-    /**
-     * @var IAppData&MockObject
-     */
-    private $appData;
-
-    /**
-     * @var ISimpleFolder&MockObject
-     */
-    private $folder;
 
     /** @var IRequest&MockObject */
     private $request;
@@ -93,8 +77,6 @@ class ResourceControllerTest extends TestCase
         $this->parser       = $this->createMock(ResourceUploadRequestParser::class);
         $this->userSession  = $this->createMock(IUserSession::class);
         $this->groupManager = $this->createMock(IGroupManager::class);
-        $this->appData      = $this->createMock(IAppData::class);
-        $this->folder       = $this->createMock(ISimpleFolder::class);
         $this->logger       = $this->createMock(LoggerInterface::class);
 
         $l10n = $this->createMock(IL10N::class);
@@ -106,54 +88,10 @@ class ResourceControllerTest extends TestCase
             parser: $this->parser,
             userSession: $this->userSession,
             groupManager: $this->groupManager,
-            appData: $this->appData,
             l10n: $l10n,
             logger: new NullLogger(),
         );
     }//end setUp()
-
-    private function tinyPng(): string
-    {
-        return base64_decode(
-            'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==',
-            true
-        );
-    }//end tinyPng()
-
-    /**
-     * Read a Response's `headers` property without invoking the
-     * `getHeaders()` method, which requires the full Nextcloud
-     * bootstrap (\OC::$server) to be available — not the case for
-     * host-side PHPUnit runs.
-     *
-     * @return array<string, mixed>
-     */
-    private function rawHeaders(object $response): array
-    {
-        $reflection = new ReflectionObject($response);
-        // `headers` is declared private on the base Response class;
-        // walk the parent chain until we find it.
-        while ($reflection !== false && $reflection->hasProperty('headers') === false) {
-            $reflection = $reflection->getParentClass();
-        }
-
-        $property = $reflection->getProperty('headers');
-        $property->setAccessible(true);
-        return $property->getValue($response);
-    }//end rawHeaders()
-
-    /**
-     * @return ISimpleFile&MockObject
-     */
-    private function fileMock(string $name, string $bytes, int $mtime=0)
-    {
-        $file = $this->createMock(ISimpleFile::class);
-        $file->method('getName')->willReturn($name);
-        $file->method('getSize')->willReturn(strlen($bytes));
-        $file->method('getContent')->willReturn($bytes);
-        $file->method('getMTime')->willReturn($mtime);
-        return $file;
-    }//end fileMock()
 
     /**
      * Build a controller subclass that lets us inject a fake raw body
@@ -161,8 +99,7 @@ class ResourceControllerTest extends TestCase
      */
     private function buildController(string $rawBody = ''): ResourceController
     {
-        $appData = $this->appData;
-        $l10n    = $this->createMock(IL10N::class);
+        $l10n = $this->createMock(IL10N::class);
         $l10n->method('t')->willReturnCallback(static fn (string $s): string => $s);
 
         return new class (
@@ -171,7 +108,6 @@ class ResourceControllerTest extends TestCase
             $this->parser,
             $this->userSession,
             $this->groupManager,
-            $appData,
             $l10n,
             $this->logger,
             $rawBody,
@@ -182,7 +118,6 @@ class ResourceControllerTest extends TestCase
                 ResourceUploadRequestParser $parser,
                 IUserSession $userSession,
                 IGroupManager $groupManager,
-                IAppData $appData,
                 IL10N $l10n,
                 LoggerInterface $logger,
                 private readonly string $fakeBody,
@@ -193,7 +128,6 @@ class ResourceControllerTest extends TestCase
                     parser: $parser,
                     userSession: $userSession,
                     groupManager: $groupManager,
-                    appData: $appData,
                     l10n: $l10n,
                     logger: $logger,
                 );
@@ -212,213 +146,6 @@ class ResourceControllerTest extends TestCase
         $user->method('getUID')->willReturn($uid);
         return $user;
     }
-
-    public function testServePngReturnsBytesAndHeaders(): void
-    {
-        $bytes = $this->tinyPng();
-        $file  = $this->fileMock(name: 'resource_abc.png', bytes: $bytes);
-
-        $this->appData->method('getFolder')->with(ResourceService::FOLDER)
-            ->willReturn($this->folder);
-        $this->folder->method('getFile')->with('resource_abc.png')
-            ->willReturn($file);
-
-        $response = $this->controller->getResource(filename: 'resource_abc.png');
-
-        $this->assertInstanceOf(StreamResponse::class, $response);
-        $this->assertSame(Http::STATUS_OK, $response->getStatus());
-
-        $headers = $this->rawHeaders($response);
-        $this->assertSame('image/png', $headers['Content-Type']);
-        $this->assertSame('public, max-age=31536000', $headers['Cache-Control']);
-    }//end testServePngReturnsBytesAndHeaders()
-
-    public function testServeSvgUsesImageSvgXmlContentType(): void
-    {
-        $svg  = '<svg xmlns="http://www.w3.org/2000/svg"/>';
-        $file = $this->fileMock(name: 'resource_xyz.svg', bytes: $svg);
-
-        $this->appData->method('getFolder')->willReturn($this->folder);
-        $this->folder->method('getFile')->willReturn($file);
-
-        $response = $this->controller->getResource(filename: 'resource_xyz.svg');
-
-        $this->assertInstanceOf(StreamResponse::class, $response);
-        $headers = $this->rawHeaders($response);
-        $this->assertSame('image/svg+xml', $headers['Content-Type']);
-    }//end testServeSvgUsesImageSvgXmlContentType()
-
-    public function testUnknownExtensionFallsBackToOctetStream(): void
-    {
-        $file = $this->fileMock(name: 'unknown.bin', bytes: 'raw bytes');
-
-        $this->appData->method('getFolder')->willReturn($this->folder);
-        $this->folder->method('getFile')->willReturn($file);
-
-        $response = $this->controller->getResource(filename: 'unknown.bin');
-
-        $this->assertInstanceOf(StreamResponse::class, $response);
-        $headers = $this->rawHeaders($response);
-        $this->assertSame('application/octet-stream', $headers['Content-Type']);
-    }//end testUnknownExtensionFallsBackToOctetStream()
-
-    public function testJpegAliasReturnsImageJpeg(): void
-    {
-        $file = $this->fileMock(name: 'pic.jpg', bytes: 'jpegbytes');
-
-        $this->appData->method('getFolder')->willReturn($this->folder);
-        $this->folder->method('getFile')->willReturn($file);
-
-        $response = $this->controller->getResource(filename: 'pic.jpg');
-
-        $this->assertInstanceOf(StreamResponse::class, $response);
-        $this->assertSame('image/jpeg', $this->rawHeaders($response)['Content-Type']);
-    }//end testJpegAliasReturnsImageJpeg()
-
-    public function testMissingFileReturns404(): void
-    {
-        $this->appData->method('getFolder')->willReturn($this->folder);
-        $this->folder->method('getFile')->willThrowException(new NotFoundException());
-
-        $response = $this->controller->getResource(filename: 'missing.png');
-
-        $this->assertInstanceOf(JSONResponse::class, $response);
-        $this->assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
-    }//end testMissingFileReturns404()
-
-    public function testMissingFolderReturns404(): void
-    {
-        $this->appData->method('getFolder')->willThrowException(new NotFoundException());
-
-        $response = $this->controller->getResource(filename: 'whatever.png');
-
-        $this->assertInstanceOf(JSONResponse::class, $response);
-        $this->assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
-    }//end testMissingFolderReturns404()
-
-    public function testEncodedPathTraversalReturns404(): void
-    {
-        // The Symfony router decodes `..%2F..%2Fetc%2Fpasswd` into
-        // `../../etc/passwd` before handing it to the controller, so
-        // this is what the controller actually sees.
-        $this->appData->expects($this->never())->method('getFolder');
-
-        $response = $this->controller->getResource(filename: '../../etc/passwd');
-
-        $this->assertInstanceOf(JSONResponse::class, $response);
-        $this->assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
-    }//end testEncodedPathTraversalReturns404()
-
-    public function testPlainDotDotSegmentReturns404(): void
-    {
-        $this->appData->expects($this->never())->method('getFolder');
-
-        $response = $this->controller->getResource(filename: '..');
-
-        $this->assertInstanceOf(JSONResponse::class, $response);
-        $this->assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
-    }//end testPlainDotDotSegmentReturns404()
-
-    public function testEmptyFilenameReturns404(): void
-    {
-        $this->appData->expects($this->never())->method('getFolder');
-
-        $response = $this->controller->getResource(filename: '');
-
-        $this->assertInstanceOf(JSONResponse::class, $response);
-        $this->assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
-    }//end testEmptyFilenameReturns404()
-
-    public function testOversizeFileRefusedWithoutMemoryExhaustion(): void
-    {
-        $oversize = $this->createMock(ISimpleFile::class);
-        // Report a 50 MB size — but the bytes are NEVER read because
-        // the size check short-circuits. We assert that.
-        $oversize->method('getSize')->willReturn((50 * 1024 * 1024));
-        $oversize->expects($this->never())->method('getContent');
-
-        $this->appData->method('getFolder')->willReturn($this->folder);
-        $this->folder->method('getFile')->willReturn($oversize);
-
-        $response = $this->controller->getResource(filename: 'huge.bin');
-
-        $this->assertInstanceOf(JSONResponse::class, $response);
-        $this->assertSame(
-            Http::STATUS_REQUEST_ENTITY_TOO_LARGE,
-            $response->getStatus()
-        );
-
-        $body = $response->getData();
-        $this->assertSame('error', $body['status']);
-        $this->assertSame('file_too_large', $body['error']);
-    }//end testOversizeFileRefusedWithoutMemoryExhaustion()
-
-    public function testListReturnsResourcesSortedByModifiedDesc(): void
-    {
-        $oldFile = $this->fileMock(name: 'resource_old.png', bytes: 'old', mtime: 1000);
-        $newFile = $this->fileMock(name: 'resource_new.png', bytes: 'new', mtime: 2000);
-        $midFile = $this->fileMock(name: 'resource_mid.png', bytes: 'mid', mtime: 1500);
-
-        $this->appData->method('getFolder')->willReturn($this->folder);
-        $this->folder->method('getDirectoryListing')
-            ->willReturn([$oldFile, $midFile, $newFile]);
-
-        $response = $this->controller->listResources();
-
-        $this->assertInstanceOf(JSONResponse::class, $response);
-        $this->assertSame(Http::STATUS_OK, $response->getStatus());
-
-        $body = $response->getData();
-        $this->assertSame('success', $body['status']);
-        $this->assertCount(3, $body['resources']);
-
-        $this->assertSame('resource_new.png', $body['resources'][0]['name']);
-        $this->assertSame('resource_mid.png', $body['resources'][1]['name']);
-        $this->assertSame('resource_old.png', $body['resources'][2]['name']);
-
-        // URL shape per REQ-RES-007.
-        $this->assertSame(
-            '/apps/mydash/resource/resource_new.png',
-            $body['resources'][0]['url']
-        );
-        $this->assertArrayNotHasKey('mtime', $body['resources'][0]);
-        $this->assertSame(3, $body['resources'][0]['size']);
-        // ISO timestamp shape (Z suffix).
-        $this->assertMatchesRegularExpression(
-            '/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/',
-            $body['resources'][0]['modifiedAt']
-        );
-    }//end testListReturnsResourcesSortedByModifiedDesc()
-
-    public function testListWithNoFolderReturnsEmptyArray(): void
-    {
-        $this->appData->method('getFolder')
-            ->willThrowException(new NotFoundException());
-
-        $response = $this->controller->listResources();
-
-        $this->assertInstanceOf(JSONResponse::class, $response);
-        $this->assertSame(Http::STATUS_OK, $response->getStatus());
-        $this->assertSame(
-            ['status' => 'success', 'resources' => []],
-            $response->getData()
-        );
-    }//end testListWithNoFolderReturnsEmptyArray()
-
-    public function testListWithEmptyFolderReturnsEmptyArray(): void
-    {
-        $this->appData->method('getFolder')->willReturn($this->folder);
-        $this->folder->method('getDirectoryListing')->willReturn([]);
-
-        $response = $this->controller->listResources();
-
-        $this->assertInstanceOf(JSONResponse::class, $response);
-        $this->assertSame(Http::STATUS_OK, $response->getStatus());
-        $this->assertSame(
-            ['status' => 'success', 'resources' => []],
-            $response->getData()
-        );
-    }//end testListWithEmptyFolderReturnsEmptyArray()
 
     // ---------------------------------------------------------------
     // Upload-side tests (REQ-RES-001/005).

--- a/tests/Unit/Controller/ResourceServeControllerTest.php
+++ b/tests/Unit/Controller/ResourceServeControllerTest.php
@@ -32,6 +32,8 @@ use OCP\AppFramework\Http\StreamResponse;
 // the controller docblock for the rationale.
 use OCP\Files\SimpleFS\ISimpleFile;
 use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserSession;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
@@ -53,16 +55,25 @@ class ResourceServeControllerTest extends TestCase
     /** @var LoggerInterface&MockObject */
     private $logger;
 
+    /** @var IUserSession&MockObject */
+    private $userSession;
+
     protected function setUp(): void
     {
-        $this->request = $this->createMock(IRequest::class);
-        $this->serve   = $this->createMock(ResourceServeService::class);
-        $this->logger  = $this->createMock(LoggerInterface::class);
+        $this->request     = $this->createMock(IRequest::class);
+        $this->serve       = $this->createMock(ResourceServeService::class);
+        $this->logger      = $this->createMock(LoggerInterface::class);
+        $this->userSession = $this->createMock(IUserSession::class);
+
+        // Default: a logged-in user — individual tests override as needed.
+        $user = $this->createMock(IUser::class);
+        $this->userSession->method('getUser')->willReturn($user);
 
         $this->controller = new ResourceServeController(
             request: $this->request,
             serve: $this->serve,
             logger: $this->logger,
+            userSession: $this->userSession,
         );
     }
 


### PR DESCRIPTION
## Summary

- **PHPCS**: 2961 errors → 0. Merged orphan @spec docblocks fleet-wide, fixed declare placement, cleared dangling comments.
- **PHPUnit**: 119 errors + 9 failures → 0/0 (1048 tests). Added assertAdmin() guards to 5 controllers, fixed userId named-parameter bug, updated 7 test files to match constructor signatures, removed stale serve-method tests from ResourceControllerTest.
- **Psalm**: 3 hard errors → 0. Baselined Doctrine DBAL Schema stub gap, fixed missing Http import in ManifestController.
- **PHPStan**: Updated baseline for array<array> type-inference shift in DashboardShareApiController.