### PR TITLE
fix(auth): wire ADR-023 requireAction for all DashboardApiController endpoints — H2, L3, L4

### DIFF
--- a/lib/Controller/DashboardApiController.php
+++ b/lib/Controller/DashboardApiController.php
@@ -132,9 +132,12 @@ class DashboardApiController extends Controller
     #[NoAdminRequired]
     public function list(): JSONResponse
     {
-        if ($this->userSession->getUser() === null) {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
             return new JSONResponse(['error' => 'Not authenticated'], \OCP\AppFramework\Http::STATUS_UNAUTHORIZED);
         }
+
+        $this->actionAuth->requireAction($user, 'dashboard.list');
 
         if ($this->userId === null) {
             return ResponseHelper::unauthorized();
@@ -162,9 +165,12 @@ class DashboardApiController extends Controller
     /** @spec openspec/specs/dashboards/spec.md */
     public function visible(): JSONResponse
     {
-        if ($this->userSession->getUser() === null) {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
             return new JSONResponse(['error' => 'Not authenticated'], \OCP\AppFramework\Http::STATUS_UNAUTHORIZED);
         }
+
+        $this->actionAuth->requireAction($user, 'dashboard.visible');
 
         if ($this->userId === null) {
             return ResponseHelper::unauthorized();
@@ -194,9 +200,12 @@ class DashboardApiController extends Controller
     #[NoAdminRequired]
     public function getActive(): JSONResponse
     {
-        if ($this->userSession->getUser() === null) {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
             return new JSONResponse(['error' => 'Not authenticated'], \OCP\AppFramework\Http::STATUS_UNAUTHORIZED);
         }
+
+        $this->actionAuth->requireAction($user, 'dashboard.get-active');
 
         if ($this->userId === null) {
             return ResponseHelper::unauthorized();
@@ -248,9 +257,12 @@ class DashboardApiController extends Controller
     #[NoAdminRequired]
     public function show(int $id): JSONResponse
     {
-        if ($this->userSession->getUser() === null) {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
             return new JSONResponse(['error' => 'Not authenticated'], \OCP\AppFramework\Http::STATUS_UNAUTHORIZED);
         }
+
+        $this->actionAuth->requireAction($user, 'dashboard.show');
 
         if ($this->userId === null) {
             return ResponseHelper::unauthorized();
@@ -315,6 +327,15 @@ class DashboardApiController extends Controller
         ?string $slug=null,
         ?int $sortOrder=null
     ): JSONResponse {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], \OCP\AppFramework\Http::STATUS_UNAUTHORIZED);
+        }
+
+        // L3: wire the create action so the matrix entry is enforced —
+        // consistent with all other mutation endpoints (ADR-023).
+        $this->actionAuth->requireAction($user, 'dashboard.create');
+
         if ($this->userId === null) {
             return ResponseHelper::unauthorized();
         }
@@ -573,9 +594,12 @@ class DashboardApiController extends Controller
     /** @spec openspec/specs/dashboards/spec.md */
     public function tree(): JSONResponse
     {
-        if ($this->userSession->getUser() === null) {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
             return new JSONResponse(['error' => 'Not authenticated'], \OCP\AppFramework\Http::STATUS_UNAUTHORIZED);
         }
+
+        $this->actionAuth->requireAction($user, 'dashboard.tree');
 
         if ($this->userId === null) {
             return ResponseHelper::unauthorized();
@@ -625,9 +649,12 @@ class DashboardApiController extends Controller
     /** @spec openspec/specs/dashboards/spec.md */
     public function byPath(string $path=''): JSONResponse
     {
-        if ($this->userSession->getUser() === null) {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
             return new JSONResponse(['error' => 'Not authenticated'], \OCP\AppFramework\Http::STATUS_UNAUTHORIZED);
         }
+
+        $this->actionAuth->requireAction($user, 'dashboard.by-path');
 
         if ($this->userId === null) {
             return ResponseHelper::unauthorized();
@@ -701,9 +728,12 @@ class DashboardApiController extends Controller
     /** @spec openspec/specs/dashboards/spec.md */
     public function computePath(string $uuid=''): JSONResponse
     {
-        if ($this->userSession->getUser() === null) {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
             return new JSONResponse(['error' => 'Not authenticated'], \OCP\AppFramework\Http::STATUS_UNAUTHORIZED);
         }
+
+        $this->actionAuth->requireAction($user, 'dashboard.compute-path');
 
         if ($this->userId === null) {
             return ResponseHelper::unauthorized();
@@ -774,9 +804,12 @@ class DashboardApiController extends Controller
     /** @spec openspec/specs/dashboards/spec.md */
     public function listGroup(string $groupId): JSONResponse
     {
-        if ($this->userSession->getUser() === null) {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
             return new JSONResponse(['error' => 'Not authenticated'], \OCP\AppFramework\Http::STATUS_UNAUTHORIZED);
         }
+
+        $this->actionAuth->requireAction($user, 'dashboard.list-group');
 
         if ($this->userId === null) {
             return ResponseHelper::unauthorized();
@@ -861,9 +894,12 @@ class DashboardApiController extends Controller
         string $groupId,
         string $uuid
     ): JSONResponse {
-        if ($this->userSession->getUser() === null) {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
             return new JSONResponse(['error' => 'Not authenticated'], \OCP\AppFramework\Http::STATUS_UNAUTHORIZED);
         }
+
+        $this->actionAuth->requireAction($user, 'dashboard.get-group');
 
         if ($this->userId === null) {
             return ResponseHelper::unauthorized();
@@ -1084,9 +1120,12 @@ class DashboardApiController extends Controller
     /** @spec openspec/specs/dashboards/spec.md */
     public function setActiveDashboard(?string $uuid=null): JSONResponse
     {
-        if ($this->userSession->getUser() === null) {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
             return new JSONResponse(['error' => 'Not authenticated'], \OCP\AppFramework\Http::STATUS_UNAUTHORIZED);
         }
+
+        $this->actionAuth->requireAction($user, 'dashboard.set-active-dashboard');
 
         if ($this->userId === null) {
             return ResponseHelper::unauthorized();
@@ -1121,9 +1160,12 @@ class DashboardApiController extends Controller
     /** @spec openspec/specs/dashboards/spec.md */
     public function setDefaultDashboard(?string $uuid=null): JSONResponse
     {
-        if ($this->userSession->getUser() === null) {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
             return new JSONResponse(['error' => 'Not authenticated'], \OCP\AppFramework\Http::STATUS_UNAUTHORIZED);
         }
+
+        $this->actionAuth->requireAction($user, 'dashboard.set-default-dashboard');
 
         if ($this->userId === null) {
             return ResponseHelper::unauthorized();
@@ -1147,9 +1189,12 @@ class DashboardApiController extends Controller
     /** @spec openspec/specs/dashboards/spec.md */
     public function getDefaultDashboard(): JSONResponse
     {
-        if ($this->userSession->getUser() === null) {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
             return new JSONResponse(['error' => 'Not authenticated'], \OCP\AppFramework\Http::STATUS_UNAUTHORIZED);
         }
+
+        $this->actionAuth->requireAction($user, 'dashboard.get-default-dashboard');
 
         if ($this->userId === null) {
             return ResponseHelper::unauthorized();
@@ -1442,9 +1487,12 @@ class DashboardApiController extends Controller
     /** @spec openspec/specs/dashboards/spec.md */
     public function viewEvent(string $uuid): JSONResponse
     {
-        if ($this->userSession->getUser() === null) {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
             return new JSONResponse(['error' => 'Not authenticated'], \OCP\AppFramework\Http::STATUS_UNAUTHORIZED);
         }
+
+        $this->actionAuth->requireAction($user, 'dashboard.view-event');
 
         if ($this->userId === null) {
             return ResponseHelper::unauthorized();

--- a/lib/Service/PermissionService.php
+++ b/lib/Service/PermissionService.php
@@ -172,9 +172,12 @@ class PermissionService
             return false;
         }
 
-        // Admin templates can only be edited by admins.
+        // L4: admin-template owners retain full metadata-edit rights
+        // (REQ-PERM-011). An admin who owns a template must not be blocked
+        // from renaming it. Non-admin users can never edit admin templates.
         if ($dashboard->getType() === Dashboard::TYPE_ADMIN_TEMPLATE) {
-            return false;
+            return $dashboard->getUserId() === $userId
+                && $this->groupManager->isAdmin(userId: $userId);
         }
 
         // Only owner can rename / change description.

--- a/lib/actions.seed.json
+++ b/lib/actions.seed.json
@@ -12,6 +12,7 @@
     "dashboard.visible": ["admin"],
     "dashboard.get-active": ["admin"],
     "dashboard.show": ["admin"],
+    "dashboard.create": ["admin"],
     "dashboard.update": ["admin"],
     "dashboard.delete": ["admin"],
     "dashboard.tree": ["admin"],


### PR DESCRIPTION
## Summary

- **H2 (#325):** Wire `requireAction` for the 13 previously-unenforced endpoints in `DashboardApiController` (list, visible, get-active, show, tree, by-path, compute-path, list-group, get-group, set-active-dashboard, set-default-dashboard, get-default-dashboard, view-event). Admin-configured action restrictions on these routes were silently ignored at runtime.
- **L3 (#339):** Add `dashboard.create` to `actions.seed.json` and wire `requireAction('dashboard.create')` in `create()` — consistent with all other mutation endpoints so future matrix configuration is honoured.
- **L4 (#340):** `PermissionService::canEditDashboardMetadata` now allows admin-template owners who are NC admins to edit their own templates (REQ-PERM-011). Previously the `admin_template` type check short-circuited to `false` even for the owning admin.

## Test plan

- [ ] Admin user can still call `GET /api/dashboards/list` → 200
- [ ] Non-admin user with `dashboard.list` matrix entry set to `["admin"]` → 403 (was 200)
- [ ] Non-admin user in allowed group for `dashboard.list` → 200
- [ ] `POST /api/dashboards` respects `dashboard.create` matrix entry
- [ ] Admin who owns an admin-template can now call `PUT /api/dashboards/{uuid}/metadata` → 200 (was 403)
- [ ] Non-admin user cannot edit admin-template metadata → 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)