### PR TITLE
fix(security): visibility/permissions ACL — H1, H4, H5, M1, M5, L2

### DIFF
--- a/lib/Controller/DashboardApiController.php
+++ b/lib/Controller/DashboardApiController.php
@@ -782,13 +782,29 @@ class DashboardApiController extends Controller
             return ResponseHelper::unauthorized();
         }
 
+        // H1: verify the caller is a member of the requested group (or
+        // admin) before returning its dashboards — mirrors the group-
+        // membership check in PermissionService::resolveAccessLevel.
+        if ($this->dashboardService->userCanAccessGroup(
+            userId: $this->userId,
+            groupId: $groupId
+        ) === false
+        ) {
+            return ResponseHelper::forbidden();
+        }
+
         $dashboards = $this->dashboardService->listGroupDashboards(
             groupId: $groupId
         );
 
-        return ResponseHelper::success(
-            data: ResponseHelper::serializeList(entities: $dashboards)
+        // M5: strip internal identity fields (userId, groupId, targetGroups)
+        // from group-shared dashboard payloads returned to non-owner viewers.
+        $viewerData = array_map(
+            static fn ($d) => $d->toViewerArray(),
+            $dashboards
         );
+
+        return ResponseHelper::success(data: $viewerData);
     }//end listGroup()
 
     /**
@@ -869,6 +885,16 @@ class DashboardApiController extends Controller
             return ResponseHelper::unauthorized();
         }
 
+        // H1: verify the caller is a member of the requested group (or
+        // admin) before fetching the dashboard payload.
+        if ($this->dashboardService->userCanAccessGroup(
+            userId: $this->userId,
+            groupId: $groupId
+        ) === false
+        ) {
+            return ResponseHelper::forbidden();
+        }
+
         try {
             $dashboard = $this->dashboardService->findGroupDashboard(
                 groupId: $groupId,
@@ -882,8 +908,9 @@ class DashboardApiController extends Controller
             );
         }
 
+        // M5: strip internal identity fields from viewer-facing payload.
         return ResponseHelper::success(
-            data: ['dashboard' => $dashboard->jsonSerialize()]
+            data: ['dashboard' => $dashboard->toViewerArray()]
         );
     }//end getGroup()
 
@@ -1448,6 +1475,28 @@ class DashboardApiController extends Controller
 
         if ($this->userId === null) {
             return ResponseHelper::unauthorized();
+        }
+
+        // H4: resolve the dashboard and assert the caller can view it
+        // before recording any counter increment (REQ-ANLT-002).
+        try {
+            $dashboard = $this->dashboardService->findByUuid(uuid: $uuid);
+        } catch (DoesNotExistException) {
+            return new JSONResponse(
+                data: [
+                    'status' => 'error',
+                    'error'  => 'not_found',
+                ],
+                statusCode: Http::STATUS_NOT_FOUND
+            );
+        }
+
+        if ($this->permissionService->canViewDashboard(
+            userId: $this->userId,
+            dashboardId: $dashboard->getId()
+        ) === false
+        ) {
+            return ResponseHelper::forbidden();
         }
 
         try {

--- a/lib/Controller/DashboardMetadataController.php
+++ b/lib/Controller/DashboardMetadataController.php
@@ -31,33 +31,38 @@ use OCA\MyDash\Db\Dashboard;
 use OCA\MyDash\Db\DashboardMapper;
 use OCA\MyDash\Exception\InvalidMetadataFieldException;
 use OCA\MyDash\Service\MetadataService;
+use OCA\MyDash\Service\PermissionService;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\JSONResponse;
-use OCP\IGroupManager;
 use OCP\IRequest;
 
 /**
  * Dashboard metadata read/write controller.
+ *
+ * All access decisions are delegated to PermissionService — the single
+ * source of truth for dashboard ACL (H5, REQ-MDFL-008).
  */
 class DashboardMetadataController extends Controller
 {
     /**
      * Constructor.
      *
-     * @param IRequest        $request         The HTTP request.
-     * @param MetadataService $metadataService The metadata service facade.
-     * @param DashboardMapper $dashboardMapper For ownership/visibility lookup.
-     * @param IGroupManager   $groupManager    For group-share access checks.
-     * @param string|null     $userId          The active user id.
+     * @param IRequest         $request           The HTTP request.
+     * @param MetadataService  $metadataService   The metadata service facade.
+     * @param DashboardMapper  $dashboardMapper   For dashboard lookup.
+     * @param PermissionService $permissionService Authoritative ACL service
+     *                                            (replaces inline canRead /
+     *                                            canWrite helpers — H5).
+     * @param string|null      $userId            The active user id.
      */
     public function __construct(
         IRequest $request,
         private readonly MetadataService $metadataService,
         private readonly DashboardMapper $dashboardMapper,
-        private readonly IGroupManager $groupManager,
+        private readonly PermissionService $permissionService,
         private readonly ?string $userId,
     ) {
         parent::__construct(
@@ -91,7 +96,12 @@ class DashboardMetadataController extends Controller
             );
         }
 
-        if ($this->canRead(dashboard: $dashboard) === false) {
+        // H5: delegate to PermissionService — the single ACL source of truth.
+        if ($this->permissionService->canViewDashboard(
+            userId: $this->userId,
+            dashboardId: $dashboard->getId()
+        ) === false
+        ) {
             return ResponseHelper::forbidden();
         }
 
@@ -131,7 +141,15 @@ class DashboardMetadataController extends Controller
             );
         }
 
-        if ($this->canWrite(dashboard: $dashboard) === false) {
+        // H5: delegate to PermissionService — canEditDashboardMetadata is
+        // owner-only for personal dashboards; admin-only for admin templates.
+        // This replaces the previous inline canWrite() which incorrectly
+        // allowed any group member to write group-shared metadata.
+        if ($this->permissionService->canEditDashboardMetadata(
+            userId: $this->userId,
+            dashboardId: $dashboard->getId()
+        ) === false
+        ) {
             return ResponseHelper::forbidden();
         }
 
@@ -168,77 +186,4 @@ class DashboardMetadataController extends Controller
             return null;
         }
     }//end loadDashboard()
-
-    /**
-     * Read access check (REQ-MDFL-008).
-     *
-     * Owners always read. For group-shared dashboards, group members
-     * read. Admin templates and the default group are world-readable
-     * (consistent with the existing dashboard read paths).
-     *
-     * @param Dashboard $dashboard The dashboard.
-     *
-     * @return bool True when the active user can read.
-     */
-    private function canRead(Dashboard $dashboard): bool
-    {
-        if ($dashboard->getUserId() !== null
-            && $dashboard->getUserId() === $this->userId
-        ) {
-            return true;
-        }
-
-        $type = (string) $dashboard->getType();
-        if ($type === Dashboard::TYPE_ADMIN_TEMPLATE) {
-            return true;
-        }
-
-        $groupId = $dashboard->getGroupId();
-        if ($groupId !== null && $this->userId !== null) {
-            return $this->groupManager->isInGroup(
-                userId: $this->userId,
-                group: $groupId
-            );
-        }
-
-        return false;
-    }//end canRead()
-
-    /**
-     * Write access check (REQ-MDFL-008).
-     *
-     * Owners write. Admins can write to admin templates. Group members
-     * can write to group-shared dashboards (same gating as the existing
-     * group-shared update path).
-     *
-     * @param Dashboard $dashboard The dashboard.
-     *
-     * @return bool True when the active user can write.
-     */
-    private function canWrite(Dashboard $dashboard): bool
-    {
-        if ($dashboard->getUserId() !== null
-            && $dashboard->getUserId() === $this->userId
-        ) {
-            return true;
-        }
-
-        $type = (string) $dashboard->getType();
-        if ($type === Dashboard::TYPE_ADMIN_TEMPLATE
-            && $this->userId !== null
-            && $this->groupManager->isAdmin(userId: $this->userId) === true
-        ) {
-            return true;
-        }
-
-        $groupId = $dashboard->getGroupId();
-        if ($groupId !== null && $this->userId !== null) {
-            return $this->groupManager->isInGroup(
-                userId: $this->userId,
-                group: $groupId
-            );
-        }
-
-        return false;
-    }//end canWrite()
 }//end class

--- a/lib/Controller/FilesWidgetController.php
+++ b/lib/Controller/FilesWidgetController.php
@@ -330,10 +330,11 @@ class FilesWidgetController extends Controller
             return null;
         }
 
-        $dashboardId = $placement->getDashboardId();
-        if ($this->permissionService->canViewDashboard(
+        // L2: upload is a write operation — require write-level permission
+        // (canAddWidget), not read-level (canViewDashboard).
+        if ($this->permissionService->canAddWidget(
             userId: $userId,
-            dashboardId: $dashboardId
+            dashboardId: $placement->getDashboardId()
         ) === false
         ) {
             return null;

--- a/lib/Controller/WidgetApiController.php
+++ b/lib/Controller/WidgetApiController.php
@@ -484,7 +484,9 @@ class WidgetApiController extends Controller
             );
         }
 
-        if ($this->permissionService->canStyleWidget(
+        // M1: data-fetch endpoints only need view permission; canStyleWidget
+        // blocks VIEW_ONLY users who are legitimate consumers of this data.
+        if ($this->permissionService->canViewPlacement(
             userId: $this->userId,
             placementId: $placementId
         ) === false
@@ -574,7 +576,9 @@ class WidgetApiController extends Controller
             );
         }
 
-        if ($this->permissionService->canStyleWidget(
+        // M1: data-fetch endpoint — view permission is sufficient;
+        // canStyleWidget would block VIEW_ONLY users.
+        if ($this->permissionService->canViewPlacement(
             userId: $this->userId,
             placementId: $placementId
         ) === false

--- a/lib/Db/Dashboard.php
+++ b/lib/Db/Dashboard.php
@@ -627,7 +627,7 @@ class Dashboard extends Entity implements JsonSerializable
     }//end setTargetGroupsArray()
 
     /**
-     * Serialize to JSON.
+     * Serialize to JSON (owner / admin view — full payload).
      *
      * @return array The serialized dashboard.
      */
@@ -670,6 +670,29 @@ class Dashboard extends Entity implements JsonSerializable
             'templatePreviewImage' => $this->templatePreviewImage,
         ];
     }//end jsonSerialize()
+
+    /**
+     * Serialize for a non-owner viewer (M5 — strips internal identity
+     * fields from the public envelope).
+     *
+     * Removes `userId`, `groupId`, `targetGroups`, `templateCategory`,
+     * and `templateDescription` which are internal administration fields
+     * that non-owner consumers have no legitimate use for.
+     *
+     * @return array The serialized dashboard without internal fields.
+     */
+    public function toViewerArray(): array
+    {
+        $full = $this->jsonSerialize();
+        unset(
+            $full['userId'],
+            $full['groupId'],
+            $full['targetGroups'],
+            $full['templateCategory'],
+            $full['templateDescription']
+        );
+        return $full;
+    }//end toViewerArray()
 
     /**
      * Whether comments are effectively enabled on this dashboard

--- a/lib/Service/DashboardService.php
+++ b/lib/Service/DashboardService.php
@@ -657,6 +657,25 @@ class DashboardService
     }//end activateDashboard()
 
     /**
+     * Look up a dashboard by its UUID.
+     *
+     * Thin wrapper so controllers can resolve a UUID to a Dashboard entity
+     * for permission checks without importing DashboardMapper directly.
+     *
+     * @param string $uuid The dashboard UUID.
+     *
+     * @return Dashboard The dashboard entity.
+     *
+     * @throws DoesNotExistException When no dashboard with that UUID exists.
+     *
+     * @spec openspec/specs/dashboards/spec.md
+     */
+    public function findByUuid(string $uuid): Dashboard
+    {
+        return $this->dashboardMapper->findByUuid(uuid: $uuid);
+    }//end findByUuid()
+
+    /**
      * List the group-shared dashboards in a single group.
      *
      * Any logged-in user may list — REQ-DASH-014.
@@ -1750,6 +1769,30 @@ class DashboardService
     {
         return $this->groupManager->isAdmin(userId: $userId);
     }//end isAdmin()
+
+    /**
+     * Check whether the user is a member of a group or is an admin.
+     *
+     * Used by listGroup / getGroup to gate group-shared dashboard
+     * endpoints against non-member callers (REQ-DASH-014, H1).
+     *
+     * @param string $userId  The user ID.
+     * @param string $groupId The group ID from the URL.
+     *
+     * @return bool True when the user is in the group or is a NC admin.
+     */
+    public function userCanAccessGroup(string $userId, string $groupId): bool
+    {
+        if ($this->groupManager->isAdmin(userId: $userId) === true) {
+            return true;
+        }
+
+        $userGroupIds = $this->adminTemplateService->getUserGroupIdsFor(
+            userId: $userId
+        );
+
+        return in_array(needle: $groupId, haystack: $userGroupIds, strict: true);
+    }//end userCanAccessGroup()
 
     /**
      * Read the admin `allow_user_dashboards` flag without throwing.

--- a/lib/Service/PermissionService.php
+++ b/lib/Service/PermissionService.php
@@ -261,6 +261,35 @@ class PermissionService
     }//end canRemoveWidget()
 
     /**
+     * Check if user can view a widget's data (read-path).
+     *
+     * Data-fetch endpoints (newsItems, calendarEvents) only require view
+     * permission on the underlying dashboard — not write/style permission.
+     * This is distinct from `canStyleWidget` which gates mutations.
+     * M1: fixes 403 for VIEW_ONLY users on data-fetch endpoints.
+     *
+     * @param string $userId      The user ID.
+     * @param int    $placementId The placement ID.
+     *
+     * @return bool Whether the user can view the widget's data.
+     *
+     * @spec openspec/specs/permissions/spec.md
+     */
+    public function canViewPlacement(string $userId, int $placementId): bool
+    {
+        try {
+            $placement = $this->placementMapper->find(id: $placementId);
+        } catch (DoesNotExistException) {
+            return false;
+        }
+
+        return $this->canViewDashboard(
+            userId: $userId,
+            dashboardId: $placement->getDashboardId()
+        );
+    }//end canViewPlacement()
+
+    /**
      * Check if user can style a widget.
      *
      * @param string $userId      The user ID.


### PR DESCRIPTION
## Summary

- **H1 (#324):** `listGroup` and `getGroup` now assert group membership (or admin) via `DashboardService::userCanAccessGroup` before returning any payload — non-members can no longer enumerate dashboards shared to groups they don't belong to.
- **H4 (#327):** `viewEvent` resolves the dashboard and calls `canViewDashboard` before recording any counter increment, preventing analytics counter poisoning via UUID enumeration.
- **H5 (#328):** `DashboardMetadataController` now delegates `canRead`/`canWrite` to `PermissionService` (the authoritative ACL), removing the divergent inline helpers that allowed any group member to write metadata on group-shared dashboards.
- **M1 (#329):** `newsItems` and `calendarEvents` switch from `canStyleWidget` (write-level) to new `PermissionService::canViewPlacement` (read-level) — VIEW_ONLY users can now fetch widget data on dashboards they can see.
- **M5 (#333):** `Dashboard::toViewerArray()` strips `userId`, `groupId`, `targetGroups`, `templateCategory`, `templateDescription`; `listGroup` and `getGroup` use it instead of `jsonSerialize()`.
- **L2 (#338):** `FilesWidgetController::loadConfig` switches from `canViewDashboard` to `canAddWidget` for the upload path — write operation now requires write-level permission.

## Test plan

- [ ] Non-member user calls `GET /api/dashboards/list-group/{groupId}` → 403
- [ ] Non-member user calls `GET /api/dashboards/get-group/{groupId}/{slug}` → 403
- [ ] Group member can still call both → 200
- [ ] VIEW_ONLY user can fetch newsItems/calendarEvents → 200 (was 403)
- [ ] `viewEvent` returns 403 for inaccessible dashboard UUID
- [ ] `setMetadata` on group-shared dashboard → only owner gets 200 (group member gets 403)
- [ ] `upload` on files widget → VIEW_ONLY user gets 403
- [ ] `listGroup` / `getGroup` responses do not contain `userId`, `targetGroups`, `groupId` fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)