### PR TITLE
fix(ci): PHPUnit Doctrine stub ordering, stylelint descending-specificity, gate-6 orphan-auth

### DIFF
--- a/lib/Controller/WidgetApiController.php
+++ b/lib/Controller/WidgetApiController.php
@@ -217,6 +217,18 @@ class WidgetApiController extends Controller
             return ResponseHelper::forbidden();
         }
 
+        // REQ-RFP-001 / REQ-RFP-003: a user may only add a widget that their
+        // role-feature-permission profile permits. `isWidgetAllowed` returns
+        // `true` when no restriction is configured (null allowed set), so
+        // unconfigured deployments are unaffected.
+        if ($this->roleFeaturePerm->isWidgetAllowed(
+            userId: $this->userId,
+            widgetId: $widgetId
+        ) === false
+        ) {
+            return ResponseHelper::forbidden();
+        }
+
         // REQ-CONT-006: reject deeply-nested container payloads BEFORE
         // touching the placement mapper so no rows are inserted on a
         // depth violation. Tolerant of non-container payloads (no-op

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
-         bootstrap="tests/bootstrap-stubs.php"
+         bootstrap="tests/bootstrap.php"
          colors="true"
          cacheDirectory=".phpunit.cache"
          executionOrder="depends,defects"

--- a/src/components/Widgets/Forms/LinksForm.vue
+++ b/src/components/Widgets/Forms/LinksForm.vue
@@ -525,10 +525,6 @@ export default {
 	flex-wrap: wrap;
 }
 
-.links-form__link-row--invalid .links-form__input {
-	border-color: var(--color-error);
-}
-
 .links-form__input {
 	flex: 1;
 	min-width: 80px;
@@ -538,6 +534,10 @@ export default {
 	background-color: var(--color-main-background);
 	color: var(--color-main-text);
 	font-size: 13px;
+}
+
+.links-form__link-row--invalid .links-form__input {
+	border-color: var(--color-error);
 }
 
 .links-form__input--narrow {

--- a/src/components/Widgets/Renderers/LinkButtonWidget.vue
+++ b/src/components/Widgets/Renderers/LinkButtonWidget.vue
@@ -638,14 +638,14 @@ export default {
 	transition: transform 0.15s ease, box-shadow 0.15s ease;
 }
 
-.link-button-widget__button:hover:not(:disabled) {
-	transform: translateY(-2px);
-	box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
-}
-
 .link-button-widget__button:disabled {
 	opacity: 0.6;
 	cursor: not-allowed;
+}
+
+.link-button-widget__button:hover:not(:disabled) {
+	transform: translateY(-2px);
+	box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
 }
 
 .link-button-widget__icon {
@@ -706,14 +706,14 @@ export default {
 	width: auto;
 }
 
-.link-button-widget__list-item:hover:not(:disabled) {
-	transform: translateY(-2px);
-	box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
-}
-
 .link-button-widget__list-item:disabled {
 	opacity: 0.6;
 	cursor: not-allowed;
+}
+
+.link-button-widget__list-item:hover:not(:disabled) {
+	transform: translateY(-2px);
+	box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
 }
 
 .link-button-widget__list-icon {

--- a/src/components/Widgets/Renderers/MenuWidget.vue
+++ b/src/components/Widgets/Renderers/MenuWidget.vue
@@ -551,6 +551,10 @@ export default {
 	width: 100%;
 }
 
+.menu-widget__mega-group-title {
+	font-weight: 600;
+}
+
 .menu-widget__bar-button:hover,
 .menu-widget__dropdown-item:hover,
 .menu-widget__mega-group-title:hover,
@@ -623,10 +627,6 @@ export default {
 	background: var(--color-main-background);
 	border: 1px solid var(--color-border);
 	border-radius: var(--border-radius);
-}
-
-.menu-widget__mega-group-title {
-	font-weight: 600;
 }
 
 .menu-widget__mega-leaves {

--- a/src/components/Widgets/Renderers/QuicklinksWidget.vue
+++ b/src/components/Widgets/Renderers/QuicklinksWidget.vue
@@ -455,6 +455,10 @@ export default {
 	display: block;
 }
 
+.quicklinks-widget--edit-mode .quicklinks-widget__link {
+	cursor: not-allowed;
+}
+
 /* Hover effects */
 .quicklinks-widget--hover-lift .quicklinks-widget__link:hover {
 	transform: translateY(-3px);
@@ -476,10 +480,6 @@ export default {
 
 .quicklinks-widget--hover-none .quicklinks-widget__link:hover {
 	cursor: pointer;
-}
-
-.quicklinks-widget--edit-mode .quicklinks-widget__link {
-	cursor: not-allowed;
 }
 
 .quicklinks-widget__empty {

--- a/src/components/Workspace/DashboardSwitcherSidebar.vue
+++ b/src/components/Workspace/DashboardSwitcherSidebar.vue
@@ -691,10 +691,6 @@ export default {
 	background: var(--color-primary-element-light, #e6f0fa);
 }
 
-.dashboard-switcher-sidebar__item.active .dashboard-switcher-sidebar__icon {
-	color: var(--color-primary, #0082c9);
-}
-
 .dashboard-switcher-sidebar__icon {
 	flex: 0 0 auto;
 	display: inline-flex;
@@ -702,6 +698,10 @@ export default {
 	justify-content: center;
 	width: 20px;
 	height: 20px;
+}
+
+.dashboard-switcher-sidebar__item.active .dashboard-switcher-sidebar__icon {
+	color: var(--color-primary, #0082c9);
 }
 
 .dashboard-switcher-sidebar__default-marker {
@@ -732,15 +732,15 @@ export default {
 	justify-content: center;
 }
 
-.dashboard-switcher-sidebar__item--personal:hover .dashboard-switcher-sidebar__delete,
-.dashboard-switcher-sidebar__item--personal:focus-within .dashboard-switcher-sidebar__delete {
-	display: inline-flex;
-}
-
 .dashboard-switcher-sidebar__delete:hover,
 .dashboard-switcher-sidebar__delete:focus {
 	background: var(--color-background-darker, #ececec);
 	color: var(--color-error, #c0392b);
+}
+
+.dashboard-switcher-sidebar__item--personal:hover .dashboard-switcher-sidebar__delete,
+.dashboard-switcher-sidebar__item--personal:focus-within .dashboard-switcher-sidebar__delete {
+	display: inline-flex;
 }
 
 .dashboard-switcher-sidebar__add-dashboard-card {

--- a/tests/bootstrap-stubs.php
+++ b/tests/bootstrap-stubs.php
@@ -20,12 +20,20 @@ define('PHPUNIT_RUN', 1);
 
 require_once __DIR__ . '/../vendor/autoload.php';
 
+// Doctrine DBAL placeholders MUST be loaded before the OCP PSR-4 loader is
+// registered. IQueryBuilder.php (used by IDBConnection) contains class
+// constants that reference Doctrine\DBAL\ParameterType directly
+// (e.g. `PARAM_NULL = ParameterType::NULL`). PHP evaluates these constant
+// expressions as soon as the interface file is parsed — before any mock
+// creation code runs. If Doctrine is not yet defined at that moment, PHP
+// emits a fatal "Class not found" error. Loading the stubs first ensures
+// that the placeholder classes are already in the class table when the OCP
+// autoloader first touches IQueryBuilder.php.
+require_once __DIR__ . '/Stubs/DoctrineStubs.php';
+
 // Register OCP stubs from vendor.
 $ocpLoader = new \Composer\Autoload\ClassLoader();
 $ocpLoader->addPsr4('OCP\\', __DIR__ . '/../vendor/nextcloud/ocp/OCP/');
 $ocpLoader->register();
-
-// Doctrine DBAL placeholders so IDBConnection can be mocked.
-require_once __DIR__ . '/Stubs/DoctrineStubs.php';
 
 error_log('[UNIT TEST BOOTSTRAP] Stub-only bootstrap loaded — OCP stubs active');

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -36,16 +36,19 @@ if (file_exists(__DIR__ . '/../../../lib/base.php')) {
     // vendor/nextcloud/ocp so unit tests that mock OCP interfaces
     // (e.g. IInitialState) can still run. These are signature-only
     // stubs and are sufficient for PHPUnit's createMock().
+    // Doctrine DBAL placeholders MUST be loaded before the OCP PSR-4
+    // loader is registered. IQueryBuilder.php contains class constants
+    // that reference Doctrine\DBAL\ParameterType directly
+    // (e.g. `PARAM_NULL = ParameterType::NULL`). PHP evaluates these
+    // constant expressions as soon as the interface file is parsed —
+    // before any mock creation code runs. Loading the stubs first
+    // ensures the placeholder classes are in the class table before
+    // the autoloader first touches IQueryBuilder.php.
+    require_once __DIR__ . '/Stubs/DoctrineStubs.php';
+
     $ocpLoader = new \Composer\Autoload\ClassLoader();
     $ocpLoader->addPsr4('OCP\\', __DIR__ . '/../vendor/nextcloud/ocp/OCP/');
     $ocpLoader->register();
-
-    // The OCP IDBConnection / IQueryBuilder stubs reference Doctrine
-    // DBAL classes that are not in our composer.json (Nextcloud
-    // provides them at runtime). Load minimal placeholder classes so
-    // PHPUnit's automatic mock generator can introspect IDBConnection
-    // for the REQ-DASH-015 tests.
-    require_once __DIR__ . '/Stubs/DoctrineStubs.php';
 }
 
 // Register Test\ namespace for NC test classes.


### PR DESCRIPTION
## Summary

- **PHPUnit bootstrap fix (176 errors → 0)**: `tests/bootstrap-stubs.php` and `tests/bootstrap.php` now load `DoctrineStubs.php` before registering the OCP PSR-4 loader. `IQueryBuilder.php` contains interface constants that evaluate `ParameterType::NULL` etc. at parse time — loading stubs after the loader caused 176 test errors with `Class Doctrine\DBAL\ParameterType not found`.
- **phpunit.xml**: flip bootstrap to `tests/bootstrap.php`. In CI (full Nextcloud server), `bootstrap.php` loads `lib/base.php` and real Doctrine. Falls back to stub path when outside NC server.
- **Stylelint (8 errors → 0)**: fix `no-descending-specificity` in `DashboardSwitcherSidebar.vue`, `LinksForm.vue`, `LinkButtonWidget.vue`, `MenuWidget.vue`, `QuicklinksWidget.vue` — reorder base selectors before compound/pseudo-class overrides.
- **gate-6 orphan-auth (1 orphan → 0)**: wire `RoleFeaturePermissionService::isWidgetAllowed()` into `WidgetApiController::addWidget()` — users can now only add widgets their role-feature-permission profile permits. Unconfigured deployments unaffected (`null` allowed set = no restriction).
- **ESLint**: already passing (0 errors); `eslint-import-resolver-exports` is published in npm registry.

## Test plan

- [ ] PHPUnit gate passes in CI (Doctrine errors gone; ZipArchive tests pass with full PHP env)
- [ ] Stylelint: `npm run stylelint` → 0 errors (verified locally)
- [ ] ESLint: `npm run lint` → 0 errors (verified locally)
- [ ] gate-6 orphan-auth: `isWidgetAllowed` called from `WidgetApiController::addWidget`
- [ ] Regression: `RoleFeaturePermissionServiceTest` still green (8/8 tests pass)