### PR TITLE
fix(security): M3 FilesWidget upload hardening + M4 ADR-023 comments/reactions wiring

### DIFF
--- a/lib/Controller/DashboardCommentsApiController.php
+++ b/lib/Controller/DashboardCommentsApiController.php
@@ -31,6 +31,7 @@ use OCA\MyDash\Db\DashboardMapper;
 use OCA\MyDash\Exception\CommentForbiddenException;
 use OCA\MyDash\Exception\CommentNotFoundException;
 use OCA\MyDash\Exception\InvalidCommentException;
+use OCA\MyDash\Service\ActionAuthService;
 use OCA\MyDash\Service\CommentService;
 use OCA\MyDash\Service\PermissionService;
 use OCP\AppFramework\Controller;
@@ -38,7 +39,9 @@ use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\JSONResponse;
+use OCP\AppFramework\OCS\OCSForbiddenException;
 use OCP\IRequest;
+use OCP\IUserSession;
 
 /**
  * Controller for `/api/dashboards/{uuid}/comments` (REQ-CMNT-001..009).
@@ -47,10 +50,11 @@ use OCP\IRequest;
  *                                                  legitimately spans the
  *                                                  comment service,
  *                                                  permission service,
- *                                                  dashboard mapper and
- *                                                  three exception types
- *                                                  — splitting would
- *                                                  fragment a four-route
+ *                                                  dashboard mapper,
+ *                                                  three exception types,
+ *                                                  and the ADR-023 action
+ *                                                  auth service — splitting
+ *                                                  would fragment a four-route
  *                                                  surface.
  */
 class DashboardCommentsApiController extends Controller
@@ -62,6 +66,8 @@ class DashboardCommentsApiController extends Controller
      * @param CommentService    $commentService    Comment business logic.
      * @param PermissionService $permissionService Dashboard permission resolver.
      * @param DashboardMapper   $dashboardMapper   Used to resolve UUIDs to ids.
+     * @param ActionAuthService $actionAuth        ADR-023 action authorization.
+     * @param IUserSession      $userSession       The current user session.
      * @param string|null       $userId            The acting user (null when
      *                                             unauthenticated).
      */
@@ -70,6 +76,8 @@ class DashboardCommentsApiController extends Controller
         private readonly CommentService $commentService,
         private readonly PermissionService $permissionService,
         private readonly DashboardMapper $dashboardMapper,
+        private readonly ActionAuthService $actionAuth,
+        private readonly IUserSession $userSession,
         private readonly ?string $userId,
     ) {
         parent::__construct(
@@ -87,15 +95,18 @@ class DashboardCommentsApiController extends Controller
      * @param string $uuid The dashboard UUID.
      *
      * @return JSONResponse The list envelope or an error.
-         *
+     *
      * @spec openspec/specs/dashboard-comments/spec.md
- */
+     */
     #[NoAdminRequired]
     public function index(string $uuid): JSONResponse
     {
-        if ($this->userId === null) {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
             return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
         }
+
+        $this->actionAuth->requireAction($user, 'dashboard-comments.index');
 
         try {
             $dashboard = $this->dashboardMapper->findByUuid(uuid: $uuid);
@@ -145,18 +156,21 @@ class DashboardCommentsApiController extends Controller
      * @param mixed       $parentId Optional parent comment id; coerced to int.
      *
      * @return JSONResponse The new comment envelope or an error.
-         *
+     *
      * @spec openspec/specs/dashboard-comments/spec.md
- */
+     */
     #[NoAdminRequired]
     public function create(
         string $uuid,
         ?string $message=null,
         $parentId=null
     ): JSONResponse {
-        if ($this->userId === null) {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
             return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
         }
+
+        $this->actionAuth->requireAction($user, 'dashboard-comments.create');
 
         try {
             $dashboard = $this->dashboardMapper->findByUuid(uuid: $uuid);
@@ -218,18 +232,21 @@ class DashboardCommentsApiController extends Controller
      * @param string|null $message The new message text.
      *
      * @return JSONResponse The updated comment envelope or an error.
-         *
+     *
      * @spec openspec/specs/dashboard-comments/spec.md
- */
+     */
     #[NoAdminRequired]
     public function update(
         string $uuid,
         int $id,
         ?string $message=null
     ): JSONResponse {
-        if ($this->userId === null) {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
             return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
         }
+
+        $this->actionAuth->requireAction($user, 'dashboard-comments.update');
 
         try {
             $dashboard = $this->dashboardMapper->findByUuid(uuid: $uuid);
@@ -284,15 +301,18 @@ class DashboardCommentsApiController extends Controller
      * @param int    $id   The comment ID.
      *
      * @return JSONResponse Empty success or an error envelope.
-         *
+     *
      * @spec openspec/specs/dashboard-comments/spec.md
- */
+     */
     #[NoAdminRequired]
     public function destroy(string $uuid, int $id): JSONResponse
     {
-        if ($this->userId === null) {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
             return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
         }
+
+        $this->actionAuth->requireAction($user, 'dashboard-comments.destroy');
 
         try {
             $dashboard = $this->dashboardMapper->findByUuid(uuid: $uuid);

--- a/lib/Controller/DashboardReactionApiController.php
+++ b/lib/Controller/DashboardReactionApiController.php
@@ -28,6 +28,7 @@ namespace OCA\MyDash\Controller;
 
 use InvalidArgumentException;
 use OCA\MyDash\AppInfo\Application;
+use OCA\MyDash\Service\ActionAuthService;
 use OCA\MyDash\Service\PermissionDeniedException;
 use OCA\MyDash\Service\ReactionService;
 use OCA\MyDash\Service\ReactionsDisabledException;
@@ -37,6 +38,7 @@ use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IRequest;
+use OCP\IUserSession;
 use Psr\Log\LoggerInterface;
 use Throwable;
 
@@ -46,20 +48,31 @@ use Throwable;
  * Permission gating is runtime (calls into PermissionService through
  * ReactionService) so every method carries `#[NoAdminRequired]` —
  * non-admins can react if and only if they can VIEW the dashboard.
+ *
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects) Reaction controller spans
+ *                                                  the reaction service,
+ *                                                  action-auth service,
+ *                                                  user session, logger,
+ *                                                  and four exception types
+ *                                                  across four routes.
  */
 class DashboardReactionApiController extends Controller
 {
     /**
      * Constructor
      *
-     * @param IRequest        $request         The request.
-     * @param ReactionService $reactionService The reaction service.
-     * @param LoggerInterface $logger          PSR logger.
-     * @param string|null     $userId          The acting user ID.
+     * @param IRequest          $request         The request.
+     * @param ReactionService   $reactionService The reaction service.
+     * @param ActionAuthService $actionAuth      ADR-023 action authorization.
+     * @param IUserSession      $userSession     The current user session.
+     * @param LoggerInterface   $logger          PSR logger.
+     * @param string|null       $userId          The acting user ID.
      */
     public function __construct(
         IRequest $request,
         private readonly ReactionService $reactionService,
+        private readonly ActionAuthService $actionAuth,
+        private readonly IUserSession $userSession,
         private readonly LoggerInterface $logger,
         private readonly ?string $userId,
     ) {
@@ -76,15 +89,18 @@ class DashboardReactionApiController extends Controller
      * @param string $uuid The dashboard UUID.
      *
      * @return JSONResponse The summary.
-         *
+     *
      * @spec openspec/specs/dashboard-reactions/spec.md
- */
+     */
     #[NoAdminRequired]
     public function getReactions(string $uuid): JSONResponse
     {
-        if ($this->userId === null) {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
             return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
         }
+
+        $this->actionAuth->requireAction($user, 'dashboard-reaction.get-reactions');
 
         try {
             $summary = $this->reactionService->getReactionsSummary(
@@ -121,15 +137,18 @@ class DashboardReactionApiController extends Controller
      * @param string $emoji The emoji to add (request body field).
      *
      * @return JSONResponse The updated summary.
-         *
+     *
      * @spec openspec/specs/dashboard-reactions/spec.md
- */
+     */
     #[NoAdminRequired]
     public function addReaction(string $uuid, string $emoji=''): JSONResponse
     {
-        if ($this->userId === null) {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
             return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
         }
+
+        $this->actionAuth->requireAction($user, 'dashboard-reaction.add-reaction');
 
         try {
             $summary = $this->reactionService->addReaction(
@@ -173,15 +192,18 @@ class DashboardReactionApiController extends Controller
      * @param string $emoji The emoji to remove.
      *
      * @return JSONResponse Empty 204 response.
-         *
+     *
      * @spec openspec/specs/dashboard-reactions/spec.md
- */
+     */
     #[NoAdminRequired]
     public function removeReaction(string $uuid, string $emoji): JSONResponse
     {
-        if ($this->userId === null) {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
             return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
         }
+
+        $this->actionAuth->requireAction($user, 'dashboard-reaction.remove-reaction');
 
         try {
             $this->reactionService->removeReaction(
@@ -225,18 +247,21 @@ class DashboardReactionApiController extends Controller
      * @param string|null $cursor Optional opaque cursor (offset).
      *
      * @return JSONResponse The reactors page.
-         *
+     *
      * @spec openspec/specs/dashboard-reactions/spec.md
- */
+     */
     #[NoAdminRequired]
     public function getReactorsByEmoji(
         string $uuid,
         string $emoji,
         ?string $cursor=null
     ): JSONResponse {
-        if ($this->userId === null) {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
             return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
         }
+
+        $this->actionAuth->requireAction($user, 'dashboard-reaction.get-reactors-by-emoji');
 
         try {
             $page = $this->reactionService->getReactorsByEmoji(

--- a/lib/Service/FeedRefreshService.php
+++ b/lib/Service/FeedRefreshService.php
@@ -118,6 +118,7 @@ class FeedRefreshService
      * @param FeedCacheMapper       $cacheMapper     The feed-cache mapper.
      * @param WidgetPlacementMapper $placementMapper The widget-placement mapper.
      * @param LoggerInterface       $logger          The diagnostic logger.
+     * @param UrlSafetyValidator    $urlValidator    SSRF guard (H3).
      */
     public function __construct(
         private readonly IClientService $clientService,
@@ -126,6 +127,7 @@ class FeedRefreshService
         private readonly FeedCacheMapper $cacheMapper,
         private readonly WidgetPlacementMapper $placementMapper,
         private readonly LoggerInterface $logger,
+        private readonly UrlSafetyValidator $urlValidator,
     ) {
     }//end __construct()
 
@@ -227,8 +229,8 @@ class FeedRefreshService
         }
 
         // H3: SSRF guard — reject URLs that resolve to private/reserved IP
-        // ranges and enforce HTTPS-only. Mirrors CalendarWidgetService::validateUrl.
-        if ($this->isPrivateIpGuarded(feedUrl: $feedUrl) === false) {
+        // ranges and enforce HTTPS-only. Delegates to UrlSafetyValidator.
+        if ($this->urlValidator->isSafe(url: $feedUrl) === false) {
             $row->setLastFailureReason('SSRF guard: private/reserved IP or non-HTTPS URL rejected');
             $row->setLastFetchedAt($now);
             $this->cacheMapper->update(entity: $row);
@@ -565,7 +567,7 @@ class FeedRefreshService
         } finally {
             libxml_clear_errors();
             libxml_use_internal_errors(use_errors: $previous);
-        }
+        }//end try
 
         $sourceTitle = $this->extractFeedTitle(xml: $xml, feedUrl: $feedUrl);
         $items       = [];
@@ -794,61 +796,6 @@ class FeedRefreshService
      *
      * @return bool True if the host is allowed.
      */
-    /**
-     * Guard a feed URL against private/reserved IP ranges (H3 — SSRF fix).
-     *
-     * Mirrors the logic in CalendarWidgetService::validateUrl: resolves the
-     * hostname via gethostbynamel() and rejects any IP that falls in a
-     * private/reserved range. Also enforces HTTPS-only for feed sources as
-     * an additional defence-in-depth measure.
-     *
-     * Note: this performs a DNS resolution at allow-list time. The HTTP
-     * client will later re-resolve the hostname (TOCTOU), but for feed
-     * refresh the background-job context means the attack window is narrow
-     * and this guard is already a significant improvement over no check.
-     *
-     * @param string $feedUrl The feed URL to validate.
-     *
-     * @return bool True when the URL passes the private-IP guard.
-     */
-    private function isPrivateIpGuarded(string $feedUrl): bool
-    {
-        $parts = parse_url(url: $feedUrl);
-        if (is_array(value: $parts) === false) {
-            return false;
-        }
-
-        // Enforce HTTPS-only for feed sources (H3 defence-in-depth).
-        $scheme = strtolower(string: (string) ($parts['scheme'] ?? ''));
-        if ($scheme !== 'https') {
-            return false;
-        }
-
-        $host = (string) ($parts['host'] ?? '');
-        if ($host === '') {
-            return false;
-        }
-
-        // Resolve and reject private/reserved IPs — mirrors CalendarWidgetService.
-        $ips = gethostbynamel(hostname: $host);
-        if ($ips === false || $ips === []) {
-            return false;
-        }
-
-        foreach ($ips as $ip) {
-            $publicIp = filter_var(
-                value: $ip,
-                filter: FILTER_VALIDATE_IP,
-                options: (FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE)
-            );
-            if ($publicIp === false) {
-                return false;
-            }
-        }
-
-        return true;
-    }//end isPrivateIpGuarded()
-
     private function isHostAllowed(string $feedUrl): bool
     {
         $allowedRaw = $this->appConfig->getValueString(

--- a/lib/Service/FilesWidgetService.php
+++ b/lib/Service/FilesWidgetService.php
@@ -36,6 +36,8 @@ declare(strict_types=1);
 
 namespace OCA\MyDash\Service;
 
+use OCA\MyDash\Exception\FileTooLargeException;
+use OCA\MyDash\Exception\FileTypeNotAllowedException;
 use OCA\MyDash\Exception\FolderNotFoundException;
 use OCA\MyDash\Exception\NoAccessException;
 use OCP\Constants;
@@ -74,6 +76,16 @@ class FilesWidgetService
      * @var integer
      */
     public const MAX_LIMIT = 200;
+
+    /**
+     * Maximum allowed upload size per file in bytes (50 MB).
+     *
+     * Rejects individual files larger than this before they reach
+     * Nextcloud's storage layer (M3 DoS / resource-exhaustion guard).
+     *
+     * @var integer
+     */
+    public const MAX_UPLOAD_BYTES = 52428800;
 
     /**
      * Constructor.
@@ -202,12 +214,19 @@ class FilesWidgetService
             throw new NoAccessException();
         }
 
+        // M3: normalise the placement's MIME type filter so we can gate
+        // uploads against it (same filter already enforced on reads).
+        $mimeFilter = $this->normaliseMimeFilter(
+            filter: ($config['mimeTypeFilter'] ?? [])
+        );
+
         $uploaded = [];
         $errors   = [];
         foreach ($uploadedFiles as $entry) {
             $name  = (string) $entry['name'];
             $tmp   = (string) $entry['tmp_name'];
             $error = (int) $entry['error'];
+            $size  = (int) $entry['size'];
 
             if ($name === '' || $error !== UPLOAD_ERR_OK || $tmp === '') {
                 $errors[] = [
@@ -217,17 +236,65 @@ class FilesWidgetService
                 continue;
             }
 
+            // M3: assert the temp file came through a real PHP upload to
+            // prevent local-file-inclusion via a crafted tmp_name.
+            if (is_uploaded_file(filename: $tmp) === false) {
+                $errors[] = [
+                    'name'  => $name,
+                    'error' => 'upload_failed',
+                ];
+                continue;
+            }
+
+            // M3: reject files that exceed the hard size cap.
+            if ($size > self::MAX_UPLOAD_BYTES) {
+                $errors[] = [
+                    'name'  => $name,
+                    'error' => 'file_too_large',
+                ];
+                continue;
+            }
+
+            // M3: honour the placement MIME type filter on writes so
+            // uploads cannot bypass a restrict-to-images-only config.
+            if ($mimeFilter !== []) {
+                $detectedMime = $this->detectMimeType(path: $tmp);
+                if ($this->mimeMatchesFilter(mime: $detectedMime, filter: $mimeFilter) === false) {
+                    $errors[] = [
+                        'name'  => $name,
+                        'error' => 'file_type_not_allowed',
+                    ];
+                    continue;
+                }
+            }
+
             $safeName = $this->resolveAvailableName(folder: $target, desired: $name);
             try {
-                $contents   = (string) @file_get_contents(filename: $tmp);
-                $file       = $target->newFile(path: $safeName, content: $contents);
+                // M3: stream-write to avoid loading the entire file into
+                // memory before handing it to Nextcloud's storage layer.
+                $handle = @fopen(filename: $tmp, mode: 'rb');
+                if ($handle === false) {
+                    throw new \RuntimeException('Cannot open temporary file');
+                }
+
+                $file      = $target->newFile(path: $safeName);
+                $outHandle = $file->fopen(mode: 'w');
+                if ($outHandle === false) {
+                    fclose($handle);
+                    throw new \RuntimeException('Cannot open destination file');
+                }
+
+                stream_copy_to_stream(from: $handle, to: $outHandle);
+                fclose($handle);
+                fclose($outHandle);
+
                 $uploaded[] = $this->buildFileMetadata(node: $file);
             } catch (Throwable $e) {
                 $errors[] = [
                     'name'  => $name,
                     'error' => 'storage_failed',
                 ];
-            }
+            }//end try
         }//end foreach
 
         return [
@@ -548,6 +615,65 @@ class FilesWidgetService
 
         return false;
     }//end matchesMimeFilter()
+
+    /**
+     * Detect the MIME type of a local file path using PHP's finfo
+     * extension (falling back to 'application/octet-stream').
+     *
+     * Used by uploadFiles to enforce the placement's mimeTypeFilter
+     * on writes (M3).
+     *
+     * @param string $path Absolute path to the local file.
+     *
+     * @return string The detected MIME type (lowercase).
+     */
+    private function detectMimeType(string $path): string
+    {
+        if (function_exists('finfo_open') === true) {
+            $finfo = finfo_open(flags: FILEINFO_MIME_TYPE);
+            if ($finfo !== false) {
+                $mime = finfo_file(finfo: $finfo, filename: $path);
+                finfo_close(finfo: $finfo);
+                if (is_string(value: $mime) === true && $mime !== '') {
+                    return strtolower(string: $mime);
+                }
+            }
+        }
+
+        return 'application/octet-stream';
+    }//end detectMimeType()
+
+    /**
+     * Test a raw MIME type string against a normalised filter list.
+     *
+     * Accepts both exact matches (`image/png`) and wildcard prefixes
+     * (`image/*`) — mirrors the read-path `matchesMimeFilter` but
+     * operates on a raw string rather than a Node.
+     *
+     * @param string       $mime   The detected MIME type.
+     * @param list<string> $filter Normalised filter list.
+     *
+     * @return boolean True when the MIME passes the filter.
+     */
+    private function mimeMatchesFilter(string $mime, array $filter): bool
+    {
+        if (count($filter) === 0) {
+            return true;
+        }
+
+        foreach ($filter as $pattern) {
+            if (str_ends_with(haystack: $pattern, needle: '/*') === true) {
+                $prefix = substr(string: $pattern, offset: 0, length: -1);
+                if (str_starts_with(haystack: $mime, needle: $prefix) === true) {
+                    return true;
+                }
+            } else if ($pattern === $mime) {
+                return true;
+            }
+        }
+
+        return false;
+    }//end mimeMatchesFilter()
 
     /**
      * Sort an item list according to the placement config.

--- a/lib/actions.seed.json
+++ b/lib/actions.seed.json
@@ -29,6 +29,8 @@
     "dashboard.schedule": ["admin"],
     "dashboard.view-event": ["admin"],
     "dashboard-comments.index": ["admin"],
+    "dashboard-comments.create": ["admin"],
+    "dashboard-comments.update": ["admin"],
     "dashboard-comments.destroy": ["admin"],
     "dashboard-lock.acquire": ["admin"],
     "dashboard-lock.get": ["admin"],

--- a/tests/Unit/Controller/DashboardCommentsApiControllerTest.php
+++ b/tests/Unit/Controller/DashboardCommentsApiControllerTest.php
@@ -1,0 +1,254 @@
+<?php
+
+/**
+ * DashboardCommentsApiController Test
+ *
+ * Covers M4: ADR-023 action-auth wiring on all four comment endpoints.
+ *
+ * @category  Test
+ * @package   OCA\MyDash\Tests\Unit\Controller
+ * @author    Conduction b.v. <info@conduction.nl>
+ * @copyright 2026 Conduction b.v.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-FileCopyrightText: 2026 MyDash Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Controller;
+
+use OCA\MyDash\Controller\DashboardCommentsApiController;
+use OCA\MyDash\Db\Dashboard;
+use OCA\MyDash\Db\DashboardMapper;
+use OCA\MyDash\Service\ActionAuthService;
+use OCA\MyDash\Service\CommentService;
+use OCA\MyDash\Service\PermissionService;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\OCS\OCSForbiddenException;
+use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for DashboardCommentsApiController (M4 ADR-023 wiring).
+ */
+class DashboardCommentsApiControllerTest extends TestCase
+{
+    /** @var IRequest&MockObject */
+    private $request;
+    /** @var CommentService&MockObject */
+    private $commentService;
+    /** @var PermissionService&MockObject */
+    private $permissionService;
+    /** @var DashboardMapper&MockObject */
+    private $dashboardMapper;
+    /** @var ActionAuthService&MockObject */
+    private $actionAuth;
+    /** @var IUserSession&MockObject */
+    private $userSession;
+    /** @var IUser&MockObject */
+    private $user;
+
+    protected function setUp(): void
+    {
+        $this->request           = $this->createMock(IRequest::class);
+        $this->commentService    = $this->createMock(CommentService::class);
+        $this->permissionService = $this->createMock(PermissionService::class);
+        $this->dashboardMapper   = $this->createMock(DashboardMapper::class);
+        $this->actionAuth        = $this->createMock(ActionAuthService::class);
+        $this->userSession       = $this->createMock(IUserSession::class);
+
+        $this->user = $this->createMock(IUser::class);
+        $this->user->method('getUID')->willReturn('user1');
+        $this->userSession->method('getUser')->willReturn($this->user);
+
+        // Default: permission checks pass.
+        $this->permissionService->method('canViewDashboard')->willReturn(true);
+        $this->permissionService->method('canEditDashboard')->willReturn(true);
+    }//end setUp()
+
+    private function makeController(?string $userId='user1'): DashboardCommentsApiController
+    {
+        return new DashboardCommentsApiController(
+            request: $this->request,
+            commentService: $this->commentService,
+            permissionService: $this->permissionService,
+            dashboardMapper: $this->dashboardMapper,
+            actionAuth: $this->actionAuth,
+            userSession: $this->userSession,
+            userId: $userId,
+        );
+    }//end makeController()
+
+    private function makeDashboard(int $id=1): Dashboard
+    {
+        $dashboard = new Dashboard();
+        $dashboard->setId($id);
+        return $dashboard;
+    }//end makeDashboard()
+
+    /**
+     * M4: index() must call requireAction with 'dashboard-comments.index'.
+     */
+    public function testIndexCallsRequireAction(): void
+    {
+        $this->dashboardMapper->method('findByUuid')->willReturn($this->makeDashboard());
+        $this->commentService->method('isEnabledFor')->willReturn(false);
+
+        $this->actionAuth
+            ->expects($this->once())
+            ->method('requireAction')
+            ->with($this->user, 'dashboard-comments.index');
+
+        $controller = $this->makeController();
+        $response   = $controller->index('some-uuid');
+
+        $this->assertSame(Http::STATUS_OK, $response->getStatus());
+    }//end testIndexCallsRequireAction()
+
+    /**
+     * M4: index() must propagate OCSForbiddenException when action is denied.
+     */
+    public function testIndexPropagatesForbiddenWhenActionDenied(): void
+    {
+        $this->actionAuth
+            ->method('requireAction')
+            ->willThrowException(new OCSForbiddenException('Forbidden'));
+
+        $this->expectException(OCSForbiddenException::class);
+
+        $controller = $this->makeController();
+        $controller->index('some-uuid');
+    }//end testIndexPropagatesForbiddenWhenActionDenied()
+
+    /**
+     * M4: create() must call requireAction with 'dashboard-comments.create'.
+     */
+    public function testCreateCallsRequireAction(): void
+    {
+        $this->dashboardMapper->method('findByUuid')->willReturn($this->makeDashboard());
+        $this->commentService->method('isEnabledFor')->willReturn(false);
+
+        $this->actionAuth
+            ->expects($this->once())
+            ->method('requireAction')
+            ->with($this->user, 'dashboard-comments.create');
+
+        $controller = $this->makeController();
+        // Comments disabled → short-circuits before calling createComment.
+        $response   = $controller->create('some-uuid', 'Hello');
+
+        $this->assertSame(Http::STATUS_FORBIDDEN, $response->getStatus());
+    }//end testCreateCallsRequireAction()
+
+    /**
+     * M4: create() must propagate OCSForbiddenException when action is denied.
+     */
+    public function testCreatePropagatesForbiddenWhenActionDenied(): void
+    {
+        $this->actionAuth
+            ->method('requireAction')
+            ->willThrowException(new OCSForbiddenException('Forbidden'));
+
+        $this->expectException(OCSForbiddenException::class);
+
+        $controller = $this->makeController();
+        $controller->create('some-uuid', 'Hello');
+    }//end testCreatePropagatesForbiddenWhenActionDenied()
+
+    /**
+     * M4: update() must call requireAction with 'dashboard-comments.update'.
+     */
+    public function testUpdateCallsRequireAction(): void
+    {
+        $this->dashboardMapper->method('findByUuid')->willReturn($this->makeDashboard());
+        $this->commentService->method('isEnabledFor')->willReturn(false);
+
+        $this->actionAuth
+            ->expects($this->once())
+            ->method('requireAction')
+            ->with($this->user, 'dashboard-comments.update');
+
+        $controller = $this->makeController();
+        $response   = $controller->update('some-uuid', 7, 'Updated text');
+
+        $this->assertSame(Http::STATUS_FORBIDDEN, $response->getStatus());
+    }//end testUpdateCallsRequireAction()
+
+    /**
+     * M4: update() must propagate OCSForbiddenException when action is denied.
+     */
+    public function testUpdatePropagatesForbiddenWhenActionDenied(): void
+    {
+        $this->actionAuth
+            ->method('requireAction')
+            ->willThrowException(new OCSForbiddenException('Forbidden'));
+
+        $this->expectException(OCSForbiddenException::class);
+
+        $controller = $this->makeController();
+        $controller->update('some-uuid', 7, 'Updated text');
+    }//end testUpdatePropagatesForbiddenWhenActionDenied()
+
+    /**
+     * M4: destroy() must call requireAction with 'dashboard-comments.destroy'.
+     */
+    public function testDestroyCallsRequireAction(): void
+    {
+        $this->dashboardMapper->method('findByUuid')->willReturn($this->makeDashboard());
+        $this->commentService->method('isEnabledFor')->willReturn(true);
+        // deleteComment returns void — no stub return value needed.
+
+        $this->actionAuth
+            ->expects($this->once())
+            ->method('requireAction')
+            ->with($this->user, 'dashboard-comments.destroy');
+
+        $controller = $this->makeController();
+        $response   = $controller->destroy('some-uuid', 7);
+
+        $this->assertSame(Http::STATUS_NO_CONTENT, $response->getStatus());
+    }//end testDestroyCallsRequireAction()
+
+    /**
+     * M4: destroy() must propagate OCSForbiddenException when action is denied.
+     */
+    public function testDestroyPropagatesForbiddenWhenActionDenied(): void
+    {
+        $this->actionAuth
+            ->method('requireAction')
+            ->willThrowException(new OCSForbiddenException('Forbidden'));
+
+        $this->expectException(OCSForbiddenException::class);
+
+        $controller = $this->makeController();
+        $controller->destroy('some-uuid', 7);
+    }//end testDestroyPropagatesForbiddenWhenActionDenied()
+
+    /**
+     * index() must return 401 when no authenticated user exists.
+     */
+    public function testIndexReturns401WhenUnauthenticated(): void
+    {
+        // Build a fresh session mock that returns null (no logged-in user).
+        $anonSession = $this->createMock(IUserSession::class);
+        $anonSession->method('getUser')->willReturn(null);
+
+        $controller = new DashboardCommentsApiController(
+            request: $this->request,
+            commentService: $this->commentService,
+            permissionService: $this->permissionService,
+            dashboardMapper: $this->dashboardMapper,
+            actionAuth: $this->actionAuth,
+            userSession: $anonSession,
+            userId: null,
+        );
+        $response = $controller->index('some-uuid');
+
+        $this->assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
+    }//end testIndexReturns401WhenUnauthenticated()
+}//end class

--- a/tests/Unit/Controller/DashboardMetadataControllerTest.php
+++ b/tests/Unit/Controller/DashboardMetadataControllerTest.php
@@ -26,9 +26,9 @@ use OCA\MyDash\Db\Dashboard;
 use OCA\MyDash\Db\DashboardMapper;
 use OCA\MyDash\Exception\InvalidMetadataFieldException;
 use OCA\MyDash\Service\MetadataService;
+use OCA\MyDash\Service\PermissionService;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Http;
-use OCP\IGroupManager;
 use OCP\IRequest;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -39,17 +39,19 @@ class DashboardMetadataControllerTest extends TestCase
     private MetadataService $metadataService;
     /** @var DashboardMapper&MockObject */
     private DashboardMapper $dashboardMapper;
-    /** @var IGroupManager&MockObject */
-    private IGroupManager $groupManager;
+    /** @var PermissionService&MockObject */
+    private PermissionService $permissionService;
     /** @var IRequest&MockObject */
     private IRequest $request;
 
     protected function setUp(): void
     {
-        $this->metadataService = $this->createMock(MetadataService::class);
-        $this->dashboardMapper = $this->createMock(DashboardMapper::class);
-        $this->groupManager    = $this->createMock(IGroupManager::class);
-        $this->request         = $this->createMock(IRequest::class);
+        $this->metadataService   = $this->createMock(MetadataService::class);
+        $this->dashboardMapper   = $this->createMock(DashboardMapper::class);
+        $this->permissionService = $this->createMock(PermissionService::class);
+        $this->request           = $this->createMock(IRequest::class);
+
+        // Default: permission checks allow access (overridden per test where needed).
     }
 
     private function controller(?string $userId): DashboardMetadataController
@@ -58,14 +60,19 @@ class DashboardMetadataControllerTest extends TestCase
             request: $this->request,
             metadataService: $this->metadataService,
             dashboardMapper: $this->dashboardMapper,
-            groupManager: $this->groupManager,
+            permissionService: $this->permissionService,
             userId: $userId,
         );
     }
 
-    private function makeDashboard(string $uuid, ?string $userId = null, ?string $groupId = null, string $type = Dashboard::TYPE_USER): Dashboard
-    {
+    private function makeDashboard(
+        string $uuid,
+        ?string $userId=null,
+        ?string $groupId=null,
+        string $type=Dashboard::TYPE_USER
+    ): Dashboard {
         $dashboard = new Dashboard();
+        $dashboard->setId(1);
         $dashboard->setUuid($uuid);
         if ($userId !== null) {
             $dashboard->setUserId($userId);
@@ -98,6 +105,7 @@ class DashboardMetadataControllerTest extends TestCase
     {
         $dashboard = $this->makeDashboard('abc', userId: 'bob');
         $this->dashboardMapper->method('findByUuid')->willReturn($dashboard);
+        $this->permissionService->method('canViewDashboard')->willReturn(false);
 
         $controller = $this->controller('alice');
         $response   = $controller->getMetadata('abc');
@@ -108,6 +116,7 @@ class DashboardMetadataControllerTest extends TestCase
     {
         $dashboard = $this->makeDashboard('abc', userId: 'alice');
         $this->dashboardMapper->method('findByUuid')->willReturn($dashboard);
+        $this->permissionService->method('canViewDashboard')->willReturn(true);
         $this->metadataService->method('getMetadataForDashboard')
             ->with('abc')
             ->willReturn(['department' => 'marketing']);
@@ -122,9 +131,7 @@ class DashboardMetadataControllerTest extends TestCase
     {
         $dashboard = $this->makeDashboard('abc', groupId: 'team', type: Dashboard::TYPE_GROUP_SHARED);
         $this->dashboardMapper->method('findByUuid')->willReturn($dashboard);
-        $this->groupManager->method('isInGroup')
-            ->with('alice', 'team')
-            ->willReturn(true);
+        $this->permissionService->method('canViewDashboard')->willReturn(true);
         $this->metadataService->method('getMetadataForDashboard')->willReturn([]);
 
         $controller = $this->controller('alice');
@@ -136,6 +143,7 @@ class DashboardMetadataControllerTest extends TestCase
     {
         $dashboard = $this->makeDashboard('abc', userId: 'alice');
         $this->dashboardMapper->method('findByUuid')->willReturn($dashboard);
+        $this->permissionService->method('canEditDashboardMetadata')->willReturn(true);
         $this->metadataService->method('setMetadataForDashboard')
             ->willThrowException(new InvalidMetadataFieldException("Field 'Priority' must be a valid number"));
 
@@ -149,6 +157,7 @@ class DashboardMetadataControllerTest extends TestCase
     {
         $dashboard = $this->makeDashboard('abc', userId: 'alice');
         $this->dashboardMapper->method('findByUuid')->willReturn($dashboard);
+        $this->permissionService->method('canEditDashboardMetadata')->willReturn(true);
         $this->metadataService
             ->expects($this->once())
             ->method('setMetadataForDashboard')

--- a/tests/Unit/Controller/DashboardReactionApiControllerTest.php
+++ b/tests/Unit/Controller/DashboardReactionApiControllerTest.php
@@ -1,0 +1,235 @@
+<?php
+
+/**
+ * DashboardReactionApiController Test
+ *
+ * Covers M4: ADR-023 action-auth wiring on all four reaction endpoints.
+ *
+ * @category  Test
+ * @package   OCA\MyDash\Tests\Unit\Controller
+ * @author    Conduction b.v. <info@conduction.nl>
+ * @copyright 2026 Conduction b.v.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-FileCopyrightText: 2026 MyDash Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Controller;
+
+use OCA\MyDash\Controller\DashboardReactionApiController;
+use OCA\MyDash\Service\ActionAuthService;
+use OCA\MyDash\Service\ReactionService;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\OCS\OCSForbiddenException;
+use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Unit tests for DashboardReactionApiController (M4 ADR-023 wiring).
+ */
+class DashboardReactionApiControllerTest extends TestCase
+{
+    /** @var IRequest&MockObject */
+    private $request;
+    /** @var ReactionService&MockObject */
+    private $reactionService;
+    /** @var ActionAuthService&MockObject */
+    private $actionAuth;
+    /** @var IUserSession&MockObject */
+    private $userSession;
+    /** @var LoggerInterface&MockObject */
+    private $logger;
+    /** @var IUser&MockObject */
+    private $user;
+
+    protected function setUp(): void
+    {
+        $this->request         = $this->createMock(IRequest::class);
+        $this->reactionService = $this->createMock(ReactionService::class);
+        $this->actionAuth      = $this->createMock(ActionAuthService::class);
+        $this->userSession     = $this->createMock(IUserSession::class);
+        $this->logger          = $this->createMock(LoggerInterface::class);
+
+        $this->user = $this->createMock(IUser::class);
+        $this->user->method('getUID')->willReturn('user1');
+        $this->userSession->method('getUser')->willReturn($this->user);
+    }//end setUp()
+
+    private function makeController(?string $userId='user1'): DashboardReactionApiController
+    {
+        return new DashboardReactionApiController(
+            request: $this->request,
+            reactionService: $this->reactionService,
+            actionAuth: $this->actionAuth,
+            userSession: $this->userSession,
+            logger: $this->logger,
+            userId: $userId,
+        );
+    }//end makeController()
+
+    /**
+     * M4: getReactions() must call requireAction with the correct action name.
+     */
+    public function testGetReactionsCallsRequireAction(): void
+    {
+        $this->reactionService
+            ->method('getReactionsSummary')
+            ->willReturn(['counts' => [], 'mine' => [], 'enabled' => true]);
+
+        $this->actionAuth
+            ->expects($this->once())
+            ->method('requireAction')
+            ->with($this->user, 'dashboard-reaction.get-reactions');
+
+        $controller = $this->makeController();
+        $response   = $controller->getReactions('some-uuid');
+
+        $this->assertSame(Http::STATUS_OK, $response->getStatus());
+    }//end testGetReactionsCallsRequireAction()
+
+    /**
+     * M4: getReactions() must propagate OCSForbiddenException when denied.
+     */
+    public function testGetReactionsPropagatesForbiddenWhenActionDenied(): void
+    {
+        $this->actionAuth
+            ->method('requireAction')
+            ->willThrowException(new OCSForbiddenException('Forbidden'));
+
+        $this->expectException(OCSForbiddenException::class);
+
+        $controller = $this->makeController();
+        $controller->getReactions('some-uuid');
+    }//end testGetReactionsPropagatesForbiddenWhenActionDenied()
+
+    /**
+     * M4: addReaction() must call requireAction with the correct action name.
+     */
+    public function testAddReactionCallsRequireAction(): void
+    {
+        $this->reactionService
+            ->method('addReaction')
+            ->willReturn(['counts' => [], 'mine' => [], 'enabled' => true]);
+
+        $this->actionAuth
+            ->expects($this->once())
+            ->method('requireAction')
+            ->with($this->user, 'dashboard-reaction.add-reaction');
+
+        $controller = $this->makeController();
+        $response   = $controller->addReaction('some-uuid', '👍');
+
+        $this->assertSame(Http::STATUS_OK, $response->getStatus());
+    }//end testAddReactionCallsRequireAction()
+
+    /**
+     * M4: addReaction() must propagate OCSForbiddenException when denied.
+     */
+    public function testAddReactionPropagatesForbiddenWhenActionDenied(): void
+    {
+        $this->actionAuth
+            ->method('requireAction')
+            ->willThrowException(new OCSForbiddenException('Forbidden'));
+
+        $this->expectException(OCSForbiddenException::class);
+
+        $controller = $this->makeController();
+        $controller->addReaction('some-uuid', '👍');
+    }//end testAddReactionPropagatesForbiddenWhenActionDenied()
+
+    /**
+     * M4: removeReaction() must call requireAction with the correct action name.
+     */
+    public function testRemoveReactionCallsRequireAction(): void
+    {
+        $this->reactionService->method('removeReaction')->willReturn(true);
+
+        $this->actionAuth
+            ->expects($this->once())
+            ->method('requireAction')
+            ->with($this->user, 'dashboard-reaction.remove-reaction');
+
+        $controller = $this->makeController();
+        $response   = $controller->removeReaction('some-uuid', '👍');
+
+        $this->assertSame(Http::STATUS_NO_CONTENT, $response->getStatus());
+    }//end testRemoveReactionCallsRequireAction()
+
+    /**
+     * M4: removeReaction() must propagate OCSForbiddenException when denied.
+     */
+    public function testRemoveReactionPropagatesForbiddenWhenActionDenied(): void
+    {
+        $this->actionAuth
+            ->method('requireAction')
+            ->willThrowException(new OCSForbiddenException('Forbidden'));
+
+        $this->expectException(OCSForbiddenException::class);
+
+        $controller = $this->makeController();
+        $controller->removeReaction('some-uuid', '👍');
+    }//end testRemoveReactionPropagatesForbiddenWhenActionDenied()
+
+    /**
+     * M4: getReactorsByEmoji() must call requireAction with the correct action name.
+     */
+    public function testGetReactorsByEmojiCallsRequireAction(): void
+    {
+        $this->reactionService
+            ->method('getReactorsByEmoji')
+            ->willReturn(['items' => [], 'nextCursor' => null]);
+
+        $this->actionAuth
+            ->expects($this->once())
+            ->method('requireAction')
+            ->with($this->user, 'dashboard-reaction.get-reactors-by-emoji');
+
+        $controller = $this->makeController();
+        $response   = $controller->getReactorsByEmoji('some-uuid', '👍');
+
+        $this->assertSame(Http::STATUS_OK, $response->getStatus());
+    }//end testGetReactorsByEmojiCallsRequireAction()
+
+    /**
+     * M4: getReactorsByEmoji() must propagate OCSForbiddenException when denied.
+     */
+    public function testGetReactorsByEmojiPropagatesForbiddenWhenActionDenied(): void
+    {
+        $this->actionAuth
+            ->method('requireAction')
+            ->willThrowException(new OCSForbiddenException('Forbidden'));
+
+        $this->expectException(OCSForbiddenException::class);
+
+        $controller = $this->makeController();
+        $controller->getReactorsByEmoji('some-uuid', '👍');
+    }//end testGetReactorsByEmojiPropagatesForbiddenWhenActionDenied()
+
+    /**
+     * All endpoints must return 401 when no authenticated user exists.
+     */
+    public function testGetReactionsReturns401WhenUnauthenticated(): void
+    {
+        $anonSession = $this->createMock(IUserSession::class);
+        $anonSession->method('getUser')->willReturn(null);
+
+        $controller = new DashboardReactionApiController(
+            request: $this->request,
+            reactionService: $this->reactionService,
+            actionAuth: $this->actionAuth,
+            userSession: $anonSession,
+            logger: $this->logger,
+            userId: null,
+        );
+        $response = $controller->getReactions('some-uuid');
+
+        $this->assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
+    }//end testGetReactionsReturns401WhenUnauthenticated()
+}//end class

--- a/tests/Unit/Service/DemoShowcasesServiceTest.php
+++ b/tests/Unit/Service/DemoShowcasesServiceTest.php
@@ -33,6 +33,7 @@ use OCP\Dashboard\IManager;
 use OCP\Dashboard\IWidget;
 use OCP\IAppConfig;
 use OCP\IDBConnection;
+use OCP\Lock\ILockingProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
@@ -58,6 +59,9 @@ class DemoShowcasesServiceTest extends TestCase
     /** @var IManager&MockObject */
     private $dashboardManager;
 
+    /** @var ILockingProvider&MockObject */
+    private $lockingProvider;
+
     private DemoShowcasesService $service;
 
     private string $fixtureDir;
@@ -71,6 +75,7 @@ class DemoShowcasesServiceTest extends TestCase
         $this->db               = $this->createMock(originalClassName: IDBConnection::class);
         $this->appConfig        = $this->createMock(originalClassName: IAppConfig::class);
         $this->dashboardManager = $this->createMock(originalClassName: IManager::class);
+        $this->lockingProvider  = $this->createMock(originalClassName: ILockingProvider::class);
 
         $this->service = new DemoShowcasesService(
             dashboardMapper: $this->dashboardMapper,
@@ -79,6 +84,7 @@ class DemoShowcasesServiceTest extends TestCase
             appConfig: $this->appConfig,
             dashboardManager: $this->dashboardManager,
             logger: new NullLogger(),
+            lockingProvider: $this->lockingProvider,
         );
 
         $this->fixtureDir = sys_get_temp_dir().'/mydash-showcase-fixture-'.uniqid();

--- a/tests/Unit/Service/FeedRefreshServiceTest.php
+++ b/tests/Unit/Service/FeedRefreshServiceTest.php
@@ -27,6 +27,7 @@ use OCA\MyDash\Db\FeedCacheMapper;
 use OCA\MyDash\Db\WidgetPlacement;
 use OCA\MyDash\Db\WidgetPlacementMapper;
 use OCA\MyDash\Service\FeedRefreshService;
+use OCA\MyDash\Service\UrlSafetyValidator;
 use OCP\Http\Client\IClient;
 use OCP\Http\Client\IClientService;
 use OCP\Http\Client\IResponse;
@@ -64,6 +65,9 @@ class FeedRefreshServiceTest extends TestCase
     /** @var LoggerInterface&MockObject */
     private $logger;
 
+    /** @var UrlSafetyValidator&MockObject */
+    private $urlValidator;
+
     private FeedRefreshService $service;
 
     /**
@@ -82,8 +86,11 @@ class FeedRefreshServiceTest extends TestCase
         $this->cacheMapper     = $this->createMock(FeedCacheMapper::class);
         $this->placementMapper = $this->createMock(WidgetPlacementMapper::class);
         $this->logger          = $this->createMock(LoggerInterface::class);
+        $this->urlValidator    = $this->createMock(UrlSafetyValidator::class);
 
         $this->clientService->method('newClient')->willReturn($this->client);
+        // Default: all URLs pass the SSRF guard in unit tests.
+        $this->urlValidator->method('isSafe')->willReturn(true);
 
         $this->service = new FeedRefreshService(
             clientService: $this->clientService,
@@ -92,6 +99,7 @@ class FeedRefreshServiceTest extends TestCase
             cacheMapper: $this->cacheMapper,
             placementMapper: $this->placementMapper,
             logger: $this->logger,
+            urlValidator: $this->urlValidator,
         );
     }//end setUp()
 

--- a/tests/Unit/Service/FilesWidgetServiceTest.php
+++ b/tests/Unit/Service/FilesWidgetServiceTest.php
@@ -312,4 +312,75 @@ class FilesWidgetServiceTest extends TestCase
             fileId: 1
         );
     }
+
+    /**
+     * M3: MAX_UPLOAD_BYTES constant is 50 MiB (50 * 1024 * 1024).
+     */
+    public function testMaxUploadBytesIs50Mib(): void
+    {
+        $this->assertSame(52428800, FilesWidgetService::MAX_UPLOAD_BYTES);
+    }//end testMaxUploadBytesIs50Mib()
+
+    /**
+     * M3: upload entries with UPLOAD_ERR_* flags produce an upload_failed
+     * error and do not attempt to write a file.
+     */
+    public function testUploadReturnsErrorForFailedUploadEntries(): void
+    {
+        $this->configuredFolder->method('isReadable')->willReturn(true);
+        $this->configuredFolder->method('isUpdateable')->willReturn(true);
+        $this->userFolder->method('getById')->willReturn([$this->configuredFolder]);
+
+        $result = $this->service->uploadFiles(
+            userId: 'alice',
+            config: ['fileId' => 99, 'allowUpload' => true],
+            currentSubPath: null,
+            uploadedFiles: [
+                [
+                    'name'     => 'bad.txt',
+                    'tmp_name' => '/tmp/doesnotexist',
+                    'error'    => UPLOAD_ERR_PARTIAL,
+                    'size'     => 100,
+                ],
+            ]
+        );
+
+        $this->assertCount(0, $result['uploaded']);
+        $this->assertCount(1, $result['errors']);
+        $this->assertSame('upload_failed', $result['errors'][0]['error']);
+        $this->assertSame('bad.txt', $result['errors'][0]['name']);
+    }//end testUploadReturnsErrorForFailedUploadEntries()
+
+    /**
+     * M3: when a file comes through with UPLOAD_ERR_OK but the path is
+     * not a genuine PHP upload (is_uploaded_file returns false), the
+     * entry must be rejected with upload_failed.
+     *
+     * In a unit-test environment every file path fails is_uploaded_file,
+     * so this covers the security invariant.
+     */
+    public function testUploadRejectsNonUploadedFilePaths(): void
+    {
+        $this->configuredFolder->method('isReadable')->willReturn(true);
+        $this->configuredFolder->method('isUpdateable')->willReturn(true);
+        $this->userFolder->method('getById')->willReturn([$this->configuredFolder]);
+
+        $result = $this->service->uploadFiles(
+            userId: 'alice',
+            config: ['fileId' => 99, 'allowUpload' => true],
+            currentSubPath: null,
+            uploadedFiles: [
+                [
+                    'name'     => 'crafted.txt',
+                    'tmp_name' => '/etc/passwd',
+                    'error'    => UPLOAD_ERR_OK,
+                    'size'     => 100,
+                ],
+            ]
+        );
+
+        $this->assertCount(0, $result['uploaded']);
+        $this->assertCount(1, $result['errors']);
+        $this->assertSame('upload_failed', $result['errors'][0]['error']);
+    }//end testUploadRejectsNonUploadedFilePaths()
 }


### PR DESCRIPTION
## Summary

- **M3 FilesWidgetService upload hardening**: reject non-PHP-uploaded `tmp_name` paths via `is_uploaded_file` (prevents local-file-inclusion via crafted requests), enforce 50 MiB hard size cap, enforce `mimeTypeFilter` on the write path (previously filter was read-only), stream-write via `fopen`/`stream_copy_to_stream` to avoid loading whole file into memory.
- **M4 DashboardCommentsApiController + DashboardReactionApiController**: wire all 8 endpoints through `ActionAuthService::requireAction` per ADR-023; add action seeds to `actions.seed.json`; replace `$userId` null-check with `IUserSession::getUser()` for consistency.
- **Pre-existing test fixes**: `DemoShowcasesServiceTest` missing `ILockingProvider` arg; `DashboardMetadataControllerTest` using removed `IGroupManager` dep (now `PermissionService`); `FeedRefreshServiceTest` failing against SSRF guard DNS resolution — refactored `FeedRefreshService` to inject `UrlSafetyValidator` (consistent with `CalendarWidgetService`/`NewsWidgetService` pattern).

## Test plan

- [x] `php vendor/bin/phpunit --no-coverage` — 1085/1085 pass, 0 failures, 0 errors
- [x] `php vendor/bin/phpstan analyse` — no errors
- [x] `php vendor/bin/phpcs --standard=phpcs.xml` — 0 errors on modified files (warnings are pre-existing @spec tags)
- [x] 9 new tests for M4 comments ADR-023 wiring
- [x] 9 new tests for M4 reactions ADR-023 wiring
- [x] 3 new tests for M3 upload hardening (is_uploaded_file guard, UPLOAD_ERR_* rejection, MAX_UPLOAD_BYTES constant)