### PR TITLE
fix(quality): enumeration guard, value cap, attribute migration, concurrency lock, group-resolution — M3, M6, M7, M8, L5

### DIFF
--- a/lib/Controller/DashboardMetadataController.php
+++ b/lib/Controller/DashboardMetadataController.php
@@ -30,6 +30,7 @@ use OCA\MyDash\AppInfo\Application;
 use OCA\MyDash\Db\Dashboard;
 use OCA\MyDash\Db\DashboardMapper;
 use OCA\MyDash\Exception\InvalidMetadataFieldException;
+use OCA\MyDash\Service\AdminTemplateService;
 use OCA\MyDash\Service\MetadataService;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Db\DoesNotExistException;
@@ -47,17 +48,23 @@ class DashboardMetadataController extends Controller
     /**
      * Constructor.
      *
-     * @param IRequest        $request         The HTTP request.
-     * @param MetadataService $metadataService The metadata service facade.
-     * @param DashboardMapper $dashboardMapper For ownership/visibility lookup.
-     * @param IGroupManager   $groupManager    For group-share access checks.
-     * @param string|null     $userId          The active user id.
+     * @param IRequest            $request              The HTTP request.
+     * @param MetadataService     $metadataService      The metadata service facade.
+     * @param DashboardMapper     $dashboardMapper       For ownership/visibility lookup.
+     * @param IGroupManager       $groupManager         For admin-check only (isAdmin).
+     * @param AdminTemplateService $adminTemplateService Single source of truth for
+     *                                                   user group IDs (REQ-TMPL-013).
+     *                                                   Replaces direct isInGroup calls
+     *                                                   (L5) so virtual/nested group
+     *                                                   resolution stays consistent.
+     * @param string|null         $userId               The active user id.
      */
     public function __construct(
         IRequest $request,
         private readonly MetadataService $metadataService,
         private readonly DashboardMapper $dashboardMapper,
         private readonly IGroupManager $groupManager,
+        private readonly AdminTemplateService $adminTemplateService,
         private readonly ?string $userId,
     ) {
         parent::__construct(
@@ -195,10 +202,13 @@ class DashboardMetadataController extends Controller
 
         $groupId = $dashboard->getGroupId();
         if ($groupId !== null && $this->userId !== null) {
-            return $this->groupManager->isInGroup(
-                userId: $this->userId,
-                group: $groupId
+            // L5: use AdminTemplateService::getUserGroupIdsFor as the single
+            // source of truth (REQ-TMPL-013) instead of IGroupManager::isInGroup
+            // — keeps virtual/nested group resolution consistent across the app.
+            $userGroupIds = $this->adminTemplateService->getUserGroupIdsFor(
+                userId: $this->userId
             );
+            return in_array(needle: $groupId, haystack: $userGroupIds, strict: true);
         }
 
         return false;
@@ -233,10 +243,11 @@ class DashboardMetadataController extends Controller
 
         $groupId = $dashboard->getGroupId();
         if ($groupId !== null && $this->userId !== null) {
-            return $this->groupManager->isInGroup(
-                userId: $this->userId,
-                group: $groupId
+            // L5: same fix — use AdminTemplateService for group membership.
+            $userGroupIds = $this->adminTemplateService->getUserGroupIdsFor(
+                userId: $this->userId
             );
+            return in_array(needle: $groupId, haystack: $userGroupIds, strict: true);
         }
 
         return false;

--- a/lib/Controller/DashboardShareApiController.php
+++ b/lib/Controller/DashboardShareApiController.php
@@ -314,7 +314,9 @@ class DashboardShareApiController extends Controller
         }
 
         $trimmed = trim(string: $query);
-        if (strlen(string: $trimmed) < 1) {
+        // M3: raise minimum query length to 2 to limit directory enumeration
+        // from single-character a..z sweeps (consistent with NC share picker).
+        if (strlen(string: $trimmed) < 2) {
             return new DataResponse(data: ['users' => [], 'groups' => []]);
         }
 

--- a/lib/Controller/PreferencesController.php
+++ b/lib/Controller/PreferencesController.php
@@ -27,6 +27,8 @@ namespace OCA\MyDash\Controller;
 use OCA\MyDash\AppInfo\Application;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\Attribute\NoAdminRequired;
+use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IConfig;
 use OCP\IRequest;
@@ -37,6 +39,16 @@ use OCP\IUserSession;
  */
 class PreferencesController extends Controller
 {
+    /**
+     * Maximum allowed byte length for a preference value (M6 — DoS guard).
+     *
+     * Values exceeding this limit are rejected with HTTP 400 to prevent
+     * unbounded database row growth on oc_preferences.
+     *
+     * @var int
+     */
+    private const MAX_VALUE_LENGTH = 8192;
+
     /**
      * Constructor.
      *
@@ -60,11 +72,11 @@ class PreferencesController extends Controller
      *
      * @return JSONResponse `{value: string|null}`.
      *
-     * @NoAdminRequired
-     * @NoCSRFRequired
-     *
      * @spec openspec/specs/admin-settings/spec.md
      */
+    // M7: PHP 8 attribute form — forward-compatible with NC 30+ strict mode.
+    #[NoAdminRequired]
+    #[NoCSRFRequired]
     public function getPreference(string $key): JSONResponse
     {
         $user = $this->userSession->getUser();
@@ -101,11 +113,11 @@ class PreferencesController extends Controller
      *
      * @return JSONResponse `{value: string|null}`.
      *
-     * @NoAdminRequired
-     * @NoCSRFRequired
-     *
      * @spec openspec/specs/admin-settings/spec.md
      */
+    // M7: PHP 8 attribute form — forward-compatible with NC 30+ strict mode.
+    #[NoAdminRequired]
+    #[NoCSRFRequired]
     public function setPreference(string $key, string $value=''): JSONResponse
     {
         $user = $this->userSession->getUser();
@@ -116,6 +128,14 @@ class PreferencesController extends Controller
         $safeKey = $this->sanitizeKey(key: $key);
         if ($safeKey === '') {
             return new JSONResponse(data: ['message' => 'Invalid key'], statusCode: Http::STATUS_BAD_REQUEST);
+        }
+
+        // M6: guard against unbounded values that would bloat oc_preferences.
+        if (strlen(string: $value) > self::MAX_VALUE_LENGTH) {
+            return new JSONResponse(
+                data: ['message' => 'Value exceeds maximum length of '.self::MAX_VALUE_LENGTH.' bytes'],
+                statusCode: Http::STATUS_BAD_REQUEST
+            );
         }
 
         $stored = null;

--- a/lib/Service/DemoShowcasesService.php
+++ b/lib/Service/DemoShowcasesService.php
@@ -43,6 +43,8 @@ use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\Dashboard\IManager;
 use OCP\IAppConfig;
 use OCP\IDBConnection;
+use OCP\Lock\ILockingProvider;
+use OCP\Lock\LockedException;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
 use Throwable;
@@ -103,6 +105,9 @@ class DemoShowcasesService
      * @param IAppConfig            $appConfig        App config service.
      * @param IManager              $dashboardManager Nextcloud dashboard registry.
      * @param LoggerInterface       $logger           PSR-3 logger.
+     * @param ILockingProvider      $lockingProvider  Advisory lock provider
+     *                                                (M8 — concurrency guard
+     *                                                on installShowcase).
      */
     public function __construct(
         private readonly DashboardMapper $dashboardMapper,
@@ -111,6 +116,7 @@ class DemoShowcasesService
         private readonly IAppConfig $appConfig,
         private readonly IManager $dashboardManager,
         private readonly LoggerInterface $logger,
+        private readonly ILockingProvider $lockingProvider,
     ) {
     }//end __construct()
 
@@ -254,18 +260,61 @@ class DemoShowcasesService
             );
         }
 
-        $existingUuid = $this->getInstalledUuid(showcaseId: $showcaseId);
-        if ($existingUuid !== '' && $force === false) {
-            return [
-                'installedDashboardUuid' => $existingUuid,
-                'skippedWidgets'         => [],
-                'alreadyInstalled'       => true,
-            ];
+        // M8: acquire an exclusive advisory lock keyed on the showcase ID
+        // before the existence check to serialise concurrent installs.
+        // Two simultaneous admin requests both pass the existence check
+        // before either inserts without this guard.
+        $lockKey = 'mydash-showcase-install-'.$showcaseId;
+        try {
+            $this->lockingProvider->acquireLock(
+                path: $lockKey,
+                type: ILockingProvider::LOCK_EXCLUSIVE
+            );
+        } catch (LockedException $e) {
+            throw new RuntimeException(
+                message: 'Showcase installation already in progress for '.$showcaseId,
+                code: 0,
+                previous: $e
+            );
         }
 
-        if ($existingUuid !== '' && $force === true) {
-            $this->uninstallShowcase(showcaseId: $showcaseId);
+        try {
+            $existingUuid = $this->getInstalledUuid(showcaseId: $showcaseId);
+            if ($existingUuid !== '' && $force === false) {
+                return [
+                    'installedDashboardUuid' => $existingUuid,
+                    'skippedWidgets'         => [],
+                    'alreadyInstalled'       => true,
+                ];
+            }
+
+            if ($existingUuid !== '' && $force === true) {
+                $this->uninstallShowcase(showcaseId: $showcaseId);
+            }
+
+            return $this->doInstallShowcase(
+                showcaseId: $showcaseId,
+                lang: $lang
+            );
+        } finally {
+            $this->lockingProvider->releaseLock(
+                path: $lockKey,
+                type: ILockingProvider::LOCK_EXCLUSIVE
+            );
         }
+    }//end installShowcase()
+
+    /**
+     * Internal install logic (called while lock is held).
+     *
+     * @param string $showcaseId The showcase ID.
+     * @param string $lang       The source language.
+     *
+     * @return array{installedDashboardUuid: string, skippedWidgets: array<int, string>, alreadyInstalled: bool}
+     */
+    private function doInstallShowcase(string $showcaseId, string $lang): array
+    {
+        $zipPath = $this->getZipPath(showcaseId: $showcaseId);
 
         $payload = $this->loadDashboardPayload(zipPath: $zipPath);
         $widgets = (array) ($payload['widgets'] ?? []);
@@ -320,7 +369,7 @@ class DemoShowcasesService
             'skippedWidgets'         => $skipped,
             'alreadyInstalled'       => false,
         ];
-    }//end installShowcase()
+    }//end doInstallShowcase()
 
     /**
      * Uninstall a previously-installed showcase.


### PR DESCRIPTION
## Summary

- **M3 (#331):** `searchSharees` minimum query length raised from 1 to 2 characters — limits single-character a..z user/group directory sweeps consistent with NC's own share-autocomplete threshold.
- **M6 (#334):** `PreferencesController::setPreference` now rejects values longer than 8192 bytes (HTTP 400) to prevent unbounded `oc_preferences` row growth from malicious callers.
- **M7 (#335):** `PreferencesController` `@NoAdminRequired` / `@NoCSRFRequired` docblock annotations converted to PHP 8 attribute form (`#[NoAdminRequired]`, `#[NoCSRFRequired]`) for forward-compatibility with NC 30+ strict-attribute mode.
- **M8 (#336):** `DemoShowcasesService::installShowcase` acquires an exclusive `ILockingProvider` advisory lock before the existence check, preventing duplicate dashboard rows from concurrent admin installs of the same showcase.
- **L5 (#341):** `DashboardMetadataController::canRead` and `canWrite` now call `AdminTemplateService::getUserGroupIdsFor` (REQ-TMPL-013 — single source of truth) instead of `IGroupManager::isInGroup` directly, keeping virtual/nested group resolution consistent with the service layer.

## Test plan

- [ ] `searchSharees?query=a` → empty result (was returning matches)
- [ ] `searchSharees?query=ab` → matches as before
- [ ] `setPreference` with value >8192 bytes → HTTP 400
- [ ] `getPreference` / `setPreference` still work for non-admin users (attributes in effect)
- [ ] Concurrent admin calls to `POST /admin/showcases/{id}/install` → second call gets error, no duplicate dashboards
- [ ] DashboardMetadataController group-share membership still checked correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)